### PR TITLE
Fix manylinux compatibility flag format

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Build wheel (Linux)
         if: runner.os == 'Linux'
-        run: maturin build --release --strip --manylinux 2017
+        run: maturin build --release --strip --compatibility manylinux2014
 
       - name: Build wheel (non-Linux)
         if: runner.os != 'Linux'


### PR DESCRIPTION
## Summary
Fix the maturin build command to use the correct manylinux compatibility flag format.

## Changes
- Use `--compatibility manylinux2014` instead of `--manylinux 2017`

## Context
The previous publish attempt failed with:
```
error: invalid value '2017' for '--compatibility [<compatibility>...]': invalid manylinux option
```

🤖 Generated with [Claude Code](https://claude.ai/code)