### PR TITLE
Use maturin-action for manylinux builds, bump to 0.1.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,21 +15,38 @@ permissions:
   contents: read
 
 jobs:
-  build-wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+  # Build Linux wheels using manylinux container
+  build-linux:
+    name: Build Linux wheels
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        exclude:
-          # Reduce matrix size - build fewer Python versions on Windows
-          - os: windows-latest
-            python-version: '3.8'
-          - os: windows-latest
-            python-version: '3.9'
+    steps:
+      - uses: actions/checkout@v4
 
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x86_64
+          manylinux: auto
+          args: --release --strip -i python${{ matrix.python-version }}
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-linux-py${{ matrix.python-version }}
+          path: target/wheels/*.whl
+
+  # Build macOS wheels
+  build-macos:
+    name: Build macOS wheels
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
 
@@ -38,63 +55,67 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
-      - name: Install maturin
-        run: pip install maturin
-
-      - name: Build wheel (Linux)
-        if: runner.os == 'Linux'
-        run: maturin build --release --strip --compatibility manylinux2014
-
-      - name: Build wheel (non-Linux)
-        if: runner.os != 'Linux'
-        run: maturin build --release --strip
+          args: --release --strip
 
       - name: Upload wheel
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.os }}-py${{ matrix.python-version }}
+          name: wheel-macos-py${{ matrix.python-version }}
           path: target/wheels/*.whl
 
+  # Build Windows wheels
+  build-windows:
+    name: Build Windows wheels
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          args: --release --strip
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-windows-py${{ matrix.python-version }}
+          path: target/wheels/*.whl
+
+  # Build source distribution
   build-sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install maturin
-        run: pip install maturin
-
       - name: Build sdist
-        run: maturin sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
 
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:
           name: sdist
-          path: target/wheels/*.tar.gz
+          path: dist/*.tar.gz
 
+  # Publish to PyPI
   publish:
     name: Publish to PyPI
-    needs: [build-wheels, build-sdist]
+    needs: [build-linux, build-macos, build-windows, build-sdist]
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-01-16
+
+### Fixed
+- Fix manylinux wheel builds using PyO3/maturin-action with proper containers
+
 ## [0.1.1] - 2026-01-16
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["djust contributors"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "djust"
-version = "0.1.1"
+version = "0.1.2"
 description = "Blazing fast reactive server-side rendering for Django, powered by Rust"
 authors = [{name = "djust contributors"}]
 readme = "README.md"


### PR DESCRIPTION
## Summary
Fix manylinux wheel builds by switching to PyO3/maturin-action which properly handles manylinux containers.

## Changes
- Replace manual maturin commands with `PyO3/maturin-action@v1`
- Linux builds now use proper manylinux Docker containers automatically
- Separate jobs for Linux, macOS, and Windows for clarity
- Bump version to 0.1.2 (0.1.1 had partial/failed uploads)

## Why maturin-action?
The previous approach failed because:
```
Error ensuring manylinux_2_17 compliance
Your library is not manylinux_2_17 compliant because of too-recent versioned symbols
```

The Ubuntu runner has a newer glibc than manylinux allows. `maturin-action` solves this by building inside manylinux Docker containers.

🤖 Generated with [Claude Code](https://claude.ai/code)