### PR TITLE
Fix LICENSE inclusion in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,10 @@ module-name = "djust._rust"
 python-source = "python"
 bindings = "pyo3"
 manifest-path = "crates/djust_live/Cargo.toml"
+include = [
+    { path = "LICENSE", format = "sdist" },
+    { path = "README.md", format = "sdist" },
+]
 
 [tool.pytest.ini_options]
 python_files = ["test_*.py", "*_test.py"]


### PR DESCRIPTION
## Summary
Fix the source distribution build to properly include LICENSE file.

## Changes
Add explicit `include` directive in `[tool.maturin]` for LICENSE and README.md files.

## Context
The 0.1.2 release failed to upload the sdist due to:
```
License-File LICENSE does not exist in distribution file djust-0.1.2.tar.gz
```

This was because maturin's `manifest-path` points to a subdirectory, so it couldn't find LICENSE in the project root.

🤖 Generated with [Claude Code](https://claude.ai/code)