### PR TITLE
fix: Include URL path and query hash in VDOM cache key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ coverage/
 
 # Build artifacts
 marketing-site/
+.serena/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "ahash",
  "criterion",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "ahash",
  "criterion",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "bincode",
  "dashmap",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "ahash",
  "chrono",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "ahash",
  "criterion",

--- a/python/tests/test_vdom_cache_key.py
+++ b/python/tests/test_vdom_cache_key.py
@@ -1,0 +1,202 @@
+"""
+Test for VDOM cache key with path and query string support.
+
+Ensures that different URLs get different VDOM caches, preventing
+render corruption when navigating between views with different
+template structures (e.g., /emails/ vs /emails/?sender=1).
+"""
+
+import pytest
+from djust import LiveView
+from django.test import RequestFactory
+from django.contrib.sessions.middleware import SessionMiddleware
+
+
+class InboxView(LiveView):
+    """
+    View that can render in two different structural modes:
+    - Grouped mode (default): shows sender groups with nested emails
+    - Flat mode (when sender_id is set): shows flat list of emails from one sender
+    """
+
+    template = """<div data-liveview-root data-live-view="InboxView">
+    <main class="content">
+        {% if filter_mode == 'sender' %}
+        <!-- FLAT MODE: Single sender's emails -->
+        <div class="sender-filter-header">
+            <div class="sender-name">{{ sender_name }}</div>
+            <button @click="clear_filter">Back to Inbox</button>
+        </div>
+        <div class="email-list-flat">
+            {% for email in emails %}
+            <div class="email-item">{{ email.subject }}</div>
+            {% endfor %}
+        </div>
+        {% else %}
+        <!-- GROUPED MODE: Emails grouped by sender -->
+        <div class="sender-groups">
+            {% for sender in senders %}
+            <div class="sender-group">
+                <span class="sender-name">{{ sender.name }}</span>
+                <a href="?sender={{ sender.id }}">View all</a>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+    </main>
+</div>"""
+
+    def mount(self, request, sender_id=None):
+        if sender_id is None and hasattr(request, "GET"):
+            sender_id = request.GET.get("sender")
+            if sender_id:
+                sender_id = int(sender_id)
+        self.sender_id = sender_id
+        if sender_id:
+            self.filter_mode = "sender"
+            self.sender_name = "John Doe"
+            self.emails = [{"subject": "Email 1"}, {"subject": "Email 2"}]
+            self.senders = []
+        else:
+            self.filter_mode = "grouped"
+            self.sender_name = ""
+            self.emails = []
+            self.senders = [
+                {"id": 1, "name": "John Doe"},
+                {"id": 2, "name": "Alice Smith"},
+            ]
+
+
+def add_session_to_request(request):
+    """Helper to add session to request"""
+    middleware = SessionMiddleware(lambda x: None)
+    middleware.process_request(request)
+    request.session.save()
+    return request
+
+
+@pytest.mark.django_db
+def test_cache_key_includes_class_name_and_path():
+    """
+    Test that the cache key includes both class name and path.
+    """
+    factory = RequestFactory()
+
+    view = InboxView()
+    request = factory.get("/emails/")
+    request = add_session_to_request(request)
+
+    # Simulate WebSocket session with path info
+    view._websocket_session_id = "test-session-123"
+    view._websocket_path = "/emails/"
+    view._websocket_query_string = ""
+
+    # Initialize the Rust view
+    view._rust_view = None
+    view._cache_key = None
+    view._initialize_rust_view(request)
+
+    cache_key = view._cache_key
+
+    # Cache key should include view class name AND path
+    assert "InboxView" in cache_key, f"Cache key should include class name: {cache_key}"
+    assert "/emails/" in cache_key, f"Cache key should include path: {cache_key}"
+
+
+@pytest.mark.django_db
+def test_cache_key_differs_for_different_query_params():
+    """
+    Test that URLs with different query params get different cache keys.
+
+    This ensures /emails/ and /emails/?sender=1 have separate VDOM caches,
+    preventing render corruption when switching between grouped and flat views.
+    """
+    factory = RequestFactory()
+
+    # View 1: No query params (grouped mode)
+    view1 = InboxView()
+    request1 = factory.get("/emails/")
+    request1 = add_session_to_request(request1)
+    view1._websocket_session_id = "test-session-123"
+    view1._websocket_path = "/emails/"
+    view1._websocket_query_string = ""
+    view1._rust_view = None
+    view1._cache_key = None
+    view1._initialize_rust_view(request1)
+    cache_key1 = view1._cache_key
+
+    # View 2: With sender query param (flat mode)
+    view2 = InboxView()
+    request2 = factory.get("/emails/?sender=1")
+    request2 = add_session_to_request(request2)
+    view2._websocket_session_id = "test-session-123"  # Same session!
+    view2._websocket_path = "/emails/"
+    view2._websocket_query_string = "sender=1"
+    view2._rust_view = None
+    view2._cache_key = None
+    view2._initialize_rust_view(request2)
+    cache_key2 = view2._cache_key
+
+    # View 3: With different sender query param
+    view3 = InboxView()
+    request3 = factory.get("/emails/?sender=2")
+    request3 = add_session_to_request(request3)
+    view3._websocket_session_id = "test-session-123"  # Same session!
+    view3._websocket_path = "/emails/"
+    view3._websocket_query_string = "sender=2"
+    view3._rust_view = None
+    view3._cache_key = None
+    view3._initialize_rust_view(request3)
+    cache_key3 = view3._cache_key
+
+    # All three should have different cache keys
+    assert cache_key1 != cache_key2, (
+        f"Grouped and flat views should have different cache keys: " f"{cache_key1} vs {cache_key2}"
+    )
+    assert cache_key2 != cache_key3, (
+        f"Different sender filters should have different cache keys: "
+        f"{cache_key2} vs {cache_key3}"
+    )
+
+
+@pytest.mark.django_db
+def test_cache_key_query_param_order_independent():
+    """
+    Test that query param ordering doesn't affect cache key.
+
+    ?a=1&b=2 and ?b=2&a=1 should produce the same cache key.
+    """
+    factory = RequestFactory()
+
+    # View with params in one order
+    view1 = InboxView()
+    request1 = factory.get("/emails/?a=1&b=2")
+    request1 = add_session_to_request(request1)
+    view1._websocket_session_id = "test-session-123"
+    view1._websocket_path = "/emails/"
+    view1._websocket_query_string = "a=1&b=2"
+    view1._rust_view = None
+    view1._cache_key = None
+    view1._initialize_rust_view(request1)
+    cache_key1 = view1._cache_key
+
+    # View with params in reverse order
+    view2 = InboxView()
+    request2 = factory.get("/emails/?b=2&a=1")
+    request2 = add_session_to_request(request2)
+    view2._websocket_session_id = "test-session-123"
+    view2._websocket_path = "/emails/"
+    view2._websocket_query_string = "b=2&a=1"
+    view2._rust_view = None
+    view2._cache_key = None
+    view2._initialize_rust_view(request2)
+    cache_key2 = view2._cache_key
+
+    # Same params in different order should produce same cache key
+    assert cache_key1 == cache_key2, (
+        f"Query param order should not affect cache key: " f"{cache_key1} vs {cache_key2}"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/uv.lock
+++ b/uv.lock
@@ -884,7 +884,7 @@ wheels = [
 
 [[package]]
 name = "djust"
-version = "0.1.0"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "channels", version = "4.2.2", source = { registry = "https://pypi.org/simple" }, extra = ["daphne"], marker = "python_full_version < '3.9'" },
@@ -977,7 +977,7 @@ version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Fixes VDOM cache key collision that causes render corruption when navigating between URLs with different template structures.

### Problem
The WebSocket cache key was `{session}_liveview_ws`, which meant:
- `/emails/` (grouped view) and `/emails/?sender=1` (flat view) shared the same cache
- Navigating between them caused patches to be computed against the wrong VDOM base
- Result: visual corruption when switching views

### Solution
Include URL path, class name, and query string hash in the cache key:
- WebSocket: `{session}_liveview_ws_{ClassName}_{path}_{query_hash}`
- HTTP: `{session}_liveview_{path}_{query_hash}`

### Example Cache Keys

| URL | Cache Key |
|-----|-----------|
| `/emails/` | `abc123_liveview_ws_InboxView_/emails/` |
| `/emails/?sender=1` | `abc123_liveview_ws_InboxView_/emails/_d969313a` |
| `/emails/?sender=2` | `abc123_liveview_ws_InboxView_/emails/_fc5a5541` |

### Changes
- `websocket.py`: Pass `_websocket_path` and `_websocket_query_string` to view instance
- `live_view.py`: Include path + query hash in cache key for both WebSocket and HTTP modes
- Query params are sorted before hashing for order-independence (`?a=1&b=2` == `?b=2&a=1`)

## Test plan
- [x] `test_cache_key_includes_class_name_and_path` - verifies class name and path in key
- [x] `test_cache_key_differs_for_different_query_params` - verifies different URLs get different caches
- [x] `test_cache_key_query_param_order_independent` - verifies param order doesn't matter
- [ ] Manual test: Navigate between `/emails/` and `/emails/?sender=X` without corruption

🤖 Generated with [Claude Code](https://claude.ai/claude-code)