### PR TITLE
Fix: Apply Django context processors in LiveView rendering

### DIFF
--- a/python/tests/test_context_processors.py
+++ b/python/tests/test_context_processors.py
@@ -67,9 +67,6 @@ class TestContextProcessors:
     @override_settings(TEMPLATES=TEMPLATES_WITH_CONTEXT_PROCESSORS)
     def test_context_processors_applied_in_get_context(self, mock_request):
         """Test that context processors are applied when building context."""
-        # Clear cache after settings override takes effect
-        LiveView._context_processors_cache = None
-
         view = AnalyticsView()
         view.setup(mock_request)
         view._initialize_temporary_assigns()
@@ -92,9 +89,6 @@ class TestContextProcessors:
     @override_settings(TEMPLATES=TEMPLATES_WITH_CONTEXT_PROCESSORS)
     def test_context_processors_not_applied_without_request(self, mock_request):
         """Test that context processors are skipped when request is None."""
-        # Clear cache after settings override takes effect
-        LiveView._context_processors_cache = None
-
         view = AnalyticsView()
         view.setup(mock_request)
         view._initialize_temporary_assigns()
@@ -111,9 +105,6 @@ class TestContextProcessors:
     @override_settings(TEMPLATES=[])
     def test_context_processors_with_no_djust_backend(self, mock_request):
         """Test graceful handling when DjustTemplateBackend is not configured."""
-        # Clear cache after settings override takes effect
-        LiveView._context_processors_cache = None
-
         view = AnalyticsView()
         view.setup(mock_request)
         view._initialize_temporary_assigns()
@@ -129,9 +120,6 @@ class TestContextProcessors:
     @override_settings(TEMPLATES=TEMPLATES_WITH_CONTEXT_PROCESSORS)
     def test_context_processors_handle_processor_errors(self, mock_request):
         """Test that errors in context processors are handled gracefully."""
-        # Clear cache after settings override takes effect
-        LiveView._context_processors_cache = None
-
         view = AnalyticsView()
         view.setup(mock_request)
         view._initialize_temporary_assigns()


### PR DESCRIPTION
## Summary

- Fix LiveView to apply Django context processors during template rendering
- This ensures variables like `GOOGLE_ANALYTICS_ID`, `user`, `messages`, etc. are available in templates

## Problem

LiveView was bypassing `DjustTemplateBackend.render()` and using `RustLiveView` directly for rendering. While `DjustTemplateBackend` has context processor support (lines 612-616), LiveView never called this code path.

This caused context processor variables to be unavailable in LiveView templates, requiring manual passing of variables in `get_context_data()` as a workaround.

## Solution

Added `_apply_context_processors()` method to LiveView that:
1. Finds `DjustTemplateBackend` in Django's `TEMPLATES` setting
2. Gets the configured context processors
3. Imports and calls each processor with the request
4. Updates the context with processor return values
5. Handles errors gracefully (logs warning, continues)

The method is called:
- In `get()` after `get_context_data()` for initial page loads
- In `render_full_template()` when building context from scratch

## Test plan

- [ ] Verify analytics works on djust.org after deploying this fix
- [ ] Test that context processors are applied on GET requests
- [ ] Test that custom context processor variables are available in templates

## Related

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)