### PR TITLE
chore: Add pre-push hooks and CI improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,22 @@ updates:
     labels:
       - "dependencies"
       - "rust"
+    ignore:
+      # bincode 3.0.0 is intentionally broken (compile_error!)
+      # See: https://xkcd.com/2347/
+      - dependency-name: "bincode"
+        versions: ["3.*"]
+
+  # JavaScript dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+      - "javascript"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ coverage/
 # Build artifacts
 marketing-site/
 .serena/
+wheels/
+
+# Claude Code
+.claude/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,13 +80,32 @@ repos:
         args: ['--baseline', '.secrets.baseline']
         exclude: package-lock\.json
 
-  # Security - Rust dependency audit
+  # Pre-push hooks (slower checks that run before git push)
   - repo: local
     hooks:
+      # Python tests
+      - id: pytest
+        name: pytest
+        entry: bash -c 'PYTHONPATH=. .venv/bin/python -m pytest tests/ python/tests/ -q'
+        language: system
+        types: [python]
+        pass_filenames: false
+        stages: [pre-push]
+
+      # Rust tests
+      - id: cargo-test
+        name: cargo test
+        entry: bash -c 'PYO3_PYTHON=$(pwd)/.venv/bin/python cargo test --workspace --exclude djust_live --release -q'
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]
+
+      # Rust dependency audit
       - id: cargo-audit
         name: cargo audit
         entry: cargo audit
         language: system
         types: [rust]
         pass_filenames: false
-        stages: [pre-push]  # Only run on push (slower check)
+        stages: [pre-push]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,9 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 # Install dependencies and build Rust extension
 uv sync --extra dev
 
-# Install pre-commit hooks (required for contributions)
+# Install pre-commit and pre-push hooks (required for contributions)
 uvx pre-commit install
+uvx pre-commit install --hook-type pre-push
 ```
 
 ## Code Style

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,9 @@ pre-commit: ## Run pre-commit hooks on all files
 pre-commit-install: ## Install pre-commit hooks (run once after clone)
 	@echo "$(GREEN)Installing pre-commit hooks...$(NC)"
 	@uvx pre-commit install
+	@uvx pre-commit install --hook-type pre-push
 	@echo "$(GREEN)Pre-commit hooks installed! They will run automatically on git commit.$(NC)"
+	@echo "$(GREEN)Pre-push hooks installed! Tests will run before git push.$(NC)"
 
 .PHONY: check
 check: lint test ## Run linters and tests


### PR DESCRIPTION
## Summary

- Add pre-push hooks for pytest, cargo test, and cargo audit
- Add npm ecosystem to Dependabot configuration
- Add bincode 3.x ignore rule (intentionally broken version)
- Update .gitignore to exclude .claude/ and wheels/
- Update CONTRIBUTING.md with pre-push hook setup

## Test plan

- [x] Pre-commit hooks pass
- [x] Pre-push hooks configured correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)