### PR TITLE
fix: CSRF token rendered as [List] - evaluate lazy string (#72)

### DIFF
--- a/python/djust/template_backend.py
+++ b/python/djust/template_backend.py
@@ -900,9 +900,10 @@ class DjustTemplate:
         # Add request to context if provided
         if request is not None:
             context_dict["request"] = request
-            # Add CSRF token functions
-            context_dict["csrf_input"] = csrf_input_lazy(request)
-            context_dict["csrf_token"] = csrf_token_lazy(request)
+            # Add CSRF token - force evaluation of lazy string for Rust serialization
+            # csrf_token_lazy returns a SimpleLazyObject which must be converted to string
+            context_dict["csrf_input"] = str(csrf_input_lazy(request))
+            context_dict["csrf_token"] = str(csrf_token_lazy(request))
 
         # Apply context processors
         if request is not None:


### PR DESCRIPTION
## Summary

- Fixed CSRF token being rendered as `[List]` instead of actual token value
- Django's `csrf_token_lazy()` and `csrf_input_lazy()` return `SimpleLazyObject` instances
- These were incorrectly serialized when passed to the Rust rendering engine
- Fix: Force evaluation by wrapping with `str()` before adding to context

## Test plan

- [x] Added tests for `csrf_token` rendering (verifies not `[List]`)
- [x] Added tests for `csrf_input` rendering (verifies proper hidden input)
- [x] All existing tests pass

Closes #72

🤖 Generated with [Claude Code](https://claude.ai/claude-code)