### PR TITLE
fix: Expose djustInitialized on window for E2E test detection (#74)

### DIFF
--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -25,6 +25,7 @@ window._djustClientLoaded = true;
 
 // Track if we've been initialized via DOMContentLoaded
 let djustInitialized = false;
+window.djustInitialized = false;  // Expose for external detection (e.g., E2E tests)
 
 // Track pending turbo:load reinit
 let pendingTurboReinit = false;
@@ -2799,6 +2800,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Mark as initialized so turbo:load handler knows we're ready
     djustInitialized = true;
+    window.djustInitialized = true;  // Expose for external detection (e.g., E2E tests)
     console.log('[LiveView] Initialization complete, djustInitialized = true');
 
     // Check if we have a pending turbo reinit (turbo:load fired before we finished init)


### PR DESCRIPTION
## Summary

- Expose `window.djustInitialized` so E2E tests can detect when LiveView initialization is complete
- The variable was previously scoped inside the IIFE, making it inaccessible externally

## Test plan

- [ ] In a browser console on a djust-powered page, verify `window.djustInitialized === true` after init
- [ ] In Playwright: `await page.waitForFunction(() => window.djustInitialized === true);`

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)