### PR TITLE
feat(breaking): Standardize event binding syntax to dj- prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING: Event Binding Syntax** - Standardized all event bindings to use `dj-` prefix instead of `@` prefix. This affects all event attributes: `@click` → `dj-click`, `@input` → `dj-input`, `@change` → `dj-change`, `@submit` → `dj-submit`, `@blur` → `dj-blur`, `@focus` → `dj-focus`, `@keydown` → `dj-keydown`, `@keyup` → `dj-keyup`, `@loading.*` → `dj-loading.*`. Benefits: namespaced attributes, no conflicts with Vue/Alpine, no CSS selector escaping required. ([#68](https://github.com/djust-org/djust/issues/68))
+
 ### Fixed
 
 - **`{% elif %}` Tag Support**: Template parser now correctly handles `{% elif %}` conditionals. Previously, elif branches fell through to the unknown tag handler and rendered all branches instead of just the matching one. ([#80](https://github.com/djust-org/djust/pull/80))
@@ -25,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Comparison Operators**: Template conditions now support `>`, `<`, `>=`, `<=` operators in addition to `==` and `!=`. ([#65](https://github.com/djust-org/djust/pull/65))
 - **Enhanced `{% include %}` Tag**: Full support for `with` clause (pass variables) and `only` keyword (isolate context). ([#65](https://github.com/djust-org/djust/pull/65))
 - **Performance Testing Infrastructure**: Comprehensive benchmarking with Criterion (Rust) and pytest-benchmark (Python). New Makefile commands: `make benchmark`, `make benchmark-quick`, `make benchmark-e2e`. Enables tracking performance across releases and detecting regressions. ([#69](https://github.com/djust-org/djust/pull/69))
-- **Inline Handler Arguments**: Event handlers now support function-call syntax with arguments directly in the template attribute. Use `@click="handler('arg')"` instead of `@click="handler" data-value="arg"`. Supports strings, numbers, booleans, null, and multiple arguments. ([#67](https://github.com/djust-org/djust/pull/67))
+- **Inline Handler Arguments**: Event handlers now support function-call syntax with arguments directly in the template attribute. Use `dj-click="handler('arg')"` instead of `dj-click="handler" data-value="arg"`. Supports strings, numbers, booleans, null, and multiple arguments. ([#67](https://github.com/djust-org/djust/pull/67))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ class CounterView(LiveView):
     template_string = """
     <div>
         <h1>Count: {{ count }}</h1>
-        <button @click="increment">+</button>
-        <button @click="decrement">-</button>
+        <button dj-click="increment">+</button>
+        <button dj-click="decrement">-</button>
     </div>
     """
 
@@ -276,9 +276,9 @@ djust supports Django template syntax with event binding:
 {% include "partials/header.html" %}
 
 <!-- Event binding -->
-<button @click="increment">Click me</button>
-<input @input="on_search" type="text" />
-<form @submit="submit_form">
+<button dj-click="increment">Click me</button>
+<input dj-input="on_search" type="text" />
+<form dj-submit="submit_form">
     <input name="email" />
     <button type="submit">Submit</button>
 </form>
@@ -286,10 +286,10 @@ djust supports Django template syntax with event binding:
 
 ### Supported Events
 
-- `@click` - Click events
-- `@input` - Input events (passes `value`)
-- `@change` - Change events (passes `value`)
-- `@submit` - Form submission (passes form data as dict)
+- `dj-click` - Click events
+- `dj-input` - Input events (passes `value`)
+- `dj-change` - Change events (passes `value`)
+- `dj-submit` - Form submission (passes form data as dict)
 
 ### Reusable Components
 
@@ -359,7 +359,7 @@ from djust import Component, register_component
 
 @register_component('my-button')
 class Button(Component):
-    template = '<button @click="on_click">{{ label }}</button>'
+    template = '<button dj-click="on_click">{{ label }}</button>'
 
     def __init__(self, label="Click"):
         super().__init__()
@@ -450,7 +450,7 @@ from djust.decorators import debounce
 
 class ProductSearchView(LiveView):
     template_string = """
-    <input @input="search" placeholder="Search products..." />
+    <input dj-input="search" placeholder="Search products..." />
     <div>{% for p in results %}<div>{{ p.name }}</div>{% endfor %}</div>
     """
 
@@ -539,7 +539,7 @@ def search(self, value: str = "", **kwargs):
     self.search_query = value
 ```
 
-**Parameter Convention**: Use `value` for form inputs (`@input`, `@change` events):
+**Parameter Convention**: Use `value` for form inputs (`dj-input`, `dj-change` events):
 
 ```python
 # ✅ Correct - matches what form events send

--- a/docs/BEST_PRACTICES_AI.md
+++ b/docs/BEST_PRACTICES_AI.md
@@ -135,12 +135,12 @@ class ProductListView(LiveView):
 <div>
     <!-- Search input with debouncing -->
     <input type="text"
-           @input="search"
+           dj-input="search"
            value="{{ search_query }}"
            placeholder="Search products..." />
 
     <!-- Category filter -->
-    <select @change="filter_by_category">
+    <select dj-change="filter_by_category">
         <option value="all" {% if filter_category == 'all' %}selected{% endif %}>
             All Categories
         </option>
@@ -282,20 +282,20 @@ def delete_item(self, item_id: int, **kwargs):
 
 ```html
 <!-- Text input -->
-<input type="text" @input="search" value="{{ search_query }}" />
+<input type="text" dj-input="search" value="{{ search_query }}" />
 
 <!-- Select/dropdown -->
-<select @change="filter_category">
+<select dj-change="filter_category">
     <option value="all">All</option>
 </select>
 
 <!-- Button with data -->
-<button @click="delete_item" data-item-id="{{ item.id }}">
+<button dj-click="delete_item" data-item-id="{{ item.id }}">
     Delete
 </button>
 
 <!-- Form submission -->
-<form @submit="save_form">
+<form dj-submit="save_form">
     <input name="email" type="email" />
     <input name="name" type="text" />
     <button type="submit">Save</button>
@@ -519,7 +519,7 @@ class LeaseFormView(FormMixin, LiveView):
     <div class="alert alert-error">{{ error_message }}</div>
     {% endif %}
 
-    <form @submit="submit_form">
+    <form dj-submit="submit_form">
         {% csrf_token %}
 
         <!-- FormMixin auto-renders with framework styling -->
@@ -528,7 +528,7 @@ class LeaseFormView(FormMixin, LiveView):
         <!-- Or manually render fields with real-time validation -->
         <div>
             <label>Tenant</label>
-            <select name="tenant" @change="validate_field">
+            <select name="tenant" dj-change="validate_field">
                 <option value="">Select tenant...</option>
                 {% for tenant in tenants %}
                 <option value="{{ tenant.id }}">{{ tenant.name }}</option>
@@ -615,7 +615,7 @@ def update_rent(self, value: str = "", **kwargs):
 
 ```html
 <!-- CSRF token required for all forms -->
-<form @submit="submit_form">
+<form dj-submit="submit_form">
     {% csrf_token %}
     <!-- form fields -->
 </form>

--- a/docs/DEBUG_PANEL.md
+++ b/docs/DEBUG_PANEL.md
@@ -239,7 +239,7 @@ Only **public variables** (not starting with `_`) are shown. This follows the JI
 2. Click **Event Handlers** tab
 3. Browse available handlers
 4. Note parameter names and types
-5. Use in template with `@click="handler_name"` or `@input="handler_name"`
+5. Use in template with `dj-click="handler_name"` or `dj-input="handler_name"`
 
 **Example**:
 ```
@@ -247,7 +247,7 @@ Debug Panel shows:
   filter_by_status(value: str = "all")
 
 Template:
-  <select @change="filter_by_status">
+  <select dj-change="filter_by_status">
     <option value="all">All</option>
     <option value="active">Active</option>
   </select>
@@ -274,7 +274,7 @@ Event History shows:
 Event Handlers shows:
   search(value: str = "")      ✅ Expects "value"
 
-Solution: Use @input="search" with parameter name "value"
+Solution: Use dj-input="search" with parameter name "value"
 ```
 
 ### Workflow 3: Performance Optimization

--- a/docs/EVENT_HANDLERS.md
+++ b/docs/EVENT_HANDLERS.md
@@ -18,13 +18,13 @@ This guide explains how to write effective event handlers in djust LiveView appl
 
 ### Always use `value` for form input events
 
-Form elements (`<input>`, `<select>`, `<textarea>`) send their value using the `value` parameter when using `@input` or `@change` events.
+Form elements (`<input>`, `<select>`, `<textarea>`) send their value using the `value` parameter when using `dj-input` or `dj-change` events.
 
 **✅ Correct:**
 ```python
 @event_handler()
 def search(self, value: str = "", **kwargs):
-    """value matches what @input/@change sends"""
+    """value matches what dj-input/dj-change sends"""
     self.search_query = value
     self._refresh_properties()
 
@@ -39,7 +39,7 @@ def filter_by_status(self, value: str = "all", **kwargs):
 ```python
 @event_handler()
 def search(self, query: str = "", **kwargs):
-    """Won't work! @input sends 'value', not 'query'"""
+    """Won't work! dj-input sends 'value', not 'query'"""
     self.search_query = query  # Will always be "" (default)
 ```
 
@@ -57,7 +57,7 @@ def delete_property(self, property_id: int, **kwargs):
 
 Template usage:
 ```html
-<button @click="delete_property" data-property-id="{{ property.id }}">
+<button dj-click="delete_property" data-property-id="{{ property.id }}">
     Delete
 </button>
 ```
@@ -70,10 +70,10 @@ You can pass arguments directly in the handler attribute using function-call syn
 
 ```html
 <!-- Instead of using data-* attributes -->
-<button @click="set_period" data-value="month">30 Days</button>
+<button dj-click="set_period" data-value="month">30 Days</button>
 
 <!-- You can use inline arguments -->
-<button @click="set_period('month')">30 Days</button>
+<button dj-click="set_period('month')">30 Days</button>
 ```
 
 Both approaches call the same handler:
@@ -105,8 +105,8 @@ Inline arguments are automatically parsed into their appropriate types:
 Pass multiple arguments separated by commas:
 
 ```html
-<button @click="sort_by('name', true)">Sort by Name (Ascending)</button>
-<button @click="filter('status', 'active', 1)">Active Items</button>
+<button dj-click="sort_by('name', true)">Sort by Name (Ascending)</button>
+<button dj-click="filter('status', 'active', 1)">Active Items</button>
 ```
 
 ```python
@@ -128,7 +128,7 @@ def filter(self, field: str, value: str, page: int = 1, **kwargs):
 You can combine inline arguments with `data-*` attributes. Inline arguments map to parameters by position, while `data-*` attributes map by name:
 
 ```html
-<button @click="update_item('delete')"
+<button dj-click="update_item('delete')"
         data-item-id="{{ item.id }}"
         data-confirm="true">
     Delete Item
@@ -162,19 +162,19 @@ def update_item(self, action: str, item_id: int = 0, confirm: bool = False, **kw
 #### Tab Selection
 ```html
 <div class="tabs">
-    <button @click="select_tab(0)">Overview</button>
-    <button @click="select_tab(1)">Details</button>
-    <button @click="select_tab(2)">Settings</button>
+    <button dj-click="select_tab(0)">Overview</button>
+    <button dj-click="select_tab(1)">Details</button>
+    <button dj-click="select_tab(2)">Settings</button>
 </div>
 ```
 
 #### Period Selector
 ```html
 <div class="period-selector">
-    <button @click="set_period('day')">Today</button>
-    <button @click="set_period('week')">This Week</button>
-    <button @click="set_period('month')">This Month</button>
-    <button @click="set_period('year')">This Year</button>
+    <button dj-click="set_period('day')">Today</button>
+    <button dj-click="set_period('week')">This Week</button>
+    <button dj-click="set_period('month')">This Month</button>
+    <button dj-click="set_period('year')">This Year</button>
 </div>
 ```
 
@@ -183,8 +183,8 @@ def update_item(self, action: str, item_id: int = 0, confirm: bool = False, **kw
 {% for item in items %}
 <div class="item-row">
     <span>{{ item.name }}</span>
-    <button @click="item_action('edit')" data-item-id="{{ item.id }}">Edit</button>
-    <button @click="item_action('delete')" data-item-id="{{ item.id }}">Delete</button>
+    <button dj-click="item_action('edit')" data-item-id="{{ item.id }}">Edit</button>
+    <button dj-click="item_action('delete')" data-item-id="{{ item.id }}">Delete</button>
 </div>
 {% endfor %}
 ```
@@ -506,7 +506,7 @@ def search(self, value: str = "", **kwargs):
 Template:
 ```html
 <input type="text"
-       @input="search"
+       dj-input="search"
        value="{{ search_query }}"
        placeholder="Search...">
 ```
@@ -523,7 +523,7 @@ def filter_by_status(self, value: str = "all", **kwargs):
 
 Template:
 ```html
-<select @change="filter_by_status">
+<select dj-change="filter_by_status">
     <option value="all" {% if filter_status == "all" %}selected{% endif %}>All</option>
     <option value="active" {% if filter_status == "active" %}selected{% endif %}>Active</option>
     <option value="inactive" {% if filter_status == "inactive" %}selected{% endif %}>Inactive</option>
@@ -589,7 +589,7 @@ def save_property(
 
 Template:
 ```html
-<form @submit="save_property">
+<form dj-submit="save_property">
     <input type="text" name="name" value="{{ property.name }}">
     <input type="text" name="address" value="{{ property.address }}">
     <input type="number" name="price" value="{{ property.price }}">
@@ -614,7 +614,7 @@ Template:
 
 **Checklist**:
 1. ✅ Is handler decorated with `@event_handler()`?
-2. ✅ Is event name correct in template (`@click="handler_name"`)?
+2. ✅ Is event name correct in template (`dj-click="handler_name"`)?
 3. ✅ Check browser console for JavaScript errors
 4. ✅ Check debug panel Event History for validation errors
 
@@ -622,7 +622,7 @@ Template:
 
 **Symptoms**: Handler receives default value instead of form value
 
-**Solution**: Use `value` parameter for form inputs:
+**Solution**: Use `value` parameter for form inputs (dj-input, dj-change events):
 
 ```python
 # ❌ Wrong
@@ -660,7 +660,7 @@ def handler(self, value: str = "", **kwargs):
 
 ```python
 # Template sends invalid string for int
-<button @click="delete_item" data-item-id="not_a_number">Delete</button>
+<button dj-click="delete_item" data-item-id="not_a_number">Delete</button>
 
 # ❌ This will fail - "not_a_number" can't be coerced to int
 @event_handler()
@@ -668,7 +668,7 @@ def delete_item(self, item_id: int):
     pass
 
 # ✅ Correct - template sends valid integer string
-<button @click="delete_item" data-item-id="{{ item.id }}">Delete</button>
+<button dj-click="delete_item" data-item-id="{{ item.id }}">Delete</button>
 
 # Handler receives item_id as int (automatically coerced)
 @event_handler()

--- a/docs/actors/ACTOR_STATE_MANAGEMENT.md
+++ b/docs/actors/ACTOR_STATE_MANAGEMENT.md
@@ -3016,8 +3016,8 @@ class CounterActorView(LiveView):
 <!-- demo_app/templates/counter.html -->
 <div data-liveview-root>
     <h1>Counter: {{ count }}</h1>
-    <button @click="increment">+</button>
-    <button @click="decrement">-</button>
+    <button dj-click="increment">+</button>
+    <button dj-click="decrement">-</button>
 </div>
 ```
 
@@ -3068,7 +3068,7 @@ class ChatActorView(LiveView):
         {% endfor %}
     </div>
 
-    <form @submit="send_message">
+    <form dj-submit="send_message">
         <input name="message" type="text" placeholder="Type a message..." />
         <button type="submit">Send</button>
     </form>

--- a/docs/components/API_REFERENCE_COMPONENTS.md
+++ b/docs/components/API_REFERENCE_COMPONENTS.md
@@ -410,7 +410,7 @@ class TabsComponent(LiveComponent):
             **kwargs: Additional event data
 
         Example template:
-            <button @click="switch_tab" data-tab="{{ tab.id }}">
+            <button dj-click="switch_tab" data-tab="{{ tab.id }}">
         """
         if tab:
             self.active_tab = tab
@@ -418,17 +418,17 @@ class TabsComponent(LiveComponent):
 ```
 
 **Event Handler Signature:**
-- Method name matches event name in template (`@click="switch_tab"`)
+- Method name matches event name in template (`dj-click="switch_tab"`)
 - Parameters come from `data-*` attributes
 - `**kwargs` captures additional data
 
 **Template Binding:**
 ```html
 <!-- Triggers: component.switch_tab(tab="profile") -->
-<button @click="switch_tab" data-tab="profile">Profile</button>
+<button dj-click="switch_tab" data-tab="profile">Profile</button>
 
 <!-- Triggers: component.page_changed(page="2", size="10") -->
-<button @click="page_changed" data-page="2" data-size="10">Next</button>
+<button dj-click="page_changed" data-page="2" data-size="10">Next</button>
 ```
 
 ### Parent Communication
@@ -493,7 +493,7 @@ class TabsComponent(LiveComponent):
                 <li class="nav-item">
                     <button
                         class="nav-link {% if tab.id == active_tab %}active{% endif %}"
-                        @click="switch_tab"
+                        dj-click="switch_tab"
                         data-tab="{{ tab.id }}"
                         {% if tab.disabled %}disabled{% endif %}>
                         {{ tab.label }}

--- a/docs/components/COMPONENTS.md
+++ b/docs/components/COMPONENTS.md
@@ -56,7 +56,7 @@ class TodoList(LiveComponent):
         <ul>
         {% for item in items %}
             <li>
-                <input type="checkbox" @change="toggle" data-id="{{ item.id }}">
+                <input type="checkbox" dj-change="toggle" data-id="{{ item.id }}">
                 {{ item.text }}
             </li>
         {% endfor %}
@@ -399,11 +399,11 @@ class FilterWidget(LiveComponent):
         <div class="filter-widget">
             <input
                 type="text"
-                @input="on_search"
+                dj-input="on_search"
                 value="{{ search_query }}"
                 placeholder="Search..."
             />
-            <select @change="on_category_change">
+            <select dj-change="on_category_change">
                 <option value="">All Categories</option>
                 {% for cat in categories %}
                 <option value="{{ cat }}" {% if cat == selected_category %}selected{% endif %}>
@@ -546,7 +546,7 @@ class MyView(LiveView):
 ```python
 # ✅ Start with inline template
 class SimpleView(LiveView):
-    template_string = '<button @click="increment">{{ count }}</button>'
+    template_string = '<button dj-click="increment">{{ count }}</button>'
 
     def mount(self, request):
         self.count = 0
@@ -564,7 +564,7 @@ class CounterButton(Component):
 
 # ✅ Upgrade to LiveComponent when you need state + interactivity
 class CounterWidget(LiveComponent):
-    template_string = '<button @click="increment">{{ count }}</button>'
+    template_string = '<button dj-click="increment">{{ count }}</button>'
 
     def mount(self, initial_count=0):
         self.count = initial_count
@@ -744,7 +744,7 @@ class StatusBadge(Component):
 # LiveComponent (stateful, for interactivity)
 class FilterWidget(LiveComponent):
     template_string = """
-        <input @input="on_search" value="{{ query }}" />
+        <input dj-input="on_search" value="{{ query }}" />
         <p>{{ results_count }} results</p>
     """
 

--- a/docs/components/COMPONENT_BEST_PRACTICES.md
+++ b/docs/components/COMPONENT_BEST_PRACTICES.md
@@ -22,7 +22,7 @@
 class MyView(LiveView):
     template_string = """
         <h1>{{ title }}</h1>
-        <button @click="increment">{{ count }}</button>
+        <button dj-click="increment">{{ count }}</button>
     """
 
     def mount(self, request):
@@ -84,7 +84,7 @@ Ask these questions in order:
 # ✅ Best: Just use template syntax
 template_string = """
     <span class="badge bg-primary">{{ count }}</span>
-    <button class="btn btn-success" @click="save">Save</button>
+    <button class="btn btn-success" dj-click="save">Save</button>
 """
 
 # ⚠️ OK: Simple component if reused everywhere
@@ -137,7 +137,7 @@ template_string = """
         {% for item in items %}
         <li class="{% if item.done %}completed{% endif %}">
             {{ item.text }}
-            <button @click="toggle_item" data-id="{{ item.id }}">✓</button>
+            <button dj-click="toggle_item" data-id="{{ item.id }}">✓</button>
         </li>
         {% endfor %}
     </ul>
@@ -161,7 +161,7 @@ class TabsComponent(LiveComponent):
         <ul class="nav nav-tabs">
             {% for tab in tabs %}
             <li class="nav-item">
-                <button @click="switch_tab" data-tab="{{ tab.id }}"
+                <button dj-click="switch_tab" data-tab="{{ tab.id }}"
                         class="nav-link {% if tab.id == active %}active{% endif %}">
                     {{ tab.label }}
                 </button>

--- a/docs/components/COMPONENT_EXAMPLES.md
+++ b/docs/components/COMPONENT_EXAMPLES.md
@@ -47,7 +47,7 @@ class TodoListComponent(LiveComponent):
                            placeholder="Add new todo..."
                            id="new-todo-{{ component_id }}"
                            @keyup.enter="add_todo">
-                    <button class="btn btn-primary" @click="add_todo">
+                    <button class="btn btn-primary" dj-click="add_todo">
                         Add
                     </button>
                 </div>
@@ -56,19 +56,19 @@ class TodoListComponent(LiveComponent):
                 <ul class="nav nav-pills mb-3">
                     <li class="nav-item">
                         <button class="nav-link {% if filter == 'all' %}active{% endif %}"
-                                @click="set_filter" data-filter="all">
+                                dj-click="set_filter" data-filter="all">
                             All ({{ total_count }})
                         </button>
                     </li>
                     <li class="nav-item">
                         <button class="nav-link {% if filter == 'active' %}active{% endif %}"
-                                @click="set_filter" data-filter="active">
+                                dj-click="set_filter" data-filter="active">
                             Active ({{ active_count }})
                         </button>
                     </li>
                     <li class="nav-item">
                         <button class="nav-link {% if filter == 'completed' %}active{% endif %}"
-                                @click="set_filter" data-filter="completed">
+                                dj-click="set_filter" data-filter="completed">
                             Completed ({{ completed_count }})
                         </button>
                     </li>
@@ -82,14 +82,14 @@ class TodoListComponent(LiveComponent):
                             <input class="form-check-input"
                                    type="checkbox"
                                    {% if item.completed %}checked{% endif %}
-                                   @change="toggle_todo"
+                                   dj-change="toggle_todo"
                                    data-id="{{ item.id }}">
                             <label class="form-check-label {% if item.completed %}text-decoration-line-through text-muted{% endif %}">
                                 {{ item.text }}
                             </label>
                         </div>
                         <button class="btn btn-sm btn-danger"
-                                @click="delete_todo"
+                                dj-click="delete_todo"
                                 data-id="{{ item.id }}">
                             ×
                         </button>
@@ -104,7 +104,7 @@ class TodoListComponent(LiveComponent):
                 <!-- Clear completed button -->
                 {% if completed_count > 0 %}
                 <div class="mt-3">
-                    <button class="btn btn-outline-danger btn-sm" @click="clear_completed">
+                    <button class="btn btn-outline-danger btn-sm" dj-click="clear_completed">
                         Clear Completed ({{ completed_count }})
                     </button>
                 </div>
@@ -236,7 +236,7 @@ class TodoAppView(LiveView):
                         {% if last_action %}
                         <div class="alert alert-success alert-dismissible fade show">
                             {{ last_action }}
-                            <button type="button" class="btn-close" @click="dismiss_alert"></button>
+                            <button type="button" class="btn-close" dj-click="dismiss_alert"></button>
                         </div>
                         {% endif %}
 
@@ -321,13 +321,13 @@ class UserListComponent(LiveComponent):
                        class="form-control mb-3"
                        placeholder="Search users..."
                        value="{{ search_term }}"
-                       @input="search">
+                       dj-input="search">
 
                 <!-- User list -->
                 <div class="list-group">
                     {% for user in filtered_users %}
                     <button class="list-group-item list-group-item-action {% if user.id == selected_id %}active{% endif %}"
-                            @click="select_user"
+                            dj-click="select_user"
                             data-user-id="{{ user.id }}">
                         <div class="d-flex w-100 justify-content-between">
                             <h6 class="mb-1">{{ user.name }}</h6>
@@ -444,10 +444,10 @@ class UserDetailComponent(LiveComponent):
 
                 <hr>
                 <div class="d-flex gap-2">
-                    <button class="btn btn-primary" @click="edit_user">
+                    <button class="btn btn-primary" dj-click="edit_user">
                         Edit
                     </button>
-                    <button class="btn btn-danger" @click="delete_user">
+                    <button class="btn btn-danger" dj-click="delete_user">
                         Delete
                     </button>
                 </div>
@@ -612,7 +612,7 @@ class ProductGridComponent(LiveComponent):
                     <div class="row">
                         <div class="col-md-4">
                             <label>Category</label>
-                            <select class="form-select" @change="filter_category">
+                            <select class="form-select" dj-change="filter_category">
                                 <option value="">All Categories</option>
                                 {% for cat in categories %}
                                 <option value="{{ cat }}" {% if cat == category_filter %}selected{% endif %}>
@@ -623,7 +623,7 @@ class ProductGridComponent(LiveComponent):
                         </div>
                         <div class="col-md-4">
                             <label>Price Range</label>
-                            <select class="form-select" @change="filter_price">
+                            <select class="form-select" dj-change="filter_price">
                                 <option value="">Any Price</option>
                                 <option value="0-50">Under $50</option>
                                 <option value="50-100">$50-$100</option>
@@ -635,7 +635,7 @@ class ProductGridComponent(LiveComponent):
                             <input type="text"
                                    class="form-control"
                                    placeholder="Search products..."
-                                   @input="search">
+                                   dj-input="search">
                         </div>
                     </div>
                 </div>
@@ -651,7 +651,7 @@ class ProductGridComponent(LiveComponent):
                             <p class="card-text text-muted">{{ product.category }}</p>
                             <h4 class="text-primary">${{ product.price }}</h4>
                             <button class="btn btn-primary w-100"
-                                    @click="add_to_cart"
+                                    dj-click="add_to_cart"
                                     data-product-id="{{ product.id }}">
                                 Add to Cart
                             </button>

--- a/docs/components/COMPONENT_MIGRATION_GUIDE.md
+++ b/docs/components/COMPONENT_MIGRATION_GUIDE.md
@@ -265,7 +265,7 @@ class TabsComponent(LiveComponent):
         <ul class="nav nav-tabs">
             {% for tab in tabs %}
             <li class="nav-item">
-                <button @click="switch_tab" data-tab="{{ tab.id }}"
+                <button dj-click="switch_tab" data-tab="{{ tab.id }}"
                         class="nav-link {% if tab.id == active %}active{% endif %}">
                     {{ tab.label }}
                 </button>
@@ -576,7 +576,7 @@ class TabsComponent(LiveComponent):
     template_string = """
         <ul class="nav nav-tabs">
             {% for tab in tabs %}
-            <button @click="switch_tab" data-tab="{{ tab.id }}"
+            <button dj-click="switch_tab" data-tab="{{ tab.id }}"
                     class="nav-link {% if tab.id == active %}active{% endif %}">
                 {{ tab.label }}
             </button>

--- a/docs/components/COMPONENT_UNIFIED_DESIGN.md
+++ b/docs/components/COMPONENT_UNIFIED_DESIGN.md
@@ -340,10 +340,10 @@ class LiveComponent(Component):
         class TodoListComponent(LiveComponent):
             template_string = '''
                 <div class="todo-list">
-                    <input type="text" @input="on_filter" value="{{ filter }}" />
+                    <input type="text" dj-input="on_filter" value="{{ filter }}" />
                     {% for item in filtered_items %}
                     <div>
-                        <input type="checkbox" @change="toggle_todo" data-id="{{ item.id }}">
+                        <input type="checkbox" dj-change="toggle_todo" data-id="{{ item.id }}">
                         {{ item.text }}
                     </div>
                     {% endfor %}

--- a/docs/components/LIVECOMPONENT_ARCHITECTURE.md
+++ b/docs/components/LIVECOMPONENT_ARCHITECTURE.md
@@ -78,7 +78,7 @@ class TabsComponent(LiveComponent):
         <ul class="nav">
             {% for tab in tabs %}
             <li class="{% if tab.id == active_tab %}active{% endif %}"
-                @click="switch_tab" data-tab="{{ tab.id }}">
+                dj-click="switch_tab" data-tab="{{ tab.id }}">
                 {{ tab.label }}
             </li>
             {% endfor %}

--- a/docs/components/RADIO_VISUAL_EXAMPLES.md
+++ b/docs/components/RADIO_VISUAL_EXAMPLES.md
@@ -234,7 +234,7 @@ class SettingsView(LiveView):
 ```html
 <div class="container">
     <h1>Settings</h1>
-    <form @submit="save_settings">
+    <form dj-submit="save_settings">
         {{ theme_radio.render|safe }}
         <button type="submit" class="btn btn-primary">Save</button>
     </form>

--- a/docs/components/RUST_COMPONENTS.md
+++ b/docs/components/RUST_COMPONENTS.md
@@ -159,7 +159,7 @@ btn = Button(
     on_click="submitForm",
     button_type="submit"
 )
-# <button class="btn btn-primary btn-lg w-100" type="submit" id="submit" @click="submitForm">Submit Form</button>
+# <button class="btn btn-primary btn-lg w-100" type="submit" id="submit" dj-click="submitForm">Submit Form</button>
 ```
 
 **Outline Button**
@@ -175,7 +175,7 @@ btn = Button("chain", "Chained") \
     .with_size("sm") \
     .with_icon("⚠️") \
     .with_on_click("showWarning")
-# <button class="btn btn-warning btn-sm" type="button" id="chain" @click="showWarning">⚠️ Chained</button>
+# <button class="btn btn-warning btn-sm" type="button" id="chain" dj-click="showWarning">⚠️ Chained</button>
 ```
 
 ### Input
@@ -260,7 +260,7 @@ input = Input(
     required=True,
     on_change="validatePassword"
 )
-# <input class="form-control" type="password" id="password" placeholder="Enter password" required="required" @change="validatePassword" />
+# <input class="form-control" type="password" id="password" placeholder="Enter password" required="required" dj-change="validatePassword" />
 ```
 
 **Number Input with Range**
@@ -285,7 +285,7 @@ input = Input(
     placeholder="Search...",
     on_input="handleSearch"
 )
-# <input class="form-control form-control-lg" type="search" id="search" placeholder="Search..." @input="handleSearch" />
+# <input class="form-control form-control-lg" type="search" id="search" placeholder="Search..." dj-input="handleSearch" />
 ```
 
 **Disabled Input**
@@ -1328,7 +1328,7 @@ Rust components can be used directly in Django templates with JSX-like syntax:
         <RustText content="{{ form_title }}" element="h3" />
     </div>
     <div class="card-body">
-        <form @submit="handleSubmit">
+        <form dj-submit="handleSubmit">
             <div class="mb-3">
                 <RustText content="Email" element="label" forInput="email" />
                 <RustInput

--- a/docs/guides/HTTP_MODE_EXAMPLE.md
+++ b/docs/guides/HTTP_MODE_EXAMPLE.md
@@ -93,8 +93,8 @@ class CounterView(LiveView):
 <body>
     <div data-liveview-root>
         <h1>Counter: {{ count }}</h1>
-        <button @click="increment">+</button>
-        <button @click="decrement">-</button>
+        <button dj-click="increment">+</button>
+        <button dj-click="decrement">-</button>
     </div>
 </body>
 </html>

--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -69,9 +69,9 @@ class HelloView(LiveView):
     template_string = """
     <div>
         <h1>Hello {{ name }}!</h1>
-        <input type="text" @input="update_name" placeholder="Your name" />
+        <input type="text" dj-input="update_name" placeholder="Your name" />
         <p>You clicked {{ clicks }} times</p>
-        <button @click="increment">Click me!</button>
+        <button dj-click="increment">Click me!</button>
     </div>
     """
 
@@ -109,9 +109,9 @@ def increment(self):
 
 ### Event Binding
 ```html
-<button @click="save">Save</button>
-<input @input="on_search" type="text" />
-<form @submit="submit_form">...</form>
+<button dj-click="save">Save</button>
+<input dj-input="on_search" type="text" />
+<form dj-submit="submit_form">...</form>
 ```
 
 ### Template Syntax (Django-compatible)
@@ -151,7 +151,7 @@ Create custom components:
 from djust import Component
 
 class Button(Component):
-    template = '<button @click="clicked">{{ label }}</button>'
+    template = '<button dj-click="clicked">{{ label }}</button>'
 
     def __init__(self, label="Click"):
         self.label = label

--- a/docs/state-management/IMPLEMENTATION_PHASE2.md
+++ b/docs/state-management/IMPLEMENTATION_PHASE2.md
@@ -431,7 +431,7 @@ class DebounceSearchView(LiveView):
     template_string = """
     <div>
         <h2>Debounce Demo</h2>
-        <input type="text" @input="search" placeholder="Search...">
+        <input type="text" dj-input="search" placeholder="Search...">
         <p>Search query: {{ query }}</p>
         <p>Search count: {{ search_count }}</p>
     </div>

--- a/docs/state-management/IMPLEMENTATION_PHASE3.md
+++ b/docs/state-management/IMPLEMENTATION_PHASE3.md
@@ -456,7 +456,7 @@ class OptimisticTodoView(LiveView):
                     <input
                         type="checkbox"
                         class="form-check-input"
-                        @change="toggle_todo"
+                        dj-change="toggle_todo"
                         data-id="{{ todo.id }}"
                         {% if todo.completed %}checked{% endif %}
                     >
@@ -528,12 +528,12 @@ class OptimisticCounterView(LiveView):
                 <div class="btn-group">
                     <button
                         class="btn btn-danger btn-lg"
-                        @click="decrement"
+                        dj-click="decrement"
                         data-loading-text="..."
                     >-</button>
                     <button
                         class="btn btn-success btn-lg"
-                        @click="increment"
+                        dj-click="increment"
                         data-loading-text="..."
                     >+</button>
                 </div>

--- a/docs/state-management/IMPLEMENTATION_PHASE4.md
+++ b/docs/state-management/IMPLEMENTATION_PHASE4.md
@@ -146,7 +146,7 @@ class TodoListComponent(LiveComponent):
     template_string = """
         <div class="todo-list">
             {% for item in items %}
-            <div @click="toggle_todo" data-id="{{ item.id }}">
+            <div dj-click="toggle_todo" data-id="{{ item.id }}">
                 {{ item.text }}
             </div>
             {% endfor %}

--- a/docs/state-management/IMPLEMENTATION_PHASE5.md
+++ b/docs/state-management/IMPLEMENTATION_PHASE5.md
@@ -444,12 +444,12 @@ export class DraftMode {
 
 **Example (HTML)**:
 ```html
-<button @click="submit_form" @loading @loading-text="Saving...">
+<button dj-click="submit_form" @loading @loading-text="Saving...">
     Save
 </button>
 
 <!-- Becomes during loading: -->
-<button @click="submit_form" @loading @loading-text="Saving..." disabled>
+<button dj-click="submit_form" @loading @loading-text="Saving..." disabled>
     Saving...
 </button>
 ```

--- a/docs/state-management/LOADING_ATTRIBUTE_IMPROVEMENTS.md
+++ b/docs/state-management/LOADING_ATTRIBUTE_IMPROVEMENTS.md
@@ -5,10 +5,10 @@ This document tracks potential enhancements to the @loading attribute system (Ph
 ## Current Implementation
 
 The @loading attribute system provides Phoenix LiveView-style loading indicators with:
-- `@loading.disable` - Disable element during loading
-- `@loading.class="class-name"` - Add CSS class during loading
-- `@loading.show` - Show element during loading
-- `@loading.hide` - Hide element during loading
+- `dj-loading.disable` - Disable element during loading
+- `dj-loading.class="class-name"` - Add CSS class during loading
+- `dj-loading.show` - Show element during loading
+- `dj-loading.hide` - Hide element during loading
 
 **Scoping**: Loading states are scoped to prevent cross-button contamination using grouping containers (`d-flex`, `btn-group`, etc.).
 
@@ -70,13 +70,13 @@ Allow explicit event name targeting for more flexible grouping:
 ```html
 <!-- Current: Relies on parent container grouping -->
 <div class="d-flex">
-    <button @click="save_article">Save</button>
-    <div @loading.show>Saving...</div>
+    <button dj-click="save_article">Save</button>
+    <div dj-loading.show>Saving...</div>
 </div>
 
 <!-- Future: Explicit event targeting -->
-<button @click="save_article">Save</button>
-<div @loading.show="save_article">Saving...</div>
+<button dj-click="save_article">Save</button>
+<div dj-loading.show="save_article">Saving...</div>
 ```
 
 **Benefits**:
@@ -91,7 +91,7 @@ Allow explicit event name targeting for more flexible grouping:
 Prevent flashing spinners on fast operations (Phoenix LiveView feature):
 
 ```html
-<div @loading.show @loading.delay="200">Loading...</div>
+<div dj-loading.show @loading.delay="200">Loading...</div>
 ```
 
 **Behavior**:
@@ -179,7 +179,7 @@ if (globalLoadingManager.isLoading('save_article')) {
 Add CSS animation support for smoother transitions:
 
 ```html
-<div @loading.show @loading.animate="fade-in">Loading...</div>
+<div dj-loading.show @loading.animate="fade-in">Loading...</div>
 ```
 
 **Behavior**:

--- a/docs/state-management/STATE_MANAGEMENT_API.md
+++ b/docs/state-management/STATE_MANAGEMENT_API.md
@@ -91,7 +91,7 @@ djust's State Management API provides Python-only abstractions for common client
    → DraftModeMixin
 
 ❓ Show loading spinner/disable button?
-   → @loading.disable, @loading.show HTML attributes
+   → dj-loading.disable, dj-loading.show HTML attributes
 ```
 
 ### Common Combinations
@@ -178,7 +178,7 @@ class ContactFormView(DraftModeMixin, FormMixin, LiveView):
 | **Debouncing** | Search input, text fields | `@debounce(0.5)` | - |
 | **Throttling** | Scroll, resize, mouse move | `@throttle(0.1)` | - |
 | **Optimistic Updates** | Counters, toggles, sliders | `@optimistic` | - |
-| **Loading States** | Button disable, spinners, overlays | - | `@loading.disable`, `@loading.show`, `@loading.hide`, `@loading.class` |
+| **Loading States** | Button disable, spinners, overlays | - | `dj-loading.disable`, `dj-loading.show`, `dj-loading.hide`, `dj-loading.class` |
 | **Loading Text** | Button text replacement | - | `@loading-text="Saving..."` (deprecated) |
 | **Client State** | Multi-component coordination | `@client_state(keys=["temp"])` | - |
 | **Caching** | Autocomplete, API calls | `@cache(ttl=300)` | - |
@@ -222,7 +222,7 @@ from djust.decorators import debounce
 class SearchView(LiveView):
     template_string = """
     <input type="text"
-           @input="on_search"
+           dj-input="on_search"
            placeholder="Search products..." />
 
     <div>Found {{ result_count }} products</div>
@@ -388,7 +388,7 @@ class CounterView(LiveView):
     template_string = """
     <div>
         <h1>Count: {{ count }}</h1>
-        <button @click="increment">+1</button>
+        <button dj-click="increment">+1</button>
     </div>
     """
 
@@ -527,7 +527,7 @@ class DashboardView(LiveView):
         <input type="range"
                min="0" max="120"
                value="{{ temperature }}"
-               @input="update_temperature" />
+               dj-input="update_temperature" />
 
         <!-- Display listens to 'temperature' state -->
         <div id="temp-display">{{ temperature }}°F</div>
@@ -675,7 +675,7 @@ from djust.decorators import cache, debounce
 class AutocompleteView(LiveView):
     template_string = """
     <input type="text"
-           @input="search"
+           dj-input="search"
            placeholder="Search languages..." />
 
     <ul>
@@ -748,10 +748,10 @@ def search(self, query: str = "", page: int = 1, **kwargs):
 
 ```html
 <!-- ✅ Correct: name="query" matches key_params=["query"] -->
-<input type="text" name="query" @input="search" />
+<input type="text" name="query" dj-input="search" />
 
 <!-- ❌ Wrong: Missing name attribute -->
-<input type="text" @input="search" />
+<input type="text" dj-input="search" />
 ```
 
 The `name` attribute is used to extract parameter values for cache key generation. Without it, the cache key will be incomplete (e.g., `"search:"` instead of `"search:python"`), causing all searches to share the same cache entry.
@@ -882,7 +882,7 @@ class CommentFormView(DraftModeMixin, LiveView):
      data-draft-enabled="{{ draft_enabled }}"
      data-draft-key="{{ draft_key }}">
 
-    <form @submit="save_comment">
+    <form dj-submit="save_comment">
         <!-- Fields with data-draft="true" are auto-saved -->
         <textarea name="comment_text"
                   placeholder="Write your comment..."
@@ -896,7 +896,7 @@ class CommentFormView(DraftModeMixin, LiveView):
                value="{{ author_name }}" />
 
         <button type="submit">Post Comment</button>
-        <button @click="discard_draft">Discard Draft</button>
+        <button dj-click="discard_draft">Discard Draft</button>
     </form>
 </div>
 ```
@@ -982,8 +982,8 @@ class AdvancedFormView(DraftModeMixin, LiveView):
 
     <textarea name="content" data-draft="true">{{ content }}</textarea>
 
-    <button @click="save_content">Save</button>
-    <button @click="discard_draft">Discard Draft</button>
+    <button dj-click="save_content">Save</button>
+    <button dj-click="discard_draft">Discard Draft</button>
 </div>
 ```
 
@@ -1107,10 +1107,10 @@ Phoenix LiveView-style loading attributes for showing/hiding elements and adding
 
 #### Supported Modifiers
 
-- `@loading.disable` - Disable element during loading
-- `@loading.class="class-name"` - Add class during loading
-- `@loading.show` - Show element during loading (display: block)
-- `@loading.hide` - Hide element during loading (display: none)
+- `dj-loading.disable` - Disable element during loading
+- `dj-loading.class="class-name"` - Add class during loading
+- `dj-loading.show` - Show element during loading (display: block)
+- `dj-loading.hide` - Hide element during loading (display: none)
 
 Multiple modifiers can be combined on the same element.
 
@@ -1118,19 +1118,19 @@ Multiple modifiers can be combined on the same element.
 
 ```html
 <!-- Disable button during event -->
-<button @loading.disable>Button Text</button>
+<button dj-loading.disable>Button Text</button>
 
 <!-- Add loading class -->
-<button @loading.class="opacity-50">Button Text</button>
+<button dj-loading.class="opacity-50">Button Text</button>
 
 <!-- Show element during loading -->
-<div @loading.show style="display: none;">Loading...</div>
+<div dj-loading.show style="display: none;">Loading...</div>
 
 <!-- Hide element during loading -->
-<div @loading.hide>Content</div>
+<div dj-loading.hide>Content</div>
 
 <!-- Combine multiple modifiers -->
-<button @loading.disable @loading.class="loading">Save</button>
+<button dj-loading.disable dj-loading.class="loading">Save</button>
 ```
 
 #### Example
@@ -1138,26 +1138,26 @@ Multiple modifiers can be combined on the same element.
 ```python
 class SaveFormView(LiveView):
     template_string = """
-    <form @submit="save_data">
+    <form dj-submit="save_data">
         <input type="text" name="title" />
 
         <!-- Disable and add class during save -->
-        <button type="submit" @loading.disable @loading.class="opacity-50">
+        <button type="submit" dj-loading.disable dj-loading.class="opacity-50">
             Save Article
         </button>
 
         <!-- Show spinner during save -->
-        <div @loading.show style="display: none;">
+        <div dj-loading.show style="display: none;">
             <i class="fas fa-spinner fa-spin"></i> Saving...
         </div>
 
         <!-- Hide form content during save -->
-        <div @loading.hide>
+        <div dj-loading.hide>
             <textarea name="content"></textarea>
         </div>
 
         <!-- Hide cancel button during save -->
-        <button type="button" @loading.hide>Cancel</button>
+        <button type="button" dj-loading.hide>Cancel</button>
     </form>
     """
 
@@ -1179,10 +1179,10 @@ class SaveFormView(LiveView):
 
 1. **User submits form** → Event sent to server
 2. **Loading starts** → `globalLoadingManager.startLoading(eventName, triggerElement)`
-   - Elements with `@loading.disable` become disabled
-   - Elements with `@loading.class` get the class added
-   - Elements with `@loading.show` become visible
-   - Elements with `@loading.hide` become hidden
+   - Elements with `dj-loading.disable` become disabled
+   - Elements with `dj-loading.class` get the class added
+   - Elements with `dj-loading.show` become visible
+   - Elements with `dj-loading.hide` become hidden
 3. **Handler executes** → Processing on server
 4. **Response received** → `globalLoadingManager.stopLoading(eventName, triggerElement)`
    - All original states restored automatically
@@ -1206,9 +1206,9 @@ Loading states are scoped to prevent cross-button contamination when multiple bu
 ```html
 <div class="card-body">
     <!-- These buttons operate INDEPENDENTLY even with same event -->
-    <button @click="save" @loading.disable>Save A</button>
-    <button @click="save" @loading.class="opacity-25">Save B</button>
-    <button @click="save" @loading.disable @loading.class="opacity-25">Save C</button>
+    <button dj-click="save" dj-loading.disable>Save A</button>
+    <button dj-click="save" dj-loading.class="opacity-25">Save B</button>
+    <button dj-click="save" dj-loading.disable dj-loading.class="opacity-25">Save C</button>
 </div>
 ```
 ✅ Clicking "Save A" only affects "Save A" (no grouping container)
@@ -1217,8 +1217,8 @@ Loading states are scoped to prevent cross-button contamination when multiple bu
 ```html
 <div class="d-flex align-items-center gap-3">
     <!-- These are grouped together because of d-flex parent -->
-    <button @click="save">Save</button>
-    <div @loading.show style="display: none;">Saving...</div>
+    <button dj-click="save">Save</button>
+    <div dj-loading.show style="display: none;">Saving...</div>
 </div>
 ```
 ✅ Clicking "Save" affects both button and spinner (d-flex grouping)
@@ -1226,22 +1226,22 @@ Loading states are scoped to prevent cross-button contamination when multiple bu
 **Example: Wrong - No Grouping**
 ```html
 <!-- ❌ Spinner won't show - no grouping container -->
-<button @click="save">Save</button>
-<div @loading.show style="display: none;">Saving...</div>
+<button dj-click="save">Save</button>
+<div dj-loading.show style="display: none;">Saving...</div>
 ```
 
 **Visual Effects:**
-- **@loading.disable**: Bootstrap applies `opacity: 0.65` automatically to disabled buttons
-- **@loading.class="opacity-25"**: Much more transparent (0.25), button stays enabled
+- **dj-loading.disable**: Bootstrap applies `opacity: 0.65` automatically to disabled buttons
+- **dj-loading.class="opacity-25"**: Much more transparent (0.25), button stays enabled
 - **Combined**: Button disabled (cursor: not-allowed) AND very transparent
 
 #### Custom Display Value
 
-Use `data-loading-display` to customize the display value for `@loading.show`:
+Use `data-loading-display` to customize the display value for `dj-loading.show`:
 
 ```html
 <!-- Show as inline-block instead of block -->
-<span @loading.show data-loading-display="inline-block" style="display: none;">
+<span dj-loading.show data-loading-display="inline-block" style="display: none;">
     Loading...
 </span>
 ```
@@ -1249,7 +1249,7 @@ Use `data-loading-display` to customize the display value for `@loading.show`:
 #### Complete Form Example
 
 ```html
-<form @submit="save_article">
+<form dj-submit="save_article">
     <!-- Form fields -->
     <input type="text" name="title" />
     <textarea name="content"></textarea>
@@ -1257,23 +1257,23 @@ Use `data-loading-display` to customize the display value for `@loading.show`:
     <!-- Multi-state loading UX -->
     <div class="form-actions">
         <!-- Disable and dim save button -->
-        <button type="submit" @loading.disable @loading.class="opacity-50">
+        <button type="submit" dj-loading.disable dj-loading.class="opacity-50">
             Save Article
         </button>
 
         <!-- Hide cancel during save -->
-        <button type="button" @loading.hide>
+        <button type="button" dj-loading.hide>
             Cancel
         </button>
 
         <!-- Show inline spinner -->
-        <span @loading.show style="display: none;" data-loading-display="inline">
+        <span dj-loading.show style="display: none;" data-loading-display="inline">
             <i class="spinner"></i> Saving...
         </span>
     </div>
 
     <!-- Show overlay during save -->
-    <div @loading.show @loading.class="overlay" style="display: none;">
+    <div dj-loading.show dj-loading.class="overlay" style="display: none;">
         Processing your request...
     </div>
 </form>
@@ -1341,7 +1341,7 @@ See `tests/js/loading.test.js` for 30 comprehensive unit tests covering all modi
 
 ### @loading-text
 
-**Status:** 🚧 Not Yet Implemented (use @loading.class instead)
+**Status:** 🚧 Not Yet Implemented (use dj-loading.class instead)
 
 Temporarily replaces button text during event processing. Simpler alternative to `@loading` for basic button text changes.
 
@@ -1358,7 +1358,7 @@ Temporarily replaces button text during event processing. Simpler alternative to
 ```python
 class UploadView(LiveView):
     template_string = """
-    <form @submit="upload_file">
+    <form dj-submit="upload_file">
         <input type="file" name="file" />
 
         <button type="submit" @loading-text="Uploading...">
@@ -1386,7 +1386,7 @@ class UploadView(LiveView):
 #### With Icons
 
 ```html
-<button @click="save" @loading-text="⏳ Saving...">
+<button dj-click="save" @loading-text="⏳ Saving...">
     💾 Save
 </button>
 
@@ -1396,7 +1396,7 @@ class UploadView(LiveView):
 #### Disable Button During Loading
 
 ```html
-<button @click="save"
+<button dj-click="save"
         @loading-text="Saving..."
         @loading-disabled>
     Save

--- a/docs/state-management/STATE_MANAGEMENT_ARCHITECTURE.md
+++ b/docs/state-management/STATE_MANAGEMENT_ARCHITECTURE.md
@@ -274,7 +274,7 @@ def search(self, query: str = "", **kwargs):
 **User Interaction:**
 
 1. User types "laptop" in search box
-2. Client intercepts `@input="search"` event
+2. Client intercepts `dj-input="search"` event
 3. Client checks `window.handlerMetadata["search"]`
 4. Client applies decorators:
    - `@optimistic`: Update DOM instantly (no server round-trip)

--- a/docs/state-management/STATE_MANAGEMENT_EXAMPLES.md
+++ b/docs/state-management/STATE_MANAGEMENT_EXAMPLES.md
@@ -254,12 +254,12 @@ class ProductSearchView(LiveView):
         <input
             type="text"
             name="query"
-            @input="search"
+            dj-input="search"
             value="{{ query }}"
             placeholder="Search products..."
         />
 
-        <select @change="search" name="category">
+        <select dj-change="search" name="category">
             {% for value, label in categories %}
             <option value="{{ value }}" {% if value == category %}selected{% endif %}>
                 {{ label }}
@@ -269,7 +269,7 @@ class ProductSearchView(LiveView):
 
         <input
             type="range"
-            @input="search"
+            dj-input="search"
             name="min_price"
             value="{{ min_price }}"
             min="0"
@@ -388,14 +388,14 @@ class ShoppingCartView(LiveView):
 
             <input
                 type="number"
-                @input="update_quantity"
+                dj-input="update_quantity"
                 data-item-id="{{ item.id }}"
                 value="{{ item.quantity }}"
                 min="0"
             />
 
             <button
-                @click="remove_item"
+                dj-click="remove_item"
                 data-item-id="{{ item.id }}"
             >
                 Remove
@@ -405,7 +405,7 @@ class ShoppingCartView(LiveView):
 
         <div class="total">
             <h2>Total: ${{ total }}</h2>
-            <button @click="clear_cart">Clear Cart</button>
+            <button dj-click="clear_cart">Clear Cart</button>
         </div>
     </div>
     {% djust_body %}
@@ -590,10 +590,10 @@ class LiveChatView(DraftModeMixin, LiveView):
             {% endfor %}
         </div>
 
-        <form @submit="send_message">
+        <form dj-submit="send_message">
             <input
                 type="text"
-                @input="typing_indicator"
+                dj-input="typing_indicator"
                 name="message"
                 data-draft="true"
                 value="{{ message }}"
@@ -745,14 +745,14 @@ class DashboardView(LiveView):
 <body>
     <div class="dashboard">
         <div class="controls">
-            <select @change="change_period">
+            <select dj-change="change_period">
                 <option value="24h" {% if period == "24h" %}selected{% endif %}>Last 24 Hours</option>
                 <option value="7d" {% if period == "7d" %}selected{% endif %}>Last 7 Days</option>
                 <option value="30d" {% if period == "30d" %}selected{% endif %}>Last 30 Days</option>
             </select>
 
             <button
-                @click="refresh"
+                dj-click="refresh"
                 @loading-text="Refreshing..."
             >
                 Refresh
@@ -913,7 +913,7 @@ class ContactFormView(DraftModeMixin, FormMixin, LiveView):
         <div class="alert alert-success">{{ success_message }}</div>
         {% endif %}
 
-        <form @submit="handle_form_submit">
+        <form dj-submit="handle_form_submit">
             {{ form.as_p }}
 
             <button

--- a/docs/state-management/STATE_MANAGEMENT_MIGRATION.md
+++ b/docs/state-management/STATE_MANAGEMENT_MIGRATION.md
@@ -90,7 +90,7 @@ from djust.decorators import optimistic, debounce
 class SliderView(LiveView):
     template_string = """
     <input type="range" min="0" max="100"
-           value="{{ value }}" @input="update_value" />
+           value="{{ value }}" dj-input="update_value" />
     <div>{{ value }}</div>
     """
 
@@ -276,7 +276,7 @@ from djust.decorators import debounce
 
 class SearchView(LiveView):
     template_string = """
-    <input type="text" @input="search" value="{{ query }}" />
+    <input type="text" dj-input="search" value="{{ query }}" />
     <div>
         {% for product in results %}
             <div>{{ product.name }}</div>
@@ -368,7 +368,7 @@ class CounterView(LiveView):
     template_string = """
     <div>
         <span>{{ count }}</span>
-        <button @click="increment">+1</button>
+        <button dj-click="increment">+1</button>
     </div>
     """
 
@@ -477,7 +477,7 @@ from djust.decorators import client_state, debounce, optimistic
 
 class DashboardView(LiveView):
     template_string = """
-    <input type="range" @input="update_temperature" value="{{ temperature }}" />
+    <input type="range" dj-input="update_temperature" value="{{ temperature }}" />
 
     <!-- Components auto-subscribe to 'temperature' -->
     <div data-subscribe="temperature">{{ temperature }}°F</div>
@@ -525,7 +525,7 @@ class CommentFormView(LiveView):
 ```
 
 ```html
-<form @submit="save_comment">
+<form dj-submit="save_comment">
     <textarea id="comment-text" name="comment_text">{{ comment_text }}</textarea>
     <button type="submit">Save</button>
 </form>
@@ -576,7 +576,7 @@ class CommentFormView(DraftModeMixin, LiveView):
     draft_restore = True
 
     template_string = """
-    <form @submit="save_comment">
+    <form dj-submit="save_comment">
         <textarea name="comment_text">{{ comment_text }}</textarea>
         <button type="submit">Save</button>
     </form>
@@ -672,7 +672,7 @@ from djust.decorators import cache, debounce
 
 class AutocompleteView(LiveView):
     template_string = """
-    <input type="text" @input="search" value="{{ query }}" />
+    <input type="text" dj-input="search" value="{{ query }}" />
     <ul>
         {% for result in results %}
             <li>{{ result }}</li>
@@ -713,7 +713,7 @@ class FormView(LiveView):
 ```
 
 ```html
-<form @submit="save_data">
+<form dj-submit="save_data">
     <input type="text" name="title" />
     <button id="submit-btn">Save</button>
     <div id="loading" style="display: none;">Saving...</div>
@@ -754,7 +754,7 @@ document.addEventListener('liveview:error', () => {
 ```python
 class FormView(LiveView):
     template_string = """
-    <form @submit="save_data">
+    <form dj-submit="save_data">
         <input type="text" name="title" />
         <button type="submit" @loading-text="Saving...">Save</button>
         <div @loading>Processing your request...</div>
@@ -853,16 +853,16 @@ class ProductSearchView(DraftModeMixin, LiveView):
 
     template_string = """
     <div>
-        <input type="text" @input="search" value="{{ query }}"
+        <input type="text" dj-input="search" value="{{ query }}"
                placeholder="Search products..." />
 
-        <select @change="apply_filters" name="category">
+        <select dj-change="apply_filters" name="category">
             <option value="">All Categories</option>
             <option value="electronics">Electronics</option>
             <option value="clothing">Clothing</option>
         </select>
 
-        <input type="number" @change="apply_filters"
+        <input type="number" dj-change="apply_filters"
                name="min_price" value="{{ min_price }}" />
 
         <div @loading>Searching...</div>

--- a/docs/state-management/STATE_MANAGEMENT_PATTERNS.md
+++ b/docs/state-management/STATE_MANAGEMENT_PATTERNS.md
@@ -51,8 +51,8 @@ Use this guide when:
 | Dropdown with many options | `@cache(ttl=600)` | Avoid re-fetching static data |
 | Multi-widget dashboard | `@client_state` | Coordinate component updates |
 | Long form (comment, article) | `DraftModeMixin` | Prevent data loss |
-| Submit button | `@loading.disable + @loading.class` | Disable button + visual feedback |
-| AJAX loading spinner | `@loading.show` | Show/hide spinner during requests |
+| Submit button | `dj-loading.disable + dj-loading.class` | Disable button + visual feedback |
+| AJAX loading spinner | `dj-loading.show` | Show/hide spinner during requests |
 
 ### Flow Chart
 
@@ -98,7 +98,7 @@ from djust.decorators import debounce
 class ProductSearchView(LiveView):
     template_string = """
     <input type="text"
-           @input="search"
+           dj-input="search"
            placeholder="Search products..."
            value="{{ query }}" />
 
@@ -182,9 +182,9 @@ from djust.decorators import optimistic
 class CounterView(LiveView):
     template_string = """
     <div class="counter">
-        <button @click="decrement">-</button>
+        <button dj-click="decrement">-</button>
         <span class="count">{{ count }}</span>
-        <button @click="increment">+</button>
+        <button dj-click="increment">+</button>
     </div>
     """
 
@@ -263,7 +263,7 @@ class BlogPostEditor(DraftModeMixin, LiveView):
     draft_restore = True
 
     template_string = """
-    <form @submit="publish_post">
+    <form dj-submit="publish_post">
         <input type="text"
                name="title"
                placeholder="Post title..."
@@ -351,7 +351,7 @@ class TemperatureDashboard(LiveView):
         <input type="range"
                min="0" max="120"
                value="{{ temperature }}"
-               @input="update_temperature" />
+               dj-input="update_temperature" />
 
         <!-- Multiple displays subscribe to 'temperature' -->
         <div id="display" data-subscribe="temperature">
@@ -429,7 +429,7 @@ from djust.decorators import cache, debounce
 class LanguageAutocomplete(LiveView):
     template_string = """
     <input type="text"
-           @input="search"
+           dj-input="search"
            placeholder="Search languages..."
            value="{{ query }}" />
 
@@ -517,7 +517,7 @@ class ColorSliderView(LiveView):
         <input type="range"
                min="0" max="360"
                value="{{ hue }}"
-               @input="update_hue" />
+               dj-input="update_hue" />
 
         <div class="stats">
             Client updates: <span id="client-count">0</span><br>
@@ -585,17 +585,17 @@ from djust import LiveView
 
 class FormSubmitView(LiveView):
     template_string = """
-    <form @submit="save_data">
+    <form dj-submit="save_data">
         <input type="text" name="title" />
 
         <div class="d-flex align-items-center gap-3">
             <!-- Button becomes disabled and semi-transparent -->
-            <button type="submit" @loading.disable @loading.class="opacity-25">
+            <button type="submit" dj-loading.disable dj-loading.class="opacity-25">
                 Save
             </button>
 
             <!-- Spinner shows during loading -->
-            <div @loading.show style="display: none;" class="spinner-border text-primary" role="status">
+            <div dj-loading.show style="display: none;" class="spinner-border text-primary" role="status">
                 <span class="visually-hidden">Saving...</span>
             </div>
         </div>
@@ -664,18 +664,18 @@ Ensure loading states are announced:
 
 ```html
 <div class="d-flex gap-2">
-    <button @loading.disable aria-busy="false">
+    <button dj-loading.disable aria-busy="false">
         Save
     </button>
 
     <!-- Screen reader will announce this when it appears -->
-    <div @loading.show style="display: none;" aria-live="polite" role="status">
+    <div dj-loading.show style="display: none;" aria-live="polite" role="status">
         Saving...
     </div>
 </div>
 ```
 
-**Note:** Use `aria-live="polite"` on elements with `@loading.show` to announce state changes to screen reader users.
+**Note:** Use `aria-live="polite"` on elements with `dj-loading.show` to announce state changes to screen reader users.
 
 ---
 

--- a/docs/state-management/STATE_MANAGEMENT_QUICKSTART.md
+++ b/docs/state-management/STATE_MANAGEMENT_QUICKSTART.md
@@ -24,7 +24,7 @@ from djust.decorators import debounce
 class ProductSearchView(LiveView):
     template_string = """
     <div>
-        <input @input="search" placeholder="Search products..." />
+        <input dj-input="search" placeholder="Search products..." />
         <div>
             {% for product in results %}
                 <div>{{ product.name }} - ${{ product.price }}</div>

--- a/docs/state-management/STATE_MANAGEMENT_TUTORIAL.md
+++ b/docs/state-management/STATE_MANAGEMENT_TUTORIAL.md
@@ -140,7 +140,7 @@ class ProductSearchView(LiveView):
         <div class="search-box">
             <input
                 type="text"
-                @input="search"
+                dj-input="search"
                 value="{{ query }}"
                 placeholder="Search products..."
                 class="form-control"
@@ -474,7 +474,7 @@ User searches "laptop" again
         <div class="search-box" @loading>
             <input
                 type="text"
-                @input="search"
+                dj-input="search"
                 value="{{ query }}"
                 placeholder="Search products..."
                 class="form-control"
@@ -631,7 +631,7 @@ class ProductSearchView(LiveView):
         <div class="search-box" @loading>
             <input
                 type="text"
-                @input="search"
+                dj-input="search"
                 value="{{ query }}"
                 placeholder="Search products..."
                 class="form-control"
@@ -642,7 +642,7 @@ class ProductSearchView(LiveView):
         <!-- Add category filter -->
         <div class="filters">
             <label>Category:</label>
-            <select @change="update_category" class="form-select">
+            <select dj-change="update_category" class="form-select">
                 {% for value, label in categories %}
                 <option value="{{ value }}" {% if value == category %}selected{% endif %}>
                     {{ label }}
@@ -850,7 +850,7 @@ class ProductSearchView(LiveView):
         <div class="search-box" @loading>
             <input
                 type="text"
-                @input="search"
+                dj-input="search"
                 value="{{ query }}"
                 placeholder="Search products..."
             />
@@ -860,7 +860,7 @@ class ProductSearchView(LiveView):
         <div class="filters">
             <div>
                 <label>Category:</label>
-                <select @change="update_category">
+                <select dj-change="update_category">
                     {% for value, label in categories %}
                     <option value="{{ value }}" {% if value == category %}selected{% endif %}>
                         {{ label }}
@@ -871,7 +871,7 @@ class ProductSearchView(LiveView):
 
             <div>
                 <label>Sort by:</label>
-                <select @change="update_sort">
+                <select dj-change="update_sort">
                     <option value="name" {% if sort == "name" %}selected{% endif %}>Name</option>
                     <option value="price" {% if sort == "price" %}selected{% endif %}>Price: Low to High</option>
                     <option value="-price" {% if sort == "-price" %}selected{% endif %}>Price: High to Low</option>
@@ -879,7 +879,7 @@ class ProductSearchView(LiveView):
             </div>
 
             <div>
-                <button @click="clear_filters" class="clear-btn">Clear Filters</button>
+                <button dj-click="clear_filters" class="clear-btn">Clear Filters</button>
             </div>
         </div>
 

--- a/docs/testing/TESTING_PAGES.md
+++ b/docs/testing/TESTING_PAGES.md
@@ -245,7 +245,7 @@ Automated testing for the @my_decorator feature
                     type="text"
                     class="form-control"
                     placeholder="Enter test value..."
-                    @input="test_handler"
+                    dj-input="test_handler"
                     value=""
                 />
             </div>

--- a/examples/demo_project/demo_app/templates/demos/chat.html
+++ b/examples/demo_project/demo_app/templates/demos/chat.html
@@ -88,7 +88,7 @@
                             </div>
 
                             <!-- Message Input Form -->
-                            <form @submit="send_message" class="flex gap-2">
+                            <form dj-submit="send_message" class="flex gap-2">
                                 <input
                                     type="text"
                                     name="message"
@@ -180,7 +180,7 @@ class ChatView(LiveView):
 &lt;/div&gt;
 
 &lt;!-- Message Input --&gt;
-&lt;form @submit="send_message"&gt;
+&lt;form dj-submit="send_message"&gt;
   &lt;input type="text"
          name="message"
          placeholder="Type a message..."

--- a/examples/demo_project/demo_app/templates/demos/component_showcase.html
+++ b/examples/demo_project/demo_app/templates/demos/component_showcase.html
@@ -90,8 +90,8 @@
                             <h5 class="font-bold mb-3" style="color: var(--color-accent);">Counter</h5>
                             <div class="text-4xl font-bold mb-3" style="color: var(--color-text);">{{ counter }}</div>
                             <div class="flex gap-2 justify-center">
-                                <button class="btn btn-sm btn-primary" @click="decrement">-</button>
-                                <button class="btn btn-sm btn-primary" @click="increment">+</button>
+                                <button class="btn btn-sm btn-primary" dj-click="decrement">-</button>
+                                <button class="btn btn-sm btn-primary" dj-click="increment">+</button>
                             </div>
                         </div>
 
@@ -99,7 +99,7 @@
                         <div class="p-4 rounded-lg text-center" style="background: rgba(16, 185, 129, 0.05); border: 1px solid rgba(16, 185, 129, 0.2);">
                             <h5 class="font-bold mb-3" style="color: var(--color-success);">Toggle Switch</h5>
                             <div class="text-3xl mb-3">{% if switch_enabled %}✅{% else %}⭕{% endif %}</div>
-                            <button class="btn btn-sm btn-success" @click="toggle_switch">Toggle</button>
+                            <button class="btn btn-sm btn-success" dj-click="toggle_switch">Toggle</button>
                             <div class="mt-2 text-sm" style="color: var(--color-text-muted);">
                                 State: <strong>{% if switch_enabled %}ON{% else %}OFF{% endif %}</strong>
                             </div>

--- a/examples/demo_project/demo_app/templates/demos/counter.html
+++ b/examples/demo_project/demo_app/templates/demos/counter.html
@@ -48,19 +48,19 @@
 
                             <!-- Buttons -->
                             <div class="flex gap-3 flex-wrap justify-center" style="width: 100%;">
-                                <button @click="increment" class="btn-primary-modern">
+                                <button dj-click="increment" class="btn-primary-modern">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
                                     </svg>
                                     <span>Increment</span>
                                 </button>
-                                <button @click="decrement" class="btn-secondary-modern">
+                                <button dj-click="decrement" class="btn-secondary-modern">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4"></path>
                                     </svg>
                                     <span>Decrement</span>
                                 </button>
-                                <button @click="reset" class="btn-secondary-modern" style="border-color: var(--color-error); color: var(--color-error);">
+                                <button dj-click="reset" class="btn-secondary-modern" style="border-color: var(--color-error); color: var(--color-error);">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
                                     </svg>
@@ -121,15 +121,15 @@ class CounterView(LiveView):
                                     <pre style="margin: 0; padding: 1rem; background: var(--color-bg); border-radius: 0 0 var(--radius-md) var(--radius-md);"><code class="language-html">&lt;div&gt;
   &lt;h2&gt;Count: &#123;&#123; count &#125;&#125;&lt;/h2&gt;
 
-  &lt;button @click="increment"&gt;
+  &lt;button dj-click="increment"&gt;
     Increment
   &lt;/button&gt;
 
-  &lt;button @click="decrement"&gt;
+  &lt;button dj-click="decrement"&gt;
     Decrement
   &lt;/button&gt;
 
-  &lt;button @click="reset"&gt;
+  &lt;button dj-click="reset"&gt;
     Reset
   &lt;/button&gt;
 &lt;/div&gt;</code></pre>

--- a/examples/demo_project/demo_app/templates/demos/index.html
+++ b/examples/demo_project/demo_app/templates/demos/index.html
@@ -392,8 +392,8 @@ class CounterView(LiveView):
                         <h5>Template with Event Handlers</h5>
                         <pre><code>&lt;div&gt;
     &lt;h1&gt;Count: &#123;&#123; count &#125;&#125;&lt;/h1&gt;
-    &lt;button @click="increment"&gt;+&lt;/button&gt;
-    &lt;button @click="decrement"&gt;-&lt;/button&gt;
+    &lt;button dj-click="increment"&gt;+&lt;/button&gt;
+    &lt;button dj-click="decrement"&gt;-&lt;/button&gt;
 &lt;/div&gt;</code></pre>
                     </div>
                 </div>

--- a/examples/demo_project/demo_app/templates/demos/performance.html
+++ b/examples/demo_project/demo_app/templates/demos/performance.html
@@ -196,25 +196,25 @@
                         <div class="p-4" style="background: var(--color-bg-elevated);">
                             <!-- Add Items Controls -->
                             <div class="flex gap-2 flex-wrap mb-4">
-                                <button @click="add_items_10" class="btn-primary-modern">
+                                <button dj-click="add_items_10" class="btn-primary-modern">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
                                     </svg>
                                     <span>Add 10 Items</span>
                                 </button>
-                                <button @click="add_items_100" class="btn-primary-modern">
+                                <button dj-click="add_items_100" class="btn-primary-modern">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
                                     </svg>
                                     <span>Add 100 Items</span>
                                 </button>
-                                <button @click="add_items_1000" class="btn-secondary-modern" style="border-color: var(--color-warning); color: var(--color-warning);">
+                                <button dj-click="add_items_1000" class="btn-secondary-modern" style="border-color: var(--color-warning); color: var(--color-warning);">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
                                     </svg>
                                     <span>Add 1000 Items</span>
                                 </button>
-                                <button @click="clear_all" class="btn-secondary-modern" style="border-color: var(--color-error); color: var(--color-error);">
+                                <button dj-click="clear_all" class="btn-secondary-modern" style="border-color: var(--color-error); color: var(--color-error);">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
                                     </svg>
@@ -227,10 +227,10 @@
                                 <input type="text"
                                        placeholder="Filter items..."
                                        value="{{ filter_text }}"
-                                       @change="filter_items"
+                                       dj-change="filter_items"
                                        class="filter-input" />
 
-                                <select @change="sort_items" class="sort-select">
+                                <select dj-change="sort_items" class="sort-select">
                                     <option value="name" {% if sort_by == 'name' %}selected{% endif %}>Sort by Name</option>
                                     <option value="priority" {% if sort_by == 'priority' %}selected{% endif %}>Sort by Priority</option>
                                     <option value="timestamp" {% if sort_by == 'timestamp' %}selected{% endif %}>Sort by Time</option>
@@ -239,16 +239,16 @@
 
                             <!-- Batch Operations -->
                             <div class="flex gap-2 flex-wrap mb-4">
-                                <button @click="select_all" class="btn-secondary-modern">
+                                <button dj-click="select_all" class="btn-secondary-modern">
                                     <span>Select All</span>
                                 </button>
-                                <button @click="deselect_all" class="btn-secondary-modern">
+                                <button dj-click="deselect_all" class="btn-secondary-modern">
                                     <span>Deselect All</span>
                                 </button>
-                                <button @click="delete_selected" class="btn-secondary-modern" style="border-color: var(--color-error); color: var(--color-error);">
+                                <button dj-click="delete_selected" class="btn-secondary-modern" style="border-color: var(--color-error); color: var(--color-error);">
                                     <span>Delete Selected</span>
                                 </button>
-                                <button @click="toggle_priority_selected" class="btn-secondary-modern" style="border-color: var(--color-warning); color: var(--color-warning);">
+                                <button dj-click="toggle_priority_selected" class="btn-secondary-modern" style="border-color: var(--color-warning); color: var(--color-warning);">
                                     <span>Toggle Priority</span>
                                 </button>
                             </div>
@@ -262,7 +262,7 @@
                                         <input type="checkbox"
                                                class="item-checkbox"
                                                {% if item.selected %}checked{% endif %}
-                                               @change="toggle_item"
+                                               dj-change="toggle_item"
                                                data-id="{{ item.id }}" />
                                         <div class="item-content">
                                             <span class="item-name">{{ item.name }}</span>
@@ -272,11 +272,11 @@
                                             {% if item.priority %}
                                             <span class="priority-badge">High Priority</span>
                                             {% endif %}
-                                            <button @click="toggle_priority"
+                                            <button dj-click="toggle_priority"
                                                     data-id="{{ item.id }}"
                                                     class="btn-secondary-modern"
                                                     style="padding: 0.25rem 0.5rem; font-size: 0.875rem;">★</button>
-                                            <button @click="delete_item"
+                                            <button dj-click="delete_item"
                                                     data-id="{{ item.id }}"
                                                     class="btn-secondary-modern"
                                                     style="padding: 0.25rem 0.5rem; font-size: 1rem; border-color: var(--color-error); color: var(--color-error);">×</button>
@@ -361,21 +361,21 @@ class PerformanceTestView(LiveView):
                                 </div>
                                 <div class="code-block-modern">
                                     <pre style="margin: 0; padding: 1rem; background: var(--color-bg); border-radius: 0 0 var(--radius-md) var(--radius-md);"><code class="language-html">&lt;!-- Add Items --&gt;
-&lt;button @click="add_items_100"&gt;
+&lt;button dj-click="add_items_100"&gt;
   Add 100 Items
 &lt;/button&gt;
 
 &lt;!-- Filter --&gt;
 &lt;input type="text"
        placeholder="Filter..."
-       @change="filter_items" /&gt;
+       dj-change="filter_items" /&gt;
 
 &lt;!-- Items List --&gt;
 &#123;% for item in items %&#125;
   &lt;div class="performance-item"&gt;
     &lt;input type="checkbox"
            &#123;% if item.selected %&#125;checked&#123;% endif %&#125;
-           @change="toggle_item"
+           dj-change="toggle_item"
            data-id="&#123;&#123; item.id &#125;&#125;" /&gt;
     &lt;span&gt;&#123;&#123; item.name &#125;&#125;&lt;/span&gt;
   &lt;/div&gt;

--- a/examples/demo_project/demo_app/templates/demos/react.html
+++ b/examples/demo_project/demo_app/templates/demos/react.html
@@ -96,7 +96,7 @@
                                     <p class="mb-3">Managed server-side with LiveView</p>
                                     <div class="counter-display">{{ server_count }}</div>
                                     <div class="text-center">
-                                        <button @click="increment_server" class="btn-primary-modern">
+                                        <button dj-click="increment_server" class="btn-primary-modern">
                                             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
                                             </svg>
@@ -151,7 +151,7 @@
                                     <TodoItem text="{{ todo.text }}" completed="{{ todo.done }}" />
                                     {% endfor %}
                                 </div>
-                                <form @submit="add_todo_item" class="flex gap-2 mt-3">
+                                <form dj-submit="add_todo_item" class="flex gap-2 mt-3">
                                     <input
                                         type="text"
                                         name="text"
@@ -275,7 +275,7 @@ class Button(ReactComponent):
                                     <pre style="margin: 0; padding: 1rem; background: var(--color-bg); border-radius: 0 0 var(--radius-md) var(--radius-md);"><code class="language-html">&lt;!-- Server Counter (LiveView) --&gt;
 &lt;div&gt;
   &lt;h3&gt;Server Count: &#123;&#123; server_count &#125;&#125;&lt;/h3&gt;
-  &lt;button @click="increment_server"&gt;
+  &lt;button dj-click="increment_server"&gt;
     Increment Server
   &lt;/button&gt;
 &lt;/div&gt;

--- a/examples/demo_project/demo_app/templates/demos/rust_components.html
+++ b/examples/demo_project/demo_app/templates/demos/rust_components.html
@@ -248,7 +248,7 @@
             {% if dropdown_message %}
             <div class="demo-message mb-4">
                 <strong>Dropdown Event:</strong> {{ dropdown_message }}
-                <button @click="clear_messages" class="btn btn-sm float-end" style="padding: 0.25rem 0.75rem;">Clear</button>
+                <button dj-click="clear_messages" class="btn btn-sm float-end" style="padding: 0.25rem 0.75rem;">Clear</button>
             </div>
             {% endif %}
 
@@ -422,13 +422,13 @@
                                 </p>
                                 <div class="mb-3 p-3" style="background: var(--color-bg); border-radius: var(--radius-md); border: 2px solid var(--color-accent);">
                                     <div class="d-flex align-items-center gap-3">
-                                        <button @click="increment_counter" class="btn btn-primary">
+                                        <button dj-click="increment_counter" class="btn btn-primary">
                                             <strong>+</strong> Increment
                                         </button>
                                         <div style="font-size: 1.5rem; font-weight: 700; color: var(--color-accent);">
                                             Counter: {{ counter }}
                                         </div>
-                                        <button @click="reset_counter" class="btn btn-secondary">
+                                        <button dj-click="reset_counter" class="btn btn-secondary">
                                             Reset
                                         </button>
                                     </div>

--- a/examples/demo_project/demo_app/templates/demos/todo.html
+++ b/examples/demo_project/demo_app/templates/demos/todo.html
@@ -63,7 +63,7 @@
                         </div>
                         <div class="p-4" style="background: var(--color-bg-elevated); min-height: 500px;">
                             <!-- Add Todo Form -->
-                            <form @submit="add_todo" class="mb-4">
+                            <form dj-submit="add_todo" class="mb-4">
                                 <div class="flex gap-2">
                                     <input
                                         type="text"
@@ -89,7 +89,7 @@
                                         <input
                                             type="checkbox"
                                             {% if todo.done %}checked{% endif %}
-                                            @change="toggle_todo"
+                                            dj-change="toggle_todo"
                                             data-id="{{ todo.id }}"
                                             style="width: 18px; height: 18px; cursor: pointer;"
                                         />
@@ -97,7 +97,7 @@
                                             {{ todo.text }}
                                         </span>
                                         <button
-                                            @click="delete_todo"
+                                            dj-click="delete_todo"
                                             data-id="{{ todo.id }}"
                                             class="btn-secondary-modern"
                                             style="padding: 0.375rem 0.75rem; border-color: var(--color-error); color: var(--color-error);"
@@ -205,7 +205,7 @@ class TodoView(LiveView):
                                 </div>
                                 <div class="code-block-modern">
                                     <pre style="margin: 0; padding: 1rem; background: var(--color-bg); border-radius: 0 0 var(--radius-md) var(--radius-md);"><code class="language-html">&lt;!-- Add Todo Form --&gt;
-&lt;form @submit="add_todo"&gt;
+&lt;form dj-submit="add_todo"&gt;
   &lt;input type="text" name="text"
          placeholder="What needs to be done?" /&gt;
   &lt;button type="submit"&gt;Add&lt;/button&gt;
@@ -216,10 +216,10 @@ class TodoView(LiveView):
   &lt;div class="todo-item"&gt;
     &lt;input type="checkbox"
            &#123;% if todo.done %&#125;checked&#123;% endif %&#125;
-           @change="toggle_todo"
+           dj-change="toggle_todo"
            data-id="&#123;&#123; todo.id &#125;&#125;" /&gt;
     &lt;span&gt;&#123;&#123; todo.text &#125;&#125;&lt;/span&gt;
-    &lt;button @click="delete_todo"
+    &lt;button dj-click="delete_todo"
             data-id="&#123;&#123; todo.id &#125;&#125;"&gt;
       Delete
     &lt;/button&gt;

--- a/examples/demo_project/demo_app/templates/forms/auto.html
+++ b/examples/demo_project/demo_app/templates/forms/auto.html
@@ -15,18 +15,18 @@
             {% if success_message %}
             <div class="alert alert-success">
                 {{ success_message }}
-                <button type="button" class="btn-close float-end" @click="clear_message"></button>
+                <button type="button" class="btn-close float-end" dj-click="clear_message"></button>
             </div>
             {% endif %}
 
             {% if error_message %}
             <div class="alert alert-danger">
                 {{ error_message }}
-                <button type="button" class="btn-close float-end" @click="clear_message"></button>
+                <button type="button" class="btn-close float-end" dj-click="clear_message"></button>
             </div>
             {% endif %}
 
-            <form @submit="submit_form" onsubmit="return false;">
+            <form dj-submit="submit_form" onsubmit="return false;">
                 {% csrf_token %}
 
                 <!-- Auto-rendered form using as_live() method -->
@@ -34,7 +34,7 @@
 
                 <div class="d-grid gap-2 mt-3">
                     <button type="submit" class="btn btn-primary">Send Message</button>
-                    <button type="button" class="btn btn-secondary" @click="reset_form">Reset</button>
+                    <button type="button" class="btn btn-secondary" dj-click="reset_form">Reset</button>
                 </div>
             </form>
 
@@ -50,7 +50,7 @@
 
                 <h5>Template Code:</h5>
                 <pre class="bg-light p-3 small"><code>{% templatetag openblock %} load live_tags {% templatetag closeblock %}
-&lt;form @submit="submit_form"&gt;
+&lt;form dj-submit="submit_form"&gt;
     {% templatetag openblock %} csrf_token {% templatetag closeblock %}
     {% templatetag openvariable %} live_form view {% templatetag closevariable %}
     &lt;button type="submit"&gt;Submit&lt;/button&gt;

--- a/examples/demo_project/demo_app/templates/forms/auto_comparison.html
+++ b/examples/demo_project/demo_app/templates/forms/auto_comparison.html
@@ -153,7 +153,7 @@ code {
         return context</code></pre>
 
         <h6 class="mt-4">Template Code:</h6>
-        <pre class="bg-light p-3"><code>&lt;form @submit="submit_form"&gt;
+        <pre class="bg-light p-3"><code>&lt;form dj-submit="submit_form"&gt;
     {% csrf_token %}
     {{ form_html }}
     &lt;button type="submit"&gt;Submit&lt;/button&gt;

--- a/examples/demo_project/demo_app/templates/forms/auto_plain.html
+++ b/examples/demo_project/demo_app/templates/forms/auto_plain.html
@@ -54,18 +54,18 @@
     {% if success_message %}
     <div class="alert alert-success">
         {{ success_message }}
-        <button type="button" style="float: right; border: none; background: none; font-size: 20px;" @click="clear_message">&times;</button>
+        <button type="button" style="float: right; border: none; background: none; font-size: 20px;" dj-click="clear_message">&times;</button>
     </div>
     {% endif %}
 
     {% if error_message %}
     <div class="alert alert-danger">
         {{ error_message }}
-        <button type="button" style="float: right; border: none; background: none; font-size: 20px;" @click="clear_message">&times;</button>
+        <button type="button" style="float: right; border: none; background: none; font-size: 20px;" dj-click="clear_message">&times;</button>
     </div>
     {% endif %}
 
-    <form @submit="submit_form" onsubmit="return false;">
+    <form dj-submit="submit_form" onsubmit="return false;">
         {% csrf_token %}
 
         <!-- Auto-rendered form using Plain adapter -->
@@ -73,7 +73,7 @@
 
         <div>
             <button type="submit">Send Message</button>
-            <button type="button" @click="reset_form">Reset</button>
+            <button type="button" dj-click="reset_form">Reset</button>
         </div>
     </form>
 

--- a/examples/demo_project/demo_app/templates/forms/auto_tailwind.html
+++ b/examples/demo_project/demo_app/templates/forms/auto_tailwind.html
@@ -20,18 +20,18 @@ body { background: #f3f4f6; }
         {% if success_message %}
         <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
             {{ success_message }}
-            <button type="button" class="float-right" @click="clear_message">&times;</button>
+            <button type="button" class="float-right" dj-click="clear_message">&times;</button>
         </div>
         {% endif %}
 
         {% if error_message %}
         <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
             {{ error_message }}
-            <button type="button" class="float-right" @click="clear_message">&times;</button>
+            <button type="button" class="float-right" dj-click="clear_message">&times;</button>
         </div>
         {% endif %}
 
-        <form @submit="submit_form" onsubmit="return false;">
+        <form dj-submit="submit_form" onsubmit="return false;">
             {% csrf_token %}
 
             <!-- Auto-rendered form using Tailwind adapter -->
@@ -41,7 +41,7 @@ body { background: #f3f4f6; }
                 <button type="submit" class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
                     Send Message
                 </button>
-                <button type="button" class="w-full bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded" @click="reset_form">
+                <button type="button" class="w-full bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded" dj-click="reset_form">
                     Reset
                 </button>
             </div>

--- a/examples/demo_project/demo_app/templates/forms/contact.html
+++ b/examples/demo_project/demo_app/templates/forms/contact.html
@@ -24,7 +24,7 @@
                     {% if success_message %}
                     <div class="alert alert-success alert-dismissible fade show" role="alert">
                         {{ success_message }}
-                        <button type="button" class="btn-close" @click="clear_message"></button>
+                        <button type="button" class="btn-close" dj-click="clear_message"></button>
                     </div>
                     {% endif %}
 
@@ -34,7 +34,7 @@
                     </div>
                     {% endif %}
 
-                    <form @submit="submit_form" class="needs-validation" novalidate>
+                    <form dj-submit="submit_form" class="needs-validation" novalidate>
                         <div class="row">
                             <!-- Name -->
                             <div class="col-md-6 mb-3">
@@ -45,7 +45,7 @@
                                     id="name"
                                     class="form-control {% if field_errors.name %}is-invalid{% endif %}"
                                     value="{{ form_data.name }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="name"
                                     required
                                 />
@@ -65,7 +65,7 @@
                                     id="email"
                                     class="form-control {% if field_errors.email %}is-invalid{% endif %}"
                                     value="{{ form_data.email }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="email"
                                     required
                                 />
@@ -84,7 +84,7 @@
                                 name="subject"
                                 id="subject"
                                 class="form-control {% if field_errors.subject %}is-invalid{% endif %}"
-                                @change="validate_field"
+                                dj-change="validate_field"
                                 data-field="subject"
                                 required
                             >
@@ -108,25 +108,25 @@
                             <div class="form-check">
                                 <input class="form-check-input" type="radio" name="priority" id="priority_low" value="low"
                                        {% if form_data.priority == "low" %}checked{% endif %}
-                                       @change="validate_field" data-field="priority">
+                                       dj-change="validate_field" data-field="priority">
                                 <label class="form-check-label" for="priority_low">Low</label>
                             </div>
                             <div class="form-check">
                                 <input class="form-check-input" type="radio" name="priority" id="priority_medium" value="medium"
                                        {% if form_data.priority == "medium" or not form_data.priority %}checked{% endif %}
-                                       @change="validate_field" data-field="priority">
+                                       dj-change="validate_field" data-field="priority">
                                 <label class="form-check-label" for="priority_medium">Medium</label>
                             </div>
                             <div class="form-check">
                                 <input class="form-check-input" type="radio" name="priority" id="priority_high" value="high"
                                        {% if form_data.priority == "high" %}checked{% endif %}
-                                       @change="validate_field" data-field="priority">
+                                       dj-change="validate_field" data-field="priority">
                                 <label class="form-check-label" for="priority_high">High</label>
                             </div>
                             <div class="form-check">
                                 <input class="form-check-input" type="radio" name="priority" id="priority_urgent" value="urgent"
                                        {% if form_data.priority == "urgent" %}checked{% endif %}
-                                       @change="validate_field" data-field="priority">
+                                       dj-change="validate_field" data-field="priority">
                                 <label class="form-check-label" for="priority_urgent">Urgent</label>
                             </div>
                         </div>
@@ -139,7 +139,7 @@
                                 id="message"
                                 class="form-control {% if field_errors.message %}is-invalid{% endif %}"
                                 rows="5"
-                                @change="validate_field"
+                                dj-change="validate_field"
                                 data-field="message"
                                 required
                             >{{ form_data.message }}</textarea>
@@ -159,7 +159,7 @@
                                 id="subscribe_newsletter"
                                 class="form-check-input"
                                 {% if form_data.subscribe_newsletter %}checked{% endif %}
-                                @change="validate_field"
+                                dj-change="validate_field"
                                 data-field="subscribe_newsletter"
                             />
                             <label class="form-check-label" for="subscribe_newsletter">
@@ -172,7 +172,7 @@
                             <button type="submit" class="btn btn-success btn-lg">
                                 Send Message
                             </button>
-                            <button type="button" class="btn btn-outline-secondary" @click="reset_form">
+                            <button type="button" class="btn btn-outline-secondary" dj-click="reset_form">
                                 Reset Form
                             </button>
                         </div>

--- a/examples/demo_project/demo_app/templates/forms/index.html
+++ b/examples/demo_project/demo_app/templates/forms/index.html
@@ -174,8 +174,8 @@ class MyFormView(FormMixin, LiveView):
         self.error_message = "Please fix errors"</code></pre>
 
                     <h5 class="mt-4">Template Usage</h5>
-                    <pre class="bg-light p-3 rounded"><code>&lt;form @submit="submit_form"&gt;
-    &lt;input name="name" @change="validate_field" data-field="name" /&gt;
+                    <pre class="bg-light p-3 rounded"><code>&lt;form dj-submit="submit_form"&gt;
+    &lt;input name="name" dj-change="validate_field" data-field="name" /&gt;
     {% templatetag openblock %} if field_errors.name {% templatetag closeblock %}
         &lt;div class="error"&gt;{% templatetag openvariable %} field_errors.name {% templatetag closevariable %}&lt;/div&gt;
     {% templatetag openblock %} endif {% templatetag closeblock %}

--- a/examples/demo_project/demo_app/templates/forms/profile.html
+++ b/examples/demo_project/demo_app/templates/forms/profile.html
@@ -24,11 +24,11 @@
                     {% if success_message %}
                     <div class="alert alert-success alert-dismissible fade show" role="alert">
                         {{ success_message }}
-                        <button type="button" class="btn-close" @click="clear_message"></button>
+                        <button type="button" class="btn-close" dj-click="clear_message"></button>
                     </div>
                     {% endif %}
 
-                    <form @submit="submit_form" class="needs-validation" novalidate>
+                    <form dj-submit="submit_form" class="needs-validation" novalidate>
                         <div class="row">
                             <!-- First Name -->
                             <div class="col-md-6 mb-3">
@@ -39,7 +39,7 @@
                                     id="first_name"
                                     class="form-control {% if field_errors.first_name %}is-invalid{% endif %}"
                                     value="{{ form_data.first_name }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="first_name"
                                     required
                                 />
@@ -59,7 +59,7 @@
                                     id="last_name"
                                     class="form-control {% if field_errors.last_name %}is-invalid{% endif %}"
                                     value="{{ form_data.last_name }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="last_name"
                                     required
                                 />
@@ -79,7 +79,7 @@
                                 id="bio"
                                 class="form-control {% if field_errors.bio %}is-invalid{% endif %}"
                                 rows="4"
-                                @change="validate_field"
+                                dj-change="validate_field"
                                 data-field="bio"
                             >{{ form_data.bio }}</textarea>
                             <small class="form-text text-muted">Tell us about yourself (max 500 characters)</small>
@@ -100,7 +100,7 @@
                                     id="birth_date"
                                     class="form-control {% if field_errors.birth_date %}is-invalid{% endif %}"
                                     value="{{ form_data.birth_date }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="birth_date"
                                 />
                                 {% if field_errors.birth_date %}
@@ -117,7 +117,7 @@
                                     name="country"
                                     id="country"
                                     class="form-control {% if field_errors.country %}is-invalid{% endif %}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="country"
                                 >
                                     <option value="">Select country...</option>
@@ -148,7 +148,7 @@
                                     id="phone"
                                     class="form-control {% if field_errors.phone %}is-invalid{% endif %}"
                                     value="{{ form_data.phone }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="phone"
                                     placeholder="+1 (555) 123-4567"
                                 />
@@ -169,7 +169,7 @@
                                     id="website"
                                     class="form-control {% if field_errors.website %}is-invalid{% endif %}"
                                     value="{{ form_data.website }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="website"
                                     placeholder="https://yourwebsite.com"
                                 />
@@ -189,7 +189,7 @@
                                 id="receive_updates"
                                 class="form-check-input"
                                 {% if form_data.receive_updates %}checked{% endif %}
-                                @change="validate_field"
+                                dj-change="validate_field"
                                 data-field="receive_updates"
                             />
                             <label class="form-check-label" for="receive_updates">
@@ -202,7 +202,7 @@
                             <button type="submit" class="btn btn-info btn-lg text-white">
                                 Save Profile
                             </button>
-                            <button type="button" class="btn btn-outline-secondary" @click="reset_form">
+                            <button type="button" class="btn btn-outline-secondary" dj-click="reset_form">
                                 Reset Form
                             </button>
                         </div>

--- a/examples/demo_project/demo_app/templates/forms/registration.html
+++ b/examples/demo_project/demo_app/templates/forms/registration.html
@@ -23,15 +23,15 @@
                     <div class="card-body">
                         <div class="alert alert-success alert-dismissible fade show{% if not success_message %} d-none{% endif %}" role="alert">
                             {{ success_message }}
-                            <button type="button" class="btn-close" @click="clear_message"></button>
+                            <button type="button" class="btn-close" dj-click="clear_message"></button>
                         </div>
 
                         <div class="alert alert-danger alert-dismissible fade show{% if not error_message %} d-none{% endif %}" role="alert">
                             {{ error_message }}
-                            <button type="button" class="btn-close" @click="clear_message"></button>
+                            <button type="button" class="btn-close" dj-click="clear_message"></button>
                         </div>
 
-                        <form @submit="submit_form" class="needs-validation" novalidate>
+                        <form dj-submit="submit_form" class="needs-validation" novalidate>
                             <!-- Username -->
                             <div class="mb-3">
                                 <label for="username" class="form-label">Username</label>
@@ -41,7 +41,7 @@
                                     id="username"
                                     class="form-control {% if field_errors.username %}is-invalid{% endif %}"
                                     value="{{ form_data.username }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="username"
                                     required
                                 />
@@ -64,7 +64,7 @@
                                     id="email"
                                     class="form-control {% if field_errors.email %}is-invalid{% endif %}"
                                     value="{{ form_data.email }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="email"
                                     required
                                 />
@@ -87,7 +87,7 @@
                                     id="password"
                                     class="form-control {% if field_errors.password %}is-invalid{% endif %}"
                                     value="{{ form_data.password }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="password"
                                     required
                                 />
@@ -110,7 +110,7 @@
                                     id="password_confirm"
                                     class="form-control {% if field_errors.password_confirm %}is-invalid{% endif %}"
                                     value="{{ form_data.password_confirm }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="password_confirm"
                                     required
                                 />
@@ -131,7 +131,7 @@
                                     id="agree_terms"
                                     class="form-check-input {% if field_errors.agree_terms %}is-invalid{% endif %}"
                                     {% if form_data.agree_terms %}checked{% endif %}
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="agree_terms"
                                     required
                                 />
@@ -161,7 +161,7 @@
                                 <button type="submit" class="btn btn-primary btn-lg">
                                     Create Account
                                 </button>
-                                <button type="button" class="btn btn-outline-secondary" @click="reset_form">
+                                <button type="button" class="btn btn-outline-secondary" dj-click="reset_form">
                                     Reset Form
                                 </button>
                             </div>

--- a/examples/demo_project/demo_app/templates/forms/simple.html
+++ b/examples/demo_project/demo_app/templates/forms/simple.html
@@ -41,18 +41,18 @@
             {% if success_message %}
             <div class="alert alert-success">
                 {{ success_message }}
-                <button type="button" class="btn-close float-end" @click="clear_message"></button>
+                <button type="button" class="btn-close float-end" dj-click="clear_message"></button>
             </div>
             {% endif %}
 
             {% if error_message %}
             <div class="alert alert-danger">
                 {{ error_message }}
-                <button type="button" class="btn-close float-end" @click="clear_message"></button>
+                <button type="button" class="btn-close float-end" dj-click="clear_message"></button>
             </div>
             {% endif %}
 
-            <form @submit="submit_form" onsubmit="return false;">
+            <form dj-submit="submit_form" onsubmit="return false;">
                 {% csrf_token %}
                 <!-- Name Field -->
                 <div class="mb-3">
@@ -63,7 +63,7 @@
                         id="name"
                         name="name"
                         value="{{ form_data.name }}"
-                        @change="validate_field"
+                        dj-change="validate_field"
                         data-field="name"
                         required
                     >
@@ -85,7 +85,7 @@
                         id="email"
                         name="email"
                         value="{{ form_data.email }}"
-                        @change="validate_field"
+                        dj-change="validate_field"
                         data-field="email"
                         required
                     >
@@ -106,7 +106,7 @@
                         id="message"
                         name="message"
                         rows="4"
-                        @change="validate_field"
+                        dj-change="validate_field"
                         data-field="message"
                         required
                     >{{ form_data.message }}</textarea>
@@ -121,7 +121,7 @@
 
                 <div class="d-grid gap-2">
                     <button type="submit" class="btn btn-primary">Send Message</button>
-                    <button type="button" class="btn btn-secondary" @click="reset_form">Reset</button>
+                    <button type="button" class="btn btn-secondary" dj-click="reset_form">Reset</button>
                 </div>
             </form>
 

--- a/examples/demo_project/demo_app/templates/forms/status_change_djust.html
+++ b/examples/demo_project/demo_app/templates/forms/status_change_djust.html
@@ -71,11 +71,11 @@
         </div>
         {% endif %}
 
-        <form @submit="submit_form">
+        <form dj-submit="submit_form">
 
             <!-- Employee Information Section -->
             <div class="card section-card">
-                <div class="section-header" @click="toggle_section('employee_info')">
+                <div class="section-header" dj-click="toggle_section('employee_info')">
                     <i class="fas fa-user"></i>
                     <h5 class="mb-0 flex-grow-1">Employee Information</h5>
                     <i class="fas fa-chevron-{{ sections_expanded.employee_info|yesno:'up,down' }}"></i>
@@ -90,7 +90,7 @@
                             <div class="invalid-feedback d-block">{{ form.employee.errors }}</div>
                             {% endif %}
                             {# Fire event when employee changes #}
-                            <select @change="on_employee_change" style="display:none"></select>
+                            <select dj-change="on_employee_change" style="display:none"></select>
                         </div>
 
                         <div class="col-md-6">
@@ -100,7 +100,7 @@
                             <div class="invalid-feedback d-block">{{ form.business_line.errors }}</div>
                             {% endif %}
                             {# Fire event when business line changes to filter executive approvers #}
-                            <select @change="on_business_line_change" style="display:none"></select>
+                            <select dj-change="on_business_line_change" style="display:none"></select>
                         </div>
 
                         <div class="col-md-6">
@@ -122,7 +122,7 @@
 
             <!-- Company Changes Section (ToFrom Pattern) -->
             <div class="card section-card">
-                <div class="section-header" @click="toggle_section('company_changes')">
+                <div class="section-header" dj-click="toggle_section('company_changes')">
                     <i class="fas fa-building"></i>
                     <h5 class="mb-0 flex-grow-1">Change Company</h5>
                     <i class="fas fa-chevron-{{ sections_expanded.company_changes|yesno:'up,down' }}"></i>
@@ -160,7 +160,7 @@
 
             <!-- Supervisor Changes Section (ToFrom Pattern) -->
             <div class="card section-card">
-                <div class="section-header" @click="toggle_section('supervisor_changes')">
+                <div class="section-header" dj-click="toggle_section('supervisor_changes')">
                     <i class="fas fa-users"></i>
                     <h5 class="mb-0 flex-grow-1">Change Supervisor</h5>
                     <i class="fas fa-chevron-{{ sections_expanded.supervisor_changes|yesno:'up,down' }}"></i>
@@ -198,7 +198,7 @@
 
             <!-- Project Information Section (Needs Pattern) -->
             <div class="card section-card">
-                <div class="section-header" @click="toggle_section('project_info')">
+                <div class="section-header" dj-click="toggle_section('project_info')">
                     <i class="fas fa-clipboard-list"></i>
                     <h5 class="mb-0 flex-grow-1">Add Project Information</h5>
                     <i class="fas fa-chevron-{{ sections_expanded.project_info|yesno:'up,down' }}"></i>
@@ -225,7 +225,7 @@
                             <label class="form-label">Project Duration</label>
                             {{ form.project_duration }}
                             {# Fire event when duration changes to show/hide expected_end_date #}
-                            <select @change="on_project_duration_change" style="display:none"></select>
+                            <select dj-change="on_project_duration_change" style="display:none"></select>
                         </div>
 
                         {% if show_expected_end_date %}
@@ -248,7 +248,7 @@
 
             <!-- Meals Per Diem Section (Needs Pattern with Calculations) -->
             <div class="card section-card">
-                <div class="section-header" @click="toggle_section('meals_per_diem')">
+                <div class="section-header" dj-click="toggle_section('meals_per_diem')">
                     <i class="fas fa-utensils"></i>
                     <h5 class="mb-0 flex-grow-1">Add Meals Per Diem</h5>
                     <i class="fas fa-chevron-{{ sections_expanded.meals_per_diem|yesno:'up,down' }}"></i>
@@ -270,14 +270,14 @@
                             <label class="form-label">Days Per Month on Jobsite</label>
                             {{ form.days_per_month_on_job_site }}
                             {# Fire calculation when this changes #}
-                            <input type="text" @input="calculate_monthly_per_diem" style="display:none">
+                            <input type="text" dj-input="calculate_monthly_per_diem" style="display:none">
                         </div>
 
                         <div class="col-md-6">
                             <label class="form-label">Per Diem Rate for Area</label>
                             {{ form.new_meals_per_diem_amount }}
                             {# Fire calculation when this changes #}
-                            <input type="text" @input="calculate_monthly_per_diem" style="display:none">
+                            <input type="text" dj-input="calculate_monthly_per_diem" style="display:none">
                         </div>
 
                         <div class="col-md-12">

--- a/examples/demo_project/demo_app/templates/tests/cache_test.html
+++ b/examples/demo_project/demo_app/templates/tests/cache_test.html
@@ -131,7 +131,7 @@
                     type="text"
                     name="query"
                     class="form-control form-control-lg"
-                    @input="search"
+                    dj-input="search"
                     placeholder="Type to test manually..."
                     value="{{ query }}"
                     autocomplete="off"
@@ -249,7 +249,7 @@
             }
             updateCacheEfficiency();
 
-            // Dispatch input event (will trigger @input="search" handler)
+            // Dispatch input event (will trigger dj-input="search" handler)
             input.value = value;
             input.dispatchEvent(new Event('input', { bubbles: true }));
 

--- a/examples/demo_project/demo_app/templates/tests/draft_mode_test.html
+++ b/examples/demo_project/demo_app/templates/tests/draft_mode_test.html
@@ -124,7 +124,7 @@ Testing localStorage auto-save with 500ms debounce, auto-restore, and draft clea
             <div class="d-flex gap-2">
                 <button
                     class="btn btn-primary"
-                    @click="save_article"
+                    dj-click="save_article"
                     data-title="title"
                     data-content="content"
                     data-author="author"
@@ -134,7 +134,7 @@ Testing localStorage auto-save with 500ms debounce, auto-restore, and draft clea
                 </button>
                 <button
                     class="btn btn-outline-secondary"
-                    @click="discard_draft"
+                    dj-click="discard_draft"
                 >
                     <i class="bi bi-trash me-2"></i>
                     Discard Draft

--- a/examples/demo_project/demo_app/templates/tests/loading_test.html
+++ b/examples/demo_project/demo_app/templates/tests/loading_test.html
@@ -9,7 +9,7 @@
 {% block page_title %}@loading Attribute Automated Test{% endblock %}
 
 {% block page_description %}
-Testing @loading.disable, @loading.class, @loading.show, @loading.hide HTML attributes
+Testing dj-loading.disable, dj-loading.class, dj-loading.show, dj-loading.hide HTML attributes
 {% endblock %}
 
 {% block content %}
@@ -84,68 +84,68 @@ Testing @loading.disable, @loading.class, @loading.show, @loading.hide HTML attr
                 Watch for visual feedback (disabled state, opacity changes, spinner visibility).
             </div>
 
-            <h6 class="mt-4 mb-3">Test 1: @loading.disable</h6>
+            <h6 class="mt-4 mb-3">Test 1: dj-loading.disable</h6>
             <p class="text-muted">Button should be disabled during 1-second operation</p>
             <button
                 class="btn btn-primary btn-lg"
-                @click="slow_operation"
-                @loading.disable>
+                dj-click="slow_operation"
+                dj-loading.disable>
                 <i class="bi bi-clock me-2"></i>
                 Slow Operation (1s)
             </button>
 
-            <h6 class="mt-4 mb-3">Test 2: @loading.class="opacity-25"</h6>
+            <h6 class="mt-4 mb-3">Test 2: dj-loading.class="opacity-25"</h6>
             <p class="text-muted">Button should become very transparent during operation (NOT disabled)</p>
             <button
                 class="btn btn-success btn-lg"
-                @click="slow_operation"
-                @loading.class="opacity-25">
+                dj-click="slow_operation"
+                dj-loading.class="opacity-25">
                 <i class="bi bi-lightning me-2"></i>
                 Opacity Effect (stays enabled)
             </button>
 
-            <h6 class="mt-4 mb-3">Test 3: @loading.disable + @loading.class="opacity-25"</h6>
+            <h6 class="mt-4 mb-3">Test 3: dj-loading.disable + dj-loading.class="opacity-25"</h6>
             <p class="text-muted">Button should be disabled AND very transparent</p>
             <button
                 class="btn btn-warning btn-lg"
-                @click="slow_operation"
-                @loading.disable
-                @loading.class="opacity-25">
+                dj-click="slow_operation"
+                dj-loading.disable
+                dj-loading.class="opacity-25">
                 <i class="bi bi-cpu me-2"></i>
                 Combined: disabled + opacity
             </button>
 
-            <h6 class="mt-4 mb-3">Test 4: @loading.show (spinner)</h6>
+            <h6 class="mt-4 mb-3">Test 4: dj-loading.show (spinner)</h6>
             <p class="text-muted">Spinner should appear during operation</p>
             <div class="d-flex align-items-center gap-3">
                 <button
                     class="btn btn-info btn-lg"
-                    @click="fast_operation">
+                    dj-click="fast_operation">
                     <i class="bi bi-play me-2"></i>
                     Fast Operation (100ms)
                 </button>
                 <div
-                    @loading.show
+                    dj-loading.show
                     style="display: none;"
                     class="spinner-border text-primary"
                     role="status">
                     <span class="visually-hidden">Loading...</span>
                 </div>
-                <span @loading.show style="display: none;" class="text-primary">
+                <span dj-loading.show style="display: none;" class="text-primary">
                     Processing...
                 </span>
             </div>
 
-            <h6 class="mt-4 mb-3">Test 5: @loading.hide (content)</h6>
+            <h6 class="mt-4 mb-3">Test 5: dj-loading.hide (content)</h6>
             <p class="text-muted">Content should hide during operation</p>
             <div class="d-flex align-items-center gap-3">
                 <button
                     class="btn btn-secondary btn-lg"
-                    @click="fast_operation">
+                    dj-click="fast_operation">
                     <i class="bi bi-eye-slash me-2"></i>
                     Hide Content Test
                 </button>
-                <div @loading.hide class="alert alert-success mb-0 py-2">
+                <div dj-loading.hide class="alert alert-success mb-0 py-2">
                     This content will disappear during loading
                 </div>
             </div>
@@ -210,10 +210,10 @@ Testing @loading.disable, @loading.class, @loading.show, @loading.hide HTML attr
         <div class="card-body">
             <h6>Available Modifiers:</h6>
             <ul>
-                <li><code class="code-block d-inline">@loading.disable</code> - Disables button/input during loading (also gets Bootstrap's default opacity: 0.65)</li>
-                <li><code class="code-block d-inline">@loading.class="class-name"</code> - Adds CSS class during loading (e.g., opacity-25, border-danger)</li>
-                <li><code class="code-block d-inline">@loading.show</code> - Shows element (display: block) during loading</li>
-                <li><code class="code-block d-inline">@loading.hide</code> - Hides element (display: none) during loading</li>
+                <li><code class="code-block d-inline">dj-loading.disable</code> - Disables button/input during loading (also gets Bootstrap's default opacity: 0.65)</li>
+                <li><code class="code-block d-inline">dj-loading.class="class-name"</code> - Adds CSS class during loading (e.g., opacity-25, border-danger)</li>
+                <li><code class="code-block d-inline">dj-loading.show</code> - Shows element (display: block) during loading</li>
+                <li><code class="code-block d-inline">dj-loading.hide</code> - Hides element (display: none) during loading</li>
             </ul>
 
             <h6 class="mt-3">Visual Differences:</h6>
@@ -308,8 +308,8 @@ function runLoadingTests() {
                 // Test 4: After slow operation completes, test fast operation
                 setTimeout(() => {
                     console.log('[Test] Simulating fast operation click...');
-                    // Find button that has @click="fast_operation"
-                    const fastButton = document.querySelector('button[\\@click="fast_operation"]');
+                    // Find button that has dj-click="fast_operation"
+                    const fastButton = document.querySelector('button[\\dj-click="fast_operation"]');
                     if (fastButton) {
                         fastButton.click();
                         // Wait for fast operation to complete (100ms + buffer)
@@ -323,7 +323,7 @@ function runLoadingTests() {
         } else {
             addClientTest(
                 'Button Disabled During Loading',
-                'Should find button with @loading.disable',
+                'Should find button with dj-loading.disable',
                 'Button not found',
                 false
             );

--- a/examples/demo_project/djust_demos/templates/demos/cache.html
+++ b/examples/demo_project/djust_demos/templates/demos/cache.html
@@ -30,7 +30,7 @@
                                 <input
                                     type="text"
                                     class="form-control form-control-lg"
-                                    @input="search"
+                                    dj-input="search"
                                     placeholder="Try: laptop, mouse, keyboard..."
                                     value="{{ query }}"
                                     autocomplete="off"

--- a/examples/demo_project/djust_demos/templates/demos/chat.html
+++ b/examples/demo_project/djust_demos/templates/demos/chat.html
@@ -88,7 +88,7 @@
                             </div>
 
                             <!-- Message Input Form -->
-                            <form @submit="send_message" class="flex gap-2">
+                            <form dj-submit="send_message" class="flex gap-2">
                                 <input
                                     type="text"
                                     name="message"
@@ -180,7 +180,7 @@ class ChatView(LiveView):
 &lt;/div&gt;
 
 &lt;!-- Message Input --&gt;
-&lt;form @submit="send_message"&gt;
+&lt;form dj-submit="send_message"&gt;
   &lt;input type="text"
          name="message"
          placeholder="Type a message..."

--- a/examples/demo_project/djust_demos/templates/demos/component_showcase.html
+++ b/examples/demo_project/djust_demos/templates/demos/component_showcase.html
@@ -90,8 +90,8 @@
                             <h5 class="font-bold mb-3" style="color: var(--color-accent);">Counter</h5>
                             <div class="text-4xl font-bold mb-3" style="color: var(--color-text);">{{ counter }}</div>
                             <div class="flex gap-2 justify-center">
-                                <button class="btn btn-sm btn-primary" @click="decrement">-</button>
-                                <button class="btn btn-sm btn-primary" @click="increment">+</button>
+                                <button class="btn btn-sm btn-primary" dj-click="decrement">-</button>
+                                <button class="btn btn-sm btn-primary" dj-click="increment">+</button>
                             </div>
                         </div>
 
@@ -99,7 +99,7 @@
                         <div class="p-4 rounded-lg text-center" style="background: rgba(16, 185, 129, 0.05); border: 1px solid rgba(16, 185, 129, 0.2);">
                             <h5 class="font-bold mb-3" style="color: var(--color-success);">Toggle Switch</h5>
                             <div class="text-3xl mb-3">{% if switch_enabled %}✅{% else %}⭕{% endif %}</div>
-                            <button class="btn btn-sm btn-success" @click="toggle_switch">Toggle</button>
+                            <button class="btn btn-sm btn-success" dj-click="toggle_switch">Toggle</button>
                             <div class="mt-2 text-sm" style="color: var(--color-text-muted);">
                                 State: <strong>{% if switch_enabled %}ON{% else %}OFF{% endif %}</strong>
                             </div>

--- a/examples/demo_project/djust_demos/templates/demos/counter.html
+++ b/examples/demo_project/djust_demos/templates/demos/counter.html
@@ -34,19 +34,19 @@
 
                             <!-- Buttons -->
                             <div class="flex gap-3 flex-wrap justify-center" style="width: 100%;">
-                                <button @click="increment" class="btn-primary-modern">
+                                <button dj-click="increment" class="btn-primary-modern">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
                                     </svg>
                                     <span>Increment</span>
                                 </button>
-                                <button @click="decrement" class="btn-secondary-modern">
+                                <button dj-click="decrement" class="btn-secondary-modern">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4"></path>
                                     </svg>
                                     <span>Decrement</span>
                                 </button>
-                                <button @click="reset" class="btn-secondary-modern">
+                                <button dj-click="reset" class="btn-secondary-modern">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
                                     </svg>

--- a/examples/demo_project/djust_demos/templates/demos/debounce.html
+++ b/examples/demo_project/djust_demos/templates/demos/debounce.html
@@ -30,7 +30,7 @@
                                 <input
                                     type="text"
                                     class="form-control form-control-lg"
-                                    @input="search"
+                                    dj-input="search"
                                     placeholder="Type something..."
                                     value="{{ query }}"
                                     style="background: var(--color-bg); color: var(--color-text); border-color: var(--color-border);"

--- a/examples/demo_project/djust_demos/templates/demos/index.html
+++ b/examples/demo_project/djust_demos/templates/demos/index.html
@@ -409,9 +409,9 @@
                             {{ counter }}
                         </div>
                         <div style="display: flex; gap: 1rem; justify-content: center;">
-                            <button @click="decrement" class="btn btn-outline-primary">Decrement</button>
-                            <button @click="reset" class="btn btn-outline-secondary">Reset</button>
-                            <button @click="increment" class="btn btn-primary">Increment</button>
+                            <button dj-click="decrement" class="btn btn-outline-primary">Decrement</button>
+                            <button dj-click="reset" class="btn btn-outline-secondary">Reset</button>
+                            <button dj-click="increment" class="btn btn-primary">Increment</button>
                         </div>
                     </div>
                 </div>
@@ -468,14 +468,14 @@
                 <!-- Live Demo -->
                 <div class="demo-live">
                     <div class="dropdown">
-                        <button @click="toggle_dropdown" class="dropdown-toggle">
+                        <button dj-click="toggle_dropdown" class="dropdown-toggle">
                             <span>{{ selected_item }}</span>
                             <span style="margin-left: 0.5rem;">{% if dropdown_open %}▲{% else %}▼{% endif %}</span>
                         </button>
                         {% if dropdown_open %}
                         <div class="dropdown-menu">
                             {% for item in dropdown_items %}
-                            <div @click="select_item" data-item="{{ item }}" class="dropdown-item">
+                            <div dj-click="select_item" data-item="{{ item }}" class="dropdown-item">
                                 {{ item }}
                             </div>
                             {% endfor %}
@@ -540,7 +540,7 @@
                         <input
                             type="text"
                             class="form-control form-control-lg"
-                            @input="debounce_search"
+                            dj-input="debounce_search"
                             placeholder="Type something..."
                             value="{{ debounce_query }}"
                             style="background: var(--color-bg); color: var(--color-text); border-color: var(--color-border);"
@@ -620,7 +620,7 @@
                         <input
                             type="text"
                             class="form-control form-control-lg"
-                            @input="cache_search"
+                            dj-input="cache_search"
                             placeholder="Try: laptop, mouse, keyboard..."
                             value="{{ cache_query }}"
                             style="background: var(--color-bg); color: var(--color-text); border-color: var(--color-border);"

--- a/examples/demo_project/djust_demos/templates/demos/index_design2.html
+++ b/examples/demo_project/djust_demos/templates/demos/index_design2.html
@@ -669,9 +669,9 @@
                 <div class="showcase-demo">
                     <div class="counter-display">{{ counter }}</div>
                     <div class="counter-controls">
-                        <button @click="decrement" class="counter-btn secondary">Decrement</button>
-                        <button @click="reset" class="counter-btn secondary">Reset</button>
-                        <button @click="increment" class="counter-btn primary">Increment</button>
+                        <button dj-click="decrement" class="counter-btn secondary">Decrement</button>
+                        <button dj-click="reset" class="counter-btn secondary">Reset</button>
+                        <button dj-click="increment" class="counter-btn primary">Increment</button>
                     </div>
                 </div>
             </div>
@@ -703,14 +703,14 @@
                 <div class="showcase-demo">
                     <div class="showcase-dropdown">
                         <div class="dropdown">
-                            <button @click="toggle_dropdown" class="dropdown-toggle">
+                            <button dj-click="toggle_dropdown" class="dropdown-toggle">
                                 <span>{{ selected_item }}</span>
                                 <span>{% if dropdown_open %}▲{% else %}▼{% endif %}</span>
                             </button>
                             {% if dropdown_open %}
                             <div class="dropdown-menu">
                                 {% for item in dropdown_items %}
-                                <div @click="select_item" data-item="{{ item }}" class="dropdown-item">
+                                <div dj-click="select_item" data-item="{{ item }}" class="dropdown-item">
                                     {{ item }}
                                 </div>
                                 {% endfor %}
@@ -749,7 +749,7 @@
                     <input
                         type="text"
                         class="search-input"
-                        @input="debounce_search"
+                        dj-input="debounce_search"
                         placeholder="Type something rapidly..."
                         value="{{ debounce_query }}"
                     >
@@ -796,7 +796,7 @@
                     <input
                         type="text"
                         class="search-input"
-                        @input="cache_search"
+                        dj-input="cache_search"
                         placeholder="Try: laptop, mouse, keyboard..."
                         value="{{ cache_query }}"
                     >

--- a/examples/demo_project/djust_demos/templates/demos/index_design3.html
+++ b/examples/demo_project/djust_demos/templates/demos/index_design3.html
@@ -544,9 +544,9 @@
                             {{ counter }}
                         </div>
                         <div style="display: flex; gap: 1rem; justify-content: center;">
-                            <button @click="decrement" class="btn btn-outline-primary">-</button>
-                            <button @click="reset" class="btn btn-outline-secondary">Reset</button>
-                            <button @click="increment" class="btn btn-primary">+</button>
+                            <button dj-click="decrement" class="btn btn-outline-primary">-</button>
+                            <button dj-click="reset" class="btn btn-outline-secondary">Reset</button>
+                            <button dj-click="increment" class="btn btn-primary">+</button>
                         </div>
                     </div>
                 </div>
@@ -596,14 +596,14 @@
             <div class="demo-content">
                 <div class="demo-preview">
                     <div class="dropdown">
-                        <button @click="toggle_dropdown" class="dropdown-toggle">
+                        <button dj-click="toggle_dropdown" class="dropdown-toggle">
                             <span>{{ selected_item }}</span>
                             <span>{% if dropdown_open %}▲{% else %}▼{% endif %}</span>
                         </button>
                         {% if dropdown_open %}
                         <div class="dropdown-menu">
                             {% for item in dropdown_items %}
-                            <div @click="select_item" data-item="{{ item }}" class="dropdown-item">
+                            <div dj-click="select_item" data-item="{{ item }}" class="dropdown-item">
                                 {{ item }}
                             </div>
                             {% endfor %}
@@ -660,7 +660,7 @@
                         <input
                             type="text"
                             class="form-control form-control-lg"
-                            @input="debounce_search"
+                            dj-input="debounce_search"
                             placeholder="Type something..."
                             value="{{ debounce_query }}"
                         >
@@ -725,7 +725,7 @@
                         <input
                             type="text"
                             class="form-control form-control-lg"
-                            @input="cache_search"
+                            dj-input="cache_search"
                             placeholder="Try: laptop, mouse, keyboard..."
                             value="{{ cache_query }}"
                         >

--- a/examples/demo_project/djust_demos/templates/demos/index_design_hybrid.html
+++ b/examples/demo_project/djust_demos/templates/demos/index_design_hybrid.html
@@ -947,9 +947,9 @@
                 <div class="demo-interactive">
                     <div class="counter-display">{{ counter }}</div>
                     <div class="counter-controls">
-                        <button @click="decrement" class="counter-btn secondary">Decrement</button>
-                        <button @click="reset" class="counter-btn secondary">Reset</button>
-                        <button @click="increment" class="counter-btn primary">Increment</button>
+                        <button dj-click="decrement" class="counter-btn secondary">Decrement</button>
+                        <button dj-click="reset" class="counter-btn secondary">Reset</button>
+                        <button dj-click="increment" class="counter-btn primary">Increment</button>
                     </div>
                 </div>
             </div>
@@ -1006,14 +1006,14 @@
                 </p>
                 <div class="demo-interactive">
                     <div class="dropdown">
-                        <button @click="toggle_dropdown" class="dropdown-toggle">
+                        <button dj-click="toggle_dropdown" class="dropdown-toggle">
                             <span>{{ selected_item }}</span>
                             <span>{% if dropdown_open %}▲{% else %}▼{% endif %}</span>
                         </button>
                         {% if dropdown_open %}
                         <div class="dropdown-menu">
                             {% for item in dropdown_items %}
-                            <div @click="select_item" data-item="{{ item }}" class="dropdown-item">
+                            <div dj-click="select_item" data-item="{{ item }}" class="dropdown-item">
                                 {{ item }}
                             </div>
                             {% endfor %}
@@ -1077,7 +1077,7 @@
                     <input
                         type="text"
                         class="search-input"
-                        @input="debounce_search"
+                        dj-input="debounce_search"
                         placeholder="Type something rapidly..."
                         value="{{ debounce_query }}"
                     >
@@ -1150,7 +1150,7 @@
                     <input
                         type="text"
                         class="search-input"
-                        @input="cache_search"
+                        dj-input="cache_search"
                         placeholder="Try: laptop, mouse, keyboard..."
                         value="{{ cache_query }}"
                     >

--- a/examples/demo_project/djust_demos/templates/demos/index_shadcn.html
+++ b/examples/demo_project/djust_demos/templates/demos/index_shadcn.html
@@ -360,13 +360,13 @@
                                 <div class="text-8xl lg:text-9xl font-black gradient-text tabular-nums">{{ counter }}</div>
                             </div>
                             <div class="flex flex-wrap justify-center gap-3">
-                                <button @click="decrement" class="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-slate-800 bg-slate-900 text-slate-50 hover:bg-slate-800 h-11 px-6">
+                                <button dj-click="decrement" class="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-slate-800 bg-slate-900 text-slate-50 hover:bg-slate-800 h-11 px-6">
                                     Decrement
                                 </button>
-                                <button @click="reset" class="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-slate-800 bg-slate-900 text-slate-50 hover:bg-slate-800 h-11 px-6">
+                                <button dj-click="reset" class="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-slate-800 bg-slate-900 text-slate-50 hover:bg-slate-800 h-11 px-6">
                                     Reset
                                 </button>
-                                <button @click="increment" class="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-slate-50 text-slate-900 hover:bg-slate-200 h-11 px-6">
+                                <button dj-click="increment" class="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-slate-50 text-slate-900 hover:bg-slate-200 h-11 px-6">
                                     Increment
                                 </button>
                             </div>
@@ -508,7 +508,7 @@
 
                     <div class="rounded-lg border border-slate-800 bg-slate-900 shadow-sm demo-card-hover p-12">
                         <div class="relative w-full max-w-md mx-auto">
-                            <button @click="toggle_dropdown" class="flex w-full items-center justify-between rounded-md border border-slate-700 bg-slate-950 px-4 py-3 text-sm font-medium text-slate-50 hover:border-slate-600 transition-colors focus-ring">
+                            <button dj-click="toggle_dropdown" class="flex w-full items-center justify-between rounded-md border border-slate-700 bg-slate-950 px-4 py-3 text-sm font-medium text-slate-50 hover:border-slate-600 transition-colors focus-ring">
                                 <span>{{ selected_item }}</span>
                                 <svg class="w-5 h-5 transition-transform {% if dropdown_open %}rotate-180{% endif %}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
@@ -517,7 +517,7 @@
                             {% if dropdown_open %}
                             <div class="absolute top-full left-0 right-0 mt-2 rounded-md border border-slate-800 bg-slate-900 shadow-lg overflow-hidden z-50">
                                 {% for item in dropdown_items %}
-                                <div @click="select_item" data-item="{{ item }}" class="px-4 py-3 text-sm text-slate-50 hover:bg-slate-800 cursor-pointer transition-colors">
+                                <div dj-click="select_item" data-item="{{ item }}" class="px-4 py-3 text-sm text-slate-50 hover:bg-slate-800 cursor-pointer transition-colors">
                                     {{ item }}
                                 </div>
                                 {% endfor %}
@@ -563,7 +563,7 @@
                             <input
                                 type="text"
                                 class="flex h-14 w-full rounded-md border border-slate-700 bg-slate-950 px-4 py-2 text-lg ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 text-slate-50"
-                                @input="debounce_search"
+                                dj-input="debounce_search"
                                 placeholder="Type something rapidly..."
                                 value="{{ debounce_query }}"
                             >
@@ -715,7 +715,7 @@
                             <input
                                 type="text"
                                 class="flex h-14 w-full rounded-md border border-slate-700 bg-slate-950 px-4 py-2 text-lg ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 text-slate-50"
-                                @input="cache_search"
+                                dj-input="cache_search"
                                 placeholder="Try: laptop, mouse, keyboard..."
                                 value="{{ cache_query }}"
                             >

--- a/examples/demo_project/djust_demos/templates/demos/partials/counter_demo.html
+++ b/examples/demo_project/djust_demos/templates/demos/partials/counter_demo.html
@@ -18,9 +18,9 @@
                     <div style="font-size: 4rem; font-weight: 800; color: var(--color-accent); line-height: 1;">{{ counter }}</div>
                 </div>
                 <div style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;">
-                    <button @click="increment" class="btn btn-secondary" style="background: var(--color-bg); color: var(--color-text); border: 2px solid var(--color-border);">Decrement</button>
-                    <button @click="reset" class="btn btn-secondary" style="background: var(--color-bg); color: var(--color-text); border: 2px solid var(--color-border);">Reset</button>
-                    <button @click="increment" class="btn btn-primary" style="background: var(--color-accent); color: white; border: none;">Increment</button>
+                    <button dj-click="increment" class="btn btn-secondary" style="background: var(--color-bg); color: var(--color-text); border: 2px solid var(--color-border);">Decrement</button>
+                    <button dj-click="reset" class="btn btn-secondary" style="background: var(--color-bg); color: var(--color-text); border: 2px solid var(--color-border);">Reset</button>
+                    <button dj-click="increment" class="btn btn-primary" style="background: var(--color-accent); color: white; border: none;">Increment</button>
                 </div>
             </div>
         </div>

--- a/examples/demo_project/djust_demos/templates/demos/performance.html
+++ b/examples/demo_project/djust_demos/templates/demos/performance.html
@@ -196,25 +196,25 @@
                         <div class="p-4" style="background: var(--color-bg-elevated);">
                             <!-- Add Items Controls -->
                             <div class="flex gap-2 flex-wrap mb-4">
-                                <button @click="add_items_10" class="btn-primary-modern">
+                                <button dj-click="add_items_10" class="btn-primary-modern">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
                                     </svg>
                                     <span>Add 10 Items</span>
                                 </button>
-                                <button @click="add_items_100" class="btn-primary-modern">
+                                <button dj-click="add_items_100" class="btn-primary-modern">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
                                     </svg>
                                     <span>Add 100 Items</span>
                                 </button>
-                                <button @click="add_items_1000" class="btn-secondary-modern" style="border-color: var(--color-warning); color: var(--color-warning);">
+                                <button dj-click="add_items_1000" class="btn-secondary-modern" style="border-color: var(--color-warning); color: var(--color-warning);">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
                                     </svg>
                                     <span>Add 1000 Items</span>
                                 </button>
-                                <button @click="clear_all" class="btn-secondary-modern" style="border-color: var(--color-error); color: var(--color-error);">
+                                <button dj-click="clear_all" class="btn-secondary-modern" style="border-color: var(--color-error); color: var(--color-error);">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
                                     </svg>
@@ -227,10 +227,10 @@
                                 <input type="text"
                                        placeholder="Filter items..."
                                        value="{{ filter_text }}"
-                                       @change="filter_items"
+                                       dj-change="filter_items"
                                        class="filter-input" />
 
-                                <select @change="sort_items" class="sort-select">
+                                <select dj-change="sort_items" class="sort-select">
                                     <option value="name" {% if sort_by == 'name' %}selected{% endif %}>Sort by Name</option>
                                     <option value="priority" {% if sort_by == 'priority' %}selected{% endif %}>Sort by Priority</option>
                                     <option value="timestamp" {% if sort_by == 'timestamp' %}selected{% endif %}>Sort by Time</option>
@@ -239,16 +239,16 @@
 
                             <!-- Batch Operations -->
                             <div class="flex gap-2 flex-wrap mb-4">
-                                <button @click="select_all" class="btn-secondary-modern">
+                                <button dj-click="select_all" class="btn-secondary-modern">
                                     <span>Select All</span>
                                 </button>
-                                <button @click="deselect_all" class="btn-secondary-modern">
+                                <button dj-click="deselect_all" class="btn-secondary-modern">
                                     <span>Deselect All</span>
                                 </button>
-                                <button @click="delete_selected" class="btn-secondary-modern" style="border-color: var(--color-error); color: var(--color-error);">
+                                <button dj-click="delete_selected" class="btn-secondary-modern" style="border-color: var(--color-error); color: var(--color-error);">
                                     <span>Delete Selected</span>
                                 </button>
-                                <button @click="toggle_priority_selected" class="btn-secondary-modern" style="border-color: var(--color-warning); color: var(--color-warning);">
+                                <button dj-click="toggle_priority_selected" class="btn-secondary-modern" style="border-color: var(--color-warning); color: var(--color-warning);">
                                     <span>Toggle Priority</span>
                                 </button>
                             </div>
@@ -262,7 +262,7 @@
                                         <input type="checkbox"
                                                class="item-checkbox"
                                                {% if item.selected %}checked{% endif %}
-                                               @change="toggle_item"
+                                               dj-change="toggle_item"
                                                data-id="{{ item.id }}" />
                                         <div class="item-content">
                                             <span class="item-name">{{ item.name }}</span>
@@ -272,11 +272,11 @@
                                             {% if item.priority %}
                                             <span class="priority-badge">High Priority</span>
                                             {% endif %}
-                                            <button @click="toggle_priority"
+                                            <button dj-click="toggle_priority"
                                                     data-id="{{ item.id }}"
                                                     class="btn-secondary-modern"
                                                     style="padding: 0.25rem 0.5rem; font-size: 0.875rem;">★</button>
-                                            <button @click="delete_item"
+                                            <button dj-click="delete_item"
                                                     data-id="{{ item.id }}"
                                                     class="btn-secondary-modern"
                                                     style="padding: 0.25rem 0.5rem; font-size: 1rem; border-color: var(--color-error); color: var(--color-error);">×</button>
@@ -361,21 +361,21 @@ class PerformanceTestView(LiveView):
                                 </div>
                                 <div class="code-block-modern">
                                     <pre style="margin: 0; padding: 1rem; background: var(--color-bg); border-radius: 0 0 var(--radius-md) var(--radius-md);"><code class="language-html">&lt;!-- Add Items --&gt;
-&lt;button @click="add_items_100"&gt;
+&lt;button dj-click="add_items_100"&gt;
   Add 100 Items
 &lt;/button&gt;
 
 &lt;!-- Filter --&gt;
 &lt;input type="text"
        placeholder="Filter..."
-       @change="filter_items" /&gt;
+       dj-change="filter_items" /&gt;
 
 &lt;!-- Items List --&gt;
 &#123;% for item in items %&#125;
   &lt;div class="performance-item"&gt;
     &lt;input type="checkbox"
            &#123;% if item.selected %&#125;checked&#123;% endif %&#125;
-           @change="toggle_item"
+           dj-change="toggle_item"
            data-id="&#123;&#123; item.id &#125;&#125;" /&gt;
     &lt;span&gt;&#123;&#123; item.name &#125;&#125;&lt;/span&gt;
   &lt;/div&gt;

--- a/examples/demo_project/djust_demos/templates/demos/react.html
+++ b/examples/demo_project/djust_demos/templates/demos/react.html
@@ -96,7 +96,7 @@
                                     <p class="mb-3">Managed server-side with LiveView</p>
                                     <div class="counter-display">{{ server_count }}</div>
                                     <div class="text-center">
-                                        <button @click="increment_server" class="btn-primary-modern">
+                                        <button dj-click="increment_server" class="btn-primary-modern">
                                             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
                                             </svg>
@@ -151,7 +151,7 @@
                                     <TodoItem text="{{ todo.text }}" completed="{{ todo.done }}" />
                                     {% endfor %}
                                 </div>
-                                <form @submit="add_todo_item" class="flex gap-2 mt-3">
+                                <form dj-submit="add_todo_item" class="flex gap-2 mt-3">
                                     <input
                                         type="text"
                                         name="text"
@@ -275,7 +275,7 @@ class Button(ReactComponent):
                                     <pre style="margin: 0; padding: 1rem; background: var(--color-bg); border-radius: 0 0 var(--radius-md) var(--radius-md);"><code class="language-html">&lt;!-- Server Counter (LiveView) --&gt;
 &lt;div&gt;
   &lt;h3&gt;Server Count: &#123;&#123; server_count &#125;&#125;&lt;/h3&gt;
-  &lt;button @click="increment_server"&gt;
+  &lt;button dj-click="increment_server"&gt;
     Increment Server
   &lt;/button&gt;
 &lt;/div&gt;

--- a/examples/demo_project/djust_demos/templates/demos/rust_components.html
+++ b/examples/demo_project/djust_demos/templates/demos/rust_components.html
@@ -248,7 +248,7 @@
             {% if dropdown_message %}
             <div class="demo-message mb-4">
                 <strong>Dropdown Event:</strong> {{ dropdown_message }}
-                <button @click="clear_messages" class="btn btn-sm float-end" style="padding: 0.25rem 0.75rem;">Clear</button>
+                <button dj-click="clear_messages" class="btn btn-sm float-end" style="padding: 0.25rem 0.75rem;">Clear</button>
             </div>
             {% endif %}
 
@@ -422,13 +422,13 @@
                                 </p>
                                 <div class="mb-3 p-3" style="background: var(--color-bg); border-radius: var(--radius-md); border: 2px solid var(--color-accent);">
                                     <div class="d-flex align-items-center gap-3">
-                                        <button @click="increment_counter" class="btn btn-primary">
+                                        <button dj-click="increment_counter" class="btn btn-primary">
                                             <strong>+</strong> Increment
                                         </button>
                                         <div style="font-size: 1.5rem; font-weight: 700; color: var(--color-accent);">
                                             Counter: {{ counter }}
                                         </div>
-                                        <button @click="reset_counter" class="btn btn-secondary">
+                                        <button dj-click="reset_counter" class="btn btn-secondary">
                                             Reset
                                         </button>
                                     </div>

--- a/examples/demo_project/djust_demos/templates/demos/smart_dashboard.html
+++ b/examples/demo_project/djust_demos/templates/demos/smart_dashboard.html
@@ -215,7 +215,7 @@
                                 max="85"
                                 step="0.1"
                                 value="{{ temperature }}"
-                                @input="set_temperature"
+                                dj-input="set_temperature"
                             />
                         </div>
 
@@ -233,7 +233,7 @@
                                 max="80"
                                 step="0.1"
                                 value="{{ humidity }}"
-                                @input="set_humidity"
+                                dj-input="set_humidity"
                             />
                         </div>
 
@@ -245,7 +245,7 @@
                                     <div style="color: var(--color-text-muted); font-size: 0.875rem;">Uses @throttle for real-time simulation (2s interval)</div>
                                 </div>
                                 <button
-                                    @click="simulate_sensor"
+                                    dj-click="simulate_sensor"
                                     class="btn-secondary-modern"
                                     style="padding: 0.5rem 1rem;"
                                 >
@@ -343,7 +343,7 @@
                             <select
                                 class="form-select"
                                 name="filter"
-                                @change="update_filter"
+                                dj-change="update_filter"
                                 style="background: var(--color-bg); border: 1px solid var(--color-border); color: var(--color-text);"
                             >
                                 <option value="all" {% if filter == "all" %}selected{% endif %}>All Devices</option>
@@ -369,7 +369,7 @@
                                     class="form-check-input"
                                     style="width: 20px; height: 20px; cursor: pointer;"
                                     {% if device.active %}checked{% endif %}
-                                    @change="toggle_device"
+                                    dj-change="toggle_device"
                                     data-device-id="{{ device.id }}"
                                 />
                             </div>
@@ -487,7 +487,7 @@ class SmartDashboardView(LiveView):
                                 <div class="code-block-modern">
                                     <pre style="margin: 0; padding: 1rem; background: var(--color-bg); border-radius: 0 0 var(--radius-md) var(--radius-md);"><code class="language-html">&lt;!-- Climate Controls Panel --&gt;
 &lt;input type="range" min="60" max="85"
-       @input="set_temperature"
+       dj-input="set_temperature"
        value="&#123;&#123; temperature &#125;&#125;" /&gt;
 
 &lt;!-- Chart Panel (auto-updates via StateBus) --&gt;
@@ -496,7 +496,7 @@ class SmartDashboardView(LiveView):
 &lt;/div&gt;
 
 &lt;!-- Device Panel --&gt;
-&lt;input type="checkbox" @change="toggle_device"
+&lt;input type="checkbox" dj-change="toggle_device"
        data-device-id="&#123;&#123; device.id &#125;&#125;" /&gt;
 
 &lt;!-- Stats Panel (auto-updates when devices change) --&gt;

--- a/examples/demo_project/djust_demos/templates/demos/todo.html
+++ b/examples/demo_project/djust_demos/templates/demos/todo.html
@@ -63,7 +63,7 @@
                         </div>
                         <div class="p-4" style="background: var(--color-bg-elevated); min-height: 500px;">
                             <!-- Add Todo Form -->
-                            <form @submit="add_todo" class="mb-4">
+                            <form dj-submit="add_todo" class="mb-4">
                                 <div class="flex gap-2">
                                     <input
                                         type="text"
@@ -89,7 +89,7 @@
                                         <input
                                             type="checkbox"
                                             {% if todo.done %}checked{% endif %}
-                                            @change="toggle_todo"
+                                            dj-change="toggle_todo"
                                             data-id="{{ todo.id }}"
                                             style="width: 18px; height: 18px; cursor: pointer;"
                                         />
@@ -97,7 +97,7 @@
                                             {{ todo.text }}
                                         </span>
                                         <button
-                                            @click="delete_todo"
+                                            dj-click="delete_todo"
                                             data-id="{{ todo.id }}"
                                             class="btn-secondary-modern"
                                             style="padding: 0.375rem 0.75rem; border-color: var(--color-error); color: var(--color-error);"
@@ -205,7 +205,7 @@ class TodoView(LiveView):
                                 </div>
                                 <div class="code-block-modern">
                                     <pre style="margin: 0; padding: 1rem; background: var(--color-bg); border-radius: 0 0 var(--radius-md) var(--radius-md);"><code class="language-html">&lt;!-- Add Todo Form --&gt;
-&lt;form @submit="add_todo"&gt;
+&lt;form dj-submit="add_todo"&gt;
   &lt;input type="text" name="text"
          placeholder="What needs to be done?" /&gt;
   &lt;button type="submit"&gt;Add&lt;/button&gt;
@@ -216,10 +216,10 @@ class TodoView(LiveView):
   &lt;div class="todo-item"&gt;
     &lt;input type="checkbox"
            &#123;% if todo.done %&#125;checked&#123;% endif %&#125;
-           @change="toggle_todo"
+           dj-change="toggle_todo"
            data-id="&#123;&#123; todo.id &#125;&#125;" /&gt;
     &lt;span&gt;&#123;&#123; todo.text &#125;&#125;&lt;/span&gt;
-    &lt;button @click="delete_todo"
+    &lt;button dj-click="delete_todo"
             data-id="&#123;&#123; todo.id &#125;&#125;"&gt;
       Delete
     &lt;/button&gt;

--- a/examples/demo_project/djust_docs/templates/docs/components-guide.html
+++ b/examples/demo_project/djust_docs/templates/docs/components-guide.html
@@ -1335,7 +1335,7 @@
 
                     <h3>Step 1: User Clicks Button</h3>
                     <p>
-                        When a user clicks the button in the browser, the <code>@click</code> directive tells the djust client JavaScript to capture this event. The <code>@click="increment_notifications"</code> attribute specifies which event handler method should be called on the server-side LiveView. No page reload occurs - this is entirely handled via WebSocket.
+                        When a user clicks the button in the browser, the <code>@click</code> directive tells the djust client JavaScript to capture this event. The <code>dj-click="increment_notifications"</code> attribute specifies which event handler method should be called on the server-side LiveView. No page reload occurs - this is entirely handled via WebSocket.
                     </p>
                     <div class="code-block-with-header">
                         <div class="code-header">
@@ -1343,7 +1343,7 @@
                             <span class="file-path">examples/demo_project/templates/index.html</span>
                         </div>
                         <div class="code-content">
-<pre><code class="language-html">&lt;button @click="increment_notifications"&gt;
+<pre><code class="language-html">&lt;button dj-click="increment_notifications"&gt;
     Add Notification
 &lt;/button&gt;</code></pre>
                         </div>
@@ -1550,7 +1550,7 @@ context['button'] = ButtonComponent(
                         </div>
                         <div class="code-content">
 <pre><code class="language-html">&lt;!-- Template --&gt;
-&lt;button @click="handle_button_click"&gt;Click Me&lt;/button&gt;</code></pre>
+&lt;button dj-click="handle_button_click"&gt;Click Me&lt;/button&gt;</code></pre>
 <pre><code class="language-python"># LiveView
 def handle_button_click(self):
     self.is_loading = True
@@ -1713,11 +1713,11 @@ def handle_button_click(self):
                     <p>This page itself demonstrates component communication:</p>
 
                     <div class="text-center my-4">
-                        <button @click="increment_demo_count"
+                        <button dj-click="increment_demo_count"
                                 class="btn btn-primary btn-lg me-2">
                             Increment Counter
                         </button>
-                        <button @click="reset_demo_count"
+                        <button dj-click="reset_demo_count"
                                 class="btn btn-secondary btn-lg">
                             Reset
                         </button>

--- a/examples/demo_project/djust_docs/templates/docs/docs.html
+++ b/examples/demo_project/djust_docs/templates/docs/docs.html
@@ -630,11 +630,11 @@ urlpatterns = [
                 <h3>Event Handlers</h3>
                 <p>Define methods to handle user interactions:</p>
                 <pre><code class="language-python">def increment(self):
-    """Called when element with @click="increment" is clicked"""
+    """Called when element with dj-click="increment" is clicked"""
     self.counter += 1
 
 def handle_submit(self):
-    """Called when form with @submit="handle_submit" is submitted"""
+    """Called when form with dj-submit="handle_submit" is submitted"""
     # Access form data via self.form_data
     query = self.form_data.get('query', '')
     self.results = search(query)
@@ -772,22 +772,22 @@ self.alert_success = AlertComponent(message="Success!")
                         <tr>
                             <td><code>@click</code></td>
                             <td>Handle click events</td>
-                            <td><code>&lt;button @click="increment"&gt;</code></td>
+                            <td><code>&lt;button dj-click="increment"&gt;</code></td>
                         </tr>
                         <tr>
                             <td><code>@submit</code></td>
                             <td>Handle form submissions</td>
-                            <td><code>&lt;form @submit="handle_submit"&gt;</code></td>
+                            <td><code>&lt;form dj-submit="handle_submit"&gt;</code></td>
                         </tr>
                         <tr>
                             <td><code>@change</code></td>
                             <td>Handle input changes</td>
-                            <td><code>&lt;input @change="validate_field"&gt;</code></td>
+                            <td><code>&lt;input dj-change="validate_field"&gt;</code></td>
                         </tr>
                         <tr>
                             <td><code>@input</code></td>
                             <td>Handle input while typing</td>
-                            <td><code>&lt;input @input="live_search"&gt;</code></td>
+                            <td><code>&lt;input dj-input="live_search"&gt;</code></td>
                         </tr>
                     </tbody>
                 </table>
@@ -796,7 +796,7 @@ self.alert_success = AlertComponent(message="Success!")
                 <p>Pass data to event handlers using <code>data-*</code> attributes:</p>
                 <pre><code class="language-html">&lt;!-- Template --&gt;
 &lt;button
-    @click="delete_item"
+    dj-click="delete_item"
     data-item-id="&#123;&#123; item.id &#125;&#125;"
     data-confirm="true"
 &gt;
@@ -870,7 +870,7 @@ class ContactFormView(LiveView):
 {&#37; load djust &#37;}
 
 &lt;div data-liveview-root&gt;
-    &lt;form @submit="handle_submit"&gt;
+    &lt;form dj-submit="handle_submit"&gt;
         {&#37; auto_form form framework="bootstrap5" &#37;}
 
         &lt;button type="submit" class="btn btn-primary"&gt;Submit&lt;/button&gt;
@@ -913,7 +913,7 @@ class ContactFormView(LiveView):
                 <pre><code class="language-html">&lt;input
     type="text"
     name="username"
-    @change="validate_username"
+    dj-change="validate_username"
     class="form-control"
 &gt;
 {&#37; if username_error &#37;}
@@ -990,7 +990,7 @@ def mount(self, request):
 {&#37; for item in items &#37;}
     &lt;div class="item"&gt;
         &lt;h3&gt;&#123;&#123; item.title &#125;&#125;&lt;/h3&gt;
-        &lt;button @click="delete" data-item-id="&#123;&#123; item.id &#125;&#125;"&gt;Delete&lt;/button&gt;
+        &lt;button dj-click="delete" data-item-id="&#123;&#123; item.id &#125;&#125;"&gt;Delete&lt;/button&gt;
     &lt;/div&gt;
 {&#37; empty &#37;}
     &lt;p&gt;No items found.&lt;/p&gt;
@@ -1133,7 +1133,7 @@ class UserCardComponent(LiveComponent):
 
         {&#37; if show_actions &#37;}
             &lt;button
-                @click="toggle_follow"
+                dj-click="toggle_follow"
                 class="btn btn-{&#37; if is_following &#37;}secondary{&#37; else &#37;}primary{&#37; endif &#37;}"
             &gt;
                 {&#37; if is_following &#37;}Unfollow{&#37; else &#37;}Follow{&#37; endif &#37;}
@@ -1237,7 +1237,7 @@ class ProfileView(LiveView):
                 <p>Apply classes conditionally based on state:</p>
                 <pre><code class="language-html">&lt;button
     class="btn {&#37; if is_active &#37;}btn-primary{&#37; else &#37;}btn-secondary{&#37; endif &#37;}"
-    @click="toggle"
+    dj-click="toggle"
 &gt;
     Toggle
 &lt;/button&gt;
@@ -1495,22 +1495,22 @@ uvicorn myproject.asgi:application --host 0.0.0.0 --port 8000 --workers 4</code>
                         <tr>
                             <td><code>@click</code></td>
                             <td>Element clicked</td>
-                            <td><code>&lt;button @click="increment"&gt;</code></td>
+                            <td><code>&lt;button dj-click="increment"&gt;</code></td>
                         </tr>
                         <tr>
                             <td><code>@submit</code></td>
                             <td>Form submitted</td>
-                            <td><code>&lt;form @submit="handle_form"&gt;</code></td>
+                            <td><code>&lt;form dj-submit="handle_form"&gt;</code></td>
                         </tr>
                         <tr>
                             <td><code>@change</code></td>
                             <td>Input value changed</td>
-                            <td><code>&lt;select @change="filter"&gt;</code></td>
+                            <td><code>&lt;select dj-change="filter"&gt;</code></td>
                         </tr>
                         <tr>
                             <td><code>@input</code></td>
                             <td>Input while typing</td>
-                            <td><code>&lt;input @input="search"&gt;</code></td>
+                            <td><code>&lt;input dj-input="search"&gt;</code></td>
                         </tr>
                     </tbody>
                 </table>

--- a/examples/demo_project/djust_docs/templates/docs/kitchen_sink.html
+++ b/examples/demo_project/djust_docs/templates/docs/kitchen_sink.html
@@ -426,7 +426,7 @@
                             <h3 class="text-lg font-bold mb-3 mt-4" style="color: var(--color-text);">Modals</h3>
                             <div class="component-demo">
                                 <div class="demo-label">Modal Dialogs</div>
-                                <button @click="show_modal" class="btn-primary-modern">
+                                <button dj-click="show_modal" class="btn-primary-modern">
                                     <span>Show Modal</span>
                                 </button>
                                 {{ modal_example.render }}
@@ -442,10 +442,10 @@
                                     {{ progress_custom.render }}
                                 </div>
                                 <div class="flex gap-2 mt-3">
-                                    <button @click="increment_progress" class="btn-primary-modern">
+                                    <button dj-click="increment_progress" class="btn-primary-modern">
                                         <span>Increment</span>
                                     </button>
-                                    <button @click="reset_progress" class="btn-secondary-modern">
+                                    <button dj-click="reset_progress" class="btn-secondary-modern">
                                         <span>Reset</span>
                                     </button>
                                 </div>
@@ -567,8 +567,8 @@ class CounterView(LiveView):
                                 <div class="code-block-modern">
                                     <pre style="margin: 0; padding: 1rem; background: var(--color-bg); border-radius: 0 0 var(--radius-md) var(--radius-md);"><code class="language-html">&lt;div data-liveview-root&gt;
   &lt;h1&gt;Count: &#123;&#123; count &#125;&#125;&lt;/h1&gt;
-  &lt;button @click="increment"&gt;+&lt;/button&gt;
-  &lt;button @click="decrement"&gt;-&lt;/button&gt;
+  &lt;button dj-click="increment"&gt;+&lt;/button&gt;
+  &lt;button dj-click="decrement"&gt;-&lt;/button&gt;
 &lt;/div&gt;
 
 &lt;script src="/static/djust/client.js"&gt;&lt;/script&gt;</code></pre>

--- a/examples/demo_project/djust_docs/templates/docs/kitchen_sink_content.html
+++ b/examples/demo_project/djust_docs/templates/docs/kitchen_sink_content.html
@@ -86,7 +86,7 @@
             <h3>Modal Dialogs</h3>
             <div class="component-demo">
                 <div class="demo-label">Modal Example</div>
-                <button class="btn btn-primary" @click="show_modal">Open Modal</button>
+                <button class="btn btn-primary" dj-click="show_modal">Open Modal</button>
                 <p class="text-muted mt-2 mb-0">
                     <small>Modal opened: <strong>{{ modal_open_count }}</strong> time(s)</small>
                 </p>
@@ -112,8 +112,8 @@
                     {{ progress_custom.render }}
                 </div>
                 <div class="mt-3">
-                    <button class="btn btn-sm btn-primary" @click="increment_progress">Increment (+10%)</button>
-                    <button class="btn btn-sm btn-secondary ms-2" @click="reset_progress">Reset</button>
+                    <button class="btn btn-sm btn-primary" dj-click="increment_progress">Increment (+10%)</button>
+                    <button class="btn btn-sm btn-secondary ms-2" dj-click="reset_progress">Reset</button>
                 </div>
             </div>
         </div>

--- a/examples/demo_project/djust_forms/templates/forms/auto.html
+++ b/examples/demo_project/djust_forms/templates/forms/auto.html
@@ -15,18 +15,18 @@
             {% if success_message %}
             <div class="alert alert-success">
                 {{ success_message }}
-                <button type="button" class="btn-close float-end" @click="clear_message"></button>
+                <button type="button" class="btn-close float-end" dj-click="clear_message"></button>
             </div>
             {% endif %}
 
             {% if error_message %}
             <div class="alert alert-danger">
                 {{ error_message }}
-                <button type="button" class="btn-close float-end" @click="clear_message"></button>
+                <button type="button" class="btn-close float-end" dj-click="clear_message"></button>
             </div>
             {% endif %}
 
-            <form @submit="submit_form" onsubmit="return false;">
+            <form dj-submit="submit_form" onsubmit="return false;">
                 {% csrf_token %}
 
                 <!-- Auto-rendered form using as_live() method -->
@@ -34,7 +34,7 @@
 
                 <div class="d-grid gap-2 mt-3">
                     <button type="submit" class="btn btn-primary">Send Message</button>
-                    <button type="button" class="btn btn-secondary" @click="reset_form">Reset</button>
+                    <button type="button" class="btn btn-secondary" dj-click="reset_form">Reset</button>
                 </div>
             </form>
 
@@ -50,7 +50,7 @@
 
                 <h5>Template Code:</h5>
                 <pre class="bg-light p-3 small"><code>{% templatetag openblock %} load live_tags {% templatetag closeblock %}
-&lt;form @submit="submit_form"&gt;
+&lt;form dj-submit="submit_form"&gt;
     {% templatetag openblock %} csrf_token {% templatetag closeblock %}
     {% templatetag openvariable %} live_form view {% templatetag closevariable %}
     &lt;button type="submit"&gt;Submit&lt;/button&gt;

--- a/examples/demo_project/djust_forms/templates/forms/auto_comparison.html
+++ b/examples/demo_project/djust_forms/templates/forms/auto_comparison.html
@@ -153,7 +153,7 @@ code {
         return context</code></pre>
 
         <h6 class="mt-4">Template Code:</h6>
-        <pre class="bg-light p-3"><code>&lt;form @submit="submit_form"&gt;
+        <pre class="bg-light p-3"><code>&lt;form dj-submit="submit_form"&gt;
     {% csrf_token %}
     {{ form_html }}
     &lt;button type="submit"&gt;Submit&lt;/button&gt;

--- a/examples/demo_project/djust_forms/templates/forms/auto_plain.html
+++ b/examples/demo_project/djust_forms/templates/forms/auto_plain.html
@@ -54,18 +54,18 @@
     {% if success_message %}
     <div class="alert alert-success">
         {{ success_message }}
-        <button type="button" style="float: right; border: none; background: none; font-size: 20px;" @click="clear_message">&times;</button>
+        <button type="button" style="float: right; border: none; background: none; font-size: 20px;" dj-click="clear_message">&times;</button>
     </div>
     {% endif %}
 
     {% if error_message %}
     <div class="alert alert-danger">
         {{ error_message }}
-        <button type="button" style="float: right; border: none; background: none; font-size: 20px;" @click="clear_message">&times;</button>
+        <button type="button" style="float: right; border: none; background: none; font-size: 20px;" dj-click="clear_message">&times;</button>
     </div>
     {% endif %}
 
-    <form @submit="submit_form" onsubmit="return false;">
+    <form dj-submit="submit_form" onsubmit="return false;">
         {% csrf_token %}
 
         <!-- Auto-rendered form using Plain adapter -->
@@ -73,7 +73,7 @@
 
         <div>
             <button type="submit">Send Message</button>
-            <button type="button" @click="reset_form">Reset</button>
+            <button type="button" dj-click="reset_form">Reset</button>
         </div>
     </form>
 

--- a/examples/demo_project/djust_forms/templates/forms/auto_tailwind.html
+++ b/examples/demo_project/djust_forms/templates/forms/auto_tailwind.html
@@ -20,18 +20,18 @@ body { background: #f3f4f6; }
         {% if success_message %}
         <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
             {{ success_message }}
-            <button type="button" class="float-right" @click="clear_message">&times;</button>
+            <button type="button" class="float-right" dj-click="clear_message">&times;</button>
         </div>
         {% endif %}
 
         {% if error_message %}
         <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
             {{ error_message }}
-            <button type="button" class="float-right" @click="clear_message">&times;</button>
+            <button type="button" class="float-right" dj-click="clear_message">&times;</button>
         </div>
         {% endif %}
 
-        <form @submit="submit_form" onsubmit="return false;">
+        <form dj-submit="submit_form" onsubmit="return false;">
             {% csrf_token %}
 
             <!-- Auto-rendered form using Tailwind adapter -->
@@ -41,7 +41,7 @@ body { background: #f3f4f6; }
                 <button type="submit" class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
                     Send Message
                 </button>
-                <button type="button" class="w-full bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded" @click="reset_form">
+                <button type="button" class="w-full bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded" dj-click="reset_form">
                     Reset
                 </button>
             </div>

--- a/examples/demo_project/djust_forms/templates/forms/contact.html
+++ b/examples/demo_project/djust_forms/templates/forms/contact.html
@@ -24,7 +24,7 @@
                     {% if success_message %}
                     <div class="alert alert-success alert-dismissible fade show" role="alert">
                         {{ success_message }}
-                        <button type="button" class="btn-close" @click="clear_message"></button>
+                        <button type="button" class="btn-close" dj-click="clear_message"></button>
                     </div>
                     {% endif %}
 
@@ -34,7 +34,7 @@
                     </div>
                     {% endif %}
 
-                    <form @submit="submit_form" class="needs-validation" novalidate>
+                    <form dj-submit="submit_form" class="needs-validation" novalidate>
                         <div class="row">
                             <!-- Name -->
                             <div class="col-md-6 mb-3">
@@ -45,7 +45,7 @@
                                     id="name"
                                     class="form-control {% if field_errors.name %}is-invalid{% endif %}"
                                     value="{{ form_data.name }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="name"
                                     required
                                 />
@@ -65,7 +65,7 @@
                                     id="email"
                                     class="form-control {% if field_errors.email %}is-invalid{% endif %}"
                                     value="{{ form_data.email }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="email"
                                     required
                                 />
@@ -84,7 +84,7 @@
                                 name="subject"
                                 id="subject"
                                 class="form-control {% if field_errors.subject %}is-invalid{% endif %}"
-                                @change="validate_field"
+                                dj-change="validate_field"
                                 data-field="subject"
                                 required
                             >
@@ -108,25 +108,25 @@
                             <div class="form-check">
                                 <input class="form-check-input" type="radio" name="priority" id="priority_low" value="low"
                                        {% if form_data.priority == "low" %}checked{% endif %}
-                                       @change="validate_field" data-field="priority">
+                                       dj-change="validate_field" data-field="priority">
                                 <label class="form-check-label" for="priority_low">Low</label>
                             </div>
                             <div class="form-check">
                                 <input class="form-check-input" type="radio" name="priority" id="priority_medium" value="medium"
                                        {% if form_data.priority == "medium" or not form_data.priority %}checked{% endif %}
-                                       @change="validate_field" data-field="priority">
+                                       dj-change="validate_field" data-field="priority">
                                 <label class="form-check-label" for="priority_medium">Medium</label>
                             </div>
                             <div class="form-check">
                                 <input class="form-check-input" type="radio" name="priority" id="priority_high" value="high"
                                        {% if form_data.priority == "high" %}checked{% endif %}
-                                       @change="validate_field" data-field="priority">
+                                       dj-change="validate_field" data-field="priority">
                                 <label class="form-check-label" for="priority_high">High</label>
                             </div>
                             <div class="form-check">
                                 <input class="form-check-input" type="radio" name="priority" id="priority_urgent" value="urgent"
                                        {% if form_data.priority == "urgent" %}checked{% endif %}
-                                       @change="validate_field" data-field="priority">
+                                       dj-change="validate_field" data-field="priority">
                                 <label class="form-check-label" for="priority_urgent">Urgent</label>
                             </div>
                         </div>
@@ -139,7 +139,7 @@
                                 id="message"
                                 class="form-control {% if field_errors.message %}is-invalid{% endif %}"
                                 rows="5"
-                                @change="validate_field"
+                                dj-change="validate_field"
                                 data-field="message"
                                 required
                             >{{ form_data.message }}</textarea>
@@ -159,7 +159,7 @@
                                 id="subscribe_newsletter"
                                 class="form-check-input"
                                 {% if form_data.subscribe_newsletter %}checked{% endif %}
-                                @change="validate_field"
+                                dj-change="validate_field"
                                 data-field="subscribe_newsletter"
                             />
                             <label class="form-check-label" for="subscribe_newsletter">
@@ -172,7 +172,7 @@
                             <button type="submit" class="btn btn-success btn-lg">
                                 Send Message
                             </button>
-                            <button type="button" class="btn btn-outline-secondary" @click="reset_form">
+                            <button type="button" class="btn btn-outline-secondary" dj-click="reset_form">
                                 Reset Form
                             </button>
                         </div>

--- a/examples/demo_project/djust_forms/templates/forms/index.html
+++ b/examples/demo_project/djust_forms/templates/forms/index.html
@@ -174,8 +174,8 @@ class MyFormView(FormMixin, LiveView):
         self.error_message = "Please fix errors"</code></pre>
 
                     <h5 class="mt-4">Template Usage</h5>
-                    <pre class="bg-light p-3 rounded"><code>&lt;form @submit="submit_form"&gt;
-    &lt;input name="name" @change="validate_field" data-field="name" /&gt;
+                    <pre class="bg-light p-3 rounded"><code>&lt;form dj-submit="submit_form"&gt;
+    &lt;input name="name" dj-change="validate_field" data-field="name" /&gt;
     {% templatetag openblock %} if field_errors.name {% templatetag closeblock %}
         &lt;div class="error"&gt;{% templatetag openvariable %} field_errors.name {% templatetag closevariable %}&lt;/div&gt;
     {% templatetag openblock %} endif {% templatetag closeblock %}

--- a/examples/demo_project/djust_forms/templates/forms/profile.html
+++ b/examples/demo_project/djust_forms/templates/forms/profile.html
@@ -24,11 +24,11 @@
                     {% if success_message %}
                     <div class="alert alert-success alert-dismissible fade show" role="alert">
                         {{ success_message }}
-                        <button type="button" class="btn-close" @click="clear_message"></button>
+                        <button type="button" class="btn-close" dj-click="clear_message"></button>
                     </div>
                     {% endif %}
 
-                    <form @submit="submit_form" class="needs-validation" novalidate>
+                    <form dj-submit="submit_form" class="needs-validation" novalidate>
                         <div class="row">
                             <!-- First Name -->
                             <div class="col-md-6 mb-3">
@@ -39,7 +39,7 @@
                                     id="first_name"
                                     class="form-control {% if field_errors.first_name %}is-invalid{% endif %}"
                                     value="{{ form_data.first_name }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="first_name"
                                     required
                                 />
@@ -59,7 +59,7 @@
                                     id="last_name"
                                     class="form-control {% if field_errors.last_name %}is-invalid{% endif %}"
                                     value="{{ form_data.last_name }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="last_name"
                                     required
                                 />
@@ -79,7 +79,7 @@
                                 id="bio"
                                 class="form-control {% if field_errors.bio %}is-invalid{% endif %}"
                                 rows="4"
-                                @change="validate_field"
+                                dj-change="validate_field"
                                 data-field="bio"
                             >{{ form_data.bio }}</textarea>
                             <small class="form-text text-muted">Tell us about yourself (max 500 characters)</small>
@@ -100,7 +100,7 @@
                                     id="birth_date"
                                     class="form-control {% if field_errors.birth_date %}is-invalid{% endif %}"
                                     value="{{ form_data.birth_date }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="birth_date"
                                 />
                                 {% if field_errors.birth_date %}
@@ -117,7 +117,7 @@
                                     name="country"
                                     id="country"
                                     class="form-control {% if field_errors.country %}is-invalid{% endif %}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="country"
                                 >
                                     <option value="">Select country...</option>
@@ -148,7 +148,7 @@
                                     id="phone"
                                     class="form-control {% if field_errors.phone %}is-invalid{% endif %}"
                                     value="{{ form_data.phone }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="phone"
                                     placeholder="+1 (555) 123-4567"
                                 />
@@ -169,7 +169,7 @@
                                     id="website"
                                     class="form-control {% if field_errors.website %}is-invalid{% endif %}"
                                     value="{{ form_data.website }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="website"
                                     placeholder="https://yourwebsite.com"
                                 />
@@ -189,7 +189,7 @@
                                 id="receive_updates"
                                 class="form-check-input"
                                 {% if form_data.receive_updates %}checked{% endif %}
-                                @change="validate_field"
+                                dj-change="validate_field"
                                 data-field="receive_updates"
                             />
                             <label class="form-check-label" for="receive_updates">
@@ -202,7 +202,7 @@
                             <button type="submit" class="btn btn-info btn-lg text-white">
                                 Save Profile
                             </button>
-                            <button type="button" class="btn btn-outline-secondary" @click="reset_form">
+                            <button type="button" class="btn btn-outline-secondary" dj-click="reset_form">
                                 Reset Form
                             </button>
                         </div>

--- a/examples/demo_project/djust_forms/templates/forms/registration.html
+++ b/examples/demo_project/djust_forms/templates/forms/registration.html
@@ -23,15 +23,15 @@
                     <div class="card-body">
                         <div class="alert alert-success alert-dismissible fade show{% if not success_message %} d-none{% endif %}" role="alert">
                             {{ success_message }}
-                            <button type="button" class="btn-close" @click="clear_message"></button>
+                            <button type="button" class="btn-close" dj-click="clear_message"></button>
                         </div>
 
                         <div class="alert alert-danger alert-dismissible fade show{% if not error_message %} d-none{% endif %}" role="alert">
                             {{ error_message }}
-                            <button type="button" class="btn-close" @click="clear_message"></button>
+                            <button type="button" class="btn-close" dj-click="clear_message"></button>
                         </div>
 
-                        <form @submit="submit_form" class="needs-validation" novalidate>
+                        <form dj-submit="submit_form" class="needs-validation" novalidate>
                             <!-- Username -->
                             <div class="mb-3">
                                 <label for="username" class="form-label">Username</label>
@@ -41,7 +41,7 @@
                                     id="username"
                                     class="form-control {% if field_errors.username %}is-invalid{% endif %}"
                                     value="{{ form_data.username }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="username"
                                     required
                                 />
@@ -64,7 +64,7 @@
                                     id="email"
                                     class="form-control {% if field_errors.email %}is-invalid{% endif %}"
                                     value="{{ form_data.email }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="email"
                                     required
                                 />
@@ -87,7 +87,7 @@
                                     id="password"
                                     class="form-control {% if field_errors.password %}is-invalid{% endif %}"
                                     value="{{ form_data.password }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="password"
                                     required
                                 />
@@ -110,7 +110,7 @@
                                     id="password_confirm"
                                     class="form-control {% if field_errors.password_confirm %}is-invalid{% endif %}"
                                     value="{{ form_data.password_confirm }}"
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="password_confirm"
                                     required
                                 />
@@ -131,7 +131,7 @@
                                     id="agree_terms"
                                     class="form-check-input {% if field_errors.agree_terms %}is-invalid{% endif %}"
                                     {% if form_data.agree_terms %}checked{% endif %}
-                                    @change="validate_field"
+                                    dj-change="validate_field"
                                     data-field="agree_terms"
                                     required
                                 />
@@ -161,7 +161,7 @@
                                 <button type="submit" class="btn btn-primary btn-lg">
                                     Create Account
                                 </button>
-                                <button type="button" class="btn btn-outline-secondary" @click="reset_form">
+                                <button type="button" class="btn btn-outline-secondary" dj-click="reset_form">
                                     Reset Form
                                 </button>
                             </div>

--- a/examples/demo_project/djust_forms/templates/forms/simple.html
+++ b/examples/demo_project/djust_forms/templates/forms/simple.html
@@ -41,18 +41,18 @@
             {% if success_message %}
             <div class="alert alert-success">
                 {{ success_message }}
-                <button type="button" class="btn-close float-end" @click="clear_message"></button>
+                <button type="button" class="btn-close float-end" dj-click="clear_message"></button>
             </div>
             {% endif %}
 
             {% if error_message %}
             <div class="alert alert-danger">
                 {{ error_message }}
-                <button type="button" class="btn-close float-end" @click="clear_message"></button>
+                <button type="button" class="btn-close float-end" dj-click="clear_message"></button>
             </div>
             {% endif %}
 
-            <form @submit="submit_form" onsubmit="return false;">
+            <form dj-submit="submit_form" onsubmit="return false;">
                 {% csrf_token %}
                 <!-- Name Field -->
                 <div class="mb-3">
@@ -63,7 +63,7 @@
                         id="name"
                         name="name"
                         value="{{ form_data.name }}"
-                        @change="validate_field"
+                        dj-change="validate_field"
                         data-field="name"
                         required
                     >
@@ -85,7 +85,7 @@
                         id="email"
                         name="email"
                         value="{{ form_data.email }}"
-                        @change="validate_field"
+                        dj-change="validate_field"
                         data-field="email"
                         required
                     >
@@ -106,7 +106,7 @@
                         id="message"
                         name="message"
                         rows="4"
-                        @change="validate_field"
+                        dj-change="validate_field"
                         data-field="message"
                         required
                     >{{ form_data.message }}</textarea>
@@ -121,7 +121,7 @@
 
                 <div class="d-grid gap-2">
                     <button type="submit" class="btn btn-primary">Send Message</button>
-                    <button type="button" class="btn btn-secondary" @click="reset_form">Reset</button>
+                    <button type="button" class="btn btn-secondary" dj-click="reset_form">Reset</button>
                 </div>
             </form>
 

--- a/examples/demo_project/djust_forms/templates/forms/status_change_djust.html
+++ b/examples/demo_project/djust_forms/templates/forms/status_change_djust.html
@@ -71,11 +71,11 @@
         </div>
         {% endif %}
 
-        <form @submit="submit_form">
+        <form dj-submit="submit_form">
 
             <!-- Employee Information Section -->
             <div class="card section-card">
-                <div class="section-header" @click="toggle_section('employee_info')">
+                <div class="section-header" dj-click="toggle_section('employee_info')">
                     <i class="fas fa-user"></i>
                     <h5 class="mb-0 flex-grow-1">Employee Information</h5>
                     <i class="fas fa-chevron-{{ sections_expanded.employee_info|yesno:'up,down' }}"></i>
@@ -90,7 +90,7 @@
                             <div class="invalid-feedback d-block">{{ form.employee.errors }}</div>
                             {% endif %}
                             {# Fire event when employee changes #}
-                            <select @change="on_employee_change" style="display:none"></select>
+                            <select dj-change="on_employee_change" style="display:none"></select>
                         </div>
 
                         <div class="col-md-6">
@@ -100,7 +100,7 @@
                             <div class="invalid-feedback d-block">{{ form.business_line.errors }}</div>
                             {% endif %}
                             {# Fire event when business line changes to filter executive approvers #}
-                            <select @change="on_business_line_change" style="display:none"></select>
+                            <select dj-change="on_business_line_change" style="display:none"></select>
                         </div>
 
                         <div class="col-md-6">
@@ -122,7 +122,7 @@
 
             <!-- Company Changes Section (ToFrom Pattern) -->
             <div class="card section-card">
-                <div class="section-header" @click="toggle_section('company_changes')">
+                <div class="section-header" dj-click="toggle_section('company_changes')">
                     <i class="fas fa-building"></i>
                     <h5 class="mb-0 flex-grow-1">Change Company</h5>
                     <i class="fas fa-chevron-{{ sections_expanded.company_changes|yesno:'up,down' }}"></i>
@@ -160,7 +160,7 @@
 
             <!-- Supervisor Changes Section (ToFrom Pattern) -->
             <div class="card section-card">
-                <div class="section-header" @click="toggle_section('supervisor_changes')">
+                <div class="section-header" dj-click="toggle_section('supervisor_changes')">
                     <i class="fas fa-users"></i>
                     <h5 class="mb-0 flex-grow-1">Change Supervisor</h5>
                     <i class="fas fa-chevron-{{ sections_expanded.supervisor_changes|yesno:'up,down' }}"></i>
@@ -198,7 +198,7 @@
 
             <!-- Project Information Section (Needs Pattern) -->
             <div class="card section-card">
-                <div class="section-header" @click="toggle_section('project_info')">
+                <div class="section-header" dj-click="toggle_section('project_info')">
                     <i class="fas fa-clipboard-list"></i>
                     <h5 class="mb-0 flex-grow-1">Add Project Information</h5>
                     <i class="fas fa-chevron-{{ sections_expanded.project_info|yesno:'up,down' }}"></i>
@@ -225,7 +225,7 @@
                             <label class="form-label">Project Duration</label>
                             {{ form.project_duration }}
                             {# Fire event when duration changes to show/hide expected_end_date #}
-                            <select @change="on_project_duration_change" style="display:none"></select>
+                            <select dj-change="on_project_duration_change" style="display:none"></select>
                         </div>
 
                         {% if show_expected_end_date %}
@@ -248,7 +248,7 @@
 
             <!-- Meals Per Diem Section (Needs Pattern with Calculations) -->
             <div class="card section-card">
-                <div class="section-header" @click="toggle_section('meals_per_diem')">
+                <div class="section-header" dj-click="toggle_section('meals_per_diem')">
                     <i class="fas fa-utensils"></i>
                     <h5 class="mb-0 flex-grow-1">Add Meals Per Diem</h5>
                     <i class="fas fa-chevron-{{ sections_expanded.meals_per_diem|yesno:'up,down' }}"></i>
@@ -270,14 +270,14 @@
                             <label class="form-label">Days Per Month on Jobsite</label>
                             {{ form.days_per_month_on_job_site }}
                             {# Fire calculation when this changes #}
-                            <input type="text" @input="calculate_monthly_per_diem" style="display:none">
+                            <input type="text" dj-input="calculate_monthly_per_diem" style="display:none">
                         </div>
 
                         <div class="col-md-6">
                             <label class="form-label">Per Diem Rate for Area</label>
                             {{ form.new_meals_per_diem_amount }}
                             {# Fire calculation when this changes #}
-                            <input type="text" @input="calculate_monthly_per_diem" style="display:none">
+                            <input type="text" dj-input="calculate_monthly_per_diem" style="display:none">
                         </div>
 
                         <div class="col-md-12">

--- a/examples/demo_project/djust_homepage/templates/homepage/index.html
+++ b/examples/demo_project/djust_homepage/templates/homepage/index.html
@@ -143,7 +143,7 @@ class CounterView(LiveView):
     template_string = """
     &lt;div&gt;
         &lt;h1&gt;Count: &#123;&#123; count &#125;&#125;&lt;/h1&gt;  &lt;!-- self.count is auto-available --&gt;
-        &lt;button @click="increment"&gt;+1&lt;/button&gt;
+        &lt;button dj-click="increment"&gt;+1&lt;/button&gt;
     &lt;/div&gt;
     """
 
@@ -503,7 +503,7 @@ class DashboardView(LiveView):
     &lt;div&gt;
         &lt;h1&gt;Dashboard &#123;&#123; badge.render &#125;&#125;&lt;/h1&gt;
 
-        &lt;button @click="add_notification"&gt;Add Notification&lt;/button&gt;
+        &lt;button dj-click="add_notification"&gt;Add Notification&lt;/button&gt;
 
         &#123;&#123; notification_list.render &#125;&#125;
     &lt;/div&gt;
@@ -602,7 +602,7 @@ class ProductListView(LiveView):
                                 <span>products.html</span>
                                 <span class="code-badge-modern">Template</span>
                             </div>
-                            <pre class="bg-white p-4" style="background: rgba(0, 0, 0, 0.2) !important;"><code class="language-html">&lt;input @input="on_search"
+                            <pre class="bg-white p-4" style="background: rgba(0, 0, 0, 0.2) !important;"><code class="language-html">&lt;input dj-input="on_search"
        placeholder="Search..."&gt;
 
 &#123;% for product in products %&#125;
@@ -771,7 +771,7 @@ export default function ProductList() {
                                 id="counter-display">
                                 {{ demo_counter }}
                             </div>
-                            <button @click="increment_counter"
+                            <button dj-click="increment_counter"
                                 style="background: var(--color-accent); color: white; border: none; padding: 0.75rem 2rem; border-radius: var(--radius-md); font-size: 1rem; font-weight: 600; cursor: pointer; transition: all var(--transition-fast);"
                                 onmouseover="this.style.background='#2563eb'; this.style.transform='translateY(-2px)'"
                                 onmouseout="this.style.background='var(--color-accent)'; this.style.transform='translateY(0)'">
@@ -796,7 +796,7 @@ export default function ProductList() {
                             </p>
                         </div>
                         <div class="p-6" style="background: var(--color-bg); min-height: 200px;">
-                            <input type="text" @input="on_search_demo" placeholder="Search programming languages..."
+                            <input type="text" dj-input="on_search_demo" placeholder="Search programming languages..."
                                 style="width: 100%; padding: 0.75rem 1rem; border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-bg-elevated); color: var(--color-text); font-size: 0.875rem; margin-bottom: 1rem;"
                                 value="{{ search_query }}" />
                             <div style="display: flex; flex-direction: column; gap: 0.5rem;">
@@ -831,7 +831,7 @@ export default function ProductList() {
                             </p>
                         </div>
                         <div class="p-6" style="background: var(--color-bg); min-height: 200px;">
-                            <form @submit="add_todo" style="display: flex; gap: 0.5rem; margin-bottom: 1rem;">
+                            <form dj-submit="add_todo" style="display: flex; gap: 0.5rem; margin-bottom: 1rem;">
                                 <input type="text" name="todo_text" placeholder="Add a task..."
                                     style="flex: 1; padding: 0.75rem 1rem; border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-bg-elevated); color: var(--color-text); font-size: 0.875rem;" />
                                 <button type="submit"
@@ -844,13 +844,13 @@ export default function ProductList() {
                                 {% for todo in demo_todos %}
                                 <div
                                     style="display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem; background: var(--color-bg-elevated); border: 1px solid var(--color-border); border-radius: var(--radius-sm);">
-                                    <input type="checkbox" {% if todo.done %}checked{% endif %} @change="toggle_todo"
+                                    <input type="checkbox" {% if todo.done %}checked{% endif %} dj-change="toggle_todo"
                                         data-index="{{ forloop.counter0 }}" style="cursor: pointer;">
                                     <span
                                         style="flex: 1; color: var(--color-text); font-size: 0.875rem; {% if todo.done %}text-decoration: line-through; opacity: 0.6;{% endif %}">
                                         {{ todo.text }}
                                     </span>
-                                    <button @click="delete_todo" data-index="{{ forloop.counter0 }}"
+                                    <button dj-click="delete_todo" data-index="{{ forloop.counter0 }}"
                                         style="background: transparent; border: 1px solid var(--color-border); color: var(--color-error); padding: 0.375rem 0.75rem; border-radius: var(--radius-sm); font-size: 0.75rem; cursor: pointer; transition: all var(--transition-fast);"
                                         onmouseover="this.style.background='var(--color-error)'; this.style.color='white'; this.style.borderColor='var(--color-error)';"
                                         onmouseout="this.style.background='transparent'; this.style.color='var(--color-error)'; this.style.borderColor='var(--color-border)';">
@@ -907,12 +907,12 @@ export default function ProductList() {
                     </p>
 
                     <div class="flex gap-3 justify-center items-center mb-4">
-                        <button @click="increment_notifications"
+                        <button dj-click="increment_notifications"
                             class="btn-primary-modern px-6 py-3 text-lg font-semibold">
                             <span class="text-xl mr-2">🔔</span>
                             Add Notification
                         </button>
-                        <button @click="reset_notifications"
+                        <button dj-click="reset_notifications"
                             class="btn-secondary-modern px-6 py-3 text-lg font-semibold">
                             <span class="text-xl mr-2">🔄</span>
                             Reset

--- a/examples/demo_project/djust_rentals/templates/rentals/financial_dashboard.html
+++ b/examples/demo_project/djust_rentals/templates/rentals/financial_dashboard.html
@@ -16,15 +16,15 @@
           <p class="text-foreground">{{ start_date|date:"M d, Y" }} - {{ end_date|date:"M d, Y" }}</p>
         </div>
         <div class="flex gap-2">
-          <button @click="change_period" data-period="month"
+          <button dj-click="change_period" data-period="month"
                   class="px-4 py-2 rounded-md text-sm font-medium transition-colors {% if period == 'month' %}bg-primary text-primary-foreground{% else %}bg-muted text-muted-foreground hover:bg-accent{% endif %}">
             Month
           </button>
-          <button @click="change_period" data-period="quarter"
+          <button dj-click="change_period" data-period="quarter"
                   class="px-4 py-2 rounded-md text-sm font-medium transition-colors {% if period == 'quarter' %}bg-primary text-primary-foreground{% else %}bg-muted text-muted-foreground hover:bg-accent{% endif %}">
             Quarter
           </button>
-          <button @click="change_period" data-period="year"
+          <button dj-click="change_period" data-period="year"
                   class="px-4 py-2 rounded-md text-sm font-medium transition-colors {% if period == 'year' %}bg-primary text-primary-foreground{% else %}bg-muted text-muted-foreground hover:bg-accent{% endif %}">
             Year
           </button>

--- a/examples/demo_project/djust_rentals/templates/rentals/lease_form.html
+++ b/examples/demo_project/djust_rentals/templates/rentals/lease_form.html
@@ -22,7 +22,7 @@
     </div>
     {% endif %}
 
-    <form @submit="save_lease" class="bg-card border border-border rounded-lg p-6">
+    <form dj-submit="save_lease" class="bg-card border border-border rounded-lg p-6">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <!-- Property -->
         <div>

--- a/examples/demo_project/djust_rentals/templates/rentals/lease_list.html
+++ b/examples/demo_project/djust_rentals/templates/rentals/lease_list.html
@@ -20,7 +20,7 @@
             </div>
           </label>
           <input type="text"
-                 @input="search"
+                 dj-input="search"
                  value="{{ search_query }}"
                  placeholder="Search by property or tenant..."
                  class="w-full px-3 py-2 bg-background border border-input rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent">
@@ -34,7 +34,7 @@
               Status
             </div>
           </label>
-          <select @change="filter_by_status"
+          <select dj-change="filter_by_status"
                   class="w-full px-3 py-2 bg-background border border-input rounded-md text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent">
             <option value="all" {% if filter_status == 'all' %}selected{% endif %}>All Statuses</option>
             {% for val, label in status_choices %}
@@ -51,7 +51,7 @@
               Sort By
             </div>
           </label>
-          <select @change="sort_leases"
+          <select dj-change="sort_leases"
                   class="w-full px-3 py-2 bg-background border border-input rounded-md text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent">
             <option value="end_date" {% if sort_by == 'end_date' %}selected{% endif %}>End Date</option>
             <option value="start_date" {% if sort_by == 'start_date' %}selected{% endif %}>Start Date</option>

--- a/examples/demo_project/djust_rentals/templates/rentals/maintenance_list.html
+++ b/examples/demo_project/djust_rentals/templates/rentals/maintenance_list.html
@@ -20,7 +20,7 @@
             </div>
           </label>
           <input type="text"
-                 @input="search"
+                 dj-input="search"
                  value="{{ search_query }}"
                  placeholder="Search by title, description, or property..."
                  class="w-full px-3 py-2 bg-background border border-input rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent">
@@ -34,7 +34,7 @@
               Priority
             </div>
           </label>
-          <select @change="filter_by_priority"
+          <select dj-change="filter_by_priority"
                   class="w-full px-3 py-2 bg-background border border-input rounded-md text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent">
             <option value="all" {% if filter_priority == 'all' %}selected{% endif %}>All Priorities</option>
             {% for val, label in priority_choices %}
@@ -51,7 +51,7 @@
               Status
             </div>
           </label>
-          <select @change="filter_by_status"
+          <select dj-change="filter_by_status"
                   class="w-full px-3 py-2 bg-background border border-input rounded-md text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent">
             <option value="pending" {% if filter_status == 'pending' %}selected{% endif %}>Pending (Open + In Progress)</option>
             <option value="all" {% if filter_status == 'all' %}selected{% endif %}>All Statuses</option>
@@ -69,7 +69,7 @@
               Sort By
             </div>
           </label>
-          <select @change="sort_requests"
+          <select dj-change="sort_requests"
                   class="w-full px-3 py-2 bg-background border border-input rounded-md text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent">
             <option value="created" {% if sort_by == 'created' %}selected{% endif %}>Date Created</option>
             <option value="priority" {% if sort_by == 'priority' %}selected{% endif %}>Priority</option>

--- a/examples/demo_project/djust_rentals/templates/rentals/maintenance_update.html
+++ b/examples/demo_project/djust_rentals/templates/rentals/maintenance_update.html
@@ -32,7 +32,7 @@
         <div class="flex flex-wrap gap-2">
           {% for val, label in status_choices %}
           <button
-            @click="update_status"
+            dj-click="update_status"
             data-status="{{ val }}"
             class="inline-flex items-center gap-2 px-4 py-2 rounded-md font-medium transition-colors border
             {% if request.status == val %}
@@ -73,7 +73,7 @@
         <div class="flex flex-wrap gap-2">
           {% for val, label in priority_choices %}
           <button
-            @click="update_priority"
+            dj-click="update_priority"
             data-priority="{{ val }}"
             class="inline-flex items-center gap-2 px-4 py-2 rounded-md font-medium transition-colors border
             {% if request.priority == val %}
@@ -97,7 +97,7 @@
       </div>
 
       <!-- Update Details Form -->
-      <form @submit="update_details" class="space-y-4 pt-6 border-t border-border">
+      <form dj-submit="update_details" class="space-y-4 pt-6 border-t border-border">
         <div class="flex items-center gap-2 mb-3">
           <i data-lucide="file-edit" class="w-5 h-5 text-primary"></i>
           <h3 class="text-lg font-semibold text-card-foreground">Update Details</h3>

--- a/examples/demo_project/djust_rentals/templates/rentals/property_delete.html
+++ b/examples/demo_project/djust_rentals/templates/rentals/property_delete.html
@@ -76,7 +76,7 @@
       <!-- Action Buttons -->
       <div class="flex gap-3 pt-4 border-t border-border">
         {% if not has_active_lease %}
-        <button @click="confirm_delete" class="inline-flex items-center gap-2 px-6 py-2 rounded-md font-medium transition-colors bg-destructive text-destructive-foreground hover:bg-destructive/90">
+        <button dj-click="confirm_delete" class="inline-flex items-center gap-2 px-6 py-2 rounded-md font-medium transition-colors bg-destructive text-destructive-foreground hover:bg-destructive/90">
           <i data-lucide="trash-2" class="w-4 h-4"></i>
           Delete Property
         </button>

--- a/examples/demo_project/djust_rentals/templates/rentals/property_form.html
+++ b/examples/demo_project/djust_rentals/templates/rentals/property_form.html
@@ -22,7 +22,7 @@
     </div>
     {% endif %}
 
-    <form @submit="save_property" class="bg-card border border-border rounded-lg p-6">
+    <form dj-submit="save_property" class="bg-card border border-border rounded-lg p-6">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <!-- Property Name -->
         <div class="md:col-span-2">

--- a/examples/demo_project/djust_rentals/templates/rentals/property_list.html
+++ b/examples/demo_project/djust_rentals/templates/rentals/property_list.html
@@ -20,7 +20,7 @@
             </div>
           </label>
           <input type="text"
-                 @input="search"
+                 dj-input="search"
                  value="{{ search_query }}"
                  placeholder="Search by name, address, or city..."
                  class="w-full px-3 py-2 bg-background border border-input rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent">
@@ -34,7 +34,7 @@
               Status
             </div>
           </label>
-          <select @change="filter_by_status"
+          <select dj-change="filter_by_status"
                   class="w-full px-3 py-2 bg-background border border-input rounded-md text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent">
             <option value="all" {% if filter_status == 'all' %}selected{% endif %}>All Statuses</option>
             {% for choice in status_choices %}
@@ -51,7 +51,7 @@
               Property Type
             </div>
           </label>
-          <select @change="filter_by_type"
+          <select dj-change="filter_by_type"
                   class="w-full px-3 py-2 bg-background border border-input rounded-md text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent">
             <option value="all" {% if filter_type == 'all' %}selected{% endif %}>All Types</option>
             {% for choice in property_types %}

--- a/examples/demo_project/djust_rentals/templates/rentals/tenant_form.html
+++ b/examples/demo_project/djust_rentals/templates/rentals/tenant_form.html
@@ -22,7 +22,7 @@
     </div>
     {% endif %}
 
-    <form @submit="save_tenant" class="bg-card border border-border rounded-lg p-6">
+    <form dj-submit="save_tenant" class="bg-card border border-border rounded-lg p-6">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <!-- First Name -->
         <div>

--- a/examples/demo_project/djust_rentals/templates/rentals/tenant_list.html
+++ b/examples/demo_project/djust_rentals/templates/rentals/tenant_list.html
@@ -20,7 +20,7 @@
             </div>
           </label>
           <input type="text"
-                 @input="search"
+                 dj-input="search"
                  value="{{ search_query }}"
                  placeholder="Search by name, email, or phone..."
                  class="w-full px-3 py-2 bg-background border border-input rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent">
@@ -34,7 +34,7 @@
               Lease Status
             </div>
           </label>
-          <select @change="filter_by_status"
+          <select dj-change="filter_by_status"
                   class="w-full px-3 py-2 bg-background border border-input rounded-md text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent">
             <option value="all" {% if filter_status == 'all' %}selected{% endif %}>All Tenants</option>
             <option value="active" {% if filter_status == 'active' %}selected{% endif %}>Active Leases</option>

--- a/examples/demo_project/djust_rentals/templates/rentals/tenant_maintenance_create.html
+++ b/examples/demo_project/djust_rentals/templates/rentals/tenant_maintenance_create.html
@@ -40,7 +40,7 @@
         <p class="text-sm text-muted-foreground">{{ current_property.address }}</p>
       </div>
 
-      <form @submit="submit_request" class="space-y-6">
+      <form dj-submit="submit_request" class="space-y-6">
         <!-- Issue Title -->
         <div>
           <label class="block text-sm font-medium text-card-foreground mb-1">

--- a/examples/demo_project/djust_rentals/templates/rentals/tenant_maintenance_list.html
+++ b/examples/demo_project/djust_rentals/templates/rentals/tenant_maintenance_list.html
@@ -17,13 +17,13 @@
     <!-- Status Filter -->
     <div class="bg-card border border-border rounded-lg p-4 mb-6">
       <div class="flex flex-wrap gap-2">
-        <button @click="filter_by_status" data-status="all" class="inline-flex items-center gap-2 px-4 py-2 rounded-md font-medium transition-colors border
+        <button dj-click="filter_by_status" data-status="all" class="inline-flex items-center gap-2 px-4 py-2 rounded-md font-medium transition-colors border
           {% if filter_status == 'all' %}bg-primary text-primary-foreground border-primary{% else %}bg-muted text-muted-foreground border-border hover:bg-accent{% endif %}">
           <i data-lucide="list" class="w-4 h-4"></i>
           All ({{ total_count }})
         </button>
         {% for val, label in status_choices %}
-        <button @click="filter_by_status" data-status="{{ val }}" class="inline-flex items-center gap-2 px-4 py-2 rounded-md font-medium transition-colors border
+        <button dj-click="filter_by_status" data-status="{{ val }}" class="inline-flex items-center gap-2 px-4 py-2 rounded-md font-medium transition-colors border
           {% if filter_status == val %}
             {% if val == 'completed' %}bg-green-500 text-white border-green-500
             {% elif val == 'in_progress' %}bg-blue-500 text-white border-blue-500

--- a/examples/demo_project/djust_tests/templates/tests/cache_test.html
+++ b/examples/demo_project/djust_tests/templates/tests/cache_test.html
@@ -131,7 +131,7 @@
                     type="text"
                     name="query"
                     class="form-control form-control-lg"
-                    @input="search"
+                    dj-input="search"
                     placeholder="Type to test manually..."
                     value="{{ query }}"
                     autocomplete="off"
@@ -249,7 +249,7 @@
             }
             updateCacheEfficiency();
 
-            // Dispatch input event (will trigger @input="search" handler)
+            // Dispatch input event (will trigger dj-input="search" handler)
             input.value = value;
             input.dispatchEvent(new Event('input', { bubbles: true }));
 

--- a/examples/demo_project/djust_tests/templates/tests/draft_mode_test.html
+++ b/examples/demo_project/djust_tests/templates/tests/draft_mode_test.html
@@ -124,7 +124,7 @@ Testing localStorage auto-save with 500ms debounce, auto-restore, and draft clea
             <div class="d-flex gap-2">
                 <button
                     class="btn btn-primary"
-                    @click="save_article"
+                    dj-click="save_article"
                     data-title="title"
                     data-content="content"
                     data-author="author"
@@ -134,7 +134,7 @@ Testing localStorage auto-save with 500ms debounce, auto-restore, and draft clea
                 </button>
                 <button
                     class="btn btn-outline-secondary"
-                    @click="discard_draft"
+                    dj-click="discard_draft"
                 >
                     <i class="bi bi-trash me-2"></i>
                     Discard Draft

--- a/examples/demo_project/djust_tests/templates/tests/loading_test.html
+++ b/examples/demo_project/djust_tests/templates/tests/loading_test.html
@@ -9,7 +9,7 @@
 {% block page_title %}@loading Attribute Automated Test{% endblock %}
 
 {% block page_description %}
-Testing @loading.disable, @loading.class, @loading.show, @loading.hide HTML attributes
+Testing dj-loading.disable, dj-loading.class, dj-loading.show, dj-loading.hide HTML attributes
 {% endblock %}
 
 {% block content %}
@@ -84,68 +84,68 @@ Testing @loading.disable, @loading.class, @loading.show, @loading.hide HTML attr
                 Watch for visual feedback (disabled state, opacity changes, spinner visibility).
             </div>
 
-            <h6 class="mt-4 mb-3">Test 1: @loading.disable</h6>
+            <h6 class="mt-4 mb-3">Test 1: dj-loading.disable</h6>
             <p class="text-muted">Button should be disabled during 1-second operation</p>
             <button
                 class="btn btn-primary btn-lg"
-                @click="slow_operation"
-                @loading.disable>
+                dj-click="slow_operation"
+                dj-loading.disable>
                 <i class="bi bi-clock me-2"></i>
                 Slow Operation (1s)
             </button>
 
-            <h6 class="mt-4 mb-3">Test 2: @loading.class="opacity-25"</h6>
+            <h6 class="mt-4 mb-3">Test 2: dj-loading.class="opacity-25"</h6>
             <p class="text-muted">Button should become very transparent during operation (NOT disabled)</p>
             <button
                 class="btn btn-success btn-lg"
-                @click="slow_operation"
-                @loading.class="opacity-25">
+                dj-click="slow_operation"
+                dj-loading.class="opacity-25">
                 <i class="bi bi-lightning me-2"></i>
                 Opacity Effect (stays enabled)
             </button>
 
-            <h6 class="mt-4 mb-3">Test 3: @loading.disable + @loading.class="opacity-25"</h6>
+            <h6 class="mt-4 mb-3">Test 3: dj-loading.disable + dj-loading.class="opacity-25"</h6>
             <p class="text-muted">Button should be disabled AND very transparent</p>
             <button
                 class="btn btn-warning btn-lg"
-                @click="slow_operation"
-                @loading.disable
-                @loading.class="opacity-25">
+                dj-click="slow_operation"
+                dj-loading.disable
+                dj-loading.class="opacity-25">
                 <i class="bi bi-cpu me-2"></i>
                 Combined: disabled + opacity
             </button>
 
-            <h6 class="mt-4 mb-3">Test 4: @loading.show (spinner)</h6>
+            <h6 class="mt-4 mb-3">Test 4: dj-loading.show (spinner)</h6>
             <p class="text-muted">Spinner should appear during operation</p>
             <div class="d-flex align-items-center gap-3">
                 <button
                     class="btn btn-info btn-lg"
-                    @click="fast_operation">
+                    dj-click="fast_operation">
                     <i class="bi bi-play me-2"></i>
                     Fast Operation (100ms)
                 </button>
                 <div
-                    @loading.show
+                    dj-loading.show
                     style="display: none;"
                     class="spinner-border text-primary"
                     role="status">
                     <span class="visually-hidden">Loading...</span>
                 </div>
-                <span @loading.show style="display: none;" class="text-primary">
+                <span dj-loading.show style="display: none;" class="text-primary">
                     Processing...
                 </span>
             </div>
 
-            <h6 class="mt-4 mb-3">Test 5: @loading.hide (content)</h6>
+            <h6 class="mt-4 mb-3">Test 5: dj-loading.hide (content)</h6>
             <p class="text-muted">Content should hide during operation</p>
             <div class="d-flex align-items-center gap-3">
                 <button
                     class="btn btn-secondary btn-lg"
-                    @click="fast_operation">
+                    dj-click="fast_operation">
                     <i class="bi bi-eye-slash me-2"></i>
                     Hide Content Test
                 </button>
-                <div @loading.hide class="alert alert-success mb-0 py-2">
+                <div dj-loading.hide class="alert alert-success mb-0 py-2">
                     This content will disappear during loading
                 </div>
             </div>
@@ -210,10 +210,10 @@ Testing @loading.disable, @loading.class, @loading.show, @loading.hide HTML attr
         <div class="card-body">
             <h6>Available Modifiers:</h6>
             <ul>
-                <li><code class="code-block d-inline">@loading.disable</code> - Disables button/input during loading (also gets Bootstrap's default opacity: 0.65)</li>
-                <li><code class="code-block d-inline">@loading.class="class-name"</code> - Adds CSS class during loading (e.g., opacity-25, border-danger)</li>
-                <li><code class="code-block d-inline">@loading.show</code> - Shows element (display: block) during loading</li>
-                <li><code class="code-block d-inline">@loading.hide</code> - Hides element (display: none) during loading</li>
+                <li><code class="code-block d-inline">dj-loading.disable</code> - Disables button/input during loading (also gets Bootstrap's default opacity: 0.65)</li>
+                <li><code class="code-block d-inline">dj-loading.class="class-name"</code> - Adds CSS class during loading (e.g., opacity-25, border-danger)</li>
+                <li><code class="code-block d-inline">dj-loading.show</code> - Shows element (display: block) during loading</li>
+                <li><code class="code-block d-inline">dj-loading.hide</code> - Hides element (display: none) during loading</li>
             </ul>
 
             <h6 class="mt-3">Visual Differences:</h6>
@@ -308,8 +308,8 @@ function runLoadingTests() {
                 // Test 4: After slow operation completes, test fast operation
                 setTimeout(() => {
                     console.log('[Test] Simulating fast operation click...');
-                    // Find button that has @click="fast_operation"
-                    const fastButton = document.querySelector('button[\\@click="fast_operation"]');
+                    // Find button that has dj-click="fast_operation"
+                    const fastButton = document.querySelector('button[\\dj-click="fast_operation"]');
                     if (fastButton) {
                         fastButton.click();
                         // Wait for fast operation to complete (100ms + buffer)
@@ -323,7 +323,7 @@ function runLoadingTests() {
         } else {
             addClientTest(
                 'Button Disabled During Loading',
-                'Should find button with @loading.disable',
+                'Should find button with dj-loading.disable',
                 'Button not found',
                 false
             );

--- a/examples/demo_project/templates/components-guide.html
+++ b/examples/demo_project/templates/components-guide.html
@@ -1335,7 +1335,7 @@
 
                     <h3>Step 1: User Clicks Button</h3>
                     <p>
-                        When a user clicks the button in the browser, the <code>@click</code> directive tells the djust client JavaScript to capture this event. The <code>@click="increment_notifications"</code> attribute specifies which event handler method should be called on the server-side LiveView. No page reload occurs - this is entirely handled via WebSocket.
+                        When a user clicks the button in the browser, the <code>@click</code> directive tells the djust client JavaScript to capture this event. The <code>dj-click="increment_notifications"</code> attribute specifies which event handler method should be called on the server-side LiveView. No page reload occurs - this is entirely handled via WebSocket.
                     </p>
                     <div class="code-block-with-header">
                         <div class="code-header">
@@ -1343,7 +1343,7 @@
                             <span class="file-path">examples/demo_project/templates/index.html</span>
                         </div>
                         <div class="code-content">
-<pre><code class="language-html">&lt;button @click="increment_notifications"&gt;
+<pre><code class="language-html">&lt;button dj-click="increment_notifications"&gt;
     Add Notification
 &lt;/button&gt;</code></pre>
                         </div>
@@ -1550,7 +1550,7 @@ context['button'] = ButtonComponent(
                         </div>
                         <div class="code-content">
 <pre><code class="language-html">&lt;!-- Template --&gt;
-&lt;button @click="handle_button_click"&gt;Click Me&lt;/button&gt;</code></pre>
+&lt;button dj-click="handle_button_click"&gt;Click Me&lt;/button&gt;</code></pre>
 <pre><code class="language-python"># LiveView
 def handle_button_click(self):
     self.is_loading = True
@@ -1713,11 +1713,11 @@ def handle_button_click(self):
                     <p>This page itself demonstrates component communication:</p>
 
                     <div class="text-center my-4">
-                        <button @click="increment_demo_count"
+                        <button dj-click="increment_demo_count"
                                 class="btn btn-primary btn-lg me-2">
                             Increment Counter
                         </button>
-                        <button @click="reset_demo_count"
+                        <button dj-click="reset_demo_count"
                                 class="btn btn-secondary btn-lg">
                             Reset
                         </button>

--- a/examples/demo_project/templates/docs.html
+++ b/examples/demo_project/templates/docs.html
@@ -630,11 +630,11 @@ urlpatterns = [
                 <h3>Event Handlers</h3>
                 <p>Define methods to handle user interactions:</p>
                 <pre><code class="language-python">def increment(self):
-    """Called when element with @click="increment" is clicked"""
+    """Called when element with dj-click="increment" is clicked"""
     self.counter += 1
 
 def handle_submit(self):
-    """Called when form with @submit="handle_submit" is submitted"""
+    """Called when form with dj-submit="handle_submit" is submitted"""
     # Access form data via self.form_data
     query = self.form_data.get('query', '')
     self.results = search(query)
@@ -772,22 +772,22 @@ self.alert_success = AlertComponent(message="Success!")
                         <tr>
                             <td><code>@click</code></td>
                             <td>Handle click events</td>
-                            <td><code>&lt;button @click="increment"&gt;</code></td>
+                            <td><code>&lt;button dj-click="increment"&gt;</code></td>
                         </tr>
                         <tr>
                             <td><code>@submit</code></td>
                             <td>Handle form submissions</td>
-                            <td><code>&lt;form @submit="handle_submit"&gt;</code></td>
+                            <td><code>&lt;form dj-submit="handle_submit"&gt;</code></td>
                         </tr>
                         <tr>
                             <td><code>@change</code></td>
                             <td>Handle input changes</td>
-                            <td><code>&lt;input @change="validate_field"&gt;</code></td>
+                            <td><code>&lt;input dj-change="validate_field"&gt;</code></td>
                         </tr>
                         <tr>
                             <td><code>@input</code></td>
                             <td>Handle input while typing</td>
-                            <td><code>&lt;input @input="live_search"&gt;</code></td>
+                            <td><code>&lt;input dj-input="live_search"&gt;</code></td>
                         </tr>
                     </tbody>
                 </table>
@@ -796,7 +796,7 @@ self.alert_success = AlertComponent(message="Success!")
                 <p>Pass data to event handlers using <code>data-*</code> attributes:</p>
                 <pre><code class="language-html">&lt;!-- Template --&gt;
 &lt;button
-    @click="delete_item"
+    dj-click="delete_item"
     data-item-id="&#123;&#123; item.id &#125;&#125;"
     data-confirm="true"
 &gt;
@@ -870,7 +870,7 @@ class ContactFormView(LiveView):
 {&#37; load djust &#37;}
 
 &lt;div data-liveview-root&gt;
-    &lt;form @submit="handle_submit"&gt;
+    &lt;form dj-submit="handle_submit"&gt;
         {&#37; auto_form form framework="bootstrap5" &#37;}
 
         &lt;button type="submit" class="btn btn-primary"&gt;Submit&lt;/button&gt;
@@ -913,7 +913,7 @@ class ContactFormView(LiveView):
                 <pre><code class="language-html">&lt;input
     type="text"
     name="username"
-    @change="validate_username"
+    dj-change="validate_username"
     class="form-control"
 &gt;
 {&#37; if username_error &#37;}
@@ -990,7 +990,7 @@ def mount(self, request):
 {&#37; for item in items &#37;}
     &lt;div class="item"&gt;
         &lt;h3&gt;&#123;&#123; item.title &#125;&#125;&lt;/h3&gt;
-        &lt;button @click="delete" data-item-id="&#123;&#123; item.id &#125;&#125;"&gt;Delete&lt;/button&gt;
+        &lt;button dj-click="delete" data-item-id="&#123;&#123; item.id &#125;&#125;"&gt;Delete&lt;/button&gt;
     &lt;/div&gt;
 {&#37; empty &#37;}
     &lt;p&gt;No items found.&lt;/p&gt;
@@ -1133,7 +1133,7 @@ class UserCardComponent(LiveComponent):
 
         {&#37; if show_actions &#37;}
             &lt;button
-                @click="toggle_follow"
+                dj-click="toggle_follow"
                 class="btn btn-{&#37; if is_following &#37;}secondary{&#37; else &#37;}primary{&#37; endif &#37;}"
             &gt;
                 {&#37; if is_following &#37;}Unfollow{&#37; else &#37;}Follow{&#37; endif &#37;}
@@ -1237,7 +1237,7 @@ class ProfileView(LiveView):
                 <p>Apply classes conditionally based on state:</p>
                 <pre><code class="language-html">&lt;button
     class="btn {&#37; if is_active &#37;}btn-primary{&#37; else &#37;}btn-secondary{&#37; endif &#37;}"
-    @click="toggle"
+    dj-click="toggle"
 &gt;
     Toggle
 &lt;/button&gt;
@@ -1495,22 +1495,22 @@ uvicorn myproject.asgi:application --host 0.0.0.0 --port 8000 --workers 4</code>
                         <tr>
                             <td><code>@click</code></td>
                             <td>Element clicked</td>
-                            <td><code>&lt;button @click="increment"&gt;</code></td>
+                            <td><code>&lt;button dj-click="increment"&gt;</code></td>
                         </tr>
                         <tr>
                             <td><code>@submit</code></td>
                             <td>Form submitted</td>
-                            <td><code>&lt;form @submit="handle_form"&gt;</code></td>
+                            <td><code>&lt;form dj-submit="handle_form"&gt;</code></td>
                         </tr>
                         <tr>
                             <td><code>@change</code></td>
                             <td>Input value changed</td>
-                            <td><code>&lt;select @change="filter"&gt;</code></td>
+                            <td><code>&lt;select dj-change="filter"&gt;</code></td>
                         </tr>
                         <tr>
                             <td><code>@input</code></td>
                             <td>Input while typing</td>
-                            <td><code>&lt;input @input="search"&gt;</code></td>
+                            <td><code>&lt;input dj-input="search"&gt;</code></td>
                         </tr>
                     </tbody>
                 </table>

--- a/examples/demo_project/templates/index.html
+++ b/examples/demo_project/templates/index.html
@@ -127,7 +127,7 @@ class CounterView(LiveView):
     template_string = """
     &lt;div&gt;
         &lt;h1&gt;Count: &#123;&#123; count &#125;&#125;&lt;/h1&gt;  &lt;!-- self.count is auto-available --&gt;
-        &lt;button @click="increment"&gt;+1&lt;/button&gt;
+        &lt;button dj-click="increment"&gt;+1&lt;/button&gt;
     &lt;/div&gt;
     """
 
@@ -370,7 +370,7 @@ class DashboardView(LiveView):
     &lt;div&gt;
         &lt;h1&gt;Dashboard &#123;&#123; badge.render &#125;&#125;&lt;/h1&gt;
 
-        &lt;button @click="add_notification"&gt;Add Notification&lt;/button&gt;
+        &lt;button dj-click="add_notification"&gt;Add Notification&lt;/button&gt;
 
         &#123;&#123; notification_list.render &#125;&#125;
     &lt;/div&gt;
@@ -464,7 +464,7 @@ class ProductListView(LiveView):
                         <span>products.html</span>
                         <span class="code-badge-modern">Template</span>
                     </div>
-                    <pre class="bg-white p-4" style="background: rgba(0, 0, 0, 0.2) !important;"><code class="language-html">&lt;input @input="on_search"
+                    <pre class="bg-white p-4" style="background: rgba(0, 0, 0, 0.2) !important;"><code class="language-html">&lt;input dj-input="on_search"
        placeholder="Search..."&gt;
 
 &#123;% for product in products %&#125;
@@ -616,7 +616,7 @@ export default function ProductList() {
                     <div style="font-size: 3rem; font-weight: 800; color: var(--color-accent);" id="counter-display">
                         {{ demo_counter }}
                     </div>
-                    <button @click="increment_counter" style="background: var(--color-accent); color: white; border: none; padding: 0.75rem 2rem; border-radius: var(--radius-md); font-size: 1rem; font-weight: 600; cursor: pointer; transition: all var(--transition-fast);" onmouseover="this.style.background='#2563eb'; this.style.transform='translateY(-2px)'" onmouseout="this.style.background='var(--color-accent)'; this.style.transform='translateY(0)'">
+                    <button dj-click="increment_counter" style="background: var(--color-accent); color: white; border: none; padding: 0.75rem 2rem; border-radius: var(--radius-md); font-size: 1rem; font-weight: 600; cursor: pointer; transition: all var(--transition-fast);" onmouseover="this.style.background='#2563eb'; this.style.transform='translateY(-2px)'" onmouseout="this.style.background='var(--color-accent)'; this.style.transform='translateY(0)'">
                         Click to Increment
                     </button>
                     <div class="text-xs" style="color: var(--color-text-subtle);">
@@ -639,7 +639,7 @@ export default function ProductList() {
                 <div class="p-6" style="background: var(--color-bg); min-height: 200px;">
                     <input
                         type="text"
-                        @input="on_search_demo"
+                        dj-input="on_search_demo"
                         placeholder="Search programming languages..."
                         style="width: 100%; padding: 0.75rem 1rem; border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-bg-elevated); color: var(--color-text); font-size: 0.875rem; margin-bottom: 1rem;"
                         value="{{ search_query }}"
@@ -672,7 +672,7 @@ export default function ProductList() {
                     </p>
                 </div>
                 <div class="p-6" style="background: var(--color-bg); min-height: 200px;">
-                    <form @submit="add_todo" style="display: flex; gap: 0.5rem; margin-bottom: 1rem;">
+                    <form dj-submit="add_todo" style="display: flex; gap: 0.5rem; margin-bottom: 1rem;">
                         <input
                             type="text"
                             name="todo_text"
@@ -687,11 +687,11 @@ export default function ProductList() {
                         {% if demo_todos %}
                             {% for todo in demo_todos %}
                             <div style="display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem; background: var(--color-bg-elevated); border: 1px solid var(--color-border); border-radius: var(--radius-sm);">
-                                <input type="checkbox" {% if todo.done %}checked{% endif %} @change="toggle_todo" data-index="{{ forloop.counter0 }}" style="cursor: pointer;">
+                                <input type="checkbox" {% if todo.done %}checked{% endif %} dj-change="toggle_todo" data-index="{{ forloop.counter0 }}" style="cursor: pointer;">
                                 <span style="flex: 1; color: var(--color-text); font-size: 0.875rem; {% if todo.done %}text-decoration: line-through; opacity: 0.6;{% endif %}">
                                     {{ todo.text }}
                                 </span>
-                                <button @click="delete_todo" data-index="{{ forloop.counter0 }}" style="background: transparent; border: 1px solid var(--color-border); color: var(--color-error); padding: 0.375rem 0.75rem; border-radius: var(--radius-sm); font-size: 0.75rem; cursor: pointer; transition: all var(--transition-fast);" onmouseover="this.style.background='var(--color-error)'; this.style.color='white'; this.style.borderColor='var(--color-error)';" onmouseout="this.style.background='transparent'; this.style.color='var(--color-error)'; this.style.borderColor='var(--color-border)';">
+                                <button dj-click="delete_todo" data-index="{{ forloop.counter0 }}" style="background: transparent; border: 1px solid var(--color-border); color: var(--color-error); padding: 0.375rem 0.75rem; border-radius: var(--radius-sm); font-size: 0.75rem; cursor: pointer; transition: all var(--transition-fast);" onmouseover="this.style.background='var(--color-error)'; this.style.color='white'; this.style.borderColor='var(--color-error)';" onmouseout="this.style.background='transparent'; this.style.color='var(--color-error)'; this.style.borderColor='var(--color-border)';">
                                     Delete
                                 </button>
                             </div>
@@ -740,12 +740,12 @@ export default function ProductList() {
             </p>
 
             <div class="flex gap-3 justify-center items-center mb-4">
-                <button @click="increment_notifications"
+                <button dj-click="increment_notifications"
                         class="btn-primary-modern px-6 py-3 text-lg font-semibold">
                     <span class="text-xl mr-2">🔔</span>
                     Add Notification
                 </button>
-                <button @click="reset_notifications"
+                <button dj-click="reset_notifications"
                         class="btn-secondary-modern px-6 py-3 text-lg font-semibold">
                     <span class="text-xl mr-2">🔄</span>
                     Reset

--- a/examples/demo_project/templates/kitchen_sink.html
+++ b/examples/demo_project/templates/kitchen_sink.html
@@ -426,7 +426,7 @@
                             <h3 class="text-lg font-bold mb-3 mt-4" style="color: var(--color-text);">Modals</h3>
                             <div class="component-demo">
                                 <div class="demo-label">Modal Dialogs</div>
-                                <button @click="show_modal" class="btn-primary-modern">
+                                <button dj-click="show_modal" class="btn-primary-modern">
                                     <span>Show Modal</span>
                                 </button>
                                 {{ modal_example.render }}
@@ -442,10 +442,10 @@
                                     {{ progress_custom.render }}
                                 </div>
                                 <div class="flex gap-2 mt-3">
-                                    <button @click="increment_progress" class="btn-primary-modern">
+                                    <button dj-click="increment_progress" class="btn-primary-modern">
                                         <span>Increment</span>
                                     </button>
-                                    <button @click="reset_progress" class="btn-secondary-modern">
+                                    <button dj-click="reset_progress" class="btn-secondary-modern">
                                         <span>Reset</span>
                                     </button>
                                 </div>
@@ -567,8 +567,8 @@ class CounterView(LiveView):
                                 <div class="code-block-modern">
                                     <pre style="margin: 0; padding: 1rem; background: var(--color-bg); border-radius: 0 0 var(--radius-md) var(--radius-md);"><code class="language-html">&lt;div data-liveview-root&gt;
   &lt;h1&gt;Count: &#123;&#123; count &#125;&#125;&lt;/h1&gt;
-  &lt;button @click="increment"&gt;+&lt;/button&gt;
-  &lt;button @click="decrement"&gt;-&lt;/button&gt;
+  &lt;button dj-click="increment"&gt;+&lt;/button&gt;
+  &lt;button dj-click="decrement"&gt;-&lt;/button&gt;
 &lt;/div&gt;
 
 &lt;script src="/static/djust/client.js"&gt;&lt;/script&gt;</code></pre>

--- a/examples/demo_project/templates/kitchen_sink_content.html
+++ b/examples/demo_project/templates/kitchen_sink_content.html
@@ -86,7 +86,7 @@
             <h3>Modal Dialogs</h3>
             <div class="component-demo">
                 <div class="demo-label">Modal Example</div>
-                <button class="btn btn-primary" @click="show_modal">Open Modal</button>
+                <button class="btn btn-primary" dj-click="show_modal">Open Modal</button>
                 <p class="text-muted mt-2 mb-0">
                     <small>Modal opened: <strong>{{ modal_open_count }}</strong> time(s)</small>
                 </p>
@@ -112,8 +112,8 @@
                     {{ progress_custom.render }}
                 </div>
                 <div class="mt-3">
-                    <button class="btn btn-sm btn-primary" @click="increment_progress">Increment (+10%)</button>
-                    <button class="btn btn-sm btn-secondary ms-2" @click="reset_progress">Reset</button>
+                    <button class="btn btn-sm btn-primary" dj-click="increment_progress">Increment (+10%)</button>
+                    <button class="btn btn-sm btn-secondary ms-2" dj-click="reset_progress">Reset</button>
                 </div>
             </div>
         </div>

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -95,7 +95,7 @@ function reinitLiveViewForTurboNav() {
     // Re-bind events
     bindLiveViewEvents();
 
-    // Re-scan @loading attributes
+    // Re-scan dj-loading attributes
     globalLoadingManager.scanAndRegister();
 
     console.log('[LiveView:TurboNav] Reinitialization complete');
@@ -1403,8 +1403,8 @@ function bindLiveViewEvents() {
     // Find all interactive elements
     const allElements = document.querySelectorAll('*');
     allElements.forEach(element => {
-        // Handle @click events
-        const clickHandler = element.getAttribute('@click');
+        // Handle dj-click events
+        const clickHandler = element.getAttribute('dj-click');
         if (clickHandler && !element.dataset.liveviewClickBound) {
             element.dataset.liveviewClickBound = 'true';
             // Parse handler string to extract function name and arguments
@@ -1416,7 +1416,7 @@ function bindLiveViewEvents() {
                 const params = extractTypedParams(element);
 
                 // Add positional arguments from handler syntax if present
-                // e.g., @click="set_period('month')" -> params._args = ['month']
+                // e.g., dj-click="set_period('month')" -> params._args = ['month']
                 if (parsed.args.length > 0) {
                     params._args = parsed.args;
                 }
@@ -1438,8 +1438,8 @@ function bindLiveViewEvents() {
             });
         }
 
-        // Handle @submit events on forms
-        const submitHandler = element.getAttribute('@submit');
+        // Handle dj-submit events on forms
+        const submitHandler = element.getAttribute('dj-submit');
         if (submitHandler && !element.dataset.liveviewSubmitBound) {
             element.dataset.liveviewSubmitBound = 'true';
             element.addEventListener('submit', async (e) => {
@@ -1481,8 +1481,8 @@ function bindLiveViewEvents() {
             return null;
         }
 
-        // Handle @change events
-        const changeHandler = element.getAttribute('@change');
+        // Handle dj-change events
+        const changeHandler = element.getAttribute('dj-change');
         if (changeHandler && !element.dataset.liveviewChangeBound) {
             element.dataset.liveviewChangeBound = 'true';
             element.addEventListener('change', async (e) => {
@@ -1506,8 +1506,8 @@ function bindLiveViewEvents() {
             });
         }
 
-        // Handle @input events (with smart debouncing/throttling)
-        const inputHandler = element.getAttribute('@input');
+        // Handle dj-input events (with smart debouncing/throttling)
+        const inputHandler = element.getAttribute('dj-input');
         if (inputHandler && !element.dataset.liveviewInputBound) {
             element.dataset.liveviewInputBound = 'true';
 
@@ -1555,8 +1555,8 @@ function bindLiveViewEvents() {
             element.addEventListener('input', wrappedHandler);
         }
 
-        // Handle @blur events
-        const blurHandler = element.getAttribute('@blur');
+        // Handle dj-blur events
+        const blurHandler = element.getAttribute('dj-blur');
         if (blurHandler && !element.dataset.liveviewBlurBound) {
             element.dataset.liveviewBlurBound = 'true';
             element.addEventListener('blur', async (e) => {
@@ -1580,8 +1580,8 @@ function bindLiveViewEvents() {
             });
         }
 
-        // Handle @focus events
-        const focusHandler = element.getAttribute('@focus');
+        // Handle dj-focus events
+        const focusHandler = element.getAttribute('dj-focus');
         if (focusHandler && !element.dataset.liveviewFocusBound) {
             element.dataset.liveviewFocusBound = 'true';
             element.addEventListener('focus', async (e) => {
@@ -1605,13 +1605,13 @@ function bindLiveViewEvents() {
             });
         }
 
-        // Handle @keydown / @keyup events
+        // Handle dj-keydown / dj-keyup events
         ['keydown', 'keyup'].forEach(eventType => {
-            const keyHandler = element.getAttribute(`@${eventType}`);
+            const keyHandler = element.getAttribute(`dj-${eventType}`);
             if (keyHandler && !element.dataset[`liveview${eventType}Bound`]) {
                 element.dataset[`liveview${eventType}Bound`] = 'true';
                 element.addEventListener(eventType, async (e) => {
-                    // Check for key modifiers (e.g. @keydown.enter)
+                    // Check for key modifiers (e.g. dj-keydown.enter)
                     const modifiers = keyHandler.split('.');
                     const handlerName = modifiers[0];
                     const requiredKey = modifiers.length > 1 ? modifiers[1] : null;
@@ -1689,20 +1689,20 @@ function clearOptimisticState(eventName) {
 }
 
 // Global Loading Manager (Phase 5)
-// Handles @loading.disable, @loading.class, @loading.show, @loading.hide attributes
+// Handles dj-loading.disable, dj-loading.class, dj-loading.show, dj-loading.hide attributes
 const globalLoadingManager = {
     // Map of element -> { originalState, modifiers }
     registeredElements: new Map(),
     pendingEvents: new Set(),
 
-    // Register an element with @loading attributes
+    // Register an element with dj-loading attributes
     register(element, eventName) {
         const modifiers = [];
         const originalState = {};
 
-        // Parse @loading.* attributes
+        // Parse dj-loading.* attributes
         Array.from(element.attributes).forEach(attr => {
-            const match = attr.name.match(/^@loading\.(.+)$/);
+            const match = attr.name.match(/^dj-loading\.(.+)$/);
             if (match) {
                 const modifier = match[1];
                 if (modifier === 'disable') {
@@ -1713,7 +1713,7 @@ const globalLoadingManager = {
                     // Store original inline display to restore when loading stops
                     originalState.display = element.style.display;
                     // Determine display value to use when showing:
-                    // 1. Use attribute value if specified (e.g., @loading.show="flex")
+                    // 1. Use attribute value if specified (e.g., dj-loading.show="flex")
                     // 2. Otherwise default to 'block'
                     originalState.visibleDisplay = attr.value || 'block';
                 } else if (modifier === 'hide') {
@@ -1738,22 +1738,21 @@ const globalLoadingManager = {
         }
     },
 
-    // Scan and register all elements with @loading attributes
+    // Scan and register all elements with dj-loading attributes
     scanAndRegister() {
         // Use targeted attribute selectors for better performance on large pages
-        // Note: CSS attribute selectors need escaped @ symbol
         const selectors = [
-            '[\\@loading\\.disable]',
-            '[\\@loading\\.show]',
-            '[\\@loading\\.hide]',
-            '[\\@loading\\.class]'
+            '[dj-loading\\.disable]',
+            '[dj-loading\\.show]',
+            '[dj-loading\\.hide]',
+            '[dj-loading\\.class]'
         ].join(',');
 
         const loadingElements = document.querySelectorAll(selectors);
         loadingElements.forEach(element => {
-            // Find the associated event from @click, @submit, etc.
+            // Find the associated event from dj-click, dj-submit, etc.
             const eventAttr = Array.from(element.attributes).find(
-                attr => attr.name.startsWith('@') && !attr.name.startsWith('@loading')
+                attr => attr.name.startsWith('dj-') && !attr.name.startsWith('dj-loading')
             );
             const eventName = eventAttr ? eventAttr.value : null;
             if (eventName) {
@@ -1761,7 +1760,7 @@ const globalLoadingManager = {
             }
         });
         if (globalThis.djustDebug) {
-            console.log(`[Loading] Scanned ${this.registeredElements.size} elements with @loading attributes`);
+            console.log(`[Loading] Scanned ${this.registeredElements.size} elements with dj-loading attributes`);
         }
     },
 
@@ -1772,11 +1771,11 @@ const globalLoadingManager = {
         if (triggerElement) {
             triggerElement.classList.add('djust-loading');
 
-            // Check if trigger element has @loading.disable
-            const hasDisable = triggerElement.hasAttribute('@loading.disable');
+            // Check if trigger element has dj-loading.disable
+            const hasDisable = triggerElement.hasAttribute('dj-loading.disable');
             if (globalThis.djustDebug) {
                 console.log(`[Loading] triggerElement:`, triggerElement);
-                console.log(`[Loading] hasAttribute('@loading.disable'):`, hasDisable);
+                console.log(`[Loading] hasAttribute('dj-loading.disable'):`, hasDisable);
             }
             if (hasDisable) {
                 triggerElement.disabled = true;
@@ -1803,8 +1802,8 @@ const globalLoadingManager = {
         // Remove loading state from trigger element
         if (triggerElement) {
             triggerElement.classList.remove('djust-loading');
-            // Check if trigger element has @loading.disable
-            const hasDisable = triggerElement.hasAttribute('@loading.disable');
+            // Check if trigger element has dj-loading.disable
+            const hasDisable = triggerElement.hasAttribute('dj-loading.disable');
             if (hasDisable) {
                 triggerElement.disabled = false;
             }
@@ -1829,7 +1828,7 @@ const globalLoadingManager = {
             if (modifier.type === 'disable') {
                 element.disabled = true;
             } else if (modifier.type === 'show') {
-                // Use stored visible display value (supports @loading.show="flex" etc.)
+                // Use stored visible display value (supports dj-loading.show="flex" etc.)
                 element.style.display = config.originalState.visibleDisplay || 'block';
             } else if (modifier.type === 'hide') {
                 element.style.display = 'none';
@@ -2045,8 +2044,8 @@ function createNodeFromVNode(vnode) {
 
     if (vnode.attrs) {
         for (const [key, value] of Object.entries(vnode.attrs)) {
-            if (key.startsWith('@')) {
-                const eventName = key.substring(1);
+            if (key.startsWith('dj-')) {
+                const eventName = key.substring(3);
                 elem.addEventListener(eventName, (e) => {
                     e.preventDefault();
                     const params = {};
@@ -2795,7 +2794,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initialize Draft Mode
     initDraftMode();
 
-    // Scan and register @loading attributes
+    // Scan and register dj-loading attributes
     globalLoadingManager.scanAndRegister();
 
     // Mark as initialized so turbo:load handler knows we're ready

--- a/python/djust/static/djust/decorators.js
+++ b/python/djust/static/djust/decorators.js
@@ -782,20 +782,20 @@ export const globalDraftManager = new DraftManager();
 // ============================================================================
 
 /**
- * LoadingManager handles @loading HTML attributes for showing/hiding elements
+ * LoadingManager handles dj-loading HTML attributes for showing/hiding elements
  * and adding/removing classes during async operations.
  *
  * Supported modifiers:
- * - @loading.disable: Disable element during loading
- * - @loading.class="class-name": Add class during loading
- * - @loading.show: Show element during loading (display: block/inline)
- * - @loading.hide: Hide element during loading (display: none)
+ * - dj-loading.disable: Disable element during loading
+ * - dj-loading.class="class-name": Add class during loading
+ * - dj-loading.show: Show element during loading (display: block/inline)
+ * - dj-loading.hide: Hide element during loading (display: none)
  *
  * Example:
- *   <button @click="save" @loading.disable>Save</button>
- *   <button @click="save" @loading.class="opacity-50">Save</button>
- *   <div @loading.show>Saving...</div>
- *   <div @loading.hide>Form content</div>
+ *   <button dj-click="save" dj-loading.disable>Save</button>
+ *   <button dj-click="save" dj-loading.class="opacity-50">Save</button>
+ *   <div dj-loading.show>Saving...</div>
+ *   <div dj-loading.hide>Form content</div>
  */
 export class LoadingManager {
     constructor() {
@@ -804,8 +804,8 @@ export class LoadingManager {
     }
 
     /**
-     * Register an element with @loading attributes
-     * @param {HTMLElement} element - Element with @loading attribute
+     * Register an element with dj-loading attributes
+     * @param {HTMLElement} element - Element with dj-loading attribute
      * @param {string} eventName - Event name that triggers loading
      */
     register(element, eventName) {
@@ -816,10 +816,10 @@ export class LoadingManager {
             originalState: {}
         };
 
-        // Parse @loading.* attributes
+        // Parse dj-loading.* attributes
         for (let i = 0; i < attributes.length; i++) {
             const attr = attributes[i];
-            const match = attr.name.match(/^@loading\.(.+)$/);
+            const match = attr.name.match(/^dj-loading\.(.+)$/);
             if (match) {
                 const modifier = match[1];
 
@@ -833,7 +833,7 @@ export class LoadingManager {
                     loadingConfig.modifiers.push({ type: 'hide' });
                     loadingConfig.originalState.display = element.style.display;
                 } else if (modifier === 'class') {
-                    // For @loading.class="className", value is in attr.value
+                    // For dj-loading.class="className", value is in attr.value
                     const className = attr.value;
                     if (className) {
                         loadingConfig.modifiers.push({ type: 'class', value: className });

--- a/tests/e2e/test_phase5_decorators.py
+++ b/tests/e2e/test_phase5_decorators.py
@@ -4,7 +4,7 @@ End-to-End tests for Phase 5 State Management decorators.
 Tests the complete integration of:
 - @cache decorator (client-side response caching)
 - @client_state decorator (StateBus coordination)
-- @loading HTML attributes (loading indicators)
+- dj-loading HTML attributes (loading indicators)
 
 These tests verify the full Python → Rust → WebSocket → JavaScript flow.
 
@@ -32,7 +32,7 @@ class TestCacheDecoratorE2E:
             template = """
             <html>
             <body>
-                <input @input="search" />
+                <input dj-input="search" />
             </body>
             </html>
             """
@@ -111,7 +111,7 @@ class TestClientStateDecoratorE2E:
             template = """
             <html>
             <body>
-                <input @input="set_filter" />
+                <input dj-input="set_filter" />
             </body>
             </html>
             """
@@ -168,16 +168,16 @@ class TestClientStateDecoratorE2E:
 
 
 class TestLoadingAttributeE2E:
-    """End-to-end tests for @loading HTML attributes."""
+    """End-to-end tests for dj-loading HTML attributes."""
 
     def test_loading_disable_in_template(self):
-        """Test @loading.disable attribute renders correctly."""
+        """Test dj-loading.disable attribute renders correctly."""
 
         class SaveFormView(LiveView):
             template = """
             <html>
             <body>
-                <button @click="save_data" @loading.disable>Save</button>
+                <button dj-click="save_data" dj-loading.disable>Save</button>
             </body>
             </html>
             """
@@ -196,17 +196,17 @@ class TestLoadingAttributeE2E:
         view.mount(request)
         html = view.render()
 
-        # Verify @loading.disable is preserved in HTML
-        assert '@loading.disable' in html
+        # Verify dj-loading.disable is preserved in HTML
+        assert "dj-loading.disable" in html
 
     def test_loading_class_in_template(self):
-        """Test @loading.class attribute renders correctly."""
+        """Test dj-loading.class attribute renders correctly."""
 
         class SaveFormView(LiveView):
             template = """
             <html>
             <body>
-                <button @click="save" @loading.class="opacity-50">Save</button>
+                <button dj-click="save" dj-loading.class="opacity-50">Save</button>
             </body>
             </html>
             """
@@ -225,19 +225,19 @@ class TestLoadingAttributeE2E:
         view.mount(request)
         html = view.render()
 
-        # Verify @loading.class is preserved in HTML
-        assert '@loading.class="opacity-50"' in html
+        # Verify dj-loading.class is preserved in HTML
+        assert 'dj-loading.class="opacity-50"' in html
 
     def test_loading_show_hide_in_template(self):
-        """Test @loading.show and @loading.hide attributes render correctly."""
+        """Test dj-loading.show and dj-loading.hide attributes render correctly."""
 
         class SaveFormView(LiveView):
             template = """
             <html>
             <body>
-                <button @click="save">Save</button>
-                <div @loading.show style="display: none;">Saving...</div>
-                <div @loading.hide>Form content</div>
+                <button dj-click="save">Save</button>
+                <div dj-loading.show style="display: none;">Saving...</div>
+                <div dj-loading.hide>Form content</div>
             </body>
             </html>
             """
@@ -256,16 +256,16 @@ class TestLoadingAttributeE2E:
         view.mount(request)
         html = view.render()
 
-        # Verify @loading.show and @loading.hide are preserved
-        assert '@loading.show' in html
-        assert '@loading.hide' in html
+        # Verify dj-loading.show and dj-loading.hide are preserved
+        assert "dj-loading.show" in html
+        assert "dj-loading.hide" in html
 
     def test_loading_multiple_modifiers(self):
-        """Test multiple @loading modifiers on same element."""
+        """Test multiple dj-loading modifiers on same element."""
 
         class SaveFormView(LiveView):
             template = """
-            <button @click="save" @loading.disable @loading.class="loading">
+            <button dj-click="save" dj-loading.disable dj-loading.class="loading">
                 Save
             </button>
             """
@@ -285,8 +285,8 @@ class TestLoadingAttributeE2E:
         html = view.render()
 
         # Verify both modifiers are preserved
-        assert '@loading.disable' in html
-        assert '@loading.class="loading"' in html
+        assert "dj-loading.disable" in html
+        assert 'dj-loading.class="loading"' in html
 
 
 class TestIntegrationScenarios:
@@ -299,8 +299,8 @@ class TestIntegrationScenarios:
             template = """
             <html>
             <body>
-                <input @input="search" placeholder="Search products..." />
-                <div @loading.show style="display: none;">Searching...</div>
+                <input dj-input="search" placeholder="Search products..." />
+                <div dj-loading.show style="display: none;">Searching...</div>
                 <div id="results">{{ results|length }} results</div>
             </body>
             </html>
@@ -329,8 +329,8 @@ class TestIntegrationScenarios:
         # Verify all features are present
         assert '"debounce"' in html
         assert '"cache"' in html
-        assert '@loading.show' in html
-        assert '@input="search"' in html
+        assert "dj-loading.show" in html
+        assert 'dj-input="search"' in html
 
     def test_dashboard_with_client_state(self):
         """Test dashboard with client state coordination."""
@@ -339,15 +339,15 @@ class TestIntegrationScenarios:
             template = """
             <html>
             <body>
-                <select @change="set_filter">
+                <select dj-change="set_filter">
                     <option value="all">All</option>
                     <option value="active">Active</option>
                 </select>
-                <select @change="set_sort">
+                <select dj-change="set_sort">
                     <option value="name">Name</option>
                     <option value="date">Date</option>
                 </select>
-                <button @click="refresh" @loading.disable>Refresh</button>
+                <button dj-click="refresh" dj-loading.disable>Refresh</button>
             </body>
             </html>
             """
@@ -379,7 +379,7 @@ class TestIntegrationScenarios:
         assert '"set_sort"' in html
         assert '"client_state"' in html
         assert '"keys": ["filter", "sort"]' in html
-        assert '@loading.disable' in html
+        assert "dj-loading.disable" in html
 
 
 class TestMetadataJSONFormat:

--- a/tests/js/loading.test.js
+++ b/tests/js/loading.test.js
@@ -18,10 +18,10 @@ describe('LoadingManager', () => {
 
         // Create mock DOM element
         document.body.innerHTML = `
-            <button id="save-btn" @loading.disable>Save</button>
-            <button id="submit-btn" @loading.class="opacity-50">Submit</button>
-            <div id="spinner" @loading.show style="display: none;">Loading...</div>
-            <div id="content" @loading.hide>Form Content</div>
+            <button id="save-btn" dj-loading.disable>Save</button>
+            <button id="submit-btn" dj-loading.class="opacity-50">Submit</button>
+            <div id="spinner" dj-loading.show style="display: none;">Loading...</div>
+            <div id="content" dj-loading.hide>Form Content</div>
         `;
 
         mockElement = document.getElementById('save-btn');
@@ -36,7 +36,7 @@ describe('LoadingManager', () => {
     // ========================================================================
 
     describe('register', () => {
-        it('should register element with @loading.disable', () => {
+        it('should register element with dj-loading.disable', () => {
             const btn = document.getElementById('save-btn');
             manager.register(btn, 'save');
 
@@ -46,16 +46,16 @@ describe('LoadingManager', () => {
             expect(config.modifiers).toContainEqual({ type: 'disable' });
         });
 
-        it('should register element with @loading.class', () => {
+        it('should register element with dj-loading.class', () => {
             const btn = document.getElementById('submit-btn');
-            btn.setAttribute('@loading.class', 'opacity-50');
+            btn.setAttribute('dj-loading.class', 'opacity-50');
             manager.register(btn, 'submit');
 
             const config = manager.loadingElements.get(btn);
             expect(config.modifiers).toContainEqual({ type: 'class', value: 'opacity-50' });
         });
 
-        it('should register element with @loading.show', () => {
+        it('should register element with dj-loading.show', () => {
             const spinner = document.getElementById('spinner');
             manager.register(spinner, 'save');
 
@@ -63,7 +63,7 @@ describe('LoadingManager', () => {
             expect(config.modifiers).toContainEqual({ type: 'show' });
         });
 
-        it('should register element with @loading.hide', () => {
+        it('should register element with dj-loading.hide', () => {
             const content = document.getElementById('content');
             manager.register(content, 'save');
 
@@ -80,7 +80,7 @@ describe('LoadingManager', () => {
             expect(config.originalState.disabled).toBe(true);
         });
 
-        it('should not register element without @loading attributes', () => {
+        it('should not register element without dj-loading attributes', () => {
             const btn = document.createElement('button');
             manager.register(btn, 'save');
 
@@ -89,8 +89,8 @@ describe('LoadingManager', () => {
 
         it('should register multiple modifiers on same element', () => {
             const btn = document.createElement('button');
-            btn.setAttribute('@loading.disable', '');
-            btn.setAttribute('@loading.class', 'loading');
+            btn.setAttribute('dj-loading.disable', '');
+            btn.setAttribute('dj-loading.class', 'loading');
             manager.register(btn, 'save');
 
             const config = manager.loadingElements.get(btn);
@@ -136,7 +136,7 @@ describe('LoadingManager', () => {
             expect(btn2.disabled).toBe(false);
         });
 
-        it('should show element with @loading.show', () => {
+        it('should show element with dj-loading.show', () => {
             const spinner = document.getElementById('spinner');
             manager.register(spinner, 'save');
 
@@ -147,7 +147,7 @@ describe('LoadingManager', () => {
             expect(spinner.style.display).toBe('block');
         });
 
-        it('should hide element with @loading.hide', () => {
+        it('should hide element with dj-loading.hide', () => {
             const content = document.getElementById('content');
             manager.register(content, 'save');
 
@@ -158,9 +158,9 @@ describe('LoadingManager', () => {
             expect(content.style.display).toBe('none');
         });
 
-        it('should add class with @loading.class', () => {
+        it('should add class with dj-loading.class', () => {
             const btn = document.getElementById('submit-btn');
-            btn.setAttribute('@loading.class', 'opacity-50');
+            btn.setAttribute('dj-loading.class', 'opacity-50');
             manager.register(btn, 'submit');
 
             expect(btn.classList.contains('opacity-50')).toBe(false);
@@ -206,9 +206,9 @@ describe('LoadingManager', () => {
             expect(spinner.style.display).toBe(originalDisplay);
         });
 
-        it('should remove class with @loading.class', () => {
+        it('should remove class with dj-loading.class', () => {
             const btn = document.getElementById('submit-btn');
-            btn.setAttribute('@loading.class', 'opacity-50');
+            btn.setAttribute('dj-loading.class', 'opacity-50');
             manager.register(btn, 'submit');
 
             manager.startLoading('submit');
@@ -319,7 +319,7 @@ describe('LoadingManager', () => {
     describe('error handling', () => {
         it('should handle element with no style gracefully', () => {
             const div = document.createElement('div');
-            div.setAttribute('@loading.show', '');
+            div.setAttribute('dj-loading.show', '');
             manager.register(div, 'save');
 
             expect(() => manager.startLoading('save')).not.toThrow();
@@ -350,7 +350,7 @@ describe('globalLoadingManager', () => {
 
     it('should be cleared by clearAllState', () => {
         const btn = document.createElement('button');
-        btn.setAttribute('@loading.disable', '');
+        btn.setAttribute('dj-loading.disable', '');
         globalLoadingManager.register(btn, 'save');
         globalLoadingManager.startLoading('save');
 
@@ -369,10 +369,10 @@ describe('Integration scenarios', () => {
         clearAllState();
         document.body.innerHTML = `
             <form>
-                <button id="save" @loading.disable @loading.class="loading">Save</button>
-                <button id="cancel" @loading.hide>Cancel</button>
-                <div id="spinner" @loading.show style="display: none;">Saving...</div>
-                <div id="form" @loading.hide>Form fields</div>
+                <button id="save" dj-loading.disable dj-loading.class="loading">Save</button>
+                <button id="cancel" dj-loading.hide>Cancel</button>
+                <div id="spinner" dj-loading.show style="display: none;">Saving...</div>
+                <div id="form" dj-loading.hide>Form fields</div>
             </form>
         `;
     });
@@ -422,8 +422,8 @@ describe('Integration scenarios', () => {
         const btn1 = document.getElementById('save');
         const btn2 = document.getElementById('cancel');
 
-        btn1.setAttribute('@loading.disable', '');
-        btn2.setAttribute('@loading.disable', '');
+        btn1.setAttribute('dj-loading.disable', '');
+        btn2.setAttribute('dj-loading.disable', '');
 
         globalLoadingManager.register(btn1, 'save');
         globalLoadingManager.register(btn2, 'delete');

--- a/tests/js/parseEventHandler.test.js
+++ b/tests/js/parseEventHandler.test.js
@@ -1,7 +1,7 @@
 /**
  * Tests for parseEventHandler function
  *
- * Tests the client-side parsing of event handler strings like @click="handler('arg')"
+ * Tests the client-side parsing of event handler strings like dj-click="handler('arg')"
  * into function name and typed arguments.
  */
 

--- a/tests/playwright/test_loading_attribute.py
+++ b/tests/playwright/test_loading_attribute.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """
-Playwright test for @loading HTML attribute functionality.
+Playwright test for dj-loading HTML attribute functionality.
 
 Tests:
 1. LoadingManager available
-2. @loading attributes present in DOM
-3. Button disabled during loading (@loading.disable)
-4. Button opacity changes during loading (@loading.class)
-5. Spinner shows during loading (@loading.show)
-6. Content hides during loading (@loading.hide)
+2. dj-loading attributes present in DOM
+3. Button disabled during loading (dj-loading.disable)
+4. Button opacity changes during loading (dj-loading.class)
+5. Spinner shows during loading (dj-loading.show)
+6. Content hides during loading (dj-loading.hide)
 7. Server-side handler invocation
 """
 
@@ -18,7 +18,7 @@ from playwright.async_api import async_playwright
 
 
 async def test_loading_attribute():
-    """Test @loading attributes with automated browser testing"""
+    """Test dj-loading attributes with automated browser testing"""
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
         context = await browser.new_context()
@@ -28,7 +28,7 @@ async def test_loading_attribute():
         console_logs = []
         page.on("console", lambda msg: console_logs.append(msg.text))
 
-        print("📄 Loading @loading attribute test page: http://localhost:8002/tests/loading/")
+        print("📄 Loading dj-loading attribute test page: http://localhost:8002/tests/loading/")
         await page.goto("http://localhost:8002/tests/loading/")
 
         # Wait for LiveView to mount
@@ -51,10 +51,14 @@ async def test_loading_attribute():
             client_failed = len(failed_tests)
 
             # Get operation counts
-            slow_count_el = await page.query_selector(".stat-card:has-text('Slow Operations') .stat-value")
+            slow_count_el = await page.query_selector(
+                ".stat-card:has-text('Slow Operations') .stat-value"
+            )
             slow_count = await slow_count_el.inner_text() if slow_count_el else "0"
 
-            fast_count_el = await page.query_selector(".stat-card:has-text('Fast Operations') .stat-value")
+            fast_count_el = await page.query_selector(
+                ".stat-card:has-text('Fast Operations') .stat-value"
+            )
             fast_count = await fast_count_el.inner_text() if fast_count_el else "0"
 
             # Get tests passed count
@@ -71,7 +75,11 @@ async def test_loading_attribute():
 
             # Print relevant console logs
             print("\n🔍 Console Logs:")
-            loading_logs = [log for log in console_logs if '[Test]' in log or '[Loading]' in log or 'LoadingManager' in log]
+            loading_logs = [
+                log
+                for log in console_logs
+                if "[Test]" in log or "[Loading]" in log or "LoadingManager" in log
+            ]
             for log in loading_logs[-30:]:  # Last 30 relevant logs
                 print(f"  {log}")
 
@@ -82,25 +90,25 @@ async def test_loading_attribute():
             """)
             print(f"  globalLoadingManager available: {has_loading_manager}")
 
-            # Check for @loading attributes in DOM
+            # Check for dj-loading attributes in DOM
             loading_elements = await page.evaluate("""
                 () => {
-                    const elements = document.querySelectorAll('[\\\\@loading\\\\.disable], [\\\\@loading\\\\.class], [\\\\@loading\\\\.show], [\\\\@loading\\\\.hide]');
+                    const elements = document.querySelectorAll('[\\\\dj-loading\\\\.disable], [\\\\dj-loading\\\\.class], [\\\\dj-loading\\\\.show], [\\\\dj-loading\\\\.hide]');
                     return elements.length;
                 }
             """)
-            print(f"  Elements with @loading attributes: {loading_elements}")
+            print(f"  Elements with dj-loading attributes: {loading_elements}")
 
             # Manual test: Click button and check disabled state
             print("\n🔍 Manual Button Disable Test:")
-            disable_button = await page.query_selector('button[\\@loading\\.disable]')
+            disable_button = await page.query_selector("button[\\dj-loading\\.disable]")
             if disable_button:
                 # Check initial state
                 is_disabled_before = await disable_button.is_disabled()
                 print(f"  Button disabled before click: {is_disabled_before}")
 
                 # Click button
-                print("  Clicking button with @loading.disable...")
+                print("  Clicking button with dj-loading.disable...")
                 await disable_button.click()
 
                 # Check disabled state immediately (should be disabled during 1s operation)
@@ -117,7 +125,7 @@ async def test_loading_attribute():
                 manual_test_passed = is_disabled_during and not is_disabled_after
                 print(f"  Manual disable test: {'✅ PASS' if manual_test_passed else '❌ FAIL'}")
             else:
-                print("  ❌ ERROR: Could not find button with @loading.disable")
+                print("  ❌ ERROR: Could not find button with dj-loading.disable")
                 manual_test_passed = False
 
             # Determine if tests passed
@@ -127,14 +135,16 @@ async def test_loading_attribute():
                 await browser.close()
                 return 0
             else:
-                print(f"\n❌ FAIL: Expected all tests to pass")
+                print("\n❌ FAIL: Expected all tests to pass")
                 print(f"           Got {client_passed} passed, {client_failed} failed")
                 print(f"           Manual test: {'PASS' if manual_test_passed else 'FAIL'}")
 
                 # Print failed test details
                 if client_failed > 0:
                     print("\n🔍 Failed Test Details:")
-                    failed_items = await page.query_selector_all("#client-test-results .test-result-failed")
+                    failed_items = await page.query_selector_all(
+                        "#client-test-results .test-result-failed"
+                    )
                     for item in failed_items:
                         name = await item.query_selector("h6")
                         expected = await item.query_selector("p:has-text('Expected:')")
@@ -158,6 +168,7 @@ async def test_loading_attribute():
         except Exception as e:
             print(f"\n❌ ERROR: {e}")
             import traceback
+
             traceback.print_exc()
             print("\n🔍 Full console output (last 50 lines):")
             for log in console_logs[-50:]:
@@ -168,7 +179,7 @@ async def test_loading_attribute():
                 html = await page.content()
                 print("\n🔍 Page HTML (first 5000 chars):")
                 print(html[:5000])
-            except:
+            except Exception:
                 print("Could not get page HTML")
 
             await browser.close()

--- a/tests/unit/test_component_parent_communication.py
+++ b/tests/unit/test_component_parent_communication.py
@@ -2,9 +2,7 @@
 Tests for parent-child component communication in LiveView.
 """
 
-import pytest
 from djust import LiveView, LiveComponent
-from unittest.mock import Mock
 
 
 class TodoListComponent(LiveComponent):
@@ -13,7 +11,7 @@ class TodoListComponent(LiveComponent):
     template = """
         <div class="todo-list">
             {% for item in items %}
-            <div @click="toggle_todo" data-id="{{ item.id }}">
+            <div dj-click="toggle_todo" data-id="{{ item.id }}">
                 {{ item.text }}
             </div>
             {% endfor %}
@@ -43,7 +41,7 @@ class UserListComponent(LiveComponent):
     template = """
         <div>
             {% for user in users %}
-            <div @click="select_user" data-id="{{ user.id }}">
+            <div dj-click="select_user" data-id="{{ user.id }}">
                 {{ user.name }}
             </div>
             {% endfor %}
@@ -125,7 +123,7 @@ class TestParentChildCommunication:
         view.mount(request)
 
         # Get context to trigger component registration
-        context = view.get_context_data()
+        view.get_context_data()
 
         # Simulate component event
         view.todo_list.toggle_todo(id="1")

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -12,6 +12,7 @@ from djust.forms import FormMixin
 
 class TestForm(forms.Form):
     """Simple test form for unit tests."""
+
     first_name = forms.CharField(max_length=100, required=True)
     last_name = forms.CharField(max_length=100, required=True)
     email = forms.EmailField(required=False)
@@ -20,10 +21,11 @@ class TestForm(forms.Form):
 
 class TestFormView(FormMixin, LiveView):
     """Test view with FormMixin."""
+
     form_class = TestForm
     template = """
     <div data-liveview-root>
-        <form @submit="submit_form">
+        <form dj-submit="submit_form">
             <input type="text" name="first_name" value="{{ form_data.first_name }}" />
             <input type="text" name="last_name" value="{{ form_data.last_name }}" />
             <input type="email" name="email" value="{{ form_data.email }}" />
@@ -53,26 +55,26 @@ class TestFormResetBehavior:
 
         # Modify form data
         view.form_data = {
-            'first_name': 'John',
-            'last_name': 'Doe',
-            'email': 'john@example.com',
-            'bio': 'Test bio'
+            "first_name": "John",
+            "last_name": "Doe",
+            "email": "john@example.com",
+            "bio": "Test bio",
         }
 
         # Reset form
         view.reset_form()
 
         # All field keys should be present (not empty dict)
-        assert 'first_name' in view.form_data
-        assert 'last_name' in view.form_data
-        assert 'email' in view.form_data
-        assert 'bio' in view.form_data
+        assert "first_name" in view.form_data
+        assert "last_name" in view.form_data
+        assert "email" in view.form_data
+        assert "bio" in view.form_data
 
         # Values should be empty/initial
-        assert view.form_data['first_name'] == ''
-        assert view.form_data['last_name'] == ''
-        assert view.form_data['email'] == ''
-        assert view.form_data['bio'] == ''
+        assert view.form_data["first_name"] == ""
+        assert view.form_data["last_name"] == ""
+        assert view.form_data["email"] == ""
+        assert view.form_data["bio"] == ""
 
     @pytest.mark.django_db
     def test_reset_form_matches_mount_state(self, get_request):
@@ -93,10 +95,10 @@ class TestFormResetBehavior:
         view2 = TestFormView()
         view2.get(get_request)
         view2.form_data = {
-            'first_name': 'Jane',
-            'last_name': 'Smith',
-            'email': 'jane@example.com',
-            'bio': 'Modified'
+            "first_name": "Jane",
+            "last_name": "Smith",
+            "email": "jane@example.com",
+            "bio": "Modified",
         }
         view2.reset_form()
         reset_state = view2.form_data.copy()
@@ -119,17 +121,17 @@ class TestFormResetBehavior:
         view.get(get_request)
 
         # Modify and reset first time
-        view.form_data = {'first_name': 'Test1', 'last_name': 'User1'}
+        view.form_data = {"first_name": "Test1", "last_name": "User1"}
         view.reset_form()
         first_reset_state = view.form_data.copy()
 
         # Modify and reset second time
-        view.form_data = {'first_name': 'Test2', 'last_name': 'User2'}
+        view.form_data = {"first_name": "Test2", "last_name": "User2"}
         view.reset_form()
         second_reset_state = view.form_data.copy()
 
         # Modify and reset third time
-        view.form_data = {'first_name': 'Test3', 'last_name': 'User3'}
+        view.form_data = {"first_name": "Test3", "last_name": "User3"}
         view.reset_form()
         third_reset_state = view.form_data.copy()
 
@@ -145,10 +147,10 @@ class TestFormResetBehavior:
         view.get(get_request)
 
         # Set errors and messages
-        view.field_errors = {'first_name': ['Required field']}
-        view.form_errors = ['Form has errors']
-        view.success_message = 'Form submitted!'
-        view.error_message = 'Please fix errors'
+        view.field_errors = {"first_name": ["Required field"]}
+        view.form_errors = ["Form has errors"]
+        view.success_message = "Form submitted!"
+        view.error_message = "Please fix errors"
         view.is_valid = True
 
         # Reset form
@@ -157,8 +159,8 @@ class TestFormResetBehavior:
         # All should be cleared
         assert view.field_errors == {}
         assert view.form_errors == {}
-        assert view.success_message == ''
-        assert view.error_message == ''
+        assert view.success_message == ""
+        assert view.error_message == ""
         assert view.is_valid is False
 
     @pytest.mark.django_db
@@ -168,7 +170,7 @@ class TestFormResetBehavior:
         view.get(get_request)
 
         # Submit invalid form
-        view.submit_form(first_name='', last_name='')
+        view.submit_form(first_name="", last_name="")
         assert view.form_instance.is_bound
         assert not view.form_instance.is_valid()
 
@@ -190,10 +192,10 @@ class TestFormValidation:
         view.get(get_request)
 
         # Validate field
-        view.validate_field(field_name='first_name', value='John')
+        view.validate_field(field_name="first_name", value="John")
 
         # form_data should be updated
-        assert view.form_data['first_name'] == 'John'
+        assert view.form_data["first_name"] == "John"
 
     @pytest.mark.django_db
     def test_validate_field_stores_errors(self, get_request):
@@ -202,11 +204,11 @@ class TestFormValidation:
         view.get(get_request)
 
         # Validate required field with empty value
-        view.validate_field(field_name='first_name', value='')
+        view.validate_field(field_name="first_name", value="")
 
         # Should have field error
-        assert 'first_name' in view.field_errors
-        assert len(view.field_errors['first_name']) > 0
+        assert "first_name" in view.field_errors
+        assert len(view.field_errors["first_name"]) > 0
 
     @pytest.mark.django_db
     def test_validate_field_clears_previous_errors(self, get_request):
@@ -215,14 +217,14 @@ class TestFormValidation:
         view.get(get_request)
 
         # Create error
-        view.validate_field(field_name='first_name', value='')
-        assert 'first_name' in view.field_errors
+        view.validate_field(field_name="first_name", value="")
+        assert "first_name" in view.field_errors
 
         # Fix error
-        view.validate_field(field_name='first_name', value='John')
+        view.validate_field(field_name="first_name", value="John")
 
         # Error should be cleared
-        assert 'first_name' not in view.field_errors
+        assert "first_name" not in view.field_errors
 
     @pytest.mark.django_db
     def test_submit_form_validates_all_fields(self, get_request):
@@ -231,16 +233,17 @@ class TestFormValidation:
         view.get(get_request)
 
         # Submit with missing required fields
-        view.submit_form(first_name='', last_name='')
+        view.submit_form(first_name="", last_name="")
 
         # Should have errors for both required fields
-        assert 'first_name' in view.field_errors
-        assert 'last_name' in view.field_errors
+        assert "first_name" in view.field_errors
+        assert "last_name" in view.field_errors
         assert not view.is_valid
 
     @pytest.mark.django_db
     def test_submit_form_calls_form_valid_hook(self, get_request):
         """Test that submit_form calls form_valid hook on success."""
+
         class TestViewWithHook(TestFormView):
             form_valid_called = False
 
@@ -251,7 +254,7 @@ class TestFormValidation:
         view.get(get_request)
 
         # Submit valid form
-        view.submit_form(first_name='John', last_name='Doe')
+        view.submit_form(first_name="John", last_name="Doe")
 
         # Hook should be called
         assert view.form_valid_called
@@ -260,6 +263,7 @@ class TestFormValidation:
     @pytest.mark.django_db
     def test_submit_form_calls_form_invalid_hook(self, get_request):
         """Test that submit_form calls form_invalid hook on failure."""
+
         class TestViewWithHook(TestFormView):
             form_invalid_called = False
 
@@ -270,7 +274,7 @@ class TestFormValidation:
         view.get(get_request)
 
         # Submit invalid form
-        view.submit_form(first_name='', last_name='')
+        view.submit_form(first_name="", last_name="")
 
         # Hook should be called
         assert view.form_invalid_called
@@ -286,10 +290,10 @@ class TestFormFieldMethods:
         view = TestFormView()
         view.get(get_request)
 
-        view.form_data['first_name'] = 'John'
+        view.form_data["first_name"] = "John"
 
-        assert view.get_field_value('first_name') == 'John'
-        assert view.get_field_value('nonexistent', 'default') == 'default'
+        assert view.get_field_value("first_name") == "John"
+        assert view.get_field_value("nonexistent", "default") == "default"
 
     @pytest.mark.django_db
     def test_get_field_errors(self, get_request):
@@ -297,11 +301,11 @@ class TestFormFieldMethods:
         view = TestFormView()
         view.get(get_request)
 
-        view.field_errors['first_name'] = ['Error 1', 'Error 2']
+        view.field_errors["first_name"] = ["Error 1", "Error 2"]
 
-        errors = view.get_field_errors('first_name')
-        assert errors == ['Error 1', 'Error 2']
-        assert view.get_field_errors('nonexistent') == []
+        errors = view.get_field_errors("first_name")
+        assert errors == ["Error 1", "Error 2"]
+        assert view.get_field_errors("nonexistent") == []
 
     @pytest.mark.django_db
     def test_has_field_errors(self, get_request):
@@ -309,10 +313,10 @@ class TestFormFieldMethods:
         view = TestFormView()
         view.get(get_request)
 
-        view.field_errors['first_name'] = ['Error']
+        view.field_errors["first_name"] = ["Error"]
 
-        assert view.has_field_errors('first_name')
-        assert not view.has_field_errors('last_name')
+        assert view.has_field_errors("first_name")
+        assert not view.has_field_errors("last_name")
 
 
 class TestFormWithInitialValues:
@@ -321,41 +325,43 @@ class TestFormWithInitialValues:
     @pytest.mark.django_db
     def test_mount_respects_initial_values(self, get_request):
         """Test that mount uses field initial values."""
+
         class FormWithInitial(forms.Form):
-            name = forms.CharField(initial='Default Name')
-            email = forms.EmailField(initial='default@example.com')
+            name = forms.CharField(initial="Default Name")
+            email = forms.EmailField(initial="default@example.com")
 
         class ViewWithInitial(FormMixin, LiveView):
             form_class = FormWithInitial
-            template = '<div data-liveview-root>{{ form_data.name }}</div>'
+            template = "<div data-liveview-root>{{ form_data.name }}</div>"
 
         view = ViewWithInitial()
         view.get(get_request)
 
         # Should use initial values
-        assert view.form_data['name'] == 'Default Name'
-        assert view.form_data['email'] == 'default@example.com'
+        assert view.form_data["name"] == "Default Name"
+        assert view.form_data["email"] == "default@example.com"
 
     @pytest.mark.django_db
     def test_reset_form_respects_initial_values(self, get_request):
         """Test that reset_form restores initial values."""
+
         class FormWithInitial(forms.Form):
-            name = forms.CharField(initial='Default Name')
-            email = forms.EmailField(initial='default@example.com')
+            name = forms.CharField(initial="Default Name")
+            email = forms.EmailField(initial="default@example.com")
 
         class ViewWithInitial(FormMixin, LiveView):
             form_class = FormWithInitial
-            template = '<div data-liveview-root>{{ form_data.name }}</div>'
+            template = "<div data-liveview-root>{{ form_data.name }}</div>"
 
         view = ViewWithInitial()
         view.get(get_request)
 
         # Modify values
-        view.form_data = {'name': 'Modified', 'email': 'modified@example.com'}
+        view.form_data = {"name": "Modified", "email": "modified@example.com"}
 
         # Reset
         view.reset_form()
 
         # Should restore initial values
-        assert view.form_data['name'] == 'Default Name'
-        assert view.form_data['email'] == 'default@example.com'
+        assert view.form_data["name"] == "Default Name"
+        assert view.form_data["email"] == "default@example.com"

--- a/tests/unit/test_live_component.py
+++ b/tests/unit/test_live_component.py
@@ -12,7 +12,7 @@ class TodoListComponent(LiveComponent):
     template = """
         <div class="todo-list">
             {% for item in items %}
-            <div @click="toggle_todo" data-id="{{ item.id }}">
+            <div dj-click="toggle_todo" data-id="{{ item.id }}">
                 <input type="checkbox" {% if item.completed %}checked{% endif %}>
                 {{ item.text }}
             </div>
@@ -50,7 +50,7 @@ class CounterComponent(LiveComponent):
     template = """
         <div>
             <span>{{ count }}</span>
-            <button @click="increment">+</button>
+            <button dj-click="increment">+</button>
         </div>
     """
 
@@ -174,9 +174,7 @@ class TestLiveComponentParentCommunication:
 
     def test_send_parent_with_custom_data(self):
         """Test send_parent() with custom event data."""
-        component = TodoListComponent(
-            items=[{"id": 1, "text": "Test", "completed": False}]
-        )
+        component = TodoListComponent(items=[{"id": 1, "text": "Test", "completed": False}])
         events = []
 
         def parent_callback(event_data):


### PR DESCRIPTION
## Summary

- Standardizes all event binding attributes from `@` prefix to `dj-` prefix
- Updates `client.js` and `decorators.js` to parse `dj-*` attributes
- Updates all documentation, example templates, and test files

**BREAKING CHANGE**: All event attributes now use `dj-` prefix instead of `@`:
- `@click` → `dj-click`
- `@input` → `dj-input`
- `@change` → `dj-change`
- `@submit` → `dj-submit`
- `@blur` → `dj-blur`
- `@focus` → `dj-focus`
- `@keydown` → `dj-keydown`
- `@keyup` → `dj-keyup`
- `@loading.*` → `dj-loading.*`

## Benefits

- **Namespaced**: Clearly identifies djust-specific attributes
- **No CSS selector escaping**: Was `\@click`, now just `dj-click`
- **No framework conflicts**: Works alongside Vue (`@click`) or Alpine (`x-on:click`)
- **Standard HTML conventions**: Consistent with `data-*`, `aria-*`, `hx-*` (htmx)
- **Django naming**: `dj-` prefix reflects Django heritage

## Files Changed (111 files)

| Category | Changes |
|----------|---------|
| Core JS | `client.js`, `decorators.js` - attribute parsing |
| Documentation | 30+ markdown files |
| Templates | 70+ example HTML templates |
| Tests | Python and JavaScript test files |

## Test plan

- [x] All Python tests pass (`make test-python`)
- [x] All JavaScript tests pass (`npm test`)
- [x] Pre-commit hooks pass
- [ ] Manual browser testing with demo project

Closes #68

🤖 Generated with [Claude Code](https://claude.ai/code)