### PR TITLE
fix(vdom): Never remove dj-* event handler attributes

### DIFF
--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -2726,6 +2726,11 @@ function applySinglePatch(patch) {
                 break;
 
             case 'RemoveAttr':
+                // Never remove dj-* event handler attributes — defense in depth
+                // against VDOM path mismatches from conditional rendering
+                if (patch.key && patch.key.startsWith('dj-')) {
+                    break;
+                }
                 node.removeAttribute(patch.key);
                 break;
 


### PR DESCRIPTION
## Summary

- Never generate or apply `RemoveAttr` patches for `dj-*` event handler attributes
- Rust-side guard in `diff_attrs` + JS-side defense in depth in `applySinglePatch`

## Problem

When conditional rendering changes DOM structure (e.g., `{% if conversation %}` adds export/share buttons), index-based diffing can incorrectly match old elements with new elements. This generates `RemoveAttr` patches that strip `dj-click`, `dj-change`, etc. from the wrong elements, breaking event handlers.

## Solution

**diff.rs**: Skip generating `RemoveAttr` for any attribute starting with `dj-`
**client.js**: Skip applying `RemoveAttr` for `dj-*` as defense in depth

## Test plan

- [x] `test_dj_event_attrs_never_removed` — verifies dj-click preserved when class changes
- [x] `test_dj_attrs_preserved_across_all_event_types` — dj-input, dj-change, dj-blur, dj-keydown.enter
- [x] `test_regular_attrs_still_removed` — non-dj attrs still removed normally
- [x] All existing tests pass

Fixes #85
Supersedes #86 (closed — SVG namespace fixes already on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)