### PR TITLE
Apply rate limiting to all WebSocket message types

### DIFF
--- a/python/djust/rate_limit.py
+++ b/python/djust/rate_limit.py
@@ -75,7 +75,7 @@ class ConnectionRateLimiter:
         if not self.global_bucket.consume():
             self.warnings += 1
             logger.warning(
-                "Rate limit exceeded for event '%s' (warning %d/%d)",
+                "Rate limit exceeded for message '%s' (warning %d/%d)",
                 sanitize_for_log(event_name),
                 self.warnings,
                 self.max_warnings,


### PR DESCRIPTION
## Summary

- Move global rate limit check before message type dispatch in `receive()`, so `mount` and `ping` messages are rate-limited alongside `event` messages
- Add `TestGlobalRateLimit` test class verifying non-event messages are rejected after burst exhaustion and that ping floods trigger disconnect

Fixes #107

## Test plan

- [x] New tests in `TestGlobalRateLimit` pass
- [x] Existing tests unaffected (2 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)