### PR TITLE
Fix message size check to use byte count, not char count

### DIFF
--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -271,8 +271,10 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 raw_size = len(bytes_data)
             elif text_data:
                 char_len = len(text_data)
-                # UTF-8 is at most 4x char length; skip encode if clearly under limit
-                raw_size = char_len if char_len <= max_msg_size else len(text_data.encode("utf-8"))
+                # Only skip encode when even worst-case (4 bytes/char) is under limit
+                raw_size = (
+                    char_len if char_len * 4 <= max_msg_size else len(text_data.encode("utf-8"))
+                )
             else:
                 raw_size = 0
             if max_msg_size and raw_size > max_msg_size:


### PR DESCRIPTION
## Summary

Fixes #111.

- The message size check in `receive()` used `len(text_data)` (character count) instead of byte count. A string of 65,536 multi-byte characters (e.g., emoji at 4 bytes each) could be up to 262,144 bytes but would pass the 65,536 limit check.
- Changed the optimization to only skip `encode("utf-8")` when `char_len * 4 <= max_msg_size`, ensuring it is mathematically impossible for the message to exceed the byte limit.
- Added regression tests in `TestMessageSizeLimit` verifying multi-byte characters are correctly measured by byte count.

## Test plan

- [x] `pytest tests/unit/test_event_security.py` passes (2 pre-existing failures unrelated to this change)
- [ ] Verify WebSocket messages with multi-byte content are correctly rejected when over the limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)