### PR TITLE
Add standalone auto_optimize() and annotate_counts() query helpers

### DIFF
--- a/python/djust/optimization/__init__.py
+++ b/python/djust/optimization/__init__.py
@@ -5,7 +5,12 @@ djust Optimization Modules
 - Fingerprint Optimization: Tracks state changes to minimize re-rendering and data transfer
 """
 
-from .query_optimizer import analyze_queryset_optimization, optimize_queryset
+from .query_optimizer import (
+    analyze_queryset_optimization,
+    optimize_queryset,
+    auto_optimize,
+    annotate_counts,
+)
 from .codegen import generate_serializer_code, compile_serializer, get_serializer_source
 from .cache import SerializerCache
 from .fingerprint import (
@@ -20,6 +25,8 @@ __all__ = [
     # Query optimization
     "analyze_queryset_optimization",
     "optimize_queryset",
+    "auto_optimize",
+    "annotate_counts",
     "generate_serializer_code",
     "compile_serializer",
     "get_serializer_source",


### PR DESCRIPTION
## Summary
- Adds `auto_optimize(queryset, *fields)` for easy N+1 prevention outside LiveView
- Adds `annotate_counts(queryset, **filters)` for bulk Count annotations on reverse relations
- Extends `QueryOptimization` with an `annotations` dict applied by `optimize_queryset()`

## Test plan
- [x] All 20 existing query optimizer tests pass
- [ ] Verify `auto_optimize()` correctly routes FK to `select_related` and M2M to `prefetch_related`
- [ ] Verify `annotate_counts()` produces correct SQL annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)