### PR TITLE
Fix data-djust-replace inserting children into wrong sibling parent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "0.2.1-alpha.1"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "0.2.1-alpha.1"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "0.2.1-alpha.1"
+version = "0.2.1"
 dependencies = [
  "bincode",
  "criterion",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "0.2.1-alpha.1"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "chrono",
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "0.2.1-alpha.1"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "criterion",

--- a/crates/djust_vdom/src/diff.rs
+++ b/crates/djust_vdom/src/diff.rs
@@ -1527,4 +1527,97 @@ mod tests {
             "RemoveChild should be in descending index order"
         );
     }
+
+    #[test]
+    fn test_data_djust_replace_with_siblings() {
+        // Regression test: when a data-djust-replace container has a sibling,
+        // all InsertChild/RemoveChild patches must have correct path and d values
+        // targeting only the replace container. This ensures the JS client's
+        // groupPatchesByParent groups them correctly (Issue #142 continued).
+        let old = VNode::element("div")
+            .with_djust_id("root")
+            .with_children(vec![
+                VNode::element("div")
+                    .with_djust_id("messages")
+                    .with_attr("data-djust-replace", "")
+                    .with_children(vec![
+                        VNode::element("p").with_child(VNode::text("No messages"))
+                    ]),
+                VNode::element("div")
+                    .with_djust_id("chat-input")
+                    .with_children(vec![VNode::element("input")]),
+            ]);
+        let new = VNode::element("div")
+            .with_djust_id("root")
+            .with_children(vec![
+                VNode::element("div")
+                    .with_djust_id("messages")
+                    .with_attr("data-djust-replace", "")
+                    .with_children(vec![
+                        VNode::element("p").with_child(VNode::text("Message 1")),
+                        VNode::element("p").with_child(VNode::text("Message 2")),
+                    ]),
+                VNode::element("div")
+                    .with_djust_id("chat-input")
+                    .with_children(vec![VNode::element("input")]),
+            ]);
+
+        let patches = diff_nodes(&old, &new, &[]);
+
+        // All child-op patches should target the messages container
+        for patch in &patches {
+            match patch {
+                Patch::InsertChild { path, d, .. } | Patch::RemoveChild { path, d, .. } => {
+                    assert_eq!(
+                        d.as_deref(),
+                        Some("messages"),
+                        "Child op patch should target 'messages' container, got d={:?} path={:?}",
+                        d,
+                        path
+                    );
+                    assert_eq!(
+                        path,
+                        &vec![0],
+                        "Child op patch path should be [0] (first child of root), got {:?}",
+                        path
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        // Should have at least 1 remove and 2 inserts
+        let remove_count = patches
+            .iter()
+            .filter(|p| matches!(p, Patch::RemoveChild { .. }))
+            .count();
+        let insert_count = patches
+            .iter()
+            .filter(|p| matches!(p, Patch::InsertChild { .. }))
+            .count();
+        assert!(
+            remove_count >= 1,
+            "Should have at least 1 RemoveChild, got {}",
+            remove_count
+        );
+        assert!(
+            insert_count >= 2,
+            "Should have at least 2 InsertChild, got {}",
+            insert_count
+        );
+
+        // No patches should target the chat-input sibling
+        for patch in &patches {
+            match patch {
+                Patch::InsertChild { d, .. } | Patch::RemoveChild { d, .. } => {
+                    assert_ne!(
+                        d.as_deref(),
+                        Some("chat-input"),
+                        "No child op patches should target the sibling 'chat-input'"
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
 }

--- a/tests/js/patch_grouping.test.js
+++ b/tests/js/patch_grouping.test.js
@@ -1,0 +1,109 @@
+/**
+ * Tests for patch grouping functions used in batched DOM updates.
+ *
+ * Verifies that groupPatchesByParent and groupConsecutiveInserts
+ * correctly separate patches targeting different parent containers.
+ * Regression test for Issue #142 (sibling parent mis-grouping).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+const clientCode = await import('fs').then(fs =>
+    fs.readFileSync('./python/djust/static/djust/client.js', 'utf-8')
+);
+
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+    runScripts: 'dangerously',
+});
+
+dom.window.eval(clientCode);
+
+const { _groupPatchesByParent, _groupConsecutiveInserts } = dom.window.djust;
+
+describe('groupPatchesByParent', () => {
+    it('should group child-op patches by full path (not grandparent)', () => {
+        const patches = [
+            { type: 'RemoveChild', path: [0, 0], d: 'messages', index: 0 },
+            { type: 'InsertChild', path: [0, 0], d: 'messages', index: 0, node: {} },
+            { type: 'InsertChild', path: [0, 0], d: 'messages', index: 1, node: {} },
+        ];
+
+        const groups = _groupPatchesByParent(patches);
+        expect(groups.size).toBe(1);
+        expect(groups.has('0/0')).toBe(true);
+        expect(groups.get('0/0').length).toBe(3);
+    });
+
+    it('should separate InsertChild patches targeting different sibling parents', () => {
+        const patches = [
+            { type: 'RemoveChild', path: [0, 0], d: 'messages', index: 0 },
+            { type: 'InsertChild', path: [0, 0], d: 'messages', index: 0, node: {} },
+            { type: 'InsertChild', path: [0, 0], d: 'messages', index: 1, node: {} },
+            // This targets a sibling container — must NOT merge with above
+            { type: 'InsertChild', path: [0, 1], d: 'chat-input', index: 0, node: {} },
+        ];
+
+        const groups = _groupPatchesByParent(patches);
+        expect(groups.size).toBe(2);
+        expect(groups.get('0/0').length).toBe(3);
+        expect(groups.get('0/1').length).toBe(1);
+        expect(groups.get('0/1')[0].d).toBe('chat-input');
+    });
+
+    it('should use slice(0,-1) for node-targeting patches like SetAttribute', () => {
+        const patches = [
+            { type: 'SetAttribute', path: [0, 0, 1], d: 'child-node', name: 'class', value: 'new' },
+            { type: 'SetAttribute', path: [0, 0, 2], d: 'other-child', name: 'class', value: 'new' },
+        ];
+
+        const groups = _groupPatchesByParent(patches);
+        // Both target nodes under parent [0,0], so grouped under '0/0'
+        expect(groups.size).toBe(1);
+        expect(groups.has('0/0')).toBe(true);
+        expect(groups.get('0/0').length).toBe(2);
+    });
+});
+
+describe('groupConsecutiveInserts', () => {
+    it('should not batch consecutive inserts from different parents', () => {
+        const inserts = [
+            { type: 'InsertChild', path: [0, 0], d: 'messages', index: 0, node: {} },
+            { type: 'InsertChild', path: [0, 0], d: 'messages', index: 1, node: {} },
+            // Different parent, consecutive index — must NOT merge
+            { type: 'InsertChild', path: [0, 1], d: 'chat-input', index: 2, node: {} },
+        ];
+
+        const groups = _groupConsecutiveInserts(inserts);
+        expect(groups.length).toBe(2);
+        expect(groups[0].length).toBe(2);
+        expect(groups[0][0].d).toBe('messages');
+        expect(groups[1].length).toBe(1);
+        expect(groups[1][0].d).toBe('chat-input');
+    });
+
+    it('should batch consecutive inserts from the same parent', () => {
+        const inserts = [
+            { type: 'InsertChild', path: [0, 0], d: 'container', index: 0, node: {} },
+            { type: 'InsertChild', path: [0, 0], d: 'container', index: 1, node: {} },
+            { type: 'InsertChild', path: [0, 0], d: 'container', index: 2, node: {} },
+        ];
+
+        const groups = _groupConsecutiveInserts(inserts);
+        expect(groups.length).toBe(1);
+        expect(groups[0].length).toBe(3);
+    });
+
+    it('should split non-consecutive indices even from same parent', () => {
+        const inserts = [
+            { type: 'InsertChild', path: [0, 0], d: 'container', index: 0, node: {} },
+            { type: 'InsertChild', path: [0, 0], d: 'container', index: 1, node: {} },
+            { type: 'InsertChild', path: [0, 0], d: 'container', index: 5, node: {} },
+        ];
+
+        const groups = _groupConsecutiveInserts(inserts);
+        expect(groups.length).toBe(2);
+        expect(groups[0].length).toBe(2);
+        expect(groups[1].length).toBe(1);
+    });
+});


### PR DESCRIPTION
## Summary

- Fix `groupPatchesByParent()` using grandparent path for child-op patches (`InsertChild`/`RemoveChild`/`MoveChild`), causing sibling containers to be incorrectly merged into one batch group
- Add parent identity check (`d` field) in `groupConsecutiveInserts()` to prevent cross-parent DocumentFragment batching
- Add Rust and Python regression tests with sibling containers

Closes #142

## Root Cause

`patch.path` for `InsertChild`/`RemoveChild` already points to the **parent container**, but `groupPatchesByParent()` applied `slice(0, -1)` unconditionally, computing the **grandparent**. Sibling containers (e.g. `#messages` at `[0,0]` and `.chat-input` at `[0,1]`) both grouped under key `"0"`, and `groupConsecutiveInserts()` batched them into a single DocumentFragment inserted into whichever parent the first patch resolved to.

## Test plan

- [x] `cargo test -p djust_vdom` — all 53 tests pass (new: `test_data_djust_replace_with_siblings`)
- [x] `pytest python/tests/test_vdom_replace.py` — 2 tests pass (new: `test_replace_patches_target_correct_parent_with_sibling`)
- [x] `npm test` — 322 JS tests pass
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)