### PR TITLE
Fix MoveChild in apply_patch by resolving via djust_id

### DIFF
--- a/crates/djust_vdom/src/patch.rs
+++ b/crates/djust_vdom/src/patch.rs
@@ -5,10 +5,76 @@
 
 use crate::{Patch, VNode};
 
-/// Apply a patch to a virtual DOM tree (for testing purposes)
+/// Apply a list of patches to a virtual DOM tree (for testing purposes).
 ///
-/// Note: The `d` field (djust_id) is used for client-side resolution
-/// and is ignored here since we're working with in-memory VNodes.
+/// This function handles `MoveChild` patches correctly by snapshotting
+/// the original children order before applying moves, resolving children
+/// by `djust_id` instead of index. This mirrors the client-side JS
+/// resolution strategy using `data-d` attributes.
+pub fn apply_patches(root: &mut VNode, patches: &[Patch]) {
+    // Snapshot djust_ids of children for each parent path before any moves.
+    // Key: parent path, Value: vec of (original_index, djust_id)
+    let mut move_sources: std::collections::HashMap<Vec<usize>, Vec<(usize, Option<String>)>> =
+        std::collections::HashMap::new();
+
+    for patch in patches {
+        if let Patch::MoveChild { path, .. } = patch {
+            move_sources.entry(path.clone()).or_insert_with(|| {
+                if let Some(target) = get_node(root, path) {
+                    target
+                        .children
+                        .iter()
+                        .enumerate()
+                        .map(|(i, c)| (i, c.djust_id.clone()))
+                        .collect()
+                } else {
+                    Vec::new()
+                }
+            });
+        }
+    }
+
+    for patch in patches {
+        match patch {
+            Patch::MoveChild { path, from, to, .. } => {
+                // Look up the djust_id of the child originally at `from`
+                let child_id = move_sources.get(path).and_then(|sources| {
+                    sources
+                        .iter()
+                        .find(|(i, _)| *i == *from)
+                        .and_then(|(_, id)| id.clone())
+                });
+
+                if let Some(target) = get_node_mut(root, path) {
+                    if let Some(ref child_id) = child_id {
+                        // Find current position by djust_id
+                        if let Some(current_pos) = target
+                            .children
+                            .iter()
+                            .position(|c| c.djust_id.as_deref() == Some(child_id.as_str()))
+                        {
+                            let node = target.children.remove(current_pos);
+                            let insert_at = (*to).min(target.children.len());
+                            target.children.insert(insert_at, node);
+                        }
+                    } else if *from < target.children.len() && *to <= target.children.len() {
+                        // Fallback: no djust_id, use index directly
+                        let node = target.children.remove(*from);
+                        target.children.insert(*to, node);
+                    }
+                }
+            }
+            _ => apply_patch(root, patch),
+        }
+    }
+}
+
+/// Apply a single patch to a virtual DOM tree (for testing purposes)
+///
+/// Note: For correct `MoveChild` handling with multiple moves, prefer
+/// `apply_patches()` which resolves children by `djust_id`. This function
+/// uses index-based `MoveChild` which may produce incorrect results when
+/// multiple moves shift indices.
 pub fn apply_patch(root: &mut VNode, patch: &Patch) {
     match patch {
         Patch::Replace { path, node, .. } => {
@@ -64,6 +130,20 @@ pub fn apply_patch(root: &mut VNode, patch: &Patch) {
             }
         }
     }
+}
+
+fn get_node<'a>(root: &'a VNode, path: &[usize]) -> Option<&'a VNode> {
+    let mut current = root;
+
+    for &index in path {
+        if index < current.children.len() {
+            current = &current.children[index];
+        } else {
+            return None;
+        }
+    }
+
+    Some(current)
 }
 
 fn get_node_mut<'a>(root: &'a mut VNode, path: &[usize]) -> Option<&'a mut VNode> {


### PR DESCRIPTION
## Summary

Fix the `MoveChild` patch application in the Rust test helper so that multiple sequential moves don't corrupt child ordering due to index shifting. Adds `apply_patches()` which snapshots original children `djust_id` values before applying any moves, then resolves each child by `djust_id` instead of raw index — matching the client-side JS resolution strategy.

## Changes

- Add `apply_patches()` function that handles `MoveChild` correctly via `djust_id` resolution
- Add `get_node()` immutable helper (complement to existing `get_node_mut()`)
- Preserve `apply_patch()` unchanged for single-patch use
- Update `diff_apply_verify` to use `apply_patches()`
- Enable full round-trip verification for `torture_keyed_move_apply_verify_simple_swap`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Maintenance / dependency update

## Test Plan

- [x] Existing tests pass (`cargo test -p djust_vdom` — 112 tests)
- [x] `torture_keyed_move_apply_verify_simple_swap` now uses `diff_apply_verify` (was previously a structural-only check)
- [x] All other `diff_apply_verify` tests continue to pass (no regression)

## Checklist

- [x] Code follows project conventions
- [x] Self-reviewed for correctness, edge cases, and security
- [x] No breaking API changes

## Related Issues

Closes #147