### PR TITLE
Add proptest/fuzzing for VDOM diff algorithm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +375,7 @@ dependencies = [
  "djust_core",
  "html5ever",
  "markup5ever_rcdom",
+ "proptest",
  "pyo3",
  "regex",
  "rmp-serde",
@@ -403,6 +419,12 @@ name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futf"
@@ -856,6 +878,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +899,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -947,6 +997,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +1016,44 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "rayon"
@@ -1058,6 +1152,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1321,6 +1427,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,6 +1479,15 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/djust_vdom/Cargo.toml
+++ b/crates/djust_vdom/Cargo.toml
@@ -24,6 +24,7 @@ djust_core = { path = "../djust_core" }
 [dev-dependencies]
 criterion = "0.8"
 tempfile = "3.24"
+proptest = "1.6"
 
 [[bench]]
 name = "diff"

--- a/crates/djust_vdom/tests/fuzz_test.rs
+++ b/crates/djust_vdom/tests/fuzz_test.rs
@@ -1,0 +1,237 @@
+//! Property-based tests for the VDOM diff algorithm using proptest.
+//!
+//! Tests four key properties:
+//! 1. Identity: diff(A, A) produces 0 patches
+//! 2. Round-trip: apply(A, diff(A, B)) structurally equals B (unkeyed trees)
+//! 3. No panics: arbitrary tree pairs (including keyed) never panic
+//! 4. Patch count bounds: patches ≤ total nodes in both trees (unkeyed trees)
+//!
+//! Note: Round-trip and patch-count tests use unkeyed trees because
+//! `apply_patches` is a test utility that applies patches sequentially by
+//! index, which doesn't handle the keyed diff's insert ordering correctly.
+//! The real client uses `data-d` attributes for O(1) element lookup.
+//! See: https://github.com/djust-org/djust/issues/152
+
+use djust_vdom::diff::diff_nodes;
+use djust_vdom::patch::apply_patches;
+use djust_vdom::VNode;
+use proptest::prelude::*;
+use std::collections::HashMap;
+
+// ============================================================================
+// Random VNode tree generators
+// ============================================================================
+
+const TAGS: &[&str] = &["div", "span", "p", "li", "ul", "a", "h1", "section"];
+const ATTR_KEYS: &[&str] = &["class", "style", "href", "title", "role"];
+
+/// Generate a random VNode tree without keys (for round-trip testing).
+fn arb_unkeyed_inner(max_depth: u32, current_depth: u32) -> BoxedStrategy<VNode> {
+    if current_depth >= max_depth {
+        prop_oneof![
+            "[a-zA-Z0-9 ]{1,20}".prop_map(VNode::text),
+            prop::sample::select(TAGS).prop_map(VNode::element),
+        ]
+        .boxed()
+    } else {
+        prop_oneof![
+            "[a-zA-Z0-9 ]{1,20}".prop_map(VNode::text),
+            (
+                prop::sample::select(TAGS),
+                prop::collection::hash_map(prop::sample::select(ATTR_KEYS), "[a-z]{1,10}", 0..=3,),
+                prop::collection::vec(arb_unkeyed_inner(max_depth, current_depth + 1), 0..=6,),
+            )
+                .prop_map(|(tag, attrs, children)| {
+                    let mut node = VNode::element(tag);
+                    node.attrs = attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
+                    node.children = children;
+                    node
+                }),
+        ]
+        .boxed()
+    }
+}
+
+/// Generate a random VNode tree with optional keys (for panic/stress testing).
+fn arb_keyed_inner(max_depth: u32, current_depth: u32) -> BoxedStrategy<VNode> {
+    if current_depth >= max_depth {
+        prop_oneof![
+            "[a-zA-Z0-9 ]{1,20}".prop_map(VNode::text),
+            prop::sample::select(TAGS).prop_map(VNode::element),
+        ]
+        .boxed()
+    } else {
+        prop_oneof![
+            "[a-zA-Z0-9 ]{1,20}".prop_map(VNode::text),
+            (
+                prop::sample::select(TAGS),
+                prop::collection::hash_map(prop::sample::select(ATTR_KEYS), "[a-z]{1,10}", 0..=3,),
+                prop::collection::vec(arb_keyed_inner(max_depth, current_depth + 1), 0..=6,),
+                prop::option::weighted(0.3, "[a-z]{1,5}"),
+            )
+                .prop_map(|(tag, attrs, children, key)| {
+                    let mut node = VNode::element(tag);
+                    node.attrs = attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
+                    node.children = children;
+                    node.key = key;
+                    node
+                }),
+        ]
+        .boxed()
+    }
+}
+
+fn arb_unkeyed_tree() -> BoxedStrategy<VNode> {
+    (0u32..=5)
+        .prop_flat_map(|depth| arb_unkeyed_inner(depth, 0))
+        .boxed()
+}
+
+fn arb_keyed_tree() -> BoxedStrategy<VNode> {
+    (0u32..=5)
+        .prop_flat_map(|depth| arb_keyed_inner(depth, 0))
+        .boxed()
+}
+
+/// Assign unique djust_ids to all element nodes in a tree.
+fn assign_ids(node: &mut VNode, counter: &mut u64) {
+    if !node.is_text() {
+        node.djust_id = Some(format!("t{}", counter));
+        *counter += 1;
+        for child in &mut node.children {
+            assign_ids(child, counter);
+        }
+    }
+}
+
+/// Count total nodes in a tree.
+fn count_nodes(node: &VNode) -> usize {
+    1 + node.children.iter().map(count_nodes).sum::<usize>()
+}
+
+/// Count total attributes across all nodes in a tree.
+fn count_attrs(node: &VNode) -> usize {
+    node.attrs.len() + node.children.iter().map(count_attrs).sum::<usize>()
+}
+
+/// Structural equality check ignoring djust_id.
+fn structurally_equal(a: &VNode, b: &VNode) -> bool {
+    if a.tag != b.tag || a.text != b.text {
+        return false;
+    }
+    let a_attrs: HashMap<String, String> = a
+        .attrs
+        .iter()
+        .filter(|(k, _)| k.as_str() != "data-dj-id")
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    let b_attrs: HashMap<String, String> = b
+        .attrs
+        .iter()
+        .filter(|(k, _)| k.as_str() != "data-dj-id")
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    if a_attrs != b_attrs {
+        return false;
+    }
+    if a.children.len() != b.children.len() {
+        return false;
+    }
+    a.children
+        .iter()
+        .zip(b.children.iter())
+        .all(|(ca, cb)| structurally_equal(ca, cb))
+}
+
+// ============================================================================
+// Property tests
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    /// Property 1: diff(A, A) always produces 0 patches.
+    #[test]
+    fn identity_diff_produces_no_patches(tree in arb_keyed_tree()) {
+        let mut a = tree;
+        let mut counter = 0u64;
+        assign_ids(&mut a, &mut counter);
+
+        let patches = diff_nodes(&a, &a, &[]);
+        prop_assert!(
+            patches.is_empty(),
+            "diff(A, A) produced {} patches: {:?}",
+            patches.len(),
+            patches
+        );
+    }
+
+    /// Property 2: apply(A, diff(A, B)) structurally equals B.
+    /// Uses unkeyed trees only — keyed apply_patches has index ordering
+    /// limitations (the real client uses data-d for O(1) resolution).
+    #[test]
+    fn round_trip_correctness(
+        tree_a in arb_unkeyed_tree(),
+        tree_b in arb_unkeyed_tree(),
+    ) {
+        let mut a = tree_a;
+        let mut b = tree_b;
+
+        let mut counter = 0u64;
+        assign_ids(&mut a, &mut counter);
+        counter = 0;
+        assign_ids(&mut b, &mut counter);
+
+        let patches = diff_nodes(&a, &b, &[]);
+        let mut patched = a.clone();
+        apply_patches(&mut patched, &patches);
+
+        prop_assert!(
+            structurally_equal(&patched, &b),
+            "Round-trip failed.\nA: {:?}\nB: {:?}\nPatches: {:?}\nPatched: {:?}",
+            a, b, patches, patched,
+        );
+    }
+
+    /// Property 3: arbitrary tree pairs (including keyed) never cause panics.
+    #[test]
+    fn no_panics_on_arbitrary_trees(
+        tree_a in arb_keyed_tree(),
+        tree_b in arb_keyed_tree(),
+    ) {
+        let mut a = tree_a;
+        let mut b = tree_b;
+        let mut counter = 0u64;
+        assign_ids(&mut a, &mut counter);
+        counter = 0;
+        assign_ids(&mut b, &mut counter);
+
+        let _patches = diff_nodes(&a, &b, &[]);
+    }
+
+    /// Property 4: patch count is bounded by total nodes + total attributes.
+    /// Each node can produce at most: 1 structural patch + N attribute patches.
+    #[test]
+    fn patch_count_bounded(
+        tree_a in arb_unkeyed_tree(),
+        tree_b in arb_unkeyed_tree(),
+    ) {
+        let mut a = tree_a;
+        let mut b = tree_b;
+        let mut counter = 0u64;
+        assign_ids(&mut a, &mut counter);
+        counter = 0;
+        assign_ids(&mut b, &mut counter);
+
+        let total_nodes = count_nodes(&a) + count_nodes(&b);
+        let total_attrs = count_attrs(&a) + count_attrs(&b);
+        let bound = total_nodes + total_attrs;
+        let patches = diff_nodes(&a, &b, &[]);
+
+        prop_assert!(
+            patches.len() <= bound,
+            "Patch count {} exceeds bound {} (nodes={}, attrs={})",
+            patches.len(), bound, total_nodes, total_attrs,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add property-based tests using proptest for the VDOM diff algorithm
- Tests 4 key properties across randomly-generated VNode trees (500 cases each)
- Discovered and filed a follow-up issue for `apply_patches` keyed diff limitation (#152)

## Changes

- **`crates/djust_vdom/Cargo.toml`**: Add `proptest = "1.6"` as dev dependency
- **`crates/djust_vdom/tests/fuzz_test.rs`**: New proptest file with:
  - Random unkeyed and keyed VNode tree generators (depth 0-5, width 0-6)
  - Identity property: `diff(A, A)` always produces 0 patches
  - Round-trip property: `apply(A, diff(A, B))` structurally equals B (unkeyed)
  - No-panics property: arbitrary keyed tree pairs never cause panics
  - Patch count bounds: patches ≤ total nodes + total attributes
- **`Cargo.lock`**: Updated with proptest dependencies

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test Plan

- [x] Existing tests pass (`cargo test` — all 42 VDOM tests pass)
- [x] New tests added for changed functionality (4 proptest properties, 500 cases each)
- [x] All pre-commit hooks pass (cargo fmt, clippy, cargo test, cargo audit)

## Checklist

- [x] Code follows project conventions
- [x] Self-reviewed for correctness, edge cases, and security
- [x] Documentation updated (if applicable)
- [x] No breaking API changes (or clearly noted above)

## Related Issues

Closes #146
Follow-up: #152 (apply_patches keyed diff limitation discovered by proptest)