### PR TITLE
feat: scope debug toolbar state persistence to current view (#158)

### DIFF
--- a/python/djust/static/djust/src/debug/11-integration.js
+++ b/python/djust/static/djust/src/debug/11-integration.js
@@ -117,10 +117,15 @@
 
             // Update view info
             if (debugInfo.view_name) {
+                const prevView = this.viewInfo && this.viewInfo.name;
                 this.viewInfo = {
                     name: debugInfo.view_name,
                     module: debugInfo.view_module
                 };
+                // If view changed, reset data and reload view-scoped state
+                if (prevView !== debugInfo.view_name && this.onViewMount) {
+                    this.onViewMount();
+                }
             }
         }
 

--- a/python/djust/static/djust/src/debug/15-panel-controls.js
+++ b/python/djust/static/djust/src/debug/15-panel-controls.js
@@ -56,20 +56,31 @@
             this.renderTabContent();
         }
 
-        // State persistence
+        // State persistence (scoped per view)
+        _stateKey() {
+            const viewName = this.viewInfo && this.viewInfo.name;
+            return viewName ? `djust-debug-state-${viewName}` : 'djust-debug-state';
+        }
+
         saveState() {
-            localStorage.setItem('djust-debug-state', JSON.stringify(this.state));
+            // Only persist UI state, not transient data like filters/search
+            const uiState = {
+                isOpen: this.state.isOpen,
+                activeTab: this.state.activeTab
+            };
+            localStorage.setItem(this._stateKey(), JSON.stringify(uiState));
         }
 
         loadState() {
-            const saved = localStorage.getItem('djust-debug-state');
+            const saved = localStorage.getItem(this._stateKey());
             if (saved) {
                 try {
                     const parsedState = JSON.parse(saved);
-                    this.state = { ...this.state, ...parsedState };
+                    // Only restore UI state fields
+                    if (parsedState.isOpen !== undefined) this.state.isOpen = parsedState.isOpen;
+                    if (parsedState.activeTab) this.state.activeTab = parsedState.activeTab;
 
                     // Restore panel visibility and active tab if saved
-                    // Combined into single setTimeout to reduce queued microtasks
                     if (parsedState.isOpen || parsedState.activeTab) {
                         setTimeout(() => {
                             if (parsedState.isOpen) this.open();
@@ -79,6 +90,25 @@
                 } catch (e) {
                     console.warn('[djust] Failed to load debug panel state:', e);
                 }
+            }
+        }
+
+        // Called when a new view connects — clear stale data, reload view-scoped state
+        onViewMount() {
+            this.eventHistory = [];
+            this.patchHistory = [];
+            this.networkHistory = [];
+            this.stateHistory = [];
+            this.errorCount = 0;
+            this.warningCount = 0;
+            this.updateErrorBadge();
+            this.updateCounter('event-count', 0);
+            this.updateCounter('patch-count', 0);
+            this.updateCounter('error-count', 0);
+            this.updateCounter('warning-count', 0);
+            this.loadState();
+            if (this.state.isOpen) {
+                this.renderTabContent();
             }
         }
 


### PR DESCRIPTION
## Summary

Fix debug toolbar state persistence so it's scoped per-view instead of global, preventing stale data after TurboNav navigation.

## Changes

- `_stateKey()` generates view-scoped localStorage key (`djust-debug-state-{viewName}`)
- `saveState()` only persists UI state (`isOpen`, `activeTab`), not filters/searchQuery
- `loadState()` only restores UI state fields
- `onViewMount()` clears data histories and reloads view-scoped state on view change
- `processDebugInfo()` detects view name changes and triggers `onViewMount()`

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test Plan

- [x] Existing tests pass (`make test`)
- [x] Manual testing: Navigate between views, verify state scoping

## Checklist

- [x] Code follows project conventions
- [x] Self-reviewed for correctness, edge cases, and security
- [x] No breaking API changes

## Related Issues

Closes #158