### PR TITLE
feat: add event replay button to Debug Toolbar Events tab (#165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Debug Toolbar: Event Filtering** — Filter events by handler/event name (substring match) and by status (all/errors/success) with a clear button to reset filters ([#164](https://github.com/djust-org/djust/issues/164))
+- **Debug Toolbar: Event Replay** — Replay button on each event entry re-sends the event through the WebSocket connection with original params, with inline pending/success/error feedback ([#165](https://github.com/djust-org/djust/issues/165))
 
 ## [0.2.2rc3] - 2026-01-31
 


### PR DESCRIPTION
## Summary

Add a replay button to each event in the Events tab history, allowing developers to re-trigger events for debugging.

## Changes

- Added replay button to each event entry (only shown when event has name and params)
- Added `replayEvent()` method that re-sends events through the WebSocket connection
- Shows inline feedback: ⏳ pending, ✓ success, ✗ error
- Status auto-clears after 3 seconds
- Replay uses filtered index to correctly map to events when filters are active

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test Plan

- [x] Existing tests pass (`npm test` — 328 passed)
- [ ] Manual testing performed

## Checklist

- [x] Code follows project conventions
- [x] Self-reviewed for correctness, edge cases, and security
- [x] Documentation updated (CHANGELOG.md)
- [x] No breaking API changes

## Related Issues

Closes #165