### PR TITLE
feat: add event filtering controls to Events tab (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Debug Toolbar: Network Message Inspection** — Network tab messages now have directional color coding (blue for sent, green for received), and expanded messages include a copy-to-clipboard button with visual feedback. ([#167](https://github.com/djust-org/djust/issues/167))
+- **Debug Toolbar: Event Filtering Controls** — Events tab now includes filter controls: text search by event/handler name (substring match), status filter (all/errors/success), clear filters button, and match count display. Filters persist across tab switches. ([#170](https://github.com/djust-org/djust/issues/170))
 
 ## [0.2.2rc3] - 2026-01-31
 

--- a/python/djust/static/djust/debug-panel.css
+++ b/python/djust/static/djust/debug-panel.css
@@ -821,3 +821,68 @@
     border-color: var(--djust-success);
     color: white;
 }
+
+/* --- Events Filter Bar --- */
+.events-filter-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background: var(--djust-bg-sidebar);
+    border-bottom: 1px solid var(--djust-border);
+    position: sticky;
+    top: 0;
+    z-index: 5;
+}
+
+.events-filter-input {
+    flex: 1;
+    max-width: 240px;
+    padding: 5px 10px;
+    font-size: 12px;
+    font-family: var(--djust-font-mono);
+    background: var(--djust-bg-item);
+    border: 1px solid var(--djust-border);
+    border-radius: 4px;
+    color: var(--djust-text-main);
+    outline: none;
+}
+
+.events-filter-input:focus {
+    border-color: var(--djust-accent);
+}
+
+.events-filter-input::placeholder {
+    color: var(--djust-text-muted);
+}
+
+.events-filter-select {
+    padding: 5px 8px;
+    font-size: 12px;
+    background: var(--djust-bg-item);
+    border: 1px solid var(--djust-border);
+    border-radius: 4px;
+    color: var(--djust-text-main);
+    cursor: pointer;
+    outline: none;
+}
+
+.events-filter-select:focus {
+    border-color: var(--djust-accent);
+}
+
+.events-filter-clear {
+    color: var(--djust-error);
+    border-color: rgba(239, 68, 68, 0.3);
+}
+
+.events-filter-clear:hover {
+    background: rgba(239, 68, 68, 0.1);
+    border-color: var(--djust-error);
+}
+
+.events-filter-count {
+    font-size: 11px;
+    color: var(--djust-text-muted);
+    margin-left: auto;
+}

--- a/python/djust/static/djust/debug-panel.js
+++ b/python/djust/static/djust/debug-panel.js
@@ -33,7 +33,9 @@
                 searchQuery: '',
                 filters: {
                     types: [],
-                    severity: 'all'
+                    severity: 'all',
+                    eventName: '',
+                    eventStatus: 'all'
                 }
             };
 
@@ -1743,14 +1745,42 @@
                 return '<div class="empty-state">No events captured yet. Interact with the page to see events.</div>';
             }
 
+            // Apply filters
+            const nameFilter = (this.state.filters.eventName || '').toLowerCase();
+            const statusFilter = this.state.filters.eventStatus || 'all';
+
+            const filtered = this.eventHistory.filter(event => {
+                const name = (event.handler || event.name || '').toLowerCase();
+                if (nameFilter && !name.includes(nameFilter)) return false;
+                if (statusFilter === 'errors' && !event.error) return false;
+                if (statusFilter === 'success' && event.error) return false;
+                return true;
+            });
+
+            const hasActiveFilters = nameFilter || statusFilter !== 'all';
+
             return `
+                <div class="events-filter-bar">
+                    <input type="text" class="events-filter-input" placeholder="Filter by event name..."
+                        value="${this.escapeHtml(this.state.filters.eventName || '')}"
+                        oninput="window.djustDebugPanel.setEventNameFilter(this.value)" />
+                    <select class="events-filter-select" onchange="window.djustDebugPanel.setEventStatusFilter(this.value)">
+                        <option value="all" ${statusFilter === 'all' ? 'selected' : ''}>All</option>
+                        <option value="errors" ${statusFilter === 'errors' ? 'selected' : ''}>Errors only</option>
+                        <option value="success" ${statusFilter === 'success' ? 'selected' : ''}>Success only</option>
+                    </select>
+                    ${hasActiveFilters ? `<button class="btn-xs events-filter-clear" onclick="window.djustDebugPanel.clearEventFilters()">Clear filters</button>` : ''}
+                    <span class="events-filter-count">${filtered.length} / ${this.eventHistory.length}</span>
+                </div>
+                ${filtered.length === 0 ? '<div class="empty-state">No events match the current filters.</div>' : `
                 <div class="events-list">
-                    ${this.eventHistory.map((event, index) => {
+                    ${filtered.map((event, index) => {
                         const hasDetails = event.params || event.error || event.result;
                         const paramCount = event.params ? Object.keys(event.params).length : 0;
+                        const originalIndex = this.eventHistory.indexOf(event);
 
                         return `
-                            <div class="event-item ${event.error ? 'error' : ''} ${hasDetails ? 'expandable' : ''}" data-index="${index}">
+                            <div class="event-item ${event.error ? 'error' : ''} ${hasDetails ? 'expandable' : ''}" data-index="${originalIndex}">
                                 <div class="event-header" ${hasDetails ? 'onclick="window.djustDebugPanel.toggleExpand(this)"' : ''}>
                                     ${hasDetails ? '<span class="expand-icon">▶</span>' : ''}
                                     <span class="event-name">${event.handler || event.name || 'unknown'}</span>
@@ -1802,7 +1832,27 @@
                         `;
                     }).join('')}
                 </div>
+                `}
             `;
+        }
+
+        setEventNameFilter(value) {
+            this.state.filters.eventName = value;
+            this.saveState();
+            this.renderTabContent();
+        }
+
+        setEventStatusFilter(value) {
+            this.state.filters.eventStatus = value;
+            this.saveState();
+            this.renderTabContent();
+        }
+
+        clearEventFilters() {
+            this.state.filters.eventName = '';
+            this.state.filters.eventStatus = 'all';
+            this.saveState();
+            this.renderTabContent();
         }
 
         renderNetworkTab() {

--- a/python/djust/static/djust/src/debug/00-panel-core.js
+++ b/python/djust/static/djust/src/debug/00-panel-core.js
@@ -33,7 +33,9 @@
                 searchQuery: '',
                 filters: {
                     types: [],
-                    severity: 'all'
+                    severity: 'all',
+                    eventName: '',
+                    eventStatus: 'all'
                 }
             };
 

--- a/tests/js/debug_panel_events_filter.test.js
+++ b/tests/js/debug_panel_events_filter.test.js
@@ -1,0 +1,100 @@
+/**
+ * Tests for debug panel Events tab filtering (Issue #170)
+ *
+ * Verifies event name filtering, status filtering, and filter clearing.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Simulate the filtering logic from renderEventsTab
+function filterEvents(events, nameFilter, statusFilter) {
+    const name = (nameFilter || '').toLowerCase();
+    const status = statusFilter || 'all';
+
+    return events.filter(event => {
+        const eventName = (event.handler || event.name || '').toLowerCase();
+        if (name && !eventName.includes(name)) return false;
+        if (status === 'errors' && !event.error) return false;
+        if (status === 'success' && event.error) return false;
+        return true;
+    });
+}
+
+const mockEvents = [
+    { handler: 'increment', name: 'increment', error: null, params: { amount: 1 }, timestamp: 1 },
+    { handler: 'decrement', name: 'decrement', error: null, params: {}, timestamp: 2 },
+    { handler: 'submit_form', name: 'submit_form', error: 'Validation failed', params: { data: 'x' }, timestamp: 3 },
+    { handler: 'increment', name: 'increment', error: 'Overflow', params: { amount: 999 }, timestamp: 4 },
+    { handler: 'reset', name: 'reset', error: null, params: {}, timestamp: 5 },
+];
+
+describe('Event name filtering', () => {
+    it('should show all events when filter is empty', () => {
+        const result = filterEvents(mockEvents, '', 'all');
+        expect(result.length).toBe(5);
+    });
+
+    it('should filter by substring match', () => {
+        const result = filterEvents(mockEvents, 'incr', 'all');
+        expect(result.length).toBe(2);
+        expect(result.every(e => e.handler === 'increment')).toBe(true);
+    });
+
+    it('should be case-insensitive', () => {
+        const result = filterEvents(mockEvents, 'INCREMENT', 'all');
+        expect(result.length).toBe(2);
+    });
+
+    it('should return empty when no match', () => {
+        const result = filterEvents(mockEvents, 'nonexistent', 'all');
+        expect(result.length).toBe(0);
+    });
+});
+
+describe('Event status filtering', () => {
+    it('should show only errors', () => {
+        const result = filterEvents(mockEvents, '', 'errors');
+        expect(result.length).toBe(2);
+        expect(result.every(e => e.error !== null)).toBe(true);
+    });
+
+    it('should show only successes', () => {
+        const result = filterEvents(mockEvents, '', 'success');
+        expect(result.length).toBe(3);
+        expect(result.every(e => e.error === null)).toBe(true);
+    });
+
+    it('should show all with "all" filter', () => {
+        const result = filterEvents(mockEvents, '', 'all');
+        expect(result.length).toBe(5);
+    });
+});
+
+describe('Combined filters', () => {
+    it('should combine name and status filters', () => {
+        const result = filterEvents(mockEvents, 'increment', 'errors');
+        expect(result.length).toBe(1);
+        expect(result[0].error).toBe('Overflow');
+    });
+
+    it('should return empty when combined filters eliminate all', () => {
+        const result = filterEvents(mockEvents, 'reset', 'errors');
+        expect(result.length).toBe(0);
+    });
+});
+
+describe('Filter state detection', () => {
+    it('should detect active filters', () => {
+        const nameFilter = 'incr';
+        const statusFilter = 'all';
+        const hasActiveFilters = nameFilter || statusFilter !== 'all';
+        expect(hasActiveFilters).toBe('incr'); // truthy
+    });
+
+    it('should detect no active filters', () => {
+        const nameFilter = '';
+        const statusFilter = 'all';
+        const hasActiveFilters = nameFilter || statusFilter !== 'all';
+        expect(hasActiveFilters).toBeFalsy();
+    });
+});


### PR DESCRIPTION
## Summary

Adds filter controls to the Events tab for quickly finding specific events in the debug history.

## Changes

- Filter bar with text input (substring match on event/handler name), status dropdown, clear button
- Match count display showing filtered/total
- Empty state when no events match active filters
- Filters persist across tab switches via `saveState()`
- Added `eventName` and `eventStatus` to default filter state

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test Plan

- [x] Existing tests pass (`make test`)
- [x] New tests added for changed functionality
- [ ] Manual testing performed (describe below)

## Checklist

- [x] Code follows project conventions
- [x] Self-reviewed for correctness, edge cases, and security
- [x] Documentation updated (if applicable)
- [x] No breaking API changes (or clearly noted above)

## Related Issues

Closes #170