### PR TITLE
feat: add event replay button to Events tab (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Debug Toolbar: Network Message Inspection** — Network tab messages now have directional color coding (blue for sent, green for received), and expanded messages include a copy-to-clipboard button with visual feedback. ([#167](https://github.com/djust-org/djust/issues/167))
 - **Debug Toolbar: Event Filtering Controls** — Events tab now includes filter controls: text search by event/handler name (substring match), status filter (all/errors/success), clear filters button, and match count display. Filters persist across tab switches. ([#170](https://github.com/djust-org/djust/issues/170))
+- **Debug Toolbar: Event Replay Button** — Each event in the Events tab with params now has a "Replay" button that re-sends the event through the WebSocket connection with inline status feedback (pending, success, error). ([#171](https://github.com/djust-org/djust/issues/171))
 
 ## [0.2.2rc3] - 2026-01-31
 

--- a/python/djust/static/djust/debug-panel.css
+++ b/python/djust/static/djust/debug-panel.css
@@ -886,3 +886,29 @@
     color: var(--djust-text-muted);
     margin-left: auto;
 }
+
+/* --- Event Replay Button --- */
+.event-replay-btn {
+    margin-left: 8px;
+    font-size: 10px;
+    padding: 2px 6px;
+    flex-shrink: 0;
+}
+
+.event-replay-btn.replay-pending {
+    background: var(--djust-warning);
+    border-color: var(--djust-warning);
+    color: #000;
+}
+
+.event-replay-btn.replay-success {
+    background: var(--djust-success);
+    border-color: var(--djust-success);
+    color: white;
+}
+
+.event-replay-btn.replay-error {
+    background: var(--djust-error);
+    border-color: var(--djust-error);
+    color: white;
+}

--- a/python/djust/static/djust/src/debug/03-tab-events.js
+++ b/python/djust/static/djust/src/debug/03-tab-events.js
@@ -49,6 +49,7 @@
                                     ${paramCount > 0 ? `<span class="event-param-count">${paramCount} param${paramCount === 1 ? '' : 's'}</span>` : ''}
                                     ${event.error ? '<span class="event-status">❌</span>' : ''}
                                     <span class="event-time">${this.formatTime(event.timestamp)}</span>
+                                    ${event.params ? `<button class="btn-xs event-replay-btn" onclick="event.stopPropagation(); window.djustDebugPanel.replayEvent(this, ${originalIndex})">Replay</button>` : ''}
                                 </div>
                                 ${hasDetails ? `
                                     <div class="event-details" style="display: none;">

--- a/python/djust/static/djust/src/debug/11-integration.js
+++ b/python/djust/static/djust/src/debug/11-integration.js
@@ -5,6 +5,9 @@
                 const self = this;
 
                 WebSocket.prototype.send = function(data) {
+                    // Store reference to the active WebSocket for replay
+                    self._activeWebSocket = this;
+
                     self.captureNetworkMessage({
                         direction: 'sent',
                         type: self.detectMessageType(data),

--- a/python/djust/static/djust/src/debug/14-utils.js
+++ b/python/djust/static/djust/src/debug/14-utils.js
@@ -204,6 +204,50 @@
             }
         }
 
+        replayEvent(buttonElement, index) {
+            const event = this.eventHistory[index];
+            if (!event || !event.params) return;
+
+            const ws = this._activeWebSocket;
+            if (!ws || ws.readyState !== WebSocket.OPEN) {
+                buttonElement.textContent = 'No connection';
+                buttonElement.classList.add('replay-error');
+                setTimeout(() => {
+                    buttonElement.textContent = 'Replay';
+                    buttonElement.classList.remove('replay-error');
+                }, 1500);
+                return;
+            }
+
+            buttonElement.textContent = 'Sending...';
+            buttonElement.classList.add('replay-pending');
+
+            try {
+                const message = JSON.stringify({
+                    type: 'event',
+                    event: event.handler || event.name,
+                    params: event.params
+                });
+                ws.send(message);
+
+                buttonElement.textContent = 'Sent!';
+                buttonElement.classList.remove('replay-pending');
+                buttonElement.classList.add('replay-success');
+                setTimeout(() => {
+                    buttonElement.textContent = 'Replay';
+                    buttonElement.classList.remove('replay-success');
+                }, 2000);
+            } catch (err) {
+                buttonElement.textContent = 'Error';
+                buttonElement.classList.remove('replay-pending');
+                buttonElement.classList.add('replay-error');
+                setTimeout(() => {
+                    buttonElement.textContent = 'Replay';
+                    buttonElement.classList.remove('replay-error');
+                }, 2000);
+            }
+        }
+
         copyPayload(buttonElement, index) {
             const stats = window.liveview && window.liveview.stats ? window.liveview.stats : null;
             const messages = stats ? stats.messages : this.networkHistory;

--- a/tests/js/debug_panel_replay.test.js
+++ b/tests/js/debug_panel_replay.test.js
@@ -1,0 +1,92 @@
+/**
+ * Tests for debug panel event replay (Issue #171)
+ *
+ * Verifies replay message construction, WebSocket availability check,
+ * and button state feedback logic.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+describe('Event replay message construction', () => {
+    it('should construct correct WebSocket message from event', () => {
+        const event = { handler: 'increment', name: 'increment', params: { amount: 5 } };
+        const message = JSON.stringify({
+            type: 'event',
+            event: event.handler || event.name,
+            params: event.params
+        });
+        const parsed = JSON.parse(message);
+
+        expect(parsed.type).toBe('event');
+        expect(parsed.event).toBe('increment');
+        expect(parsed.params.amount).toBe(5);
+    });
+
+    it('should fall back to name when handler is missing', () => {
+        const event = { name: 'submit', params: { data: 'test' } };
+        const message = JSON.stringify({
+            type: 'event',
+            event: event.handler || event.name,
+            params: event.params
+        });
+        const parsed = JSON.parse(message);
+
+        expect(parsed.event).toBe('submit');
+    });
+
+    it('should not be replayable without params', () => {
+        const event = { handler: 'reset', params: null };
+        const canReplay = !!event.params;
+        expect(canReplay).toBe(false);
+    });
+
+    it('should be replayable with empty params object', () => {
+        const event = { handler: 'reset', params: {} };
+        const canReplay = !!event.params;
+        expect(canReplay).toBe(true);
+    });
+});
+
+describe('WebSocket readiness check', () => {
+    it('should detect when WebSocket is not available', () => {
+        const ws = null;
+        const isReady = ws && ws.readyState === 1; // WebSocket.OPEN = 1
+        expect(isReady).toBeFalsy();
+    });
+
+    it('should detect when WebSocket is open', () => {
+        const ws = { readyState: 1 }; // WebSocket.OPEN
+        const isReady = ws && ws.readyState === 1;
+        expect(isReady).toBe(true);
+    });
+
+    it('should detect when WebSocket is closed', () => {
+        const ws = { readyState: 3 }; // WebSocket.CLOSED
+        const isReady = ws && ws.readyState === 1;
+        expect(isReady).toBeFalsy();
+    });
+});
+
+describe('Replay button feedback states', () => {
+    it('should cycle through pending -> success states', () => {
+        const states = [];
+        const btn = {
+            textContent: 'Replay',
+            classList: {
+                add: (cls) => states.push(`+${cls}`),
+                remove: (cls) => states.push(`-${cls}`),
+            }
+        };
+
+        // Simulate success flow
+        btn.textContent = 'Sending...';
+        btn.classList.add('replay-pending');
+        expect(btn.textContent).toBe('Sending...');
+
+        btn.textContent = 'Sent!';
+        btn.classList.remove('replay-pending');
+        btn.classList.add('replay-success');
+        expect(btn.textContent).toBe('Sent!');
+        expect(states).toContain('+replay-success');
+    });
+});


### PR DESCRIPTION
## Summary

Adds a "Replay" button to each event in the Events tab, allowing developers to re-trigger events for debugging.

## Changes

- Replay button on each event with params (sends via active WebSocket)
- Inline feedback: pending (yellow), success (green), error (red)
- Stores reference to active WebSocket via intercepted `send` calls
- `replayEvent()` method with connection check and error handling

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test Plan

- [x] Existing tests pass (`make test`)
- [x] New tests added for changed functionality
- [ ] Manual testing performed (describe below)

## Checklist

- [x] Code follows project conventions
- [x] Self-reviewed for correctness, edge cases, and security
- [x] Documentation updated (if applicable)
- [x] No breaking API changes (or clearly noted above)

## Related Issues

Closes #171