### PR TITLE
feat: add event filtering controls to Events tab (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Debug Toolbar: Event Filtering** — Events tab now has filter controls to search by event/handler name (substring match) and filter by status (all/errors/success). Includes a clear button and match count display. (#176)
+
 ## [0.2.2rc3] - 2026-01-31
 
 ### Fixed

--- a/docs/DEBUG_PANEL.md
+++ b/docs/DEBUG_PANEL.md
@@ -136,6 +136,9 @@ search • 45.2ms • 4:32:15 PM   [Click to expand]
 - **Copy JSON**: Copy event data for testing
 - **Export all**: Download entire event history as JSON
 - **Color coding**: Green for success, red for errors
+- **Filter by name**: Substring search to find specific events quickly
+- **Filter by status**: Show all, errors only, or successes only
+- **Clear filters**: Single action to reset all active filters
 
 ### VDOM Patches Tab
 

--- a/python/djust/static/djust/debug-panel.css
+++ b/python/djust/static/djust/debug-panel.css
@@ -243,6 +243,77 @@
     color: var(--djust-text-muted);
 }
 
+/* Event Filter Bar */
+.events-filter-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background: var(--djust-bg-item);
+    border: 1px solid var(--djust-border);
+    border-radius: 4px;
+    margin-bottom: 8px;
+}
+
+.events-filter-input {
+    flex: 1;
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid var(--djust-border);
+    border-radius: 4px;
+    padding: 4px 8px;
+    color: var(--djust-text);
+    font-family: var(--djust-font-mono);
+    font-size: 12px;
+    outline: none;
+}
+
+.events-filter-input:focus {
+    border-color: var(--djust-accent);
+}
+
+.events-filter-input::placeholder {
+    color: var(--djust-text-muted);
+}
+
+.events-filter-select {
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid var(--djust-border);
+    border-radius: 4px;
+    padding: 4px 8px;
+    color: var(--djust-text);
+    font-family: var(--djust-font-mono);
+    font-size: 12px;
+    cursor: pointer;
+    outline: none;
+}
+
+.events-filter-select:focus {
+    border-color: var(--djust-accent);
+}
+
+.events-filter-clear {
+    background: rgba(239, 68, 68, 0.15);
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    border-radius: 4px;
+    padding: 4px 10px;
+    color: var(--djust-error);
+    font-family: var(--djust-font-mono);
+    font-size: 11px;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.events-filter-clear:hover {
+    background: rgba(239, 68, 68, 0.25);
+}
+
+.events-filter-count {
+    color: var(--djust-text-muted);
+    font-family: var(--djust-font-mono);
+    font-size: 11px;
+    white-space: nowrap;
+}
+
 /* Event Item */
 .event-item {
     background: var(--djust-bg-item);

--- a/python/djust/static/djust/src/debug/00-panel-core.js
+++ b/python/djust/static/djust/src/debug/00-panel-core.js
@@ -33,7 +33,9 @@
                 searchQuery: '',
                 filters: {
                     types: [],
-                    severity: 'all'
+                    severity: 'all',
+                    eventName: '',
+                    eventStatus: 'all'
                 }
             };
 

--- a/python/djust/static/djust/src/debug/03-tab-events.js
+++ b/python/djust/static/djust/src/debug/03-tab-events.js
@@ -5,9 +5,38 @@
                 return '<div class="empty-state">No events captured yet. Interact with the page to see events.</div>';
             }
 
+            const nameFilter = (this.state.filters.eventName || '').toLowerCase();
+            const statusFilter = this.state.filters.eventStatus || 'all';
+
+            const filtered = this.eventHistory.filter(event => {
+                const eventName = (event.handler || event.name || 'unknown').toLowerCase();
+                if (nameFilter && !eventName.includes(nameFilter)) return false;
+                if (statusFilter === 'errors' && !event.error) return false;
+                if (statusFilter === 'success' && event.error) return false;
+                return true;
+            });
+
+            const hasActiveFilters = nameFilter || statusFilter !== 'all';
+
             return `
+                <div class="events-filter-bar">
+                    <input type="text"
+                        class="events-filter-input"
+                        placeholder="Filter by event name..."
+                        value="${this.escapeHtml(this.state.filters.eventName || '')}"
+                        oninput="window.djustDebugPanel.onEventNameFilter(this.value)" />
+                    <select class="events-filter-select"
+                        onchange="window.djustDebugPanel.onEventStatusFilter(this.value)">
+                        <option value="all"${statusFilter === 'all' ? ' selected' : ''}>All</option>
+                        <option value="errors"${statusFilter === 'errors' ? ' selected' : ''}>Errors only</option>
+                        <option value="success"${statusFilter === 'success' ? ' selected' : ''}>Success only</option>
+                    </select>
+                    ${hasActiveFilters ? `<button class="events-filter-clear" onclick="window.djustDebugPanel.clearEventFilters()">Clear</button>` : ''}
+                    <span class="events-filter-count">${filtered.length} / ${this.eventHistory.length}</span>
+                </div>
                 <div class="events-list">
-                    ${this.eventHistory.map((event, index) => {
+                    ${filtered.length === 0 ? '<div class="empty-state">No events match the current filters.</div>' :
+                    filtered.map((event, index) => {
                         const hasDetails = event.params || event.error || event.result;
                         const paramCount = event.params ? Object.keys(event.params).length : 0;
 
@@ -65,4 +94,20 @@
                     }).join('')}
                 </div>
             `;
+        }
+
+        onEventNameFilter(value) {
+            this.state.filters.eventName = value;
+            this.renderTabContent();
+        }
+
+        onEventStatusFilter(value) {
+            this.state.filters.eventStatus = value;
+            this.renderTabContent();
+        }
+
+        clearEventFilters() {
+            this.state.filters.eventName = '';
+            this.state.filters.eventStatus = 'all';
+            this.renderTabContent();
         }

--- a/tests/js/debug_event_filter.test.js
+++ b/tests/js/debug_event_filter.test.js
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for debug panel event filtering (Issue #176)
+ *
+ * Since the debug panel is an IIFE, we test the filtering logic
+ * by replicating the filter function used in renderEventsTab().
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Replicate the filter logic from 03-tab-events.js
+function filterEvents(events, nameFilter, statusFilter) {
+    const name = (nameFilter || '').toLowerCase();
+    const status = statusFilter || 'all';
+    return events.filter(event => {
+        const eventName = (event.handler || event.name || 'unknown').toLowerCase();
+        if (name && !eventName.includes(name)) return false;
+        if (status === 'errors' && !event.error) return false;
+        if (status === 'success' && event.error) return false;
+        return true;
+    });
+}
+
+const sampleEvents = [
+    { handler: 'increment', timestamp: Date.now(), params: { amount: 1 } },
+    { handler: 'decrement', timestamp: Date.now() },
+    { handler: 'search', timestamp: Date.now(), error: 'Not found' },
+    { handler: 'fetch_data', timestamp: Date.now(), params: { id: 5 } },
+    { name: 'click_handler', timestamp: Date.now(), error: 'Timeout' },
+];
+
+describe('Event Filter Logic', () => {
+    it('returns all events when no filters active', () => {
+        const result = filterEvents(sampleEvents, '', 'all');
+        expect(result).toHaveLength(5);
+    });
+
+    it('filters by name substring (case-insensitive)', () => {
+        const result = filterEvents(sampleEvents, 'inc', 'all');
+        expect(result).toHaveLength(1);
+        expect(result[0].handler).toBe('increment');
+    });
+
+    it('filters by name substring matching multiple events', () => {
+        const result = filterEvents(sampleEvents, 'cre', 'all');
+        // increment, decrement both contain 'cre'
+        expect(result).toHaveLength(2);
+    });
+
+    it('filters errors only', () => {
+        const result = filterEvents(sampleEvents, '', 'errors');
+        expect(result).toHaveLength(2);
+        result.forEach(e => expect(e.error).toBeTruthy());
+    });
+
+    it('filters success only', () => {
+        const result = filterEvents(sampleEvents, '', 'success');
+        expect(result).toHaveLength(3);
+        result.forEach(e => expect(e.error).toBeFalsy());
+    });
+
+    it('combines name and status filters', () => {
+        const result = filterEvents(sampleEvents, 'search', 'errors');
+        expect(result).toHaveLength(1);
+        expect(result[0].handler).toBe('search');
+    });
+
+    it('returns empty when no match', () => {
+        const result = filterEvents(sampleEvents, 'nonexistent', 'all');
+        expect(result).toHaveLength(0);
+    });
+
+    it('falls back to "unknown" for events without handler or name', () => {
+        const events = [{ timestamp: Date.now() }];
+        const result = filterEvents(events, 'unknown', 'all');
+        expect(result).toHaveLength(1);
+    });
+
+    it('handles empty event list', () => {
+        const result = filterEvents([], 'test', 'errors');
+        expect(result).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Summary

Add filter controls to the Events tab in the debug toolbar so users can quickly find specific events in the history.

## Changes

- Added filter bar with text input for name search (substring match, case-insensitive)
- Added status dropdown filter (All / Errors only / Success only)
- Added clear button that resets all filters
- Added match count display (filtered / total)
- Filter state persists when switching between tabs via `state.filters`
- Empty state shown when no events match filters
- Added CSS styles for filter bar components
- Initialized `eventName` and `eventStatus` filter keys in panel core state

Closes #176

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test Plan

- [x] Existing tests pass (`make test`)
- [x] New tests added for changed functionality
- [ ] Manual testing performed (describe below)

New JS unit tests in `tests/js/debug_event_filter.test.js` covering:
- No filters returns all events
- Name substring filtering (case-insensitive)
- Multiple match filtering
- Error-only and success-only status filters
- Combined name + status filters
- Empty results
- Fallback to "unknown" for unnamed events
- Empty event list handling

## Checklist

- [x] Code follows project conventions
- [x] Self-reviewed for correctness, edge cases, and security
- [x] CHANGELOG.md updated
- [x] Documentation updated (docs/DEBUG_PANEL.md)

## Related Issues

Closes #176