### PR TITLE
feat: scope panel state persistence to current view (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Debug Toolbar: Event Filtering** — Events tab now has filter controls to search by event/handler name (substring match) and filter by status (all/errors/success). Includes a clear button and match count display. (#176)
 - **Debug Toolbar: Event Replay** — Each event in the Events tab now has a replay button (⟳) that re-sends the event through the WebSocket with original params. Shows inline pending/success/error feedback. (#177)
+- **Debug Toolbar: Scoped State Persistence** — Panel UI state (open/closed, active tab) is now scoped per view class via localStorage. Data histories are not persisted, preventing stale data after navigation. (#178)
 
 ## [0.2.2rc3] - 2026-01-31
 

--- a/docs/DEBUG_PANEL.md
+++ b/docs/DEBUG_PANEL.md
@@ -378,6 +378,7 @@ def test_save_property(self):
 
 ### Minimize Impact
 
+- **Per-view state**: Panel open/closed state and active tab are remembered per view class, so each view gets its own panel preferences. Data histories (events, patches, network) are cleared on navigation to prevent stale data.
 - **Close when not needed**: Panel uses ~10KB memory per 50 events
 - **Clear history**: Click "Clear" button in Event History/VDOM Patches tabs
 - **Limit history**: Configure `maxHistory` in client.js (default: 50)

--- a/python/djust/static/djust/debug-panel.js
+++ b/python/djust/static/djust/debug-panel.js
@@ -3417,20 +3417,31 @@
             this.renderTabContent();
         }
 
-        // State persistence
+        // State persistence — scoped per view
+        _stateKey() {
+            const viewName = (window.DJUST_DEBUG_INFO && window.DJUST_DEBUG_INFO.view_class) || 'global';
+            return `djust-debug-state:${viewName}`;
+        }
+
         saveState() {
-            localStorage.setItem('djust-debug-state', JSON.stringify(this.state));
+            // Only persist UI preferences, not data or filters
+            const uiState = {
+                isOpen: this.state.isOpen,
+                activeTab: this.state.activeTab,
+            };
+            localStorage.setItem(this._stateKey(), JSON.stringify(uiState));
         }
 
         loadState() {
-            const saved = localStorage.getItem('djust-debug-state');
+            const saved = localStorage.getItem(this._stateKey());
             if (saved) {
                 try {
                     const parsedState = JSON.parse(saved);
-                    this.state = { ...this.state, ...parsedState };
+                    // Merge only UI preferences into state
+                    this.state.isOpen = parsedState.isOpen || false;
+                    this.state.activeTab = parsedState.activeTab || 'events';
 
                     // Restore panel visibility and active tab if saved
-                    // Combined into single setTimeout to reduce queued microtasks
                     if (parsedState.isOpen || parsedState.activeTab) {
                         setTimeout(() => {
                             if (parsedState.isOpen) this.open();

--- a/python/djust/static/djust/src/debug/15-panel-controls.js
+++ b/python/djust/static/djust/src/debug/15-panel-controls.js
@@ -56,20 +56,31 @@
             this.renderTabContent();
         }
 
-        // State persistence
+        // State persistence — scoped per view
+        _stateKey() {
+            const viewName = (window.DJUST_DEBUG_INFO && window.DJUST_DEBUG_INFO.view_class) || 'global';
+            return `djust-debug-state:${viewName}`;
+        }
+
         saveState() {
-            localStorage.setItem('djust-debug-state', JSON.stringify(this.state));
+            // Only persist UI preferences, not data or filters
+            const uiState = {
+                isOpen: this.state.isOpen,
+                activeTab: this.state.activeTab,
+            };
+            localStorage.setItem(this._stateKey(), JSON.stringify(uiState));
         }
 
         loadState() {
-            const saved = localStorage.getItem('djust-debug-state');
+            const saved = localStorage.getItem(this._stateKey());
             if (saved) {
                 try {
                     const parsedState = JSON.parse(saved);
-                    this.state = { ...this.state, ...parsedState };
+                    // Merge only UI preferences into state
+                    this.state.isOpen = parsedState.isOpen || false;
+                    this.state.activeTab = parsedState.activeTab || 'events';
 
                     // Restore panel visibility and active tab if saved
-                    // Combined into single setTimeout to reduce queued microtasks
                     if (parsedState.isOpen || parsedState.activeTab) {
                         setTimeout(() => {
                             if (parsedState.isOpen) this.open();

--- a/tests/js/debug_state_persistence.test.js
+++ b/tests/js/debug_state_persistence.test.js
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for debug panel scoped state persistence (Issue #178)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Replicate the state key logic from 15-panel-controls.js
+function stateKey(viewClass) {
+    const viewName = viewClass || 'global';
+    return `djust-debug-state:${viewName}`;
+}
+
+// Replicate saveState logic: only UI preferences
+function saveState(state, viewClass) {
+    const uiState = {
+        isOpen: state.isOpen,
+        activeTab: state.activeTab,
+    };
+    return { key: stateKey(viewClass), value: JSON.stringify(uiState) };
+}
+
+// Replicate loadState logic
+function loadState(stored, currentState) {
+    if (!stored) return currentState;
+    try {
+        const parsed = JSON.parse(stored);
+        return {
+            ...currentState,
+            isOpen: parsed.isOpen || false,
+            activeTab: parsed.activeTab || 'events',
+        };
+    } catch {
+        return currentState;
+    }
+}
+
+describe('Scoped State Persistence', () => {
+    it('generates different keys for different views', () => {
+        expect(stateKey('CounterView')).toBe('djust-debug-state:CounterView');
+        expect(stateKey('DashboardView')).toBe('djust-debug-state:DashboardView');
+    });
+
+    it('falls back to global key when no view class', () => {
+        expect(stateKey(null)).toBe('djust-debug-state:global');
+        expect(stateKey(undefined)).toBe('djust-debug-state:global');
+    });
+
+    it('only saves UI preferences, not filters or data', () => {
+        const state = {
+            isOpen: true,
+            activeTab: 'network',
+            searchQuery: 'test',
+            filters: { eventName: 'search', eventStatus: 'errors' }
+        };
+        const { value } = saveState(state, 'MyView');
+        const saved = JSON.parse(value);
+
+        expect(saved.isOpen).toBe(true);
+        expect(saved.activeTab).toBe('network');
+        expect(saved.searchQuery).toBeUndefined();
+        expect(saved.filters).toBeUndefined();
+    });
+
+    it('restores UI preferences from saved state', () => {
+        const stored = JSON.stringify({ isOpen: true, activeTab: 'patches' });
+        const defaultState = {
+            isOpen: false,
+            activeTab: 'events',
+            filters: { eventName: '', eventStatus: 'all' }
+        };
+        const result = loadState(stored, defaultState);
+
+        expect(result.isOpen).toBe(true);
+        expect(result.activeTab).toBe('patches');
+        expect(result.filters).toEqual({ eventName: '', eventStatus: 'all' });
+    });
+
+    it('handles missing saved state gracefully', () => {
+        const defaultState = { isOpen: false, activeTab: 'events' };
+        const result = loadState(null, defaultState);
+        expect(result).toEqual(defaultState);
+    });
+
+    it('handles corrupt saved state gracefully', () => {
+        const defaultState = { isOpen: false, activeTab: 'events' };
+        const result = loadState('not-json', defaultState);
+        expect(result).toEqual(defaultState);
+    });
+});


### PR DESCRIPTION
## Summary

Fix debug toolbar state persistence so it is scoped per-view instead of global, preventing stale data from appearing after navigation.

## Changes

- localStorage key now includes the view class name (`djust-debug-state:<ViewClass>`)
- Only UI preferences (open/closed, active tab) are persisted — filters and data histories are not saved
- Falls back to `global` key when no view class is available

Closes #178

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test Plan

- [x] Existing tests pass (`make test`)
- [x] New tests added for changed functionality

New JS unit tests in `tests/js/debug_state_persistence.test.js` covering:
- Different keys for different views
- Fallback to global key
- Only UI preferences saved (not filters/data)
- Correct restoration of UI preferences
- Graceful handling of missing/corrupt saved state

## Checklist

- [x] Code follows project conventions
- [x] Self-reviewed for correctness, edge cases, and security
- [x] CHANGELOG.md updated
- [x] Documentation updated (docs/DEBUG_PANEL.md)

## Related Issues

Closes #178