### PR TITLE
fix: fuzz test overlapping ID assignment (#200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Fuzz Test: Overlapping ID Assignment** — Proptest `round_trip_correctness` assigned IDs to both trees starting from counter 0, causing false failures when `djust_id` values collided. Now continues the counter from tree A into tree B, matching real `parse_html_continue()` behavior. (#200)
 - **VDOM: Non-breaking Space Text Nodes Stripped** — Rust parser stripped `&nbsp;`-only text nodes (used in syntax highlighting) because `char::is_whitespace()` includes U+00A0. Now preserves `\u00A0` text nodes in parser, `to_html()`, and client-side path traversal. Also adds `sync_ids()` to prevent ID drift between server VDOM and client DOM after diffing, and 4-phase patch ordering matching Rust's `apply_patches()`. (#198, #199)
 - **Debug Toolbar: Received WebSocket Messages Not Captured** — Network tab now captures both sent and received WebSocket messages by intercepting the `onmessage` property setter (not just `addEventListener`). (#186)
 - **Debug Toolbar: Events Tab Always Empty** — Events tab now populates by extracting event data from sent WebSocket messages and matching responses, replacing the broken `window.liveView` hook. Event replay now uses `window.djust.liveViewInstance`. (#187)

--- a/crates/djust_vdom/tests/fuzz_test.rs
+++ b/crates/djust_vdom/tests/fuzz_test.rs
@@ -189,7 +189,7 @@ proptest! {
 
         let mut counter = 0u64;
         assign_ids(&mut a, &mut counter);
-        counter = 0;
+        // Continue counter from tree A so IDs don't overlap (mirrors real parse_html_continue)
         assign_ids(&mut b, &mut counter);
 
         let patches = diff_nodes(&a, &b, &[]);
@@ -213,7 +213,7 @@ proptest! {
         let mut b = tree_b;
         let mut counter = 0u64;
         assign_ids(&mut a, &mut counter);
-        counter = 0;
+        // Continue counter from tree A so IDs don't overlap (mirrors real parse_html_continue)
         assign_ids(&mut b, &mut counter);
 
         let _patches = diff_nodes(&a, &b, &[]);
@@ -230,7 +230,7 @@ proptest! {
         let mut b = tree_b;
         let mut counter = 0u64;
         assign_ids(&mut a, &mut counter);
-        counter = 0;
+        // Continue counter from tree A so IDs don't overlap (mirrors real parse_html_continue)
         assign_ids(&mut b, &mut counter);
 
         let total_nodes = count_nodes(&a) + count_nodes(&b);


### PR DESCRIPTION
## Summary

Fixes false round-trip failures in the VDOM fuzz test caused by overlapping `djust_id` values between tree A and tree B.

## Changes

- Removed `counter = 0` reset in `round_trip_correctness`, `no_panics_on_arbitrary_trees`, and `patch_count_bounded` proptests so tree B IDs continue from where tree A left off

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Plan

- [x] Existing tests pass (`make test`)
- [x] New tests added for changed functionality — the fix itself improves existing fuzz tests
- [ ] Manual testing performed

## Checklist

- [x] Code follows project conventions
- [x] Self-reviewed for correctness, edge cases, and security
- [x] Documentation updated (if applicable) — CHANGELOG updated
- [x] No breaking API changes

## Related Issues

Closes #200