### PR TITLE
Fix CSRF token lookup on formless pages

### DIFF
--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -1955,7 +1955,9 @@ async function handleEvent(eventName, params = {}) {
     console.log('[LiveView] WebSocket unavailable, falling back to HTTP');
 
     try {
-        const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value;
+        const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value
+            || document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/)?.[1]
+            || '';
         const response = await fetch(window.location.href, {
             method: 'POST',
             headers: {

--- a/python/djust/static/djust/src/11-event-handler.js
+++ b/python/djust/static/djust/src/11-event-handler.js
@@ -77,7 +77,9 @@ async function handleEvent(eventName, params = {}) {
     console.log('[LiveView] WebSocket unavailable, falling back to HTTP');
 
     try {
-        const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value;
+        const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value
+            || document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/)?.[1]
+            || '';
         const response = await fetch(window.location.href, {
             method: 'POST',
             headers: {

--- a/tests/js/csrf_token.test.js
+++ b/tests/js/csrf_token.test.js
@@ -1,0 +1,112 @@
+/**
+ * Tests for CSRF token fallback to cookie when no form input is present (#204)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import fs from 'fs';
+
+const clientCode = fs.readFileSync('./python/djust/static/djust/client.js', 'utf-8');
+
+function createEnv({ formToken, cookie } = {}) {
+    const formInput = formToken
+        ? `<input type="hidden" name="csrfmiddlewaretoken" value="${formToken}">`
+        : '';
+
+    const dom = new JSDOM(
+        `<!DOCTYPE html><html><body>
+            <div data-djust-root>
+                ${formInput}
+                <button dj-click="my_action">Click</button>
+            </div>
+        </body></html>`,
+        { url: 'http://localhost:8000/test/', runScripts: 'dangerously', pretendToBeVisual: true }
+    );
+
+    const { window } = dom;
+
+    if (cookie) {
+        Object.defineProperty(window.document, 'cookie', {
+            get: () => cookie,
+            configurable: true,
+        });
+    }
+
+    // Make WebSocket unavailable so handleEvent falls back to HTTP
+    delete window.WebSocket;
+
+    // Capture fetch calls
+    const fetchCalls = [];
+    window.fetch = vi.fn(async (url, opts) => {
+        fetchCalls.push({ url, opts });
+        return { ok: true, json: async () => ({ patches: [] }) };
+    });
+
+    // Suppress console noise
+    window.console = { log: () => {}, error: () => {}, warn: () => {}, debug: () => {}, info: () => {} };
+
+    // Execute client code in JSDOM
+    try {
+        window.eval(clientCode);
+    } catch (e) {
+        // client.js may throw on missing DOM APIs; the key parts we need still get defined
+    }
+
+    return { window, dom, fetchCalls };
+}
+
+describe('CSRF token resolution', () => {
+    it('reads token from cookie when no form input exists', async () => {
+        const { window, fetchCalls } = createEnv({
+            cookie: 'csrftoken=COOKIE_TOKEN_VALUE',
+        });
+
+        await window.djust.handleEvent('my_action', {});
+
+        expect(fetchCalls.length).toBe(1);
+        expect(fetchCalls[0].opts.headers['X-CSRFToken']).toBe('COOKIE_TOKEN_VALUE');
+    });
+
+    it('prefers form input over cookie', async () => {
+        const { window, fetchCalls } = createEnv({
+            formToken: 'FORM_TOKEN',
+            cookie: 'csrftoken=COOKIE_TOKEN',
+        });
+
+        await window.djust.handleEvent('my_action', {});
+
+        expect(fetchCalls.length).toBe(1);
+        expect(fetchCalls[0].opts.headers['X-CSRFToken']).toBe('FORM_TOKEN');
+    });
+
+    it('extracts token from multi-cookie string', async () => {
+        const { window, fetchCalls } = createEnv({
+            cookie: 'sessionid=abc123; csrftoken=MIDDLE_TOKEN; other=xyz',
+        });
+
+        await window.djust.handleEvent('my_action', {});
+
+        expect(fetchCalls.length).toBe(1);
+        expect(fetchCalls[0].opts.headers['X-CSRFToken']).toBe('MIDDLE_TOKEN');
+    });
+
+    it('ignores cookies whose name ends with csrftoken', async () => {
+        const { window, fetchCalls } = createEnv({
+            cookie: 'notcsrftoken=WRONG',
+        });
+
+        await window.djust.handleEvent('my_action', {});
+
+        expect(fetchCalls.length).toBe(1);
+        expect(fetchCalls[0].opts.headers['X-CSRFToken']).toBe('');
+    });
+
+    it('sends empty string when neither form input nor cookie exists', async () => {
+        const { window, fetchCalls } = createEnv();
+
+        await window.djust.handleEvent('my_action', {});
+
+        expect(fetchCalls.length).toBe(1);
+        expect(fetchCalls[0].opts.headers['X-CSRFToken']).toBe('');
+    });
+});


### PR DESCRIPTION
## Summary
- Fall back to `csrftoken` cookie when no `<input name="csrfmiddlewaretoken">` exists in the DOM
- Prevents Django from rejecting HTTP fallback requests with "incorrect length" on pages without forms
- Applied to both `client.js` and source file `src/11-event-handler.js`

## Test plan
- [x] 3 new tests in `tests/js/csrf_token.test.js` (cookie fallback, form input priority, empty string default)
- [x] All 414 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)