### PR TITLE
Fix VDOM diff/patch round-trip on keyed child reorder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "0.2.2-rc.5"
+version = "0.2.2"
 dependencies = [
  "ahash",
  "criterion",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "0.2.2-rc.5"
+version = "0.2.2"
 dependencies = [
  "ahash",
  "criterion",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "0.2.2-rc.5"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "criterion",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "0.2.2-rc.5"
+version = "0.2.2"
 dependencies = [
  "ahash",
  "chrono",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "0.2.2-rc.5"
+version = "0.2.2"
 dependencies = [
  "ahash",
  "criterion",


### PR DESCRIPTION
## Summary
- Fix `apply_patches` to process patches level-by-level (shallowest parent first), ensuring structural changes establish tree shape before deeper patches navigate into children
- MoveChild now resolves children by `djust_id` (mirroring client-side `data-d` strategy)
- Add regression test reproducing the exact failure from #212

## Test plan
- [x] Regression test `issue_212_keyed_reorder_round_trip` passes
- [x] All existing tests pass (unit, fuzz/proptest, torture)
- [x] `cargo clippy` clean

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)