### PR TITLE
Add pre-commit hook to auto-build client.js from src/ modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,9 +62,17 @@ repos:
         args: ["-ll", "-ii", "-x", "tests/,python/tests/,python/djust/tests/", "-s", "B703,B308,B324,B301,B102"]
         files: ^python/
 
-  # JavaScript - Test and lint
+  # JavaScript - Build, test, and lint
   - repo: local
     hooks:
+      - id: build-js
+        name: build client.js from src/ modules
+        entry: bash -c 'bash scripts/build-client.sh && git add python/djust/static/djust/client.js python/djust/static/djust/debug-panel.js'
+        language: system
+        files: ^python/djust/static/djust/src/
+        types: [javascript]
+        pass_filenames: false
+
       - id: npm-test
         name: npm test
         entry: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Auto-build client.js from src/ modules** — Pre-commit hook runs `build-client.sh` when `src/` files change, eliminating manual concatenation drift between `src/` and built JS files. ([#211](https://github.com/djust-org/djust/issues/211))
+
+### Fixed
+
+- **VDOM diff/patch round-trip failure on keyed child reorder** — `apply_patches` now processes patches level-by-level (shallowest parent first) so structural changes establish correct tree shape before deeper patches navigate into children. ([#212](https://github.com/djust-org/djust/issues/212))
+
 ## [0.2.2] - 2026-02-01
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Add `build-js` pre-commit hook that runs `build-client.sh` when `src/` JS files change
- Auto-stages rebuilt `client.js` and `debug-panel.js` so they stay in sync with source modules
- Updates CHANGELOG with both this change and the #212 fix

## Test plan
- [x] Pre-commit config valid (hook installed and recognized)
- [x] Hook skips when no src/ files changed
- [x] `build-client.sh` already tested by existing `make build-js` target

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)