### PR TITLE
fix: VDOM-created elements never receive event listeners

### DIFF
--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -2913,25 +2913,17 @@ function createNodeFromVNode(vnode, inSvgContext = false) {
     if (vnode.attrs) {
         for (const [key, value] of Object.entries(vnode.attrs)) {
             // Set all attributes on the element (including dj-* attributes).
-            // For dj-* event attributes, bind the event listener immediately and
-            // mark as bound in the WeakMap to prevent bindLiveViewEvents() from
-            // adding duplicate listeners. This ensures VDOM-inserted elements
-            // are properly bound without double-binding.
+            // Event listeners for dj-* attributes are attached by bindLiveViewEvents()
+            // after patches are applied, which already uses _markHandlerBound to
+            // prevent double-binding on subsequent calls.
             if (key === 'value' && (elem.tagName === 'INPUT' || elem.tagName === 'TEXTAREA')) {
                 elem.value = value;
             }
             elem.setAttribute(key, value);
 
-            // Bind dj-* event handlers for VDOM-created elements
-            if (key.startsWith('dj-')) {
-                const eventType = key.substring(3); // e.g., 'dj-click' -> 'click'
-                // Only bind standard djust events, skip special attributes like dj-root, dj-view, dj-model, etc.
-                const EVENT_TYPES = ['click', 'submit', 'change', 'input', 'blur', 'focus', 'keydown', 'keyup'];
-                if (EVENT_TYPES.includes(eventType)) {
-                    // Mark as bound immediately to prevent bindLiveViewEvents() from re-binding
-                    window.djust._markHandlerBound(elem, eventType);
-                }
-            }
+            // Note: dj-* event listeners are attached by bindLiveViewEvents() after
+            // patch application. Do NOT pre-mark elements here — that would prevent
+            // bindLiveViewEvents() from ever attaching the listener.
         }
     }
 

--- a/python/djust/static/djust/src/12-vdom-patch.js
+++ b/python/djust/static/djust/src/12-vdom-patch.js
@@ -336,25 +336,17 @@ function createNodeFromVNode(vnode, inSvgContext = false) {
     if (vnode.attrs) {
         for (const [key, value] of Object.entries(vnode.attrs)) {
             // Set all attributes on the element (including dj-* attributes).
-            // For dj-* event attributes, bind the event listener immediately and
-            // mark as bound in the WeakMap to prevent bindLiveViewEvents() from
-            // adding duplicate listeners. This ensures VDOM-inserted elements
-            // are properly bound without double-binding.
+            // Event listeners for dj-* attributes are attached by bindLiveViewEvents()
+            // after patches are applied, which already uses _markHandlerBound to
+            // prevent double-binding on subsequent calls.
             if (key === 'value' && (elem.tagName === 'INPUT' || elem.tagName === 'TEXTAREA')) {
                 elem.value = value;
             }
             elem.setAttribute(key, value);
 
-            // Bind dj-* event handlers for VDOM-created elements
-            if (key.startsWith('dj-')) {
-                const eventType = key.substring(3); // e.g., 'dj-click' -> 'click'
-                // Only bind standard djust events, skip special attributes like dj-root, dj-view, dj-model, etc.
-                const EVENT_TYPES = ['click', 'submit', 'change', 'input', 'blur', 'focus', 'keydown', 'keyup'];
-                if (EVENT_TYPES.includes(eventType)) {
-                    // Mark as bound immediately to prevent bindLiveViewEvents() from re-binding
-                    window.djust._markHandlerBound(elem, eventType);
-                }
-            }
+            // Note: dj-* event listeners are attached by bindLiveViewEvents() after
+            // patch application. Do NOT pre-mark elements here — that would prevent
+            // bindLiveViewEvents() from ever attaching the listener.
         }
     }
 

--- a/tests/js/double_bind.test.js
+++ b/tests/js/double_bind.test.js
@@ -1,7 +1,9 @@
 /**
- * Tests for double-bind prevention and stale closure bugs on VDOM-patched elements.
+ * Tests for event binding on VDOM-patched elements and stale closure bugs.
  *
  * Regression test for #201 — delete_todo sends wrong args after patch.
+ * Regression test for #315 — VDOM-inserted elements never get event listeners
+ *   because createNodeFromVNode pre-marked them as bound without attaching listeners.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -41,42 +43,51 @@ describe('Double bind prevention on VDOM-inserted elements', () => {
         window.eval(clientCode);
     });
 
-    it('createNodeFromVNode binds click handler on dj-click elements', () => {
+    it('bindLiveViewEvents attaches click listener to VDOM-created elements', () => {
+        // createNodeFromVNode must NOT pre-mark elements as bound.
+        // bindLiveViewEvents() must attach the listener on first call.
         const elem = window.djust.createNodeFromVNode({
-            tag: 'button',
-            attrs: { 'dj-click': 'delete_todo(1)', 'data-dj-id': 'b2' },
-            children: [{ tag: '', attrs: {}, children: [], text: 'Delete' }],
-        });
-        // WeakMap tracks binding internally; verify bindLiveViewEvents won't double-bind
-        let addEventCount = 0;
-        const origAddEvent = elem.addEventListener.bind(elem);
-        elem.addEventListener = function(type, ...args) {
-            if (type === 'click') addEventCount++;
-            return origAddEvent(type, ...args);
-        };
-        window.djust.bindLiveViewEvents();
-        expect(addEventCount).toBe(0);
-    });
-
-    it('bindLiveViewEvents skips elements already bound via WeakMap', () => {
-        const newBtn = window.djust.createNodeFromVNode({
             tag: 'button',
             attrs: { 'dj-click': 'delete_todo(1)', 'data-dj-id': 'b2' },
             children: [{ tag: '', attrs: {}, children: [], text: 'Delete' }],
         });
 
         const root = window.document.getElementById('root');
-        root.querySelector('[data-dj-id="b1"]').replaceWith(newBtn);
+        root.querySelector('[data-dj-id="b1"]').replaceWith(elem);
 
         let addEventCount = 0;
-        const origAddEvent = newBtn.addEventListener.bind(newBtn);
-        newBtn.addEventListener = function(type, ...args) {
+        const origAddEvent = elem.addEventListener.bind(elem);
+        elem.addEventListener = function(type, ...args) {
+            if (type === 'click') addEventCount++;
+            return origAddEvent(type, ...args);
+        };
+
+        // First call: should bind the listener (count = 1)
+        window.djust.bindLiveViewEvents();
+        expect(addEventCount).toBe(1);
+
+        // Second call: element already bound via WeakMap, no double-bind (count stays 1)
+        window.djust.bindLiveViewEvents();
+        expect(addEventCount).toBe(1);
+    });
+
+    it('bindLiveViewEvents does not double-bind elements already in the DOM', () => {
+        // Elements in the initial HTML are bound on first bindLiveViewEvents call.
+        // Subsequent calls must not add duplicate listeners.
+        const btn = window.document.querySelector('[data-dj-id="b1"]');
+
+        let addEventCount = 0;
+        const origAddEvent = btn.addEventListener.bind(btn);
+        btn.addEventListener = function(type, ...args) {
             if (type === 'click') addEventCount++;
             return origAddEvent(type, ...args);
         };
 
         window.djust.bindLiveViewEvents();
-        expect(addEventCount).toBe(0);
+        const countAfterFirst = addEventCount;
+
+        window.djust.bindLiveViewEvents();
+        expect(addEventCount).toBe(countAfterFirst); // no extra binds
     });
 
     it('binds handlers for other event types (submit, change) without double-binding', () => {
@@ -90,7 +101,10 @@ describe('Double bind prevention on VDOM-inserted elements', () => {
         expect(form.getAttribute('dj-submit')).toBe('save');
         expect(input.getAttribute('dj-change')).toBe('validate');
 
-        // Verify calling bindLiveViewEvents doesn't double-bind
+        const root = window.document.getElementById('root');
+        root.appendChild(form);
+        root.appendChild(input);
+
         let submitCount = 0;
         const origFormAdd = form.addEventListener.bind(form);
         form.addEventListener = function(type, ...args) {
@@ -103,9 +117,16 @@ describe('Double bind prevention on VDOM-inserted elements', () => {
             if (type === 'change') changeCount++;
             return origInputAdd(type, ...args);
         };
+
+        // First call: each element gets exactly 1 listener
         window.djust.bindLiveViewEvents();
-        expect(submitCount).toBe(0);
-        expect(changeCount).toBe(0);
+        expect(submitCount).toBe(1);
+        expect(changeCount).toBe(1);
+
+        // Second call: no double-binding
+        window.djust.bindLiveViewEvents();
+        expect(submitCount).toBe(1);
+        expect(changeCount).toBe(1);
     });
 
     it('createNodeFromVNode sets dj-click as DOM attribute', () => {


### PR DESCRIPTION
## Summary

- Fixes #320
- `createNodeFromVNode` was calling `_markHandlerBound()` for `dj-*` event attributes **without** attaching `addEventListener`, then `bindLiveViewEvents()` would see the element as already bound and skip it — leaving the element permanently unresponsive
- Fix: remove the premature `_markHandlerBound()` call from `createNodeFromVNode`; let `bindLiveViewEvents()` own all event binding as it always has

## Root Cause

Commit `0dfe5d0` intended to prevent double-binding by marking VDOM-created elements in the WeakMap. But it removed the `addEventListener` calls without providing a replacement — creating a situation where elements are marked as bound but have no actual listeners.

`bindLiveViewEvents()` is called after every patch application and already prevents double-binding via `_markHandlerBound` → `_isHandlerBound`. There is no need for `createNodeFromVNode` to participate in binding at all.

## Test plan

- [x] `npx vitest run tests/js/double_bind.test.js` — 6 tests pass
- [x] `npx vitest run` — 629 tests pass (full JS suite)
- Updated `double_bind.test.js` to assert correct behaviour: `bindLiveViewEvents()` attaches exactly 1 listener to VDOM-created elements on first call, 0 on subsequent calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)