### PR TITLE
fix: avoid Illegal invocation in debug panel WebSocket hook

### DIFF
--- a/python/djust/static/djust/debug-panel.js
+++ b/python/djust/static/djust/debug-panel.js
@@ -2696,15 +2696,12 @@
             // prototype setter hook didn't intercept it. Use the original
             // property descriptor to read/write the raw handler and avoid
             // double-wrapping through our own setter hook.
-            const desc = this._originalOnmessageDescriptor;
-            if (desc) {
-                const currentHandler = desc.get.call(ws);
-                if (currentHandler) {
-                    desc.set.call(ws, function(event) {
-                        self._handleReceivedMessage(event);
-                        return currentHandler.call(this, event);
-                    });
-                }
+            const currentHandler = ws.onmessage;
+            if (currentHandler) {
+                ws.onmessage = function(event) {
+                    self._handleReceivedMessage(event);
+                    return currentHandler.call(this, event);
+                };
             }
 
             ws._djustDebugHooked = true;


### PR DESCRIPTION
## Summary

- `DjustDebugPanel._hookExistingWebSocket()` stored the native `onmessage` property descriptor from the WebSocket prototype and later called `desc.get.call(ws)` / `desc.set.call(ws, ...)` to read/write the existing handler
- In some browser contexts (Chrome 145 / macOS), calling a native prototype getter via `.call()` throws `TypeError: Illegal invocation`
- Fix: replace the descriptor-based access with direct `ws.onmessage` property read/write, which correctly invokes the getter/setter through the prototype chain without the illegal invocation

## Test plan

- [ ] Open a djust app with the debug panel enabled
- [ ] Verify no `TypeError: Illegal invocation` in the browser console
- [ ] Verify the debug panel still captures sent/received WebSocket messages correctly
- [ ] Confirm no new errors appear in djust-monitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)