### PR TITLE
feat: add liveview_server_error signal for monitor integration

### DIFF
--- a/python/djust/signals.py
+++ b/python/djust/signals.py
@@ -29,3 +29,14 @@ from django.dispatch import Signal
 #   html_snippet            – str or None, first 500 chars of rendered HTML
 #   previous_html_snippet   – str or None, first 500 chars of previous render
 full_html_update = Signal()
+
+liveview_server_error = Signal()
+"""
+Sent whenever send_error() is called on the WebSocket consumer.
+
+Kwargs sent:
+    sender    (type)  — the LiveView class, or None if no view is mounted yet
+    error     (str)   — human-readable error message sent to the client
+    view_name (str)   — "module.ClassName" of the view, or "" if unknown
+    context   (dict)  — extra kwargs passed to send_error() (e.g. validation_details)
+"""

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -24,7 +24,7 @@ from .websocket_utils import (
     get_handler_coerce_setting,
 )
 from .presence import PresenceManager
-from .signals import full_html_update
+from .signals import full_html_update, liveview_server_error
 
 logger = logging.getLogger(__name__)
 hotreload_logger = logging.getLogger("djust.hotreload")
@@ -108,6 +108,22 @@ def _build_context_snapshot(context, max_value_len=100):
         else:
             snapshot[key] = f"[{type(value).__name__}]"
     return snapshot
+
+
+def _emit_liveview_server_error(view_instance, error: str, context: dict) -> None:
+    """Emit the liveview_server_error signal from send_error()."""
+    if view_instance is not None:
+        view_cls = view_instance.__class__
+        view_name = f"{view_cls.__module__}.{view_cls.__qualname__}"
+    else:
+        view_cls = None
+        view_name = ""
+    liveview_server_error.send(
+        sender=view_cls,
+        error=error,
+        view_name=view_name,
+        context=context,
+    )
 
 
 def _emit_full_html_update(
@@ -278,34 +294,12 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
     async def send_error(self, error: str, **context) -> None:
         """
         Send an error response to the client with consistent formatting.
-
-        Args:
-            error: Human-readable error message
-            **context: Additional context to include in the response
-                (e.g., validation_details, expected_params)
+        Also emits the liveview_server_error signal for monitor integrations.
         """
         response: Dict[str, Any] = {"type": "error", "error": error}
         response.update(context)
         await self.send_json(response)
-
-        # Report to djust-monitor if configured
-        try:
-            import djust_monitor
-
-            view_name = ""
-            if hasattr(self, "view_instance") and self.view_instance:
-                view_name = type(self.view_instance).__qualname__
-            djust_monitor.capture_event(
-                "LiveViewError",
-                error,
-                context={
-                    "view": view_name,
-                    "source": "websocket",
-                    **context,
-                },
-            )
-        except Exception:
-            pass
+        _emit_liveview_server_error(getattr(self, "view_instance", None), error, context)
 
     async def _dispatch_async_work(self) -> None:
         """


### PR DESCRIPTION
## Summary

- Adds `liveview_server_error = Signal()` to `signals.py` with full kwarg documentation
- Adds `_emit_liveview_server_error()` helper next to `_emit_full_html_update()`
- Replaces the direct `import djust_monitor` try/except block in `send_error()` with a signal emit — no more tight coupling to the monitor package

## Test plan

- [ ] Trigger a handler validation error in the browser (e.g. navigate to `/email/`)
- [ ] Confirm `LiveViewServerError` appears in monitor API after djust-monitor-client PR is merged and deployed
- [ ] Confirm no regression: `send_error()` still sends `{"type": "error"}` JSON to the client

🤖 Generated with [Claude Code](https://claude.com/claude-code)