### PR TITLE
fix: remove double-wrapped djustDebug guards and example tests from core

### DIFF
--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -13,7 +13,7 @@ window.djust = window.djust || {};
 // Prevent double execution when client.js is included in both base template
 // (for TurboNav compatibility) and injected by LiveView.
 if (window._djustClientLoaded) {
-    console.log('[LiveView] client.js already loaded, skipping duplicate initialization');
+    if (globalThis.djustDebug) console.log('[LiveView] client.js already loaded, skipping duplicate initialization');
 } else {
 window._djustClientLoaded = true;
 
@@ -388,7 +388,7 @@ class LiveViewWebSocket {
      * Cleanly disconnect the WebSocket for TurboNav navigation
      */
     disconnect() {
-        console.log('[LiveView] Disconnecting for navigation...');
+        if (globalThis.djustDebug) console.log('[LiveView] Disconnecting for navigation...');
 
         // Stop heartbeat
         if (this.heartbeatInterval) {
@@ -432,11 +432,11 @@ class LiveViewWebSocket {
             url = `${protocol}//${host}/ws/live/`;
         }
 
-        console.log('[LiveView] Connecting to WebSocket:', url);
+        if (globalThis.djustDebug) console.log('[LiveView] Connecting to WebSocket:', url);
         this.ws = new WebSocket(url);
 
         this.ws.onopen = (_event) => {
-            console.log('[LiveView] WebSocket connected');
+            if (globalThis.djustDebug) console.log('[LiveView] WebSocket connected');
             this.reconnectAttempts = 0;
             this._intentionalDisconnect = false;
 
@@ -450,7 +450,7 @@ class LiveViewWebSocket {
         };
 
         this.ws.onclose = (_event) => {
-            console.log('[LiveView] WebSocket disconnected');
+            if (globalThis.djustDebug) console.log('[LiveView] WebSocket disconnected');
             this.viewMounted = false;
 
             // Notify hooks of disconnection
@@ -491,7 +491,7 @@ class LiveViewWebSocket {
             if (this.reconnectAttempts < this.maxReconnectAttempts) {
                 this.reconnectAttempts++;
                 const delay = this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1);
-                console.log(`[LiveView] Reconnecting in ${delay}ms...`);
+                if (globalThis.djustDebug) console.log(`[LiveView] Reconnecting in ${delay}ms...`);
                 setTimeout(() => this.connect(url), delay);
             } else {
                 console.warn('[LiveView] Max reconnection attempts reached. Falling back to HTTP mode.');
@@ -530,23 +530,23 @@ class LiveViewWebSocket {
     }
 
     handleMessage(data) {
-        console.log('[LiveView] Received:', data.type, data);
+        if (globalThis.djustDebug) console.log('[LiveView] Received:', data.type, data);
 
         switch (data.type) {
             case 'connect':
                 this.sessionId = data.session_id;
-                console.log('[LiveView] Session ID:', this.sessionId);
+                if (globalThis.djustDebug) console.log('[LiveView] Session ID:', this.sessionId);
                 this.autoMount();
                 break;
 
             case 'mount':
                 this.viewMounted = true;
-                console.log('[LiveView] View mounted:', data.view);
+                if (globalThis.djustDebug) console.log('[LiveView] View mounted:', data.view);
 
                 // Initialize VDOM version from mount response (critical for patch generation)
                 if (data.version !== undefined) {
                     clientVdomVersion = data.version;
-                    console.log('[LiveView] VDOM version initialized:', clientVdomVersion);
+                    if (globalThis.djustDebug) console.log('[LiveView] VDOM version initialized:', clientVdomVersion);
                 }
 
                 // Initialize cache configuration from mount response
@@ -567,17 +567,17 @@ class LiveViewWebSocket {
                     // If server HTML has data-dj-id attributes, stamp them onto existing DOM
                     // This preserves whitespace (e.g. in code blocks) that innerHTML would destroy
                     if (hasDataDjAttrs && data.html) {
-                        console.log('[LiveView] Stamping data-dj-id attributes onto pre-rendered DOM');
+                        if (globalThis.djustDebug) console.log('[LiveView] Stamping data-dj-id attributes onto pre-rendered DOM');
                         _stampDjIds(data.html);
                     } else {
-                        console.log('[LiveView] Skipping mount HTML - using pre-rendered content');
+                        if (globalThis.djustDebug) console.log('[LiveView] Skipping mount HTML - using pre-rendered content');
                     }
                     this.skipMountHtml = false;
                     bindLiveViewEvents();
                 } else if (data.html) {
                     // No pre-rendered content - use server HTML directly
                     if (hasDataDjAttrs) {
-                        console.log('[LiveView] Hydrating DOM with data-dj-id attributes for reliable patching');
+                        if (globalThis.djustDebug) console.log('[LiveView] Hydrating DOM with data-dj-id attributes for reliable patching');
                     }
                     let container = document.querySelector('[dj-view]');
                     if (!container) {
@@ -679,8 +679,8 @@ class LiveViewWebSocket {
                 if (this.lastEventName) {
                     if (!data.async_pending) {
                         globalLoadingManager.stopLoading(this.lastEventName, this.lastTriggerElement);
-                    } else if (globalThis.djustDebug) {
-                        console.log('[LiveView] Keeping loading state — async work pending');
+                    } else {
+                        if (globalThis.djustDebug) console.log('[LiveView] Keeping loading state — async work pending');
                     }
                     this.lastEventName = null;
                     this.lastTriggerElement = null;
@@ -757,7 +757,7 @@ class LiveViewWebSocket {
             return false;
         }
 
-        console.log('[LiveView] Mounting view:', viewPath);
+        if (globalThis.djustDebug) console.log('[LiveView] Mounting view:', viewPath);
         // Detect browser timezone for server-side local time rendering
         let clientTimezone = null;
         try {
@@ -831,7 +831,7 @@ class LiveViewWebSocket {
                 const hasContent = container.innerHTML && container.innerHTML.trim().length > 0;
 
                 if (hasContent) {
-                    console.log('[LiveView] Content pre-rendered via HTTP - will skip HTML in mount response');
+                    if (globalThis.djustDebug) console.log('[LiveView] Content pre-rendered via HTTP - will skip HTML in mount response');
                     this.skipMountHtml = true;
                 }
 
@@ -1343,7 +1343,7 @@ function initDraftMode() {
         return;
     }
 
-    console.log(`[DraftMode] Initializing draft mode with key: ${draftKey}`);
+    if (globalThis.djustDebug) console.log(`[DraftMode] Initializing draft mode with key: ${draftKey}`);
 
     // Load existing draft on page load
     const savedDraft = globalDraftManager.loadDraft(draftKey);
@@ -1387,7 +1387,7 @@ function initDraftMode() {
 
     // Check for draft clear flag
     if (draftRoot.hasAttribute('data-draft-clear')) {
-        console.log('[DraftMode] Draft clear flag detected, clearing draft...');
+        if (globalThis.djustDebug) console.log('[DraftMode] Draft clear flag detected, clearing draft...');
         globalDraftManager.clearDraft(draftKey);
         draftRoot.removeAttribute('data-draft-clear');
     }
@@ -2555,7 +2555,7 @@ async function handleEvent(eventName, params = {}) {
     }
 
     // Fallback to HTTP
-    console.log('[LiveView] WebSocket unavailable, falling back to HTTP');
+    if (globalThis.djustDebug) console.log('[LiveView] WebSocket unavailable, falling back to HTTP');
 
     try {
         const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value

--- a/python/djust/static/djust/src/02-response-handler.js
+++ b/python/djust/static/djust/src/02-response-handler.js
@@ -27,7 +27,7 @@ function handleServerResponse(data, eventName, triggerElement) {
                 expiresAt
             });
             if (globalThis.djustDebug) {
-                if (globalThis.djustDebug) console.log(`[LiveView:cache] Cached patches: ${cacheKey} (TTL: ${ttl}s)`);
+                console.log(`[LiveView:cache] Cached patches: ${cacheKey} (TTL: ${ttl}s)`);
             }
             pendingCacheRequests.delete(data.cache_request_id);
         }
@@ -188,7 +188,7 @@ function handleServerResponse(data, eventName, triggerElement) {
                 globalLoadingManager.stopLoading(loadingEventName, triggerElement);
             }
         } else if (globalThis.djustDebug) {
-            if (globalThis.djustDebug) console.log('[LiveView] Keeping loading state — async work pending');
+            console.log('[LiveView] Keeping loading state — async work pending');
         }
         return true;
 

--- a/python/djust/static/djust/src/03-websocket.js
+++ b/python/djust/static/djust/src/03-websocket.js
@@ -266,7 +266,7 @@ class LiveViewWebSocket {
                 initTodoItems();
                 bindLiveViewEvents();
                 if (globalThis.djustDebug) {
-                    if (globalThis.djustDebug) console.log('[LiveView] DOM recovered via morph, version:', data.version);
+                    console.log('[LiveView] DOM recovered via morph, version:', data.version);
                 }
                 break;
             }

--- a/python/djust/static/djust/src/04-cache.js
+++ b/python/djust/static/djust/src/04-cache.js
@@ -33,7 +33,7 @@ function addToCache(cacheKey, value) {
         const oldestKey = resultCache.keys().next().value;
         resultCache.delete(oldestKey);
         if (globalThis.djustDebug) {
-            if (globalThis.djustDebug) console.log(`[LiveView:cache] Evicted (LRU): ${oldestKey}`);
+            console.log(`[LiveView:cache] Evicted (LRU): ${oldestKey}`);
         }
     }
 
@@ -50,7 +50,7 @@ function setCacheConfig(config) {
     Object.entries(config).forEach(([handlerName, handlerConfig]) => {
         cacheConfig.set(handlerName, handlerConfig);
         if (globalThis.djustDebug) {
-            if (globalThis.djustDebug) console.log(`[LiveView:cache] Configured cache for ${handlerName}:`, handlerConfig);
+            console.log(`[LiveView:cache] Configured cache for ${handlerName}:`, handlerConfig);
         }
     });
 }
@@ -138,7 +138,7 @@ function clearCache() {
     const size = resultCache.size;
     resultCache.clear();
     if (globalThis.djustDebug) {
-        if (globalThis.djustDebug) console.log(`[LiveView:cache] Cleared all ${size} cached entries`);
+        console.log(`[LiveView:cache] Cleared all ${size} cached entries`);
     }
 }
 
@@ -168,7 +168,7 @@ function invalidateCache(pattern) {
     }
 
     if (globalThis.djustDebug) {
-        if (globalThis.djustDebug) console.log(`[LiveView:cache] Invalidated ${count} entries matching: ${pattern}`);
+        console.log(`[LiveView:cache] Invalidated ${count} entries matching: ${pattern}`);
     }
 
     return count;

--- a/python/djust/static/djust/src/05-state-bus.js
+++ b/python/djust/static/djust/src/05-state-bus.js
@@ -10,7 +10,7 @@ class StateBus {
         const oldValue = this.state.get(key);
         this.state.set(key, value);
         if (globalThis.djustDebug) {
-            if (globalThis.djustDebug) console.log(`[StateBus] Set: ${key} =`, value, `(was:`, oldValue, `)`);
+            console.log(`[StateBus] Set: ${key} =`, value, `(was:`, oldValue, `)`);
         }
         this.notify(key, value, oldValue);
     }
@@ -25,14 +25,14 @@ class StateBus {
         }
         this.subscribers.get(key).add(callback);
         if (globalThis.djustDebug) {
-            if (globalThis.djustDebug) console.log(`[StateBus] Subscribed to: ${key} (${this.subscribers.get(key).size} subscribers)`);
+            console.log(`[StateBus] Subscribed to: ${key} (${this.subscribers.get(key).size} subscribers)`);
         }
         return () => {
             const subs = this.subscribers.get(key);
             if (subs) {
                 subs.delete(callback);
                 if (globalThis.djustDebug) {
-                    if (globalThis.djustDebug) console.log(`[StateBus] Unsubscribed from: ${key} (${subs.size} remaining)`);
+                    console.log(`[StateBus] Unsubscribed from: ${key} (${subs.size} remaining)`);
                 }
             }
         };
@@ -41,7 +41,7 @@ class StateBus {
     notify(key, newValue, oldValue) {
         const callbacks = this.subscribers.get(key) || new Set();
         if (callbacks.size > 0 && globalThis.djustDebug) {
-            if (globalThis.djustDebug) console.log(`[StateBus] Notifying ${callbacks.size} subscribers of: ${key}`);
+            console.log(`[StateBus] Notifying ${callbacks.size} subscribers of: ${key}`);
         }
         callbacks.forEach(callback => {
             try {
@@ -56,7 +56,7 @@ class StateBus {
         this.state.clear();
         this.subscribers.clear();
         if (globalThis.djustDebug) {
-            if (globalThis.djustDebug) console.log('[StateBus] Cleared all state');
+            console.log('[StateBus] Cleared all state');
         }
     }
 

--- a/python/djust/static/djust/src/06-draft-manager.js
+++ b/python/djust/static/djust/src/06-draft-manager.js
@@ -20,7 +20,7 @@ class DraftManager {
                 localStorage.setItem(`djust_draft_${draftKey}`, JSON.stringify(draftData));
 
                 if (globalThis.djustDebug) {
-                    if (globalThis.djustDebug) console.log(`[DraftMode] Saved draft: ${draftKey}`, data);
+                    console.log(`[DraftMode] Saved draft: ${draftKey}`, data);
                 }
             } catch (error) {
                 console.error(`[DraftMode] Failed to save draft ${draftKey}:`, error);
@@ -42,7 +42,7 @@ class DraftManager {
 
             if (globalThis.djustDebug) {
                 const age = Math.round((Date.now() - draftData.timestamp) / 1000);
-                if (globalThis.djustDebug) console.log(`[DraftMode] Loaded draft: ${draftKey} (${age}s old)`, draftData.data);
+                console.log(`[DraftMode] Loaded draft: ${draftKey} (${age}s old)`, draftData.data);
             }
 
             return draftData.data;
@@ -62,7 +62,7 @@ class DraftManager {
             localStorage.removeItem(`djust_draft_${draftKey}`);
 
             if (globalThis.djustDebug) {
-                if (globalThis.djustDebug) console.log(`[DraftMode] Cleared draft: ${draftKey}`);
+                console.log(`[DraftMode] Cleared draft: ${draftKey}`);
             }
         } catch (error) {
             console.error(`[DraftMode] Failed to clear draft ${draftKey}:`, error);
@@ -89,7 +89,7 @@ class DraftManager {
         keys.forEach(key => this.clearDraft(key));
 
         if (globalThis.djustDebug) {
-            if (globalThis.djustDebug) console.log(`[DraftMode] Cleared all ${keys.length} drafts`);
+            console.log(`[DraftMode] Cleared all ${keys.length} drafts`);
         }
     }
 }

--- a/python/djust/static/djust/src/07-form-data.js
+++ b/python/djust/static/djust/src/07-form-data.js
@@ -61,6 +61,6 @@ function restoreFormData(container, data) {
     });
 
     if (globalThis.djustDebug) {
-        if (globalThis.djustDebug) console.log('[DraftMode] Restored form data:', data);
+        console.log('[DraftMode] Restored form data:', data);
     }
 }

--- a/python/djust/static/djust/src/09-event-binding.js
+++ b/python/djust/static/djust/src/09-event-binding.js
@@ -233,7 +233,7 @@ function bindLiveViewEvents() {
                 }
 
                 if (globalThis.djustDebug) {
-                    if (globalThis.djustDebug) console.log(`[LiveView] dj-change handler: value="${value}", params=`, params);
+                    console.log(`[LiveView] dj-change handler: value="${value}", params=`, params);
                 }
                 await handleEvent(parsedChange.name, params);
             };

--- a/python/djust/static/djust/src/10-loading-states.js
+++ b/python/djust/static/djust/src/10-loading-states.js
@@ -44,7 +44,7 @@ const globalLoadingManager = {
         if (modifiers.length > 0) {
             this.registeredElements.set(element, { eventName, modifiers, originalState });
             if (globalThis.djustDebug) {
-                if (globalThis.djustDebug) console.log(`[Loading] Registered element for "${eventName}":`, modifiers);
+                console.log(`[Loading] Registered element for "${eventName}":`, modifiers);
             }
         }
     },
@@ -88,7 +88,7 @@ const globalLoadingManager = {
             }
         });
         if (globalThis.djustDebug) {
-            if (globalThis.djustDebug) console.log(`[Loading] Scanned ${this.registeredElements.size} elements with dj-loading attributes`);
+            console.log(`[Loading] Scanned ${this.registeredElements.size} elements with dj-loading attributes`);
         }
     },
 
@@ -102,8 +102,8 @@ const globalLoadingManager = {
             // Check if trigger element has dj-loading.disable
             const hasDisable = triggerElement.hasAttribute('dj-loading.disable');
             if (globalThis.djustDebug) {
-                if (globalThis.djustDebug) console.log(`[Loading] triggerElement:`, triggerElement);
-                if (globalThis.djustDebug) console.log(`[Loading] hasAttribute('dj-loading.disable'):`, hasDisable);
+                console.log(`[Loading] triggerElement:`, triggerElement);
+                console.log(`[Loading] hasAttribute('dj-loading.disable'):`, hasDisable);
             }
             if (hasDisable) {
                 triggerElement.disabled = true;
@@ -120,7 +120,7 @@ const globalLoadingManager = {
         document.body.classList.add('djust-global-loading');
 
         if (globalThis.djustDebug) {
-            if (globalThis.djustDebug) console.log(`[Loading] Started: ${eventName}`);
+            console.log(`[Loading] Started: ${eventName}`);
         }
     },
 
@@ -147,7 +147,7 @@ const globalLoadingManager = {
         document.body.classList.remove('djust-global-loading');
 
         if (globalThis.djustDebug) {
-            if (globalThis.djustDebug) console.log(`[Loading] Stopped: ${eventName}`);
+            console.log(`[Loading] Stopped: ${eventName}`);
         }
     },
 

--- a/python/djust/static/djust/src/11-event-handler.js
+++ b/python/djust/static/djust/src/11-event-handler.js
@@ -2,7 +2,7 @@
 // Main Event Handler
 async function handleEvent(eventName, params = {}) {
     if (globalThis.djustDebug) {
-        if (globalThis.djustDebug) console.log(`[LiveView] Handling event: ${eventName}`, params);
+        console.log(`[LiveView] Handling event: ${eventName}`, params);
     }
 
     // Extract client-only properties before sending to server.
@@ -30,7 +30,7 @@ async function handleEvent(eventName, params = {}) {
     if (cached) {
         // Cache hit! Apply cached patches without server round-trip
         if (globalThis.djustDebug) {
-            if (globalThis.djustDebug) console.log(`[LiveView:cache] Cache hit: ${cacheKey}`);
+            console.log(`[LiveView:cache] Cache hit: ${cacheKey}`);
         }
 
         // Still show brief loading state for UX consistency
@@ -50,7 +50,7 @@ async function handleEvent(eventName, params = {}) {
 
     // Cache miss - need to fetch from server
     if (globalThis.djustDebug && cacheConfig.has(eventName)) {
-        if (globalThis.djustDebug) console.log(`[LiveView:cache] Cache miss: ${cacheKey}`);
+        console.log(`[LiveView:cache] Cache miss: ${cacheKey}`);
     }
 
     if (!skipLoading) globalLoadingManager.startLoading(eventName, triggerElement);
@@ -69,7 +69,7 @@ async function handleEvent(eventName, params = {}) {
             if (pendingCacheRequests.has(cacheRequestId)) {
                 pendingCacheRequests.delete(cacheRequestId);
                 if (globalThis.djustDebug) {
-                    if (globalThis.djustDebug) console.log(`[LiveView:cache] Cleaned up stale pending request: ${cacheRequestId}`);
+                    console.log(`[LiveView:cache] Cleaned up stale pending request: ${cacheRequestId}`);
                 }
             }
         }, PENDING_CACHE_TIMEOUT);

--- a/python/djust/static/djust/src/12-vdom-patch.js
+++ b/python/djust/static/djust/src/12-vdom-patch.js
@@ -32,7 +32,7 @@ function getNodeByPath(path, djustId = null) {
         // ID not found - fall through to path-based
         if (globalThis.djustDebug) {
             // Log without user data to avoid log injection
-            if (globalThis.djustDebug) console.log('[LiveView] ID lookup failed, trying path fallback');
+            console.log('[LiveView] ID lookup failed, trying path fallback');
         }
     }
 
@@ -712,7 +712,7 @@ function applyDjUpdateElements(existingRoot, newRoot) {
                         // Clone and append new child
                         existingElement.appendChild(newChild.cloneNode(true));
                         if (globalThis.djustDebug) {
-                            if (globalThis.djustDebug) console.log(`[LiveView:dj-update] Appended #${newChild.id} to #${elementId}`);
+                            console.log(`[LiveView:dj-update] Appended #${newChild.id} to #${elementId}`);
                         }
                     }
                 }
@@ -733,7 +733,7 @@ function applyDjUpdateElements(existingRoot, newRoot) {
                         // Clone and prepend new child
                         existingElement.insertBefore(newChild.cloneNode(true), firstExisting);
                         if (globalThis.djustDebug) {
-                            if (globalThis.djustDebug) console.log(`[LiveView:dj-update] Prepended #${newChild.id} to #${elementId}`);
+                            console.log(`[LiveView:dj-update] Prepended #${newChild.id} to #${elementId}`);
                         }
                     }
                 }
@@ -743,7 +743,7 @@ function applyDjUpdateElements(existingRoot, newRoot) {
             case 'ignore':
                 // Don't update this element at all
                 if (globalThis.djustDebug) {
-                    if (globalThis.djustDebug) console.log(`[LiveView:dj-update] Ignoring #${elementId}`);
+                    console.log(`[LiveView:dj-update] Ignoring #${elementId}`);
                 }
                 break;
 

--- a/python/djust/static/djust/src/13-lazy-hydration.js
+++ b/python/djust/static/djust/src/13-lazy-hydration.js
@@ -110,7 +110,7 @@ const lazyHydrationManager = {
         }
 
         if (globalThis.djustDebug) {
-            if (globalThis.djustDebug) console.log(`[LiveView:lazy] Registered element for lazy hydration (mode: ${lazyMode})`, element);
+            console.log(`[LiveView:lazy] Registered element for lazy hydration (mode: ${lazyMode})`, element);
         }
     },
 

--- a/python/tests/test_components_security.py
+++ b/python/tests/test_components_security.py
@@ -38,8 +38,8 @@ class TestComponentSecurityEscaping:
 
         # Script tags should be escaped
         assert '<script>alert("xss")</script>' not in html
-        assert '&lt;script&gt;' in html or '&#x3C;script&#x3E;' in html
-        assert 'data-component-id=' in html
+        assert "&lt;script&gt;" in html or "&#x3C;script&#x3E;" in html
+        assert "data-component-id=" in html
 
     def test_component_id_with_quotes_is_escaped(self, request_factory):
         """Component ID containing quotes should be HTML-escaped in inline templates."""
@@ -62,7 +62,7 @@ class TestComponentSecurityEscaping:
 
         # Should not allow attribute injection
         assert 'onload="alert(1)' not in html
-        assert '&quot;' in html or '&#34;' in html or '&#x22;' in html
+        assert "&quot;" in html or "&#34;" in html or "&#x22;" in html
 
     def test_component_id_with_angle_brackets_is_escaped(self, request_factory):
         """Component ID containing angle brackets should be HTML-escaped in inline templates."""
@@ -83,8 +83,8 @@ class TestComponentSecurityEscaping:
         html = component.render()
 
         # Angle brackets should be escaped
-        assert '<img src=x' not in html
-        assert '&lt;' in html or '&#x3C;' in html
+        assert "<img src=x" not in html
+        assert "&lt;" in html or "&#x3C;" in html
 
     def test_normal_component_id_renders_correctly(self, request_factory):
         """Normal component IDs should render without issues in inline templates."""
@@ -131,152 +131,3 @@ class TestComponentSecurityEscaping:
         # We should see &lt;b&gt; not &amp;lt;b&amp;gt;
         if "&lt;" in html:  # If template escaped it
             assert "&amp;lt;" not in html  # Should not be double-escaped
-
-
-class TestExampleComponentSecurity:
-    """Test example components for XSS vulnerabilities."""
-
-    @pytest.fixture
-    def request_factory(self):
-        return RequestFactory()
-
-    def test_status_badge_escapes_malicious_label(self, request_factory):
-        """StatusBadge component should escape malicious labels."""
-        from djust_rentals.components.status_badge import StatusBadge
-
-        # Create badge with XSS attempt in label
-        badge = StatusBadge(
-            status="active",
-            label='<script>alert("xss")</script>',
-            color='green'
-        )
-
-        html = badge.render()
-
-        # Script tags should be escaped
-        assert '<script>alert("xss")</script>' not in html
-        assert '&lt;script&gt;' in html or '&#x3C;script&#x3E;' in html
-
-    def test_status_badge_escapes_img_onerror(self, request_factory):
-        """StatusBadge component should escape img onerror XSS."""
-        from djust_rentals.components.status_badge import StatusBadge
-
-        badge = StatusBadge(
-            status="urgent",
-            label='<img src=x onerror=alert(1)>',
-            color='red'
-        )
-
-        html = badge.render()
-
-        # XSS attempt should be escaped - the < and > should be HTML entities
-        assert '<img src=x onerror=alert(1)>' not in html  # Raw HTML should not appear
-        assert '&lt;img' in html or '&#x3C;img' in html  # Opening tag should be escaped
-        assert '&gt;' in html or '&#x3E;' in html  # Closing tag should be escaped
-
-    def test_data_table_escapes_malicious_headers(self, request_factory):
-        """DataTable component should escape malicious header values."""
-        from djust_rentals.components.data_table import DataTable
-
-        # Headers with XSS attempts
-        headers = ['<script>alert("xss")</script>', "Value"]
-        rows = [{"col1": "Test", "col2": "123"}]
-
-        table = DataTable(headers=headers, rows=rows)
-        html = table.render()
-
-        # Script tags in headers should be escaped
-        assert '<script>alert("xss")</script>' not in html
-
-    def test_data_table_escapes_malicious_cell_values(self, request_factory):
-        """DataTable component should escape malicious cell values."""
-        from djust_rentals.components.data_table import DataTable
-
-        headers = ["Name", "Value"]
-        rows = [
-            {"Name": '<img src=x onerror=alert(1)>', "Value": "123"}
-        ]
-
-        table = DataTable(headers=headers, rows=rows)
-        html = table.render()
-
-        # XSS attempt should be escaped - the < and > should be HTML entities
-        assert '<img src=x onerror=alert(1)>' not in html  # Raw HTML should not appear
-        assert '&lt;img' in html or '&#x3C;img' in html  # Opening tag should be escaped
-        assert '&gt;' in html or '&#x3E;' in html  # Closing tag should be escaped
-
-    def test_page_header_escapes_malicious_title(self, request_factory):
-        """PageHeader component should escape malicious titles."""
-        from djust_rentals.components.page_header import PageHeader
-
-        header = PageHeader(
-            title='<script>alert("xss")</script>',
-            subtitle="Safe subtitle"
-        )
-        html = header.render()
-
-        # Script tags should be escaped
-        assert '<script>alert("xss")</script>' not in html
-        assert '&lt;script&gt;' in html or '&#x3C;script&#x3E;' in html
-
-    def test_stat_card_escapes_malicious_label(self, request_factory):
-        """StatCard component should escape malicious labels."""
-        from djust_rentals.components.stat_card import StatCard
-
-        card = StatCard(
-            label='<script>alert("xss")</script>',
-            value="1234",
-            icon="dollar-sign"
-        )
-        html = card.render()
-
-        # Script tags should be escaped
-        assert '<script>alert("xss")</script>' not in html
-        assert '&lt;script&gt;' in html or '&#x3C;script&#x3E;' in html
-
-    def test_stat_card_escapes_malicious_value(self, request_factory):
-        """StatCard component should escape malicious values."""
-        from djust_rentals.components.stat_card import StatCard
-
-        card = StatCard(
-            label="Revenue",
-            value='<img src=x onerror=alert(1)>',
-            icon="dollar-sign"
-        )
-        html = card.render()
-
-        # XSS attempt should be escaped
-        assert '<img src=x onerror=alert(1)>' not in html
-        assert '&lt;img' in html or '&#x3C;img' in html
-
-    def test_stat_card_escapes_malicious_trend(self, request_factory):
-        """StatCard component should escape malicious trend values."""
-        from djust_rentals.components.stat_card import StatCard
-
-        card = StatCard(
-            label="Sales",
-            value="1000",
-            trend='<script>alert("xss")</script>',
-            trend_direction="up",
-            icon="trending-up"
-        )
-        html = card.render()
-
-        # Script tags in trend should be escaped
-        assert '<script>alert("xss")</script>' not in html
-        assert '&lt;script&gt;' in html or '&#x3C;script&#x3E;' in html
-
-    def test_stat_card_escapes_malicious_icon(self, request_factory):
-        """StatCard component should escape malicious icon names."""
-        from djust_rentals.components.stat_card import StatCard
-
-        card = StatCard(
-            label="Users",
-            value="500",
-            icon='"><script>alert(1)</script><i x="',
-        )
-        html = card.render()
-
-        # Script tags should be escaped
-        assert '<script>alert(1)</script>' not in html
-        assert '&lt;script&gt;' in html or '&#x3C;script&#x3E;' in html


### PR DESCRIPTION
## Summary

- **#348**: Remove 33 redundant inner `if (globalThis.djustDebug)` guards from 11 JS source files where console.log calls were already inside an outer `if (globalThis.djustDebug) { ... }` block
- **#349**: Remove `TestExampleComponentSecurity` class from `python/tests/test_components_security.py` — it imports from the demo project's `djust_rentals` components and doesn't belong in the core test suite. The example-specific tests already exist at `examples/demo_project/`

Closes #348
Closes #349

## Test plan

- [x] All 641 JS tests pass (`npm test`)
- [x] Pre-commit hooks pass (build client.js, eslint, ruff, bandit, etc.)
- [x] Grep confirms no remaining double-wrapped djustDebug guards
- [x] `pytest python/tests/test_components_security.py` — remaining `TestComponentSecurityEscaping` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)