### PR TITLE
fix: handle #comment vnode type in createNodeFromVNode

### DIFF
--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -3179,6 +3179,10 @@ function createNodeFromVNode(vnode, inSvgContext = false) {
         return document.createTextNode(vnode.text || '');
     }
 
+    if (vnode.tag === '#comment') {
+        return document.createComment(vnode.text || '');
+    }
+
     // Validate tag name against whitelist (security: prevents script injection)
     // Convert to lowercase for consistent matching
     const tagLower = String(vnode.tag || '').toLowerCase();


### PR DESCRIPTION
## Summary

Closes #371

`createNodeFromVNode` did not handle comment vnodes (`type === '#comment'`), causing a crash when the VDOM tried to create a `<!--dj-if-->` placeholder comment node from a vnode during reconciliation.

## Changes
- `python/djust/static/djust/client.js` — added `#comment` case to `createNodeFromVNode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)