### PR TITLE
fix: replace desc.get/set.call(ws) with property access in _hookExistingWebSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Developer Tools Events tab not capturing events** — The debug panel loaded after the WebSocket connected, so its prototype hooks missed the existing connection's `onmessage` handler. Fixed `_hookExistingWebSocket()` to wrap the existing handler using the original property descriptor. Also added `html_update` to event response type matching.
+- **Developer Tools Events tab not capturing events** — The debug panel loaded after the WebSocket connected, so its prototype hooks missed the existing connection's `onmessage` handler. Fixed `_hookExistingWebSocket()` to re-trigger the patched `WebSocket.prototype.onmessage` setter via property assignment, which wraps the pre-existing handler with `_handleReceivedMessage`. Also added `html_update` to event response type matching. ([#367](https://github.com/djust-org/djust/issues/367))
+- **`TypeError: Illegal invocation` in debug panel on Chrome/Edge** — `_hookExistingWebSocket` called native WebSocket getter/setter functions via `Function.prototype.call()` from external code, which fails V8's brand check on IDL-generated bindings. Fixed by using normal property access (`ws.onmessage`) and assignment (`ws.onmessage = handler`) instead of `desc.get/set.call(ws)`. ([#367](https://github.com/djust-org/djust/issues/367))
 
 ### Removed
 

--- a/python/djust/static/djust/debug-panel.js
+++ b/python/djust/static/djust/debug-panel.js
@@ -2643,9 +2643,6 @@
                 // Hook into onmessage property setter to capture messages
                 // assigned via ws.onmessage = handler (bypasses addEventListener)
                 const onmessageDescriptor = Object.getOwnPropertyDescriptor(WebSocket.prototype, 'onmessage');
-                // Save original descriptor for _hookExistingWebSocket to use
-                // when wrapping an already-assigned onmessage handler
-                this._originalOnmessageDescriptor = onmessageDescriptor;
                 if (onmessageDescriptor) {
                     Object.defineProperty(WebSocket.prototype, 'onmessage', {
                         set(handler) {

--- a/python/djust/static/djust/src/debug/11-integration.js
+++ b/python/djust/static/djust/src/debug/11-integration.js
@@ -44,9 +44,6 @@
                 // Hook into onmessage property setter to capture messages
                 // assigned via ws.onmessage = handler (bypasses addEventListener)
                 const onmessageDescriptor = Object.getOwnPropertyDescriptor(WebSocket.prototype, 'onmessage');
-                // Save original descriptor for _hookExistingWebSocket to use
-                // when wrapping an already-assigned onmessage handler
-                this._originalOnmessageDescriptor = onmessageDescriptor;
                 if (onmessageDescriptor) {
                     Object.defineProperty(WebSocket.prototype, 'onmessage', {
                         set(handler) {


### PR DESCRIPTION
## Summary

Fixes the `TypeError: Illegal invocation` thrown by `DjustDebugPanel._hookExistingWebSocket` on page load when a WebSocket connection is already present.

## Root cause

V8 enforces a brand check on native WebSocket/EventTarget IDL-generated getter/setter functions. When invoked via `Function.prototype.call()` from external JavaScript, the brand check fails and throws `TypeError: Illegal invocation`. This only affects Blink (Chrome/Edge); Firefox and Safari handle it differently.

The fix replaces direct descriptor `.call()` invocations with normal property access/assignment:

```js
// Before — throws on Chrome:
const currentHandler = desc.get.call(ws);
desc.set.call(ws, function(event) { ... });

// After — works everywhere:
const currentOnmessage = ws.onmessage;
if (currentOnmessage) { ws.onmessage = currentOnmessage; }
```

`ws.onmessage` (getter) triggers the patched prototype getter which calls the original descriptor's get with `this = ws` — the brand check passes because V8's own property access machinery set the receiver. The setter then wraps the current handler with `_handleReceivedMessage`.

## Test plan
- [ ] Open a page using the debug panel with an active WebSocket — no `Illegal invocation` in console
- [ ] Verify sent/received messages are still captured in the debug panel

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)