### PR TITLE
fix: add super().__init__() calls to component and backend subclasses

### DIFF
--- a/examples/demo_project/djust_rentals/components/data_table.py
+++ b/examples/demo_project/djust_rentals/components/data_table.py
@@ -47,6 +47,7 @@ class DataTable(Component):
         hover: bool = True,
         striped: bool = False
     ):
+        super().__init__()
         self.headers = headers
         self.rows = rows
         self.empty_message = empty_message

--- a/examples/demo_project/djust_rentals/components/page_header.py
+++ b/examples/demo_project/djust_rentals/components/page_header.py
@@ -41,6 +41,7 @@ class PageHeader(Component):
         icon: Optional[str] = None,
         actions: Optional[List[Dict[str, str]]] = None
     ):
+        super().__init__()
         self.title = title
         self.subtitle = subtitle
         self.icon = icon

--- a/examples/demo_project/djust_rentals/components/stat_card.py
+++ b/examples/demo_project/djust_rentals/components/stat_card.py
@@ -39,6 +39,7 @@ class StatCard(Component):
         trend_direction: str = None,  # "up" or "down"
         color: str = "primary"  # "primary", "destructive", "muted"
     ):
+        super().__init__()
         self.label = label
         self.value = value
         self.icon = icon

--- a/examples/demo_project/djust_rentals/components/status_badge.py
+++ b/examples/demo_project/djust_rentals/components/status_badge.py
@@ -78,6 +78,7 @@ class StatusBadge(Component):
         icon: Optional[str] = None,
         color: Optional[str] = None  # Override auto-color
     ):
+        super().__init__()
         self.status = status.lower()
         self.label = label or status.replace('_', ' ').title()
         self.icon = icon

--- a/examples/demo_project/djust_shared/components/code_highlighting.py
+++ b/examples/demo_project/djust_shared/components/code_highlighting.py
@@ -34,6 +34,7 @@ class CodeHighlightingSetup(Component):
             theme: highlight.js theme name (default: atom-one-dark)
                    See: https://highlightjs.org/static/demo/
         """
+        super().__init__()
         self.theme = theme
 
     def render(self) -> str:
@@ -104,6 +105,7 @@ class CodeBlockWithHighlighting(Component):
 
     def __init__(self, code: str, language: str = "python", filename: str = None,
                  show_header: bool = True, theme: str = "atom-one-dark"):
+        super().__init__()
         from .ui import CodeBlock
         self.code_block = CodeBlock(code, language, filename, show_header)
         self.setup = CodeHighlightingSetup(theme)

--- a/examples/demo_project/djust_shared/components/ui.py
+++ b/examples/demo_project/djust_shared/components/ui.py
@@ -38,6 +38,7 @@ class CodeBlock(Component):
         show_header: bool = True,
         theme: str = "atom-one-dark"
     ):
+        super().__init__()
         self.code = code
         self.language = language
         self.filename = filename
@@ -95,6 +96,7 @@ class HeroSection(Component):
         icon: Optional[str] = None,
         padding: str = "4rem 0 2rem"
     ):
+        super().__init__()
         self.title = title
         self.subtitle = subtitle
         self.icon = icon
@@ -145,6 +147,7 @@ class Card(Component):
         header_color: Optional[str] = None,
         show_header: bool = True
     ):
+        super().__init__()
         self.content = content
         self.title = title
         self.subtitle = subtitle
@@ -192,6 +195,7 @@ class FeatureCard(Component):
     """
 
     def __init__(self, icon: str, title: str, description: str):
+        super().__init__()
         self.icon = icon
         self.title = title
         self.description = description
@@ -222,6 +226,7 @@ class FeatureGrid(Component):
     """
 
     def __init__(self, features: List[Component], columns: int = 3):
+        super().__init__()
         self.features = features
         self.columns = columns
 
@@ -274,6 +279,7 @@ class Button(Component):
         icon_svg: Optional[str] = None,
         extra_attrs: Optional[str] = None
     ):
+        super().__init__()
         self.text = text
         self.event = event
         self.variant = variant
@@ -325,6 +331,7 @@ class Section(Component):
         padding: str = "4rem 0",
         max_width: str = "1200px"
     ):
+        super().__init__()
         self.content = content
         self.title = title
         self.subtitle = subtitle
@@ -362,6 +369,7 @@ class BackButton(Component):
     """
 
     def __init__(self, href: str = "/demos/", text: str = "Back to Demos"):
+        super().__init__()
         self.href = href
         self.text = text
 

--- a/examples/marketing_site/marketing/components/code_block.py
+++ b/examples/marketing_site/marketing/components/code_block.py
@@ -29,6 +29,7 @@ class CodeBlock(Component):
             filename: Optional filename to display above code
             show_line_numbers: Whether to show line numbers
         """
+        super().__init__()
         self.code = code.strip()
         self.language = language
         self.filename = filename
@@ -92,6 +93,7 @@ class CodeTabs(Component):
         Args:
             tabs: List of dicts with 'label', 'code', 'language', optional 'filename'
         """
+        super().__init__()
         self.tabs = tabs
 
     def render(self) -> str:
@@ -165,6 +167,7 @@ class CodeTabsWithHighlighting(Component):
             theme: Prism.js theme name (default: tomorrow)
             include_highlighting: Override automatic detection - force include/exclude setup
         """
+        super().__init__()
         self.code_tabs = CodeTabs(tabs)
         self.setup = CodeHighlightingSetup(theme)
 

--- a/python/djust/tenants/backends.py
+++ b/python/djust/tenants/backends.py
@@ -76,6 +76,7 @@ class TenantAwareRedisBackend(TenantAwareBackendMixin, PresenceBackend):
         key_prefix: str = "djust",
         timeout: int = PRESENCE_TIMEOUT,
     ):
+        super().__init__(tenant_id=tenant_id)
         try:
             import redis as redis_lib
         except ImportError:
@@ -247,6 +248,7 @@ class TenantAwareMemoryBackend(TenantAwareBackendMixin, PresenceBackend):
     _heartbeats: Dict[str, Dict[str, float]] = {}
 
     def __init__(self, tenant_id: str, timeout: int = PRESENCE_TIMEOUT):
+        super().__init__(tenant_id=tenant_id)
         self._tenant_id = tenant_id
         self._timeout = timeout
 


### PR DESCRIPTION
## Summary

Addresses CodeQL `py/missing-call-to-init` alerts by adding `super().__init__()` calls to all component and backend `__init__` methods that were missing them.

## Changes

### Production code
- `python/djust/tenants/backends.py`: `TenantAwareRedisBackend` and `TenantAwareMemoryBackend` now call `super().__init__(tenant_id=tenant_id)` to correctly chain through `TenantAwareBackendMixin`

### Example components (not production framework code)
- `examples/demo_project/djust_shared/components/ui.py`: 8 components call `super().__init__()`
- `examples/demo_project/djust_shared/components/code_highlighting.py`: 2 components
- `examples/demo_project/djust_rentals/components/`: 4 components (StatusBadge, StatCard, PageHeader, DataTable)
- `examples/marketing_site/marketing/components/code_block.py`: 3 components

### False-positive dismissals (via GitHub API)
- **#469, #468**: Cyclic imports — guarded by `TYPE_CHECKING`, no runtime circular import
- **#684, #683**: Test signature mismatches — test code, not production code
- **#2**: `simple_live_view.py` — already fixed in PR #385

## Test plan
- [x] `make test-python` — 2045 passed, 9 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)