### PR TITLE
fix: remove unused import and fix render_full_template signature

### DIFF
--- a/examples/demo_project/demo_app/views/no_template_demo.py
+++ b/examples/demo_project/demo_app/views/no_template_demo.py
@@ -338,10 +338,10 @@ class NoTemplateDemo(LiveView):
             action="switch_tab"
         )
 
-    def render_full_template(self, request=None):
+    def render_full_template(self, request=None, serialized_context=None):
         """Override to wrap template_string content with full HTML document"""
         # Get the inner content (just the template_string rendered, no wrapper)
-        inner_content = super().render_full_template(request)
+        inner_content = super().render_full_template(request, serialized_context=serialized_context)
 
         # Get view path for WebSocket mounting
         view_path = f"{self.__class__.__module__}.{self.__class__.__name__}"

--- a/examples/demo_project/djust_rentals/components/data_table.py
+++ b/examples/demo_project/djust_rentals/components/data_table.py
@@ -6,7 +6,7 @@ Used for property lists, tenant lists, lease lists, maintenance lists, etc.
 """
 
 from djust.components.base import Component
-from django.utils.html import format_html, escape
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from typing import List, Dict, Any, Optional
 


### PR DESCRIPTION
## Summary

Two real code fixes + 23 false-positive alert dismissals (via GitHub API).

## Real Code Fixes

### 1. Remove unused `escape` import — `data_table.py` (#685)
`escape` was imported from `django.utils.html` but never used — only `format_html` and `mark_safe` are used in the file.

### 2. Fix `render_full_template` signature mismatch — `no_template_demo.py` (#31, #30)
`render_full_template(self, request=None)` was missing the `serialized_context` parameter present on the parent `TemplateMixin.render_full_template(self, request=None, serialized_context=None)`. Fixed by adding the missing parameter and forwarding it to `super()`.

## False-Positive Dismissals (23 alerts via GitHub API)

| Alerts | Rule | Reason |
|--------|------|--------|
| #752, #754, #753 | XSS / log-injection | Suppression comments already on preceding lines in source; all innerHTML/console assignments receive data from the trusted server over authenticated WebSocket |
| #751 | Info exposure | Exception details are `if settings.DEBUG`-gated; never returned in production |
| #107 | Missing `super().__init__()` | Already fixed in PR #386 |
| #682, #681, #680 | Signature mismatch | Test code — `mount(request, **kwargs)` overrides intentionally differ in test scaffolding |
| #19, #18 | Variable defined multiple times | Mutually exclusive code paths separated by `continue`; CodeQL can't see through the branch |
| #382, #381 | Potentially uninitialized | `module_path`/`class_name` are always set before the `AttributeError`/`ImportError` branches can execute (the `ValueError` branch returns early) |
| #22, #21, #20 | Potentially uninitialized | Test code — `FailingRedisClient` mock usage pattern |
| #604, #603, #602, #601 | Unnecessary `del` | Intentional — `del ViewClass` removes dynamically-created subclasses from `LiveView.__subclasses__()` to prevent test isolation failures |
| #558 | Conflicting attributes | Intentional Django mixin MRO pattern used throughout the framework |
| #103 | `__init__` calls overridden method | Intentional LiveComponent lifecycle — `mount()` is `@abstractmethod` and always overridden |
| #735 | Missing variable declaration | `liveViewWS` is declared as `let liveViewWS = null` in `src/03-websocket.js`; all `src/` files are concatenated into a single IIFE |

## Test plan
- [x] `make test-python` — 2045 passed, 9 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)