### PR TITLE
test: add RemoveAttr checked coverage for focused checkbox (#428)

### DIFF
--- a/tests/js/checked_selected_property_sync.test.js
+++ b/tests/js/checked_selected_property_sync.test.js
@@ -5,7 +5,7 @@
  * - createNodeFromVNode: syncs checked on INPUT, selected on OPTION
  * - SetAttr/RemoveAttr: selected on OPTION elements
  * - Radio inputs: checked property sync
- * - activeElement guard: checked updates even when focused (unlike value)
+ * - activeElement guard: SetAttr/RemoveAttr checked update even when focused (unlike value)
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
@@ -175,6 +175,17 @@ describe('SetAttr checked updates even when element is activeElement', () => {
         _applySinglePatch({ type: 'SetAttr', d: 'chk-focused', path: [], key: 'checked', value: '' });
 
         expect(checkbox.checked).toBe(true);
+    });
+
+    it('RemoveAttr checked updates el.checked when checkbox is document.activeElement', () => {
+        setup();
+        checkbox.checked = true;
+        checkbox.setAttribute('checked', '');
+        expect(dom.window.document.activeElement).toBe(checkbox);
+
+        _applySinglePatch({ type: 'RemoveAttr', d: 'chk-focused', path: [], key: 'checked' });
+
+        expect(checkbox.checked).toBe(false);
     });
 
     it('SetAttr value skips el.value update when input is document.activeElement', () => {


### PR DESCRIPTION
## Summary

- Adds a test for `RemoveAttr checked` when the checkbox is `document.activeElement`
- Completes the coverage matrix: SetAttr/RemoveAttr × focused/unfocused for `checked` property sync
- Updates file header comment to reflect both SetAttr and RemoveAttr activeElement coverage

## Context

The `checked` branch in VDOM patching intentionally has no `activeElement` guard (unlike `value`, which skips focused elements to protect in-progress typing). The existing SetAttr test at line 171 documented this for setting checked, but no parallel test existed for RemoveAttr on a focused checkbox.

| Operation | Focused? | Before | After |
|-----------|----------|--------|-------|
| SetAttr checked | Yes | ✅ line 171 | ✅ line 171 |
| RemoveAttr checked | Yes | ❌ missing | ✅ line 180 |

## Test plan

- [x] New test passes (`RemoveAttr checked updates el.checked when checkbox is document.activeElement`)
- [x] Full JS suite: 46 files, 688 tests — all passing
- [x] No source code changes — test-only addition

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)