### PR TITLE
feat: add djust-deploy CLI with --server flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`djust-deploy` CLI** — new `python/djust/deploy_cli.py` module providing deployment commands for [djustlive.com](https://djustlive.com). Available via the `djust-deploy` entry point after installation:
+  - `djust-deploy login` — prompts for email/password, authenticates against djustlive.com, and stores the token in `~/.djustlive/credentials` (mode `0o600`)
+  - `djust-deploy logout` — calls the server logout endpoint and removes the local credentials file
+  - `djust-deploy status [project]` — fetches current deployment state; optionally filtered by project slug
+  - `djust-deploy deploy <project-slug>` — validates the git working tree is clean, triggers a production deployment, and streams build logs to stdout
+  - `--server` flag / `DJUST_SERVER` env var to override the default server URL (`https://djustlive.com`)
+
 ### Fixed
 
 - **Auto-reload on unrecoverable VDOM state** — When VDOM patch recovery fails because recovery HTML is unavailable (e.g. after server restart), the client now auto-reloads the page instead of showing a confusing error overlay. The server sends `recoverable: false` to signal the client.

--- a/python/djust/deploy_cli.py
+++ b/python/djust/deploy_cli.py
@@ -31,11 +31,11 @@ def credentials_path() -> Path:
     return Path.home() / _CREDS_DIR_NAME / _CREDS_FILE_NAME
 
 
-def save_credentials(token: str, email: str) -> None:
+def save_credentials(token: str, email: str, server_url: str) -> None:
     """Write credentials to disk with mode 0o600 (created atomically)."""
     path = credentials_path()
     path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    data = {"token": token, "email": email}
+    data = {"token": token, "email": email, "server_url": server_url}
     fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(fd, "w") as f:
         f.write(json.dumps(data))
@@ -47,11 +47,6 @@ def load_credentials() -> dict:
     if not path.exists():
         raise click.ClickException("Not logged in. Run `djust-deploy login` first.")
     return json.loads(path.read_text())
-
-
-def _server_url() -> str:
-    """Return server URL. Uses DJUST_SERVER env var if set (internal use only)."""
-    return os.environ.get("DJUST_SERVER", DEFAULT_SERVER).rstrip("/")
 
 
 def _api_headers(token: str) -> dict:
@@ -92,8 +87,18 @@ def _check_git_clean() -> None:
 
 
 @click.group()
-def cli() -> None:
+@click.option(
+    "--server",
+    default=None,
+    envvar="DJUST_SERVER",
+    help="djustlive server URL (default: https://djustlive.com).",
+    metavar="URL",
+)
+@click.pass_context
+def cli(ctx: click.Context, server: Optional[str]) -> None:
     """djust deploy — manage deployments on djustlive.com."""
+    ctx.ensure_object(dict)
+    ctx.obj["server"] = (server or DEFAULT_SERVER).rstrip("/")
 
 
 # ---------------------------------------------------------------------------
@@ -102,9 +107,10 @@ def cli() -> None:
 
 
 @cli.command()
-def login() -> None:
+@click.pass_context
+def login(ctx: click.Context) -> None:
     """Log in to djustlive.com and store credentials."""
-    server = _server_url()
+    server = ctx.obj["server"]
     email = click.prompt("Email")
     password = click.prompt("Password", hide_input=True)
 
@@ -129,7 +135,7 @@ def login() -> None:
     if not token:
         raise click.ClickException("Server did not return a token.")
 
-    save_credentials(token, email)
+    save_credentials(token, email, server)
     click.echo(f"Logged in as {email}.")
 
 
@@ -139,7 +145,8 @@ def login() -> None:
 
 
 @cli.command()
-def logout() -> None:
+@click.pass_context
+def logout(ctx: click.Context) -> None:
     """Log out and remove stored credentials."""
     try:
         creds = load_credentials()
@@ -147,7 +154,7 @@ def logout() -> None:
         click.echo("Not logged in.")
         return
 
-    server = _server_url()
+    server = creds.get("server_url", ctx.obj["server"])
     token = creds["token"]
 
     try:
@@ -173,10 +180,11 @@ def logout() -> None:
 
 @cli.command()
 @click.argument("project", required=False, default=None)
-def status(project: Optional[str]) -> None:
+@click.pass_context
+def status(ctx: click.Context, project: Optional[str]) -> None:
     """Show current deployment status. Optionally filter by PROJECT slug."""
     creds = load_credentials()
-    server = _server_url()
+    server = ctx.obj["server"]
     token = creds["token"]
 
     params = {}
@@ -207,12 +215,13 @@ def status(project: Optional[str]) -> None:
 
 @cli.command()
 @click.argument("project_slug")
-def deploy(project_slug: str) -> None:
+@click.pass_context
+def deploy(ctx: click.Context, project_slug: str) -> None:
     """Deploy PROJECT_SLUG to production on djustlive.com."""
     _check_git_clean()
 
     creds = load_credentials()
-    server = _server_url()
+    server = ctx.obj["server"]
     token = creds["token"]
 
     url = f"{server}/api/v1/projects/{project_slug}/environments/production/deploy/"

--- a/python/tests/test_deploy_cli.py
+++ b/python/tests/test_deploy_cli.py
@@ -54,6 +54,7 @@ def saved_creds(creds_dir):
     creds = {
         "token": "test-token-abc",
         "email": "user@example.com",
+        "server_url": "https://djustlive.com",
     }
     cred_file = creds_dir / "credentials"
     cred_file.write_text(json.dumps(creds))
@@ -76,36 +77,48 @@ class TestCredentialHelpers:
     def test_save_credentials_creates_file(self, tmp_path, monkeypatch):
         cred_file = tmp_path / ".djustlive" / "credentials"
         monkeypatch.setattr("djust.deploy_cli.credentials_path", lambda: cred_file)
-        save_credentials("tok123", "a@b.com")
+        save_credentials("tok123", "a@b.com", "https://djustlive.com")
         assert cred_file.exists()
 
     def test_save_credentials_creates_parent_dir(self, tmp_path, monkeypatch):
         cred_file = tmp_path / ".djustlive" / "credentials"
         monkeypatch.setattr("djust.deploy_cli.credentials_path", lambda: cred_file)
-        save_credentials("tok123", "a@b.com")
+        save_credentials("tok123", "a@b.com", "https://djustlive.com")
         assert cred_file.parent.is_dir()
 
     def test_save_credentials_file_mode_0o600(self, tmp_path, monkeypatch):
         cred_file = tmp_path / ".djustlive" / "credentials"
         monkeypatch.setattr("djust.deploy_cli.credentials_path", lambda: cred_file)
-        save_credentials("tok123", "a@b.com")
+        save_credentials("tok123", "a@b.com", "https://djustlive.com")
         file_mode = stat.S_IMODE(cred_file.stat().st_mode)
         assert file_mode == 0o600
 
     def test_save_credentials_json_content(self, tmp_path, monkeypatch):
         cred_file = tmp_path / ".djustlive" / "credentials"
         monkeypatch.setattr("djust.deploy_cli.credentials_path", lambda: cred_file)
-        save_credentials("tok123", "a@b.com")
+        save_credentials("tok123", "a@b.com", "https://myserver.com")
         data = json.loads(cred_file.read_text())
         assert data == {
             "token": "tok123",
             "email": "a@b.com",
+            "server_url": "https://myserver.com",
         }
+
+    def test_save_credentials_overwrites_existing(self, tmp_path, monkeypatch):
+        cred_file = tmp_path / ".djustlive" / "credentials"
+        monkeypatch.setattr("djust.deploy_cli.credentials_path", lambda: cred_file)
+        save_credentials("tok1", "a@a.com", "https://s1.com")
+        save_credentials("tok2", "b@b.com", "https://s2.com")
+        data = json.loads(cred_file.read_text())
+        assert data["token"] == "tok2"
+        assert data["email"] == "b@b.com"
 
     def test_load_credentials_returns_dict(self, tmp_path, monkeypatch):
         cred_file = tmp_path / ".djustlive" / "credentials"
         cred_file.parent.mkdir(parents=True, exist_ok=True)
-        cred_file.write_text(json.dumps({"token": "t", "email": "e@e.com"}))
+        cred_file.write_text(
+            json.dumps({"token": "t", "email": "e@e.com", "server_url": "https://s"})
+        )
         monkeypatch.setattr("djust.deploy_cli.credentials_path", lambda: cred_file)
         creds = load_credentials()
         assert creds["token"] == "t"
@@ -141,6 +154,7 @@ class TestLoginCommand:
         data = json.loads(cred_file.read_text())
         assert data["token"] == "server-token-xyz"
         assert data["email"] == "user@example.com"
+        assert data["server_url"] == "https://djustlive.com"
 
     def test_login_success_prints_success_message(self, runner, creds_dir, requests_mock):
         requests_mock.post(
@@ -175,6 +189,44 @@ class TestLoginCommand:
             or "error" in result.output.lower()
             or "failed" in result.output.lower()
         )
+
+    def test_login_custom_server_flag(self, runner, creds_dir, requests_mock):
+        requests_mock.post(
+            "https://myserver.example.com/api/v1/auth/login/",
+            json={"token": "custom-token"},
+            status_code=200,
+        )
+        result = runner.invoke(
+            cli,
+            ["--server", "https://myserver.example.com", "login"],
+            input="u@u.com\npass\n",
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads((creds_dir / "credentials").read_text())
+        assert data["server_url"] == "https://myserver.example.com"
+
+    def test_login_server_env_var(self, runner, creds_dir, requests_mock):
+        requests_mock.post(
+            "https://env-server.com/api/v1/auth/login/",
+            json={"token": "env-token"},
+            status_code=200,
+        )
+        result = runner.invoke(
+            cli,
+            ["login"],
+            input="u@u.com\npass\n",
+            env={"DJUST_SERVER": "https://env-server.com"},
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_login_empty_email_prompts(self, runner, creds_dir, requests_mock):
+        requests_mock.post(
+            "https://djustlive.com/api/v1/auth/login/",
+            json={"token": "t"},
+            status_code=200,
+        )
+        result = runner.invoke(cli, ["login"], input="test@test.com\npass\n")
+        assert result.exit_code == 0
 
 
 # ---------------------------------------------------------------------------
@@ -323,3 +375,18 @@ class TestDeployCommand:
         with patch("djust.deploy_cli._check_git_clean"):
             result = runner.invoke(cli, ["deploy", "bad-slug"])
         assert result.exit_code != 0
+
+    def test_deploy_server_flag_overrides_default(
+        self, runner, creds_dir, saved_creds, requests_mock
+    ):
+        adapter = requests_mock.post(
+            "https://other-server.com/api/v1/projects/proj/environments/production/deploy/",
+            text="ok\n",
+            status_code=200,
+        )
+        with patch("djust.deploy_cli._check_git_clean"):
+            runner.invoke(
+                cli,
+                ["--server", "https://other-server.com", "deploy", "proj"],
+            )
+        assert adapter.called


### PR DESCRIPTION
## Summary

- Add `djust-deploy` CLI with four commands: `login`, `logout`, `status`, `deploy`
- Add `--server` flag and `DJUST_SERVER` env var to override the default server URL (`https://djustlive.com`)
- Store `{token, email, server_url}` in `~/.djustlive/credentials` with mode `0o600`
- Validate git working tree is clean before deploying; stream build logs to stdout
- 31 tests covering credential helpers, all CLI commands, server override, and edge cases

## Test plan

- [x] All 31 deploy CLI tests pass (`pytest python/tests/test_deploy_cli.py`)
- [x] Ruff lint passes on all changed files
- [x] No security issues (`mark_safe`, `shell=True`, hardcoded secrets)
- [x] CHANGELOG updated under `[Unreleased] > Added`
- [x] Entry point `djust-deploy = djust.deploy_cli:cli` already in `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)