### PR TITLE
fix: revert Cargo.lock crate versions from 0.3.3-rc.2 to 0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "0.3.3-rc.2"
+version = "0.3.5"
 dependencies = [
  "ahash",
  "criterion",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "0.3.3-rc.2"
+version = "0.3.5"
 dependencies = [
  "ahash",
  "criterion",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "0.3.3-rc.2"
+version = "0.3.5"
 dependencies = [
  "bincode",
  "criterion",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "0.3.3-rc.2"
+version = "0.3.5"
 dependencies = [
  "ahash",
  "chrono",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "0.3.3-rc.2"
+version = "0.3.5"
 dependencies = [
  "ahash",
  "criterion",


### PR DESCRIPTION
## Summary
- Reverts stale `Cargo.lock` that downgraded all five crates (`djust_components`, `djust_core`, `djust_live`, `djust_templates`, `djust_vdom`) from `0.3.5` to `0.3.3-rc.2`
- Root cause: stale lockfile from a developer's working tree committed to `development`, unrelated to any feature work
- Fix: restored `Cargo.lock` from `main` (`git checkout origin/main -- Cargo.lock`)

## Test plan
- [x] All 891 tests pass (887 passed, 4 skipped)
- [x] Cargo.lock matches `origin/main` exactly (zero diff)
- [x] All five crate versions confirmed at `0.3.5`

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)