### PR TITLE
fix: add security comment to custom adapter docs example

### DIFF
--- a/docs/website/guides/css-frameworks.md
+++ b/docs/website/guides/css-frameworks.md
@@ -213,6 +213,7 @@ Register a custom adapter to override framework classes:
 from djust.frameworks import BaseAdapter, register_adapter
 
 class MyAdapter(BaseAdapter):
+    # Static HTML only — never interpolate user data here
     required_marker = ' <span class="required">*</span>'
     help_text_class = "hint"
 


### PR DESCRIPTION
## Summary
- Adds `# Static HTML only — never interpolate user data here` comment above the `required_marker` assignment in the custom adapter example in `docs/website/guides/css-frameworks.md`
- Prevents copy-paste XSS vulnerabilities: `required_marker` is rendered without escaping in `frameworks.py`, so user data must never be interpolated

## Test plan
- [x] All 887 tests pass (docs-only change, no runtime impact)
- [x] No merge conflicts
- [x] Regression check passed

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)