### PR TITLE
docs: add Django migration note for urlize safe filter behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,12 @@ djust supports Django template syntax with event binding:
 </form>
 ```
 
+> **Django migration note:** In standard Django, `urlize` requires `|safe` to render
+> its HTML output. djust's Rust template engine automatically marks `urlize`,
+> `urlizetrunc`, and `unordered_list` as safe (via `safe_output_filters` in the
+> renderer) because these filters handle their own HTML escaping internally.
+> Adding `|safe` after them is unnecessary.
+
 ### Supported Events
 
 - `dj-click` - Click events


### PR DESCRIPTION
## Summary

- Added a "Django migration note" blockquote to `README.md` after the template syntax code block
- Explains that djust's Rust template engine auto-marks `urlize`, `urlizetrunc`, and `unordered_list` as safe via `safe_output_filters` in the renderer
- Clarifies for Django users that `|safe` is unnecessary after these filters (unlike standard Django)

Closes #433

## Test plan

- [x] Verified only `README.md` changed (docs-only, no code impact)
- [x] Full test suite passes (2202 passed, 9 skipped, 1 pre-existing error unrelated to this change)
- [x] Markdown renders correctly with blockquote syntax
- [x] Technical claims verified against `crates/djust_templates/src/renderer.rs:85-96`

🤖 Generated with [Claude Code](https://claude.com/claude-code)