### PR TITLE
docs: fix wrong check ID (V003→V007) in BEST_PRACTICES.md

### DIFF
--- a/docs/guides/BEST_PRACTICES.md
+++ b/docs/guides/BEST_PRACTICES.md
@@ -1197,7 +1197,7 @@ Always add `data-key` to list items:
 **Why it's wrong:**
 - Breaks when extra params are passed from client
 - Not forward-compatible with new framework features
-- System check `djust.V003` warns about this
+- System check `djust.V007` warns about this
 
 **Solution:**
 Always include `**kwargs`:


### PR DESCRIPTION
## Summary

- Fixes incorrect check ID in the "Missing **kwargs in Event Handlers" section of BEST_PRACTICES.md
- The section cited `djust.V003` (mount() signature check) but the correct check is `djust.V007`

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)