### PR TITLE
feat: batch fixes — redis delete_all, stale tests, CHANGELOG breaking change (#424-#429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **`model.id` now returns the native type, not a string** — `_serialize_model_safely()` previously wrapped `obj.pk` with `str()` when producing the `"id"` key, causing template comparisons like `{% if edit_id == todo.id %}` to fail silently when `edit_id` was an integer. `model.id` now matches `model.pk` and returns the native Python type (e.g. `int`, `UUID`). **Migration:** if your templates or event handlers compare `model.id` against string literals or string-typed variables, update them to use the native type. PR #262 fixed `.pk`; this PR (#472) completes the fix for `.id`.
+
 ### Fixed
 
 - **`djust cache --all` now correctly clears all sessions on the Redis backend** — The CLI called `cleanup_expired(ttl=0)` to force-clear sessions, but the semantics of `ttl=0` changed in 0.3.5 to mean "never expire". The command now calls the explicit `delete_all()` method, which uses a Redis pipeline for an efficient single round-trip bulk delete. (#409)

--- a/python/djust/state_backends/redis.py
+++ b/python/djust/state_backends/redis.py
@@ -276,21 +276,26 @@ class RedisStateBackend(StateBackend):
         return 0
 
     def delete_all(self) -> int:
-        """Delete every session unconditionally (used by ``djust clear --all``)."""
-        deleted = 0
+        """Delete every session unconditionally (used by ``djust clear --all``).
+
+        Returns the number of sessions actually deleted, or 0 if a Redis error
+        occurred (in which case the pipeline was never executed).
+        """
         pattern = f"{self._key_prefix}*"
         try:
             pipeline = self._client.pipeline()
+            queued = 0
             for key in self._client.scan_iter(match=pattern, count=100):
                 pipeline.delete(key)
-                deleted += 1
-            if deleted:
+                queued += 1
+            if queued:
                 pipeline.execute()
+            if queued:
+                logger.info("Deleted all %s sessions from Redis", queued)
+            return queued
         except Exception:
             logger.exception("Error during Redis delete_all()")
-        if deleted:
-            logger.info("Deleted all %s sessions from Redis", deleted)
-        return deleted
+            return 0
 
     def get_stats(self) -> Dict[str, Any]:
         """Get Redis backend statistics."""

--- a/python/djust/tests/test_websocket_lazy_session.py
+++ b/python/djust/tests/test_websocket_lazy_session.py
@@ -9,7 +9,7 @@ browser's existing session.
 The fix uses `getattr(scope_session, "session_key", None)` which forces
 resolution of the LazyObject before the attribute is accessed.
 
-See: https://github.com/djust-org/djust/issues/NNN
+See: https://github.com/djust-org/djust/issues/396
 """
 
 from unittest.mock import MagicMock

--- a/tests/unit/test_redis_state_backend_delete_all.py
+++ b/tests/unit/test_redis_state_backend_delete_all.py
@@ -1,0 +1,144 @@
+"""
+Tests for RedisStateBackend.delete_all() — issue #428.
+
+Covers three scenarios:
+1. Normal path — keys found and deleted via pipeline, correct count returned.
+2. Scan error path — scan_iter raises mid-iteration, returns 0 (not a partial count).
+3. Empty keyspace — no keys, returns 0 without calling pipeline.execute().
+"""
+
+from unittest.mock import MagicMock, patch
+
+from djust.state_backends.redis import RedisStateBackend
+
+
+def _make_backend(keys=None, scan_error=None):
+    """
+    Build a RedisStateBackend with all Redis I/O mocked.
+
+    Bypasses __init__ (which requires a live Redis connection) by using
+    __new__ and directly injecting a mock client.
+
+    Args:
+        keys: list of byte-string keys scan_iter should yield (default: [])
+        scan_error: if set, scan_iter raises this exception after yielding keys
+    """
+    backend = RedisStateBackend.__new__(RedisStateBackend)
+
+    mock_client = MagicMock()
+    backend._client = mock_client
+    backend._key_prefix = "djust:"
+    backend._default_ttl = 3600
+    backend._compression_enabled = False
+    backend._compression_threshold = 10240
+    backend._compression_level = 3
+    backend._compressor = None
+    backend._decompressor = None
+    backend._stats = {
+        "compressed_count": 0,
+        "uncompressed_count": 0,
+        "total_bytes_saved": 0,
+    }
+
+    # Configure scan_iter behavior
+    if scan_error is not None:
+        def _iter_with_error(*args, **kwargs):
+            for k in keys or []:
+                yield k
+            raise scan_error
+
+        mock_client.scan_iter.side_effect = _iter_with_error
+    else:
+        mock_client.scan_iter.return_value = iter(keys or [])
+
+    # pipeline() returns a mock pipeline
+    mock_pipeline = MagicMock()
+    mock_client.pipeline.return_value = mock_pipeline
+
+    return backend, mock_client, mock_pipeline
+
+
+class TestRedisDeleteAllNormalPath:
+    def test_returns_correct_count_when_keys_exist(self):
+        keys = [b"djust:sess1", b"djust:sess2", b"djust:sess3"]
+        backend, client, pipeline = _make_backend(keys=keys)
+
+        result = backend.delete_all()
+
+        assert result == 3
+
+    def test_pipeline_delete_called_for_each_key(self):
+        keys = [b"djust:sess1", b"djust:sess2"]
+        backend, client, pipeline = _make_backend(keys=keys)
+
+        backend.delete_all()
+
+        assert pipeline.delete.call_count == 2
+        pipeline.delete.assert_any_call(b"djust:sess1")
+        pipeline.delete.assert_any_call(b"djust:sess2")
+
+    def test_pipeline_execute_called_when_keys_exist(self):
+        keys = [b"djust:sess1"]
+        backend, client, pipeline = _make_backend(keys=keys)
+
+        backend.delete_all()
+
+        pipeline.execute.assert_called_once()
+
+    def test_scan_iter_uses_key_prefix_pattern(self):
+        backend, client, pipeline = _make_backend(keys=[])
+
+        backend.delete_all()
+
+        client.scan_iter.assert_called_once_with(match="djust:*", count=100)
+
+
+class TestRedisDeleteAllEmptyKeyspace:
+    def test_returns_zero_when_no_keys(self):
+        backend, client, pipeline = _make_backend(keys=[])
+
+        result = backend.delete_all()
+
+        assert result == 0
+
+    def test_pipeline_execute_not_called_when_no_keys(self):
+        backend, client, pipeline = _make_backend(keys=[])
+
+        backend.delete_all()
+
+        pipeline.execute.assert_not_called()
+
+
+class TestRedisDeleteAllScanError:
+    def test_returns_zero_on_scan_error(self):
+        """scan_iter raises — must return 0, not a partial queued count."""
+        backend, client, pipeline = _make_backend(
+            keys=[b"djust:sess1", b"djust:sess2"],
+            scan_error=Exception("Redis connection lost"),
+        )
+
+        result = backend.delete_all()
+
+        assert result == 0
+
+    def test_pipeline_execute_not_called_on_scan_error(self):
+        """If scan_iter raises, the pipeline was never fully built — do not execute."""
+        backend, client, pipeline = _make_backend(
+            keys=[b"djust:sess1"],
+            scan_error=RuntimeError("scan failed"),
+        )
+
+        backend.delete_all()
+
+        pipeline.execute.assert_not_called()
+
+    def test_logs_exception_on_error(self):
+        backend, client, pipeline = _make_backend(
+            keys=[],
+            scan_error=OSError("timeout"),
+        )
+
+        with patch("djust.state_backends.redis.logger") as mock_logger:
+            backend.delete_all()
+            mock_logger.exception.assert_called_once()
+            assert "delete_all" in mock_logger.exception.call_args[0][0]

--- a/tests/unit/test_state_backend.py
+++ b/tests/unit/test_state_backend.py
@@ -157,11 +157,12 @@ class TestInMemoryBackend:
         assert cleaned == 1
         assert backend.get("key1") is None
 
-    def test_cleanup_ttl_zero_expires_all_sessions(self):
-        """SESSION_TTL=0 immediately expires every session (#410).
+    def test_cleanup_ttl_zero_never_expires(self):
+        """SESSION_TTL=0 means "never expire" — cleanup_expired is a no-op (#409).
 
-        TTL=0 is used by the test fixture teardown (conftest cleanup_session_cache)
-        and by `djust clear --all` to wipe all live sessions without waiting.
+        TTL=0 was redefined in 0.3.5 to mean "never expire" so that sessions
+        configured with no expiry aren't accidentally wiped. Bulk removal is
+        now handled by ``delete_all()`` (see #409).
         """
         backend = InMemoryStateBackend()
 
@@ -172,10 +173,10 @@ class TestInMemoryBackend:
 
         assert backend.get_stats()["total_sessions"] == 3
 
-        # TTL=0 should expire everything immediately
+        # TTL=0 is a no-op — sessions must survive
         cleaned = backend.cleanup_expired(ttl=0)
-        assert cleaned == 3, "TTL=0 must clean up all sessions regardless of age"
-        assert backend.get_stats()["total_sessions"] == 0
+        assert cleaned == 0, "TTL=0 must not remove any sessions (never-expire semantics)"
+        assert backend.get_stats()["total_sessions"] == 3
 
     def test_cleanup_ttl_zero_on_empty_backend(self):
         """SESSION_TTL=0 on an empty backend returns 0, not an error (#410)."""
@@ -183,8 +184,12 @@ class TestInMemoryBackend:
         cleaned = backend.cleanup_expired(ttl=0)
         assert cleaned == 0
 
-    def test_cleanup_ttl_zero_leaves_no_sessions(self):
-        """After TTL=0 cleanup no sessions are retrievable (#410)."""
+    def test_cleanup_ttl_zero_preserves_sessions(self):
+        """After TTL=0 cleanup all sessions are still retrievable (#409).
+
+        TTL=0 means "never expire" — cleanup_expired must leave sessions intact.
+        Use delete_all() for unconditional removal.
+        """
         backend = InMemoryStateBackend()
 
         view = RustLiveView("<div>persist-check</div>")
@@ -192,8 +197,8 @@ class TestInMemoryBackend:
 
         backend.cleanup_expired(ttl=0)
 
-        # The session must be gone — cannot survive a TTL=0 wipe
-        assert backend.get("survive") is None
+        # The session must still be present — TTL=0 is a no-op
+        assert backend.get("survive") is not None
 
     def test_stats(self):
         """Test statistics tracking."""


### PR DESCRIPTION
## Summary

- **#426** — `RedisStateBackend.delete_all()` returned a misleading non-zero count when `scan_iter` raised mid-iteration (pipeline was never executed). Now returns `0` on any exception, with `pipeline.execute()` moved inside the `try` block.
- **#428** — Added 9 unit tests for `RedisStateBackend.delete_all()` covering the normal path, empty keyspace, and scan-error path. Uses `__new__` + mock injection to bypass the Redis connection requirement.
- **#427** — Updated stale TTL=0 test docstrings and assertions in `test_state_backend.py`: the old tests asserted that `cleanup_expired(ttl=0)` wiped all sessions, but 0.3.5 changed `ttl=0` to mean "never expire". Tests renamed and assertions corrected.
- **#429** — Replaced `issues/NNN` placeholder URL with `issues/396` (the LazyObject session crash fix) in `test_websocket_lazy_session.py`.
- **#424** — Added `### Breaking Changes` section to CHANGELOG `[Unreleased]` documenting the `model.id` native-type change from PR #472, with migration guidance.

## Test plan

- [x] 9 new `RedisStateBackend.delete_all()` tests pass
- [x] Updated TTL=0 test assertions match current `InMemoryStateBackend` behavior
- [x] Full test suite: 849 passed, 4 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)