### PR TITLE
feat: batch polish — depth reset, UUID pk tests, docstrings, redis simplification (#435-#439)

### DIFF
--- a/python/djust/state_backends/redis.py
+++ b/python/djust/state_backends/redis.py
@@ -229,8 +229,7 @@ class RedisStateBackend(StateBackend):
         - Timestamp embedded in serialized data
         """
         redis_key = self._make_key(key)
-        if ttl is None:
-            ttl = self._default_ttl
+        ttl = self._default_ttl if ttl is None else ttl
 
         with profiler.profile(profiler.OP_STATE_SAVE):
             try:
@@ -243,7 +242,6 @@ class RedisStateBackend(StateBackend):
                 with profiler.profile(profiler.OP_COMPRESSION):
                     data = self._compress(serialized)
 
-                # Store with TTL.
                 # TTL=0 means "never expire"; use SET without expiry instead of
                 # SETEX (which requires TTL >= 1 and would raise a Redis error).
                 if ttl > 0:

--- a/python/tests/test_deploy_cli.py
+++ b/python/tests/test_deploy_cli.py
@@ -125,6 +125,11 @@ class TestCredentialHelpers:
         assert creds["email"] == "e@e.com"
 
     def test_load_credentials_missing_file_raises(self, tmp_path, monkeypatch):
+        """load_credentials() raises ClickException when the credentials file does not exist.
+
+        The exception message must contain "Not logged in" so that the CLI
+        surfaces a clear, actionable error rather than a bare FileNotFoundError.
+        """
         cred_file = tmp_path / ".djustlive" / "credentials"
         monkeypatch.setattr("djust.deploy_cli.credentials_path", lambda: cred_file)
         with pytest.raises(click.ClickException, match="Not logged in"):

--- a/python/tests/test_jit_fixes.py
+++ b/python/tests/test_jit_fixes.py
@@ -84,6 +84,16 @@ class TestCodegenAllWithSubtree:
 
 
 class TestDeepDictSerialization:
+    def setup_method(self):
+        # DjangoJSONEncoder._depth is a class-level counter.  Reset it before
+        # each test so that a crash in a previous test (which would leave it
+        # non-zero despite the try/finally in default()) cannot affect later
+        # assertions about serialized output.
+        DjangoJSONEncoder._depth = 0
+
+    def teardown_method(self):
+        DjangoJSONEncoder._depth = 0
+
     def _make_model(self, **kwargs):
         """Create a mock Django Model instance."""
         obj = MagicMock()
@@ -147,6 +157,22 @@ class TestDeepDictSerialization:
         assert result["id"] == uuid.UUID("12345678-1234-5678-1234-567812345678")
         # pk should also be the native UUID object
         assert isinstance(result["pk"], uuid.UUID)
+
+    def test_serialize_model_uuid_pk_via_json_dumps(self):
+        """UUID pk model serialized through json.dumps produces a string id in JSON output.
+
+        _serialize_model_safely() returns id as a native UUID object.  When
+        that dict is re-encoded by json.dumps, DjangoJSONEncoder.default()
+        converts the UUID to a string.  This test exercises the full pipeline
+        so both the direct and json.dumps code paths are covered.
+        """
+        import uuid
+
+        model = self._make_model(title="UUID PK via dumps")
+        model.pk = uuid.UUID("12345678-1234-5678-1234-567812345678")
+        serialized = json.loads(json.dumps(model, cls=DjangoJSONEncoder))
+        assert serialized["id"] == "12345678-1234-5678-1234-567812345678"
+        assert serialized["pk"] == "12345678-1234-5678-1234-567812345678"
 
     def test_serialize_model_none_pk(self):
         """Model with pk=None (unsaved) serializes id as None, not 'None' (#408)."""
@@ -261,6 +287,10 @@ class TestPropertyCache:
         obj.pk = 1
         obj.__dict__["id"] = 1
 
+        # Reset class-level counter before the test.  This is safe because
+        # _call_count is only written by _CountingModel.expensive_prop and read
+        # here; no other test touches this class attribute, so resetting it
+        # directly avoids the need for a pytest fixture.
         _CountingModel._call_count = 0
 
         result1 = {}


### PR DESCRIPTION
## Summary

- **#436** — Add `setup_method`/`teardown_method` to `TestDeepDictSerialization` resetting `DjangoJSONEncoder._depth = 0` before/after each test, preventing shared class-level counter from leaking between tests
- **#435** — Add `test_serialize_model_uuid_pk_via_json_dumps` covering the full `json.dumps()` pipeline path where a UUID primary key is stringified by `DjangoJSONEncoder.default()`
- **#439** — Add inline comment on `_CountingModel._call_count = 0` explaining why direct class-state mutation is safe in that test
- **#437** — Add docstring to `test_load_credentials_missing_file_raises` clarifying it asserts `ClickException` with "Not logged in" (not a bare `FileNotFoundError`)
- **#438** — Collapse two-statement TTL None-check (`if ttl is None: ttl = …`) into a single conditional expression in `RedisStateBackend.save()`

## Test plan
- [x] All 910 tests pass (`uv run pytest tests/ -x -q`)
- [x] Ruff lint clean on all changed files
- [x] No conflict markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)