### PR TITLE
fix: form submit reset and auto-skip render bypass

### DIFF
--- a/python/djust/forms.py
+++ b/python/djust/forms.py
@@ -197,6 +197,12 @@ class FormMixin:
             if hasattr(self, "form_invalid"):
                 self.form_invalid(form)
 
+        # Always re-render after form submission so confirmation messages
+        # and updated field values are sent to the client, even when the
+        # submitted values match the previous state (which would otherwise
+        # trigger auto-skip via _snapshot_assigns equality).
+        self._force_render = True
+
     def reset_form(self, **kwargs):
         """Reset form to initial state"""
         # Reset form_data with all field keys initialized (matching mount() behavior)

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -2319,7 +2319,6 @@ function bindLiveViewEvents() {
                 params._targetElement = e.target;
 
                 await handleEvent(submitHandler, params);
-                e.target.reset();
             });
         }
 

--- a/python/djust/static/djust/src/09-event-binding.js
+++ b/python/djust/static/djust/src/09-event-binding.js
@@ -159,7 +159,6 @@ function bindLiveViewEvents() {
                 params._targetElement = e.target;
 
                 await handleEvent(submitHandler, params);
-                e.target.reset();
             });
         }
 

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -1434,6 +1434,10 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         # In-place mutations (list.append) are NOT detected and
                         # will still trigger a render — this is the safe default.
                         skip_render = getattr(self.view_instance, "_skip_render", False)
+                        force_render = getattr(self.view_instance, "_force_render", False)
+                        if force_render:
+                            self.view_instance._force_render = False
+                            skip_render = False
                         if not skip_render:
                             post_assigns = _snapshot_assigns(self.view_instance)
                             if pre_assigns == post_assigns:


### PR DESCRIPTION
## Summary

- **Remove unconditional `e.target.reset()`** after `dj-submit` — this was wiping all form fields (selects reverting, inputs clearing) after every submission. The server-controlled reset (`reset_form: true`) already exists and works correctly.
- **Add `_force_render` flag** to bypass auto-skip after form submit — when submitting the same values twice, `_snapshot_assigns` saw no diff and sent a noop, preventing the "Saved." confirmation from appearing. `FormMixin.submit_form()` now sets `_force_render = True`, and the WebSocket consumer checks it before the snapshot comparison.

## Test plan

- [x] All 2114 tests pass
- [ ] Manual: Submit a form with `dj-submit` — verify fields retain values after save
- [ ] Manual: Submit same form values twice — verify "Saved." message appears both times
- [ ] Manual: Submit a create form — verify `reset_form()` still clears fields when explicitly called
- [ ] Manual: Test `dj-model` real-time validation — should still work (not affected by these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)