### PR TITLE
fix: include comment nodes in VDOM child index resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **VDOM patching fails when `{% if %}` blocks add/remove DOM elements** — Comment node placeholders (`<!--dj-if-->`) emitted by the Rust template engine were excluded from client-side child index resolution (`getSignificantChildren` and `getNodeByPath`), causing path traversal errors and silent patch failures. Also added `#comment` handling to `createNodeFromVNode` so comment placeholders can be correctly created during `InsertChild` patches. ([#559](https://github.com/djust-org/djust/issues/559))
+
 ## [0.3.8rc1] - 2026-03-17
 
 ### Fixed

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -2982,6 +2982,9 @@ function getNodeByPath(path, djustId = null) {
                 // JS \s includes \u00A0, so we use an explicit ASCII whitespace pattern instead.
                 return (/[^ \t\n\r\f]/.test(child.textContent));
             }
+            // Include comment nodes — the Rust VDOM parser preserves <!--dj-if-->
+            // placeholders and counts them when computing child indices (#559).
+            if (child.nodeType === Node.COMMENT_NODE) return true;
             return false;
         });
 
@@ -3232,6 +3235,11 @@ function createHtmlElement(tagLower) {
 function createNodeFromVNode(vnode, inSvgContext = false) {
     if (vnode.tag === '#text') {
         return document.createTextNode(vnode.text || '');
+    }
+    // Handle comment nodes — Rust emits <!--dj-if--> placeholders for
+    // {% if %} blocks that evaluate to False (#559).
+    if (vnode.tag === '#comment') {
+        return document.createComment(vnode.text || '');
     }
 
     // Validate tag name against whitelist (security: prevents script injection)
@@ -3814,6 +3822,9 @@ function getSignificantChildren(node) {
             // Only filter out ASCII whitespace-only text nodes.
             return (/[^ \t\n\r\f]/.test(child.textContent));
         }
+        // Include comment nodes — the Rust VDOM parser preserves <!--dj-if-->
+        // placeholders and counts them in child indices (#559).
+        if (child.nodeType === Node.COMMENT_NODE) return true;
         return false;
     });
 }

--- a/python/djust/static/djust/src/12-vdom-patch.js
+++ b/python/djust/static/djust/src/12-vdom-patch.js
@@ -53,6 +53,9 @@ function getNodeByPath(path, djustId = null) {
                 // JS \s includes \u00A0, so we use an explicit ASCII whitespace pattern instead.
                 return (/[^ \t\n\r\f]/.test(child.textContent));
             }
+            // Include comment nodes — the Rust VDOM parser preserves <!--dj-if-->
+            // placeholders and counts them when computing child indices (#559).
+            if (child.nodeType === Node.COMMENT_NODE) return true;
             return false;
         });
 
@@ -303,6 +306,11 @@ function createHtmlElement(tagLower) {
 function createNodeFromVNode(vnode, inSvgContext = false) {
     if (vnode.tag === '#text') {
         return document.createTextNode(vnode.text || '');
+    }
+    // Handle comment nodes — Rust emits <!--dj-if--> placeholders for
+    // {% if %} blocks that evaluate to False (#559).
+    if (vnode.tag === '#comment') {
+        return document.createComment(vnode.text || '');
     }
 
     // Validate tag name against whitelist (security: prevents script injection)
@@ -885,6 +893,9 @@ function getSignificantChildren(node) {
             // Only filter out ASCII whitespace-only text nodes.
             return (/[^ \t\n\r\f]/.test(child.textContent));
         }
+        // Include comment nodes — the Rust VDOM parser preserves <!--dj-if-->
+        // placeholders and counts them in child indices (#559).
+        if (child.nodeType === Node.COMMENT_NODE) return true;
         return false;
     });
 }

--- a/tests/js/vdom_if_block.test.js
+++ b/tests/js/vdom_if_block.test.js
@@ -1,0 +1,111 @@
+/**
+ * Regression tests for VDOM patching with {% if %} blocks (#559).
+ *
+ * When {% if %} blocks toggle, the Rust VDOM emits <!--dj-if--> comment
+ * placeholders and counts them in child indices. The client must also
+ * count comment nodes to keep indices aligned.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+const fs = await import('fs');
+const clientCode = fs.readFileSync('./python/djust/static/djust/client.js', 'utf-8');
+
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+    runScripts: 'dangerously',
+});
+
+if (!dom.window.CSS) dom.window.CSS = {};
+if (!dom.window.CSS.escape) {
+    dom.window.CSS.escape = function(value) {
+        return String(value).replace(/([^\w-])/g, '\\$1');
+    };
+}
+
+dom.window.eval(clientCode);
+
+const {
+    getSignificantChildren,
+    createNodeFromVNode,
+} = dom.window.djust;
+
+const document = dom.window.document;
+
+describe('Comment node handling for {% if %} blocks (#559)', () => {
+
+    describe('getSignificantChildren', () => {
+        it('includes comment nodes in child list', () => {
+            const parent = document.createElement('div');
+            parent.innerHTML = '<h5>Title</h5><!--dj-if--><p>Description</p>';
+
+            const children = getSignificantChildren(parent);
+
+            // Should include: h5, comment, p (3 children)
+            expect(children.length).toBe(3);
+            expect(children[0].tagName).toBe('H5');
+            expect(children[1].nodeType).toBe(dom.window.Node.COMMENT_NODE);
+            expect(children[1].textContent).toBe('dj-if');
+            expect(children[2].tagName).toBe('P');
+        });
+
+        it('still filters whitespace-only text nodes', () => {
+            const parent = document.createElement('div');
+            parent.appendChild(document.createTextNode('  \n  '));
+            parent.appendChild(document.createElement('span'));
+            parent.appendChild(document.createComment('dj-if'));
+
+            const children = getSignificantChildren(parent);
+
+            // Whitespace text filtered, span + comment kept
+            expect(children.length).toBe(2);
+            expect(children[0].tagName).toBe('SPAN');
+            expect(children[1].nodeType).toBe(dom.window.Node.COMMENT_NODE);
+        });
+
+        it('preserves correct indices matching server VDOM', () => {
+            // Server VDOM for: <h5>Title</h5>{% if show %}...{% endif %}<p>Desc</p>
+            // When show=False: h5, <!--dj-if-->, p → indices 0, 1, 2
+            const parent = document.createElement('div');
+            parent.innerHTML = '<h5>Title</h5><!--dj-if--><p>Description</p>';
+
+            const children = getSignificantChildren(parent);
+
+            // Index 1 should be the comment (matching server index)
+            expect(children[1].nodeType).toBe(dom.window.Node.COMMENT_NODE);
+            // Index 2 should be <p> (matching server index)
+            expect(children[2].tagName).toBe('P');
+        });
+    });
+
+    describe('createNodeFromVNode', () => {
+        it('creates a comment node for #comment tag', () => {
+            const node = createNodeFromVNode({ tag: '#comment', text: 'dj-if' });
+
+            expect(node.nodeType).toBe(dom.window.Node.COMMENT_NODE);
+            expect(node.textContent).toBe('dj-if');
+        });
+
+        it('creates a comment with empty text when no text provided', () => {
+            const node = createNodeFromVNode({ tag: '#comment' });
+
+            expect(node.nodeType).toBe(dom.window.Node.COMMENT_NODE);
+            expect(node.textContent).toBe('');
+        });
+
+        it('still creates text nodes for #text tag', () => {
+            const node = createNodeFromVNode({ tag: '#text', text: 'hello' });
+
+            expect(node.nodeType).toBe(dom.window.Node.TEXT_NODE);
+            expect(node.textContent).toBe('hello');
+        });
+
+        it('still creates element nodes for HTML tags', () => {
+            const node = createNodeFromVNode({ tag: 'div', attrs: { class: 'test' } });
+
+            expect(node.nodeType).toBe(dom.window.Node.ELEMENT_NODE);
+            expect(node.tagName).toBe('DIV');
+            expect(node.getAttribute('class')).toBe('test');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes the #1 reported pain point for new djust users: `{% if %}` blocks that add/remove DOM elements cause VDOM patches to fail silently.

### Root Cause

The Rust template engine emits `<!--dj-if-->` comment placeholders for `{% if %}` blocks that evaluate to `False`, and counts them when computing child indices for `RemoveChild`/`InsertChild` patches. But the client-side `getSignificantChildren()` and `getNodeByPath()` **filtered out comment nodes**, creating an index mismatch:

- Server: `[h5(0), <!--dj-if-->(1), p(2)]` → patch targets index 1 (the comment)
- Client: `[h5(0), p(1)]` → index 1 is `<p>`, not the comment → **wrong node patched**

This caused `12/15 patches failed`, `Path traversal failed at index 5, only 5 children`, and silent fallback to full HTML recovery.

### Fix (3 changes, all client-side JS)

1. **`getNodeByPath()`**: Include `COMMENT_NODE` in child filter so path indices match server
2. **`getSignificantChildren()`**: Include `COMMENT_NODE` in child filter for `RemoveChild`/`InsertChild` resolution
3. **`createNodeFromVNode()`**: Handle `#comment` tag — creates a `Comment` node instead of falling through to `<span>` placeholder

### What this enables

- `{% if show %}<span>Badge</span>{% endif %}` works correctly
- `{% if %}` / `{% elif %}` / `{% else %}` chains patch cleanly
- `{% if %}` inside `{% for %}` loops works
- No more need for `style="display:none"` workaround

Closes #559

## Test plan

- [x] 7 new JS tests in `tests/js/vdom_if_block.test.js`
- [x] All 773 JS tests pass
- [x] Pre-commit hooks pass (eslint, build, npm test)
- [x] Verified Rust VDOM produces correct `RemoveChild`/`InsertChild` patches for if-block toggling
- [ ] Manual: Toggle `{% if %}` block via event → patches apply correctly without recovery fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)