### PR TITLE
feat(v0.4.0): add dj-value-* static event parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`dj-value-*` — Static event parameters** — Pass static values alongside events without `data-*` attributes or hidden inputs: `<button dj-click="delete" dj-value-id:int="{{ item.id }}" dj-value-type="soft">`. Supports type-hint suffixes (`:int`, `:float`, `:bool`, `:json`, `:list`), kebab-to-snake_case conversion, and prototype pollution prevention. Works with all event types: `dj-click`, `dj-submit`, `dj-change`, `dj-input`, `dj-keydown`, `dj-keyup`, `dj-blur`, `dj-focus`, `dj-poll`. Phoenix LiveView's `phx-value-*` equivalent.
+
 ### Fixed
 
 - **Focus lost during VDOM patches** — When the server pushed VDOM patches (e.g., updating a counter while the user was typing), the focused input/textarea lost focus, cursor position, selection range, and scroll position. Added `saveFocusState()` / `restoreFocusState()` around the `applyPatches()` cycle to capture and restore `activeElement`, `selectionStart`/`selectionEnd`, and `scrollTop`/`scrollLeft`. Element matching uses id → name → dj-id → positional index. Broadcast (remote) updates correctly skip focus restoration.

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -2155,12 +2155,110 @@ function extractTypedParams(element) {
         }
     }
 
+    // Merge dj-value-* attributes. dj-value-* takes precedence over data-*
+    // and dj-params, matching Phoenix's phx-value-* semantics.
+    const djValues = collectDjValues(element);
+    for (const [k, v] of Object.entries(djValues)) {
+        params[k] = v;
+    }
+
     return params;
+}
+
+/**
+ * Collect dj-value-* attributes from an element and return as a params object.
+ *
+ * dj-value-* is the standard way to pass static context alongside events
+ * (Phoenix LiveView's phx-value-* equivalent). Supports the same type-hint
+ * suffixes as data-* attributes.
+ *
+ * Examples:
+ *   dj-value-id="42"             -> { id: "42" }
+ *   dj-value-id:int="42"        -> { id: 42 }
+ *   dj-value-item-type="soft"   -> { item_type: "soft" }
+ *   dj-value-active:bool="true" -> { active: true }
+ *   dj-value-tags:list="a,b,c"  -> { tags: ["a", "b", "c"] }
+ *
+ * @param {HTMLElement} element - Element to extract dj-value-* from
+ * @returns {Object} - Collected params with coerced types
+ */
+function collectDjValues(element) {
+    const values = Object.create(null);
+
+    for (const attr of element.attributes) {
+        if (!attr.name.startsWith('dj-value-')) continue;
+
+        // Parse: dj-value-item-id:int -> key="item_id", type="int"
+        const nameWithoutPrefix = attr.name.slice(9); // Remove "dj-value-"
+        const colonIndex = nameWithoutPrefix.lastIndexOf(':');
+        let rawKey, typeHint;
+
+        if (colonIndex !== -1) {
+            rawKey = nameWithoutPrefix.slice(0, colonIndex);
+            typeHint = nameWithoutPrefix.slice(colonIndex + 1);
+        } else {
+            rawKey = nameWithoutPrefix;
+            typeHint = null;
+        }
+
+        // Convert kebab-case to snake_case
+        const key = rawKey.replace(/-/g, '_');
+
+        // Prevent prototype pollution
+        if (UNSAFE_KEYS.includes(key)) continue;
+
+        let value = attr.value;
+
+        // Apply type coercion (same logic as extractTypedParams)
+        if (typeHint) {
+            const safeAttrName = String(attr.name).slice(0, 50).replace(/[^a-z0-9-:]/gi, '_');
+            switch (typeHint) {
+                case 'int':
+                case 'integer': {
+                    if (value === '') { value = 0; }
+                    else {
+                        const parsed = parseInt(value, 10);
+                        value = isNaN(parsed) ? null : parsed;
+                    }
+                    break;
+                }
+                case 'float':
+                case 'number': {
+                    if (value === '') { value = 0.0; }
+                    else {
+                        const parsed = parseFloat(value);
+                        value = isNaN(parsed) ? null : parsed;
+                    }
+                    break;
+                }
+                case 'bool':
+                case 'boolean':
+                    value = ['true', '1', 'yes', 'on', 'checked'].includes(value.toLowerCase());
+                    break;
+                case 'json':
+                case 'object':
+                case 'array':
+                    try { value = JSON.parse(value); }
+                    catch { /* keep as string */ }
+                    break;
+                case 'list':
+                    value = value ? value.split(',').map(v => v.trim()).filter(v => v) : [];
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        values[key] = value;
+    }
+
+    return values;
 }
 
 // Export for global access
 window.djust = window.djust || {};
 window.djust.extractTypedParams = extractTypedParams;
+window.djust.collectDjValues = collectDjValues;
 /**
  * Check if element has dj-confirm and show confirmation dialog.
  * @param {HTMLElement} element - Element with potential dj-confirm attribute
@@ -2309,6 +2407,9 @@ function bindLiveViewEvents() {
                 const formData = new FormData(e.target);
                 const params = Object.fromEntries(formData.entries());
 
+                // Merge dj-value-* attributes from the form element
+                Object.assign(params, collectDjValues(e.target));
+
                 addEventContext(params, e.target);
 
                 // Pass target element for optimistic updates (Phase 3)
@@ -2344,6 +2445,8 @@ function bindLiveViewEvents() {
         function buildFormEventParams(element, value) {
             const fieldName = getFieldName(element);
             const params = { value, field: fieldName };
+            // Merge dj-value-* attributes from the triggering element
+            Object.assign(params, collectDjValues(element));
             addEventContext(params, element);
             return params;
         }
@@ -2506,6 +2609,9 @@ function bindLiveViewEvents() {
                         value: e.target.value,
                         field: fieldName
                     };
+
+                    // Merge dj-value-* attributes from the element
+                    Object.assign(params, collectDjValues(element));
 
                     addEventContext(params, e.target);
 

--- a/python/djust/static/djust/src/08-event-parsing.js
+++ b/python/djust/static/djust/src/08-event-parsing.js
@@ -375,9 +375,107 @@ function extractTypedParams(element) {
         }
     }
 
+    // Merge dj-value-* attributes. dj-value-* takes precedence over data-*
+    // and dj-params, matching Phoenix's phx-value-* semantics.
+    const djValues = collectDjValues(element);
+    for (const [k, v] of Object.entries(djValues)) {
+        params[k] = v;
+    }
+
     return params;
+}
+
+/**
+ * Collect dj-value-* attributes from an element and return as a params object.
+ *
+ * dj-value-* is the standard way to pass static context alongside events
+ * (Phoenix LiveView's phx-value-* equivalent). Supports the same type-hint
+ * suffixes as data-* attributes.
+ *
+ * Examples:
+ *   dj-value-id="42"             -> { id: "42" }
+ *   dj-value-id:int="42"        -> { id: 42 }
+ *   dj-value-item-type="soft"   -> { item_type: "soft" }
+ *   dj-value-active:bool="true" -> { active: true }
+ *   dj-value-tags:list="a,b,c"  -> { tags: ["a", "b", "c"] }
+ *
+ * @param {HTMLElement} element - Element to extract dj-value-* from
+ * @returns {Object} - Collected params with coerced types
+ */
+function collectDjValues(element) {
+    const values = Object.create(null);
+
+    for (const attr of element.attributes) {
+        if (!attr.name.startsWith('dj-value-')) continue;
+
+        // Parse: dj-value-item-id:int -> key="item_id", type="int"
+        const nameWithoutPrefix = attr.name.slice(9); // Remove "dj-value-"
+        const colonIndex = nameWithoutPrefix.lastIndexOf(':');
+        let rawKey, typeHint;
+
+        if (colonIndex !== -1) {
+            rawKey = nameWithoutPrefix.slice(0, colonIndex);
+            typeHint = nameWithoutPrefix.slice(colonIndex + 1);
+        } else {
+            rawKey = nameWithoutPrefix;
+            typeHint = null;
+        }
+
+        // Convert kebab-case to snake_case
+        const key = rawKey.replace(/-/g, '_');
+
+        // Prevent prototype pollution
+        if (UNSAFE_KEYS.includes(key)) continue;
+
+        let value = attr.value;
+
+        // Apply type coercion (same logic as extractTypedParams)
+        if (typeHint) {
+            const safeAttrName = String(attr.name).slice(0, 50).replace(/[^a-z0-9-:]/gi, '_');
+            switch (typeHint) {
+                case 'int':
+                case 'integer': {
+                    if (value === '') { value = 0; }
+                    else {
+                        const parsed = parseInt(value, 10);
+                        value = isNaN(parsed) ? null : parsed;
+                    }
+                    break;
+                }
+                case 'float':
+                case 'number': {
+                    if (value === '') { value = 0.0; }
+                    else {
+                        const parsed = parseFloat(value);
+                        value = isNaN(parsed) ? null : parsed;
+                    }
+                    break;
+                }
+                case 'bool':
+                case 'boolean':
+                    value = ['true', '1', 'yes', 'on', 'checked'].includes(value.toLowerCase());
+                    break;
+                case 'json':
+                case 'object':
+                case 'array':
+                    try { value = JSON.parse(value); }
+                    catch { /* keep as string */ }
+                    break;
+                case 'list':
+                    value = value ? value.split(',').map(v => v.trim()).filter(v => v) : [];
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        values[key] = value;
+    }
+
+    return values;
 }
 
 // Export for global access
 window.djust = window.djust || {};
 window.djust.extractTypedParams = extractTypedParams;
+window.djust.collectDjValues = collectDjValues;

--- a/python/djust/static/djust/src/09-event-binding.js
+++ b/python/djust/static/djust/src/09-event-binding.js
@@ -146,6 +146,9 @@ function bindLiveViewEvents() {
                 const formData = new FormData(e.target);
                 const params = Object.fromEntries(formData.entries());
 
+                // Merge dj-value-* attributes from the form element
+                Object.assign(params, collectDjValues(e.target));
+
                 addEventContext(params, e.target);
 
                 // Pass target element for optimistic updates (Phase 3)
@@ -181,6 +184,8 @@ function bindLiveViewEvents() {
         function buildFormEventParams(element, value) {
             const fieldName = getFieldName(element);
             const params = { value, field: fieldName };
+            // Merge dj-value-* attributes from the triggering element
+            Object.assign(params, collectDjValues(element));
             addEventContext(params, element);
             return params;
         }
@@ -343,6 +348,9 @@ function bindLiveViewEvents() {
                         value: e.target.value,
                         field: fieldName
                     };
+
+                    // Merge dj-value-* attributes from the element
+                    Object.assign(params, collectDjValues(element));
 
                     addEventContext(params, e.target);
 

--- a/tests/js/dj_value_params.test.js
+++ b/tests/js/dj_value_params.test.js
@@ -1,0 +1,233 @@
+/**
+ * Tests for dj-value-* static event parameters.
+ *
+ * dj-value-* attributes pass static context alongside events, matching
+ * Phoenix LiveView's phx-value-* semantics.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+const fs = await import('fs');
+const clientCode = fs.readFileSync('./python/djust/static/djust/client.js', 'utf-8');
+
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+    runScripts: 'dangerously',
+});
+
+if (!dom.window.CSS) dom.window.CSS = {};
+if (!dom.window.CSS.escape) {
+    dom.window.CSS.escape = function(value) {
+        return String(value).replace(/([^\w-])/g, '\\$1');
+    };
+}
+
+dom.window.eval(clientCode);
+
+const {
+    collectDjValues,
+    extractTypedParams,
+} = dom.window.djust;
+
+const document = dom.window.document;
+
+describe('dj-value-* static event parameters', () => {
+
+    describe('collectDjValues', () => {
+        it('extracts simple string values', () => {
+            const el = document.createElement('button');
+            el.setAttribute('dj-value-id', '42');
+            el.setAttribute('dj-value-type', 'soft');
+
+            const values = collectDjValues(el);
+
+            expect(values.id).toBe('42');
+            expect(values.type).toBe('soft');
+        });
+
+        it('converts kebab-case to snake_case', () => {
+            const el = document.createElement('button');
+            el.setAttribute('dj-value-item-id', '42');
+            el.setAttribute('dj-value-item-type', 'post');
+
+            const values = collectDjValues(el);
+
+            expect(values.item_id).toBe('42');
+            expect(values.item_type).toBe('post');
+        });
+
+        it('supports :int type hint', () => {
+            const el = document.createElement('button');
+            el.setAttribute('dj-value-id:int', '42');
+
+            const values = collectDjValues(el);
+
+            expect(values.id).toBe(42);
+            expect(typeof values.id).toBe('number');
+        });
+
+        it('supports :float type hint', () => {
+            const el = document.createElement('button');
+            el.setAttribute('dj-value-price:float', '19.99');
+
+            const values = collectDjValues(el);
+
+            expect(values.price).toBe(19.99);
+        });
+
+        it('supports :bool type hint', () => {
+            const el = document.createElement('button');
+            el.setAttribute('dj-value-active:bool', 'true');
+            el.setAttribute('dj-value-deleted:bool', 'false');
+
+            const values = collectDjValues(el);
+
+            expect(values.active).toBe(true);
+            expect(values.deleted).toBe(false);
+        });
+
+        it('supports :json type hint', () => {
+            const el = document.createElement('button');
+            el.setAttribute('dj-value-config:json', '{"theme":"dark"}');
+
+            const values = collectDjValues(el);
+
+            expect(values.config).toEqual({ theme: 'dark' });
+        });
+
+        it('supports :list type hint', () => {
+            const el = document.createElement('button');
+            el.setAttribute('dj-value-tags:list', 'a,b,c');
+
+            const values = collectDjValues(el);
+
+            expect(values.tags).toEqual(['a', 'b', 'c']);
+        });
+
+        it('returns empty object when no dj-value-* attributes', () => {
+            const el = document.createElement('button');
+            el.setAttribute('dj-click', 'submit');
+            el.setAttribute('data-id', '42');
+
+            const values = collectDjValues(el);
+
+            expect(Object.keys(values).length).toBe(0);
+        });
+
+        it('ignores non-dj-value attributes', () => {
+            const el = document.createElement('button');
+            el.setAttribute('dj-click', 'submit');
+            el.setAttribute('dj-confirm', 'Are you sure?');
+            el.setAttribute('data-id', '99');
+            el.setAttribute('dj-value-id', '42');
+
+            const values = collectDjValues(el);
+
+            expect(Object.keys(values).length).toBe(1);
+            expect(values.id).toBe('42');
+        });
+
+        it('prevents prototype pollution', () => {
+            const el = document.createElement('button');
+            el.setAttribute('dj-value-__proto__', 'polluted');
+            el.setAttribute('dj-value-constructor', 'polluted');
+            el.setAttribute('dj-value-safe-key', 'safe');
+
+            const values = collectDjValues(el);
+
+            expect(values.__proto__).toBeUndefined();
+            expect(values.constructor).toBeUndefined();
+            expect(values.safe_key).toBe('safe');
+        });
+
+        it('handles empty string values', () => {
+            const el = document.createElement('button');
+            el.setAttribute('dj-value-query', '');
+
+            const values = collectDjValues(el);
+
+            expect(values.query).toBe('');
+        });
+
+        it('handles :int with empty string', () => {
+            const el = document.createElement('button');
+            el.setAttribute('dj-value-count:int', '');
+
+            const values = collectDjValues(el);
+
+            expect(values.count).toBe(0);
+        });
+    });
+
+    describe('extractTypedParams integration', () => {
+        it('merges dj-value-* with data-* attributes', () => {
+            const el = document.createElement('button');
+            el.setAttribute('data-page:int', '1');
+            el.setAttribute('dj-value-id:int', '42');
+
+            const params = extractTypedParams(el);
+
+            expect(params.page).toBe(1);
+            expect(params.id).toBe(42);
+        });
+
+        it('dj-value-* takes precedence over data-*', () => {
+            const el = document.createElement('button');
+            el.setAttribute('data-id', 'from-data');
+            el.setAttribute('dj-value-id', 'from-dj-value');
+
+            const params = extractTypedParams(el);
+
+            expect(params.id).toBe('from-dj-value');
+        });
+
+        it('dj-value-* takes precedence over dj-params', () => {
+            const el = document.createElement('button');
+            el.setAttribute('dj-params', '{"id": "from-dj-params"}');
+            el.setAttribute('dj-value-id', 'from-dj-value');
+
+            const params = extractTypedParams(el);
+
+            expect(params.id).toBe('from-dj-value');
+        });
+    });
+
+    describe('typical usage patterns', () => {
+        it('delete button with item context', () => {
+            // <button dj-click="delete" dj-value-id:int="42" dj-value-type="soft">
+            const el = document.createElement('button');
+            el.setAttribute('dj-click', 'delete');
+            el.setAttribute('dj-value-id:int', '42');
+            el.setAttribute('dj-value-type', 'soft');
+
+            const params = extractTypedParams(el);
+
+            expect(params.id).toBe(42);
+            expect(params.type).toBe('soft');
+        });
+
+        it('list item with multiple values', () => {
+            // <tr dj-click="select" dj-value-row-id:int="7" dj-value-category="users">
+            const el = document.createElement('tr');
+            el.setAttribute('dj-click', 'select');
+            el.setAttribute('dj-value-row-id:int', '7');
+            el.setAttribute('dj-value-category', 'users');
+
+            const params = extractTypedParams(el);
+
+            expect(params.row_id).toBe(7);
+            expect(params.category).toBe('users');
+        });
+
+        it('toggle with boolean flag', () => {
+            // <button dj-click="toggle" dj-value-expanded:bool="true">
+            const el = document.createElement('button');
+            el.setAttribute('dj-click', 'toggle');
+            el.setAttribute('dj-value-expanded:bool', 'true');
+
+            const params = extractTypedParams(el);
+
+            expect(params.expanded).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- New `dj-value-*` attributes for passing static context alongside events (Phoenix `phx-value-*` parity)
- `<button dj-click="delete" dj-value-id:int="{{ item.id }}" dj-value-type="soft">` sends `{id: 42, type: "soft"}` as event params
- Supports type-hint suffixes: `:int`, `:float`, `:bool`, `:json`, `:list`
- Kebab-to-snake_case conversion: `dj-value-item-type` → `item_type`
- Prototype pollution prevention via `UNSAFE_KEYS` check
- Works with all event types: `dj-click`, `dj-submit`, `dj-change`, `dj-input`, `dj-keydown/keyup`, `dj-blur`, `dj-focus`, `dj-poll`
- `dj-value-*` takes precedence over `data-*` and `dj-params` attributes
- No server-side changes needed — params pass through as `**kwargs`

## Files changed

- `python/djust/static/djust/src/08-event-parsing.js` — New `collectDjValues()` function + integration in `extractTypedParams()`
- `python/djust/static/djust/src/09-event-binding.js` — Merge `dj-value-*` in `dj-submit`, `buildFormEventParams()`, `dj-keydown/keyup`
- `python/djust/static/djust/client.js` — Rebuilt from source modules
- `tests/js/dj_value_params.test.js` — 18 new tests
- `CHANGELOG.md` — Entry added

## Test plan

- [x] 18 new JS tests covering string/int/float/bool/json/list types, kebab-to-snake, prototype pollution, precedence, empty values
- [x] All 809 JS tests pass (55 test files)
- [x] All 2218 Python tests pass
- [ ] Manual test: add `dj-value-id:int="{{ item.id }}"` to a button and verify handler receives integer param

🤖 Generated with [Claude Code](https://claude.com/claude-code)