### PR TITLE
chore: run test suites in parallel for 3x speedup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,31 @@ dev-build: ## Build Rust extensions in development mode
 ##@ Testing & Quality
 
 .PHONY: test
-test: test-python test-js test-rust ## Run all tests (Python + JavaScript + Rust)
+test: ## Run all tests (Python + JavaScript + Rust) in parallel
+	@echo "$(GREEN)Running all tests in parallel...$(NC)"
+	@PY_EXIT=0; RS_EXIT=0; JS_EXIT=0; \
+	PYTHONPATH=. .venv/bin/python -m pytest tests/ python/tests/ -n auto -q > /tmp/djust-test-py.log 2>&1 & PY_PID=$$!; \
+	PYO3_PYTHON=$$(pwd)/.venv/bin/python cargo test --workspace --exclude djust_live -q > /tmp/djust-test-rs.log 2>&1 & RS_PID=$$!; \
+	npm test > /tmp/djust-test-js.log 2>&1 & JS_PID=$$!; \
+	wait $$PY_PID || PY_EXIT=$$?; \
+	wait $$RS_PID || RS_EXIT=$$?; \
+	wait $$JS_PID || JS_EXIT=$$?; \
+	echo ""; \
+	echo "$(GREEN)Python tests:$(NC)"; tail -3 /tmp/djust-test-py.log; \
+	echo "$(GREEN)Rust tests:$(NC)"; tail -3 /tmp/djust-test-rs.log; \
+	echo "$(GREEN)JavaScript tests:$(NC)"; tail -5 /tmp/djust-test-js.log; \
+	if [ $$PY_EXIT -ne 0 ] || [ $$RS_EXIT -ne 0 ] || [ $$JS_EXIT -ne 0 ]; then \
+		echo ""; \
+		echo "$(RED)Some tests failed (Python=$$PY_EXIT, Rust=$$RS_EXIT, JS=$$JS_EXIT)$(NC)"; \
+		[ $$PY_EXIT -ne 0 ] && echo "$(YELLOW)Full Python output:$(NC) cat /tmp/djust-test-py.log"; \
+		[ $$RS_EXIT -ne 0 ] && echo "$(YELLOW)Full Rust output:$(NC) cat /tmp/djust-test-rs.log"; \
+		[ $$JS_EXIT -ne 0 ] && echo "$(YELLOW)Full JS output:$(NC) cat /tmp/djust-test-js.log"; \
+		exit 1; \
+	fi; \
+	echo ""; echo "$(GREEN)All tests passed!$(NC)"
+
+.PHONY: test-sequential
+test-sequential: test-python test-js test-rust ## Run all tests sequentially (fallback)
 
 .PHONY: test-rust
 test-rust: ## Run Rust tests


### PR DESCRIPTION
## Summary

- Run Python, Rust, and JS test suites concurrently instead of sequentially
- Use `pytest -n auto` (pytest-xdist) for Python test parallelism across CPU cores
- Preserve old sequential behavior as `make test-sequential`

## Motivation

`make test` ran three independent suites sequentially (~60s). Since they share no state, running them in parallel with background processes cuts wall time to ~18s.

| Suite | Tests | Time |
|-------|-------|------|
| Python (pytest -n auto) | 2,319 | ~15s |
| Rust (cargo test) | 564 | ~15s |
| JavaScript (vitest) | 993 | ~13s |
| **Total (parallel)** | **3,876** | **~18s** |

## Test plan

- [x] `make test` runs all three suites in parallel, reports summary
- [x] Failures in any suite cause non-zero exit and point to log file
- [x] `make test-sequential` still works as before
- [x] Pre-push hook continues to work (uses `make test-python` directly)

Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)