### PR TITLE
fix: resolve 25 CodeQL alerts (unused code, empty except, no-effect statements)

### DIFF
--- a/python/djust/__init__.py
+++ b/python/djust/__init__.py
@@ -55,10 +55,10 @@ except ImportError:
 
 # Import Rust components (optional, requires separate build)
 try:
-    from . import rust_components
+    from . import rust_components  # noqa: F401 — re-exported as djust.rust_components
 except ImportError:
     # Rust components not yet built - this is optional
-    rust_components = None
+    rust_components = None  # noqa: F841 — accessed as djust.rust_components by user code
 
 __version__ = "0.4.0rc2"
 

--- a/python/djust/checks.py
+++ b/python/djust/checks.py
@@ -605,7 +605,7 @@ def check_liveviews(app_configs, **kwargs):
                     cls_file = inspect.getfile(cls)
                     cls_line = inspect.getsourcelines(cls)[1]
                 except (OSError, TypeError):
-                    pass
+                    pass  # Source introspection may fail for built-in or C-extension classes
                 errors.append(
                     DjustWarning(
                         "%s: missing 'template_name' attribute." % cls_label,
@@ -637,7 +637,7 @@ def check_liveviews(app_configs, **kwargs):
                     cls_file = inspect.getfile(cls)
                     cls_line = inspect.getsourcelines(cls)[1]
                 except (OSError, TypeError):
-                    pass
+                    pass  # Source introspection may fail for built-in or C-extension classes
                 errors.append(
                     DjustInfo(
                         "%s: no mount() method defined." % cls_label,
@@ -665,7 +665,7 @@ def check_liveviews(app_configs, **kwargs):
                     cls_file = inspect.getfile(cls)
                     cls_line = inspect.getsourcelines(mount_method)[1]
                 except (OSError, TypeError):
-                    pass
+                    pass  # Source introspection may fail for built-in or C-extension classes
                 errors.append(
                     DjustError(
                         "%s: mount() should accept (self, request, **kwargs)." % cls_label,
@@ -710,7 +710,7 @@ def check_liveviews(app_configs, **kwargs):
                     method_file = inspect.getfile(method)
                     method_line = inspect.getsourcelines(method)[1]
                 except (OSError, TypeError):
-                    pass
+                    pass  # Source introspection may fail for built-in or C-extension classes
                 errors.append(
                     DjustInfo(
                         "%s.%s() looks like an event handler but is missing @event_handler."
@@ -737,7 +737,7 @@ def check_liveviews(app_configs, **kwargs):
                 cls_file = inspect.getfile(cls)
                 cls_line = inspect.getsourcelines(cls)[1]
             except (OSError, TypeError):
-                pass
+                pass  # Source introspection may fail for built-in or C-extension classes
             errors.append(
                 DjustWarning(
                     "%s: keys %s appear in both static_assigns and temporary_assigns."
@@ -796,7 +796,7 @@ def check_liveviews(app_configs, **kwargs):
                     method_file = inspect.getfile(sig_target)
                     method_line = inspect.getsourcelines(sig_target)[1]
                 except (OSError, TypeError):
-                    pass
+                    pass  # Source introspection may fail for built-in or C-extension classes
                 errors.append(
                     DjustWarning(
                         "%s.%s() event handler missing **kwargs in signature." % (cls_label, name),

--- a/python/djust/live_view.py
+++ b/python/djust/live_view.py
@@ -48,12 +48,12 @@ try:
     from ._rust import (
         RustLiveView,
         SessionActorHandle,
-        extract_template_variables,  # noqa: F401 — re-exported, used by JIT tests
+        extract_template_variables,  # noqa: F401 — re-exported, used by JIT and template tests
     )
 except ImportError:
     RustLiveView = None
     SessionActorHandle = None
-    extract_template_variables = None  # noqa: F841
+    extract_template_variables = None  # noqa: F401 — fallback for re-export
 
 
 class LiveView(
@@ -265,7 +265,7 @@ class LiveView(
             if isinstance(value, (models.Model, QuerySet)):
                 return True
         except ImportError:
-            pass
+            pass  # Django ORM not available; skip model/queryset check
 
         # Non-serializable types: file handles, threads, locks, sockets
         _non_serializable = (io.IOBase, threading.Thread, socket.socket)
@@ -275,7 +275,7 @@ class LiveView(
 
             _non_serializable = _non_serializable + (_thread.LockType,)
         except (ImportError, AttributeError):
-            pass
+            pass  # _thread.LockType unavailable on some platforms; skip lock detection
         if isinstance(value, _non_serializable):
             return False
 

--- a/python/djust/mcp/server.py
+++ b/python/djust/mcp/server.py
@@ -241,7 +241,7 @@ def create_server():
         try:
             import djust.checks  # noqa: F401 — ensure checks are registered
         except ImportError:
-            pass
+            pass  # djust.checks may not be importable if Django isn't fully configured
 
         from django.core.checks import Error, Warning, run_checks
 

--- a/python/djust/mixins/context.py
+++ b/python/djust/mixins/context.py
@@ -30,8 +30,8 @@ def _clear_processor_caches(**kwargs):
 setting_changed.connect(_clear_processor_caches)
 
 try:
-    import djust.optimization.query_optimizer  # noqa: F401
-    import djust.optimization.codegen  # noqa: F401
+    import djust.optimization.query_optimizer  # noqa: F401 — availability check sets JIT_AVAILABLE
+    import djust.optimization.codegen  # noqa: F401 — availability check sets JIT_AVAILABLE
 
     JIT_AVAILABLE = True
 except ImportError:

--- a/python/djust/scaffolding/generator.py
+++ b/python/djust/scaffolding/generator.py
@@ -20,22 +20,6 @@ from . import templates as T
 
 logger = logging.getLogger(__name__)
 
-# Django field type mapping for --from-schema
-_SCHEMA_FIELD_MAP = {
-    "string": "models.CharField(max_length=%(max_length)s)",
-    "text": "models.TextField(%(blank)s)",
-    "integer": "models.IntegerField(%(default)s)",
-    "float": "models.FloatField(%(default)s)",
-    "decimal": "models.DecimalField(max_digits=%(max_digits)s, decimal_places=%(decimal_places)s)",
-    "boolean": "models.BooleanField(default=%(default)s)",
-    "date": "models.DateField(%(null)s)",
-    "datetime": "models.DateTimeField(%(null)s)",
-    "email": "models.EmailField(%(blank)s)",
-    "url": "models.URLField(%(blank)s)",
-    "slug": "models.SlugField(unique=True)",
-    "foreignkey": "models.ForeignKey(%(related_model)s, on_delete=models.CASCADE)",
-}
-
 
 def generate_project(
     app_name: str,

--- a/python/djust/schema.py
+++ b/python/djust/schema.py
@@ -1204,7 +1204,7 @@ def _walk_url_patterns(patterns: list, prefix: str, routes: List[Dict[str, str]]
                             }
                         )
                 except (ImportError, TypeError):
-                    pass
+                    pass  # Skip routes where LiveView import or subclass check fails
 
 
 def _get_version() -> str:

--- a/python/djust/state_backends/base.py
+++ b/python/djust/state_backends/base.py
@@ -19,7 +19,7 @@ NO_COMPRESSION_MARKER = b"\x00"  # Prefix byte for uncompressed data
 
 # Try to import zstd for compression (optional dependency)
 try:
-    import zstandard  # noqa: F401
+    import zstandard  # noqa: F401 — availability check sets ZSTD_AVAILABLE
 
     ZSTD_AVAILABLE = True
     logger.debug("zstd compression available")

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -536,7 +536,7 @@ class LiveViewWebSocket {
                 // Set reconnect flag for dj-auto-recover
                 if (window.djust) window.djust._isReconnect = true;
                 // Notify hooks of reconnection
-                if (typeof notifyHooksReconnected === 'function') notifyHooksReconnected();
+                notifyHooksReconnected();
             }
             this.stats.connectedAt = Date.now();
         };
@@ -550,7 +550,7 @@ class LiveViewWebSocket {
             document.body.classList.remove('dj-connected');
 
             // Notify hooks of disconnection
-            if (typeof notifyHooksDisconnected === 'function') notifyHooksDisconnected();
+            notifyHooksDisconnected();
 
             // Clear all decorator state on disconnect
             // Phase 2: Debounce timers
@@ -6105,12 +6105,6 @@ if (document.readyState === 'loading') {
         if (bytes < 1024) return bytes + ' B';
         if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
         return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
-    }
-
-    function escapeHtml(str) {
-        const div = document.createElement('div');
-        div.textContent = str;
-        return div.innerHTML;
     }
 
     /**

--- a/python/djust/static/djust/debug-panel.js
+++ b/python/djust/static/djust/debug-panel.js
@@ -1854,7 +1854,6 @@
         }
 
         showReplayStatus(btnElement, status, message) {
-            const original = btnElement.textContent;
             if (status === 'pending') {
                 btnElement.textContent = '⏳';
                 btnElement.classList.add('replay-pending');
@@ -3429,7 +3428,6 @@
             }
 
             const renderNode = (node, depth = 0) => {
-                const indent = '│  '.repeat(depth);
                 const isLast = false; // Can be enhanced to track last child
                 const prefix = depth === 0 ? '' : isLast ? '└─ ' : '├─ ';
 

--- a/python/djust/static/djust/src/03-websocket.js
+++ b/python/djust/static/djust/src/03-websocket.js
@@ -120,7 +120,7 @@ class LiveViewWebSocket {
                 // Set reconnect flag for dj-auto-recover
                 if (window.djust) window.djust._isReconnect = true;
                 // Notify hooks of reconnection
-                if (typeof notifyHooksReconnected === 'function') notifyHooksReconnected();
+                notifyHooksReconnected();
             }
             this.stats.connectedAt = Date.now();
         };
@@ -134,7 +134,7 @@ class LiveViewWebSocket {
             document.body.classList.remove('dj-connected');
 
             // Notify hooks of disconnection
-            if (typeof notifyHooksDisconnected === 'function') notifyHooksDisconnected();
+            notifyHooksDisconnected();
 
             // Clear all decorator state on disconnect
             // Phase 2: Debounce timers

--- a/python/djust/static/djust/src/15-uploads.js
+++ b/python/djust/static/djust/src/15-uploads.js
@@ -274,12 +274,6 @@
         return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
     }
 
-    function escapeHtml(str) {
-        const div = document.createElement('div');
-        div.textContent = str;
-        return div.innerHTML;
-    }
-
     /**
      * Handle file selection from dj-upload input.
      */

--- a/python/djust/static/djust/src/debug/03-tab-events.js
+++ b/python/djust/static/djust/src/debug/03-tab-events.js
@@ -142,7 +142,6 @@
         }
 
         showReplayStatus(btnElement, status, message) {
-            const original = btnElement.textContent;
             if (status === 'pending') {
                 btnElement.textContent = '⏳';
                 btnElement.classList.add('replay-pending');

--- a/python/djust/static/djust/src/debug/14-utils.js
+++ b/python/djust/static/djust/src/debug/14-utils.js
@@ -11,7 +11,6 @@
             }
 
             const renderNode = (node, depth = 0) => {
-                const indent = '│  '.repeat(depth);
                 const isLast = false; // Can be enhanced to track last child
                 const prefix = depth === 0 ? '' : isLast ? '└─ ' : '├─ ';
 

--- a/python/djust/tenants/resolvers.py
+++ b/python/djust/tenants/resolvers.py
@@ -105,7 +105,6 @@ class TenantResolver(ABC):
         Returns:
             TenantInfo if tenant found, None otherwise
         """
-        ...
 
     def get_config(self, key: str, default: Any = None) -> Any:
         """Get a value from DJUST_CONFIG."""


### PR DESCRIPTION
## Summary

Fix 25 CodeQL code-scanning alerts across Python and JavaScript.

### Python (10 files)
- Add explanatory comments to 9 empty `except: pass` clauses (checks.py, live_view.py, mcp/server.py, schema.py)
- Add `noqa` comments to intentional availability-check imports (mixins/context.py, state_backends/base.py, __init__.py)
- Remove unused `_SCHEMA_FIELD_MAP` global in scaffolding/generator.py
- Remove bare `...` (Ellipsis) in abstract method in tenants/resolvers.py

### JavaScript (4 src files + 2 debug files → rebuilt)
- Remove unused `escapeHtml` function from uploads.js
- Remove `typeof` guards on hoisted `notifyHooksReconnected`/`notifyHooksDisconnected`
- Remove unused `original` variable in debug tab-events.js
- Remove unused `indent` variable in debug utils.js

### Not changed (false positives)
- Unused import alerts on re-exported symbols (live_view.py, websocket.py) — these are imported by tests and management commands via `from djust.live_view import ...`
- Availability-check imports (context.py, base.py) — `try: import X` sets feature flags like `JIT_AVAILABLE`, `ZSTD_AVAILABLE`

## Test plan
- [x] All 2396 Python tests pass
- [x] All 1016 JS tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)