### PR TITLE
fix: defer reinitAfterDOMUpdate to prevent layout shift on pre-rendered mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Layout shift on pre-rendered mount** — Deferred `reinitAfterDOMUpdate()` and post-mount work (form recovery, `_mountReady` flag) to `requestAnimationFrame` when content is pre-rendered via HTTP GET. Prevents visible flash where elements briefly render at wrong sizes during WebSocket mount. Falls back to synchronous execution in environments without `requestAnimationFrame`. ([#618](https://github.com/djust-org/djust/issues/618), [#619](https://github.com/djust-org/djust/pull/619))
+
 ## [0.4.0] - 2026-03-27
 
 ### Security

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -708,18 +708,29 @@ class LiveViewWebSocket {
                         if (globalThis.djustDebug) console.log('[LiveView] Skipping mount HTML - using pre-rendered content');
                     }
                     this.skipMountHtml = false;
-                    reinitAfterDOMUpdate();
-                    // Set mount ready flag so dj-mounted handlers only fire
-                    // for elements added by subsequent VDOM patches, not on initial load
-                    window.djust._mountReady = true;
-                    // Trigger form recovery and dj-auto-recover after reconnect mount
-                    if (window.djust._isReconnect) {
-                        if (typeof window.djust._processFormRecovery === 'function') {
-                            window.djust._processFormRecovery();
+                    // Defer event binding and post-mount work to next frame
+                    // to avoid layout shift on pre-rendered content.
+                    // All post-mount work must run AFTER reinitAfterDOMUpdate
+                    // so event handlers are bound before form recovery fires.
+                    const postMount = () => {
+                        reinitAfterDOMUpdate();
+                        // Set mount ready flag so dj-mounted handlers only fire
+                        // for elements added by subsequent VDOM patches, not on initial load
+                        window.djust._mountReady = true;
+                        // Trigger form recovery and dj-auto-recover after reconnect mount
+                        if (window.djust._isReconnect) {
+                            if (typeof window.djust._processFormRecovery === 'function') {
+                                window.djust._processFormRecovery();
+                            }
+                            if (typeof window.djust._processAutoRecover === 'function') {
+                                window.djust._processAutoRecover();
+                            }
                         }
-                        if (typeof window.djust._processAutoRecover === 'function') {
-                            window.djust._processAutoRecover();
-                        }
+                    };
+                    if (typeof requestAnimationFrame === 'function') {
+                        requestAnimationFrame(postMount);
+                    } else {
+                        postMount();
                     }
                 } else if (data.html) {
                     // No pre-rendered content - use server HTML directly

--- a/python/djust/static/djust/src/03-websocket.js
+++ b/python/djust/static/djust/src/03-websocket.js
@@ -292,18 +292,29 @@ class LiveViewWebSocket {
                         if (globalThis.djustDebug) console.log('[LiveView] Skipping mount HTML - using pre-rendered content');
                     }
                     this.skipMountHtml = false;
-                    reinitAfterDOMUpdate();
-                    // Set mount ready flag so dj-mounted handlers only fire
-                    // for elements added by subsequent VDOM patches, not on initial load
-                    window.djust._mountReady = true;
-                    // Trigger form recovery and dj-auto-recover after reconnect mount
-                    if (window.djust._isReconnect) {
-                        if (typeof window.djust._processFormRecovery === 'function') {
-                            window.djust._processFormRecovery();
+                    // Defer event binding and post-mount work to next frame
+                    // to avoid layout shift on pre-rendered content.
+                    // All post-mount work must run AFTER reinitAfterDOMUpdate
+                    // so event handlers are bound before form recovery fires.
+                    const postMount = () => {
+                        reinitAfterDOMUpdate();
+                        // Set mount ready flag so dj-mounted handlers only fire
+                        // for elements added by subsequent VDOM patches, not on initial load
+                        window.djust._mountReady = true;
+                        // Trigger form recovery and dj-auto-recover after reconnect mount
+                        if (window.djust._isReconnect) {
+                            if (typeof window.djust._processFormRecovery === 'function') {
+                                window.djust._processFormRecovery();
+                            }
+                            if (typeof window.djust._processAutoRecover === 'function') {
+                                window.djust._processAutoRecover();
+                            }
                         }
-                        if (typeof window.djust._processAutoRecover === 'function') {
-                            window.djust._processAutoRecover();
-                        }
+                    };
+                    if (typeof requestAnimationFrame === 'function') {
+                        requestAnimationFrame(postMount);
+                    } else {
+                        postMount();
                     }
                 } else if (data.html) {
                     // No pre-rendered content - use server HTML directly

--- a/tests/js/mount-deferred-reinit.test.js
+++ b/tests/js/mount-deferred-reinit.test.js
@@ -1,0 +1,148 @@
+/**
+ * Tests for deferred reinitAfterDOMUpdate on pre-rendered mount.
+ *
+ * When content is pre-rendered via HTTP GET, the WebSocket mount should
+ * defer reinitAfterDOMUpdate() to the next animation frame to avoid
+ * layout shift. Regression test for #618.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import fs from 'fs';
+
+const clientCode = fs.readFileSync('./python/djust/static/djust/client.js', 'utf-8');
+
+function createDom(bodyHtml = '<div class="stat-value">42</div>') {
+    const dom = new JSDOM(`<!DOCTYPE html>
+<html><head></head>
+<body>
+  <div dj-view="test.views.TestView" dj-root>
+    ${bodyHtml}
+  </div>
+</body>
+</html>`, { runScripts: 'dangerously' });
+
+    class MockWebSocket {
+        static CONNECTING = 0;
+        static OPEN = 1;
+        static CLOSING = 2;
+        static CLOSED = 3;
+        constructor() {
+            this.readyState = MockWebSocket.OPEN;
+            this.onopen = null;
+            this.onclose = null;
+            this.onmessage = null;
+            this.onerror = null;
+        }
+        send() {}
+        close() {}
+    }
+    dom.window.WebSocket = MockWebSocket;
+
+    dom.window.eval(clientCode);
+
+    return { dom, MockWebSocket };
+}
+
+describe('pre-rendered mount deferred reinit', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('defers reinitAfterDOMUpdate when requestAnimationFrame is available', () => {
+        const { dom } = createDom();
+        const rafCallbacks = [];
+
+        // Provide requestAnimationFrame
+        dom.window.requestAnimationFrame = (cb) => {
+            rafCallbacks.push(cb);
+            return rafCallbacks.length;
+        };
+
+        // Re-evaluate client code with rAF available
+        dom.window.eval(clientCode);
+
+        const ws = new dom.window.djust.LiveViewWebSocket();
+        ws.connect('ws://localhost/ws/live/');
+        ws.ws.onopen({ type: 'open' });
+        ws.handleMessage({ type: 'connect', session_id: 'test-session' });
+
+        // Mark as pre-rendered
+        ws.skipMountHtml = true;
+
+        // _mountReady should be false before mount
+        expect(dom.window.djust._mountReady).toBeFalsy();
+
+        // Trigger mount
+        ws.handleMessage({
+            type: 'mount',
+            view: 'test.views.TestView',
+            html: '<div class="stat-value" dj-id="1">42</div>',
+            version: 1,
+            has_ids: true,
+        });
+
+        // After mount but before rAF fires, _mountReady should NOT be set
+        // (it's deferred along with reinitAfterDOMUpdate)
+        expect(dom.window.djust._mountReady).toBeFalsy();
+
+        // rAF should have been called
+        expect(rafCallbacks.length).toBeGreaterThan(0);
+
+        // Execute the deferred callback
+        rafCallbacks.forEach(cb => cb());
+
+        // Now _mountReady should be true
+        expect(dom.window.djust._mountReady).toBe(true);
+    });
+
+    it('falls back to synchronous reinit without requestAnimationFrame', () => {
+        const { dom } = createDom();
+
+        // JSDOM doesn't have requestAnimationFrame by default
+        delete dom.window.requestAnimationFrame;
+
+        const ws = new dom.window.djust.LiveViewWebSocket();
+        ws.connect('ws://localhost/ws/live/');
+        ws.ws.onopen({ type: 'open' });
+        ws.handleMessage({ type: 'connect', session_id: 'test-session' });
+
+        ws.skipMountHtml = true;
+
+        ws.handleMessage({
+            type: 'mount',
+            view: 'test.views.TestView',
+            html: '<div class="stat-value">42</div>',
+            version: 1,
+        });
+
+        // Without rAF, _mountReady should be set synchronously
+        expect(dom.window.djust._mountReady).toBe(true);
+    });
+
+    it('does not modify pre-rendered DOM content during mount', () => {
+        const { dom } = createDom('<div id="stat">42</div><p id="desc">description</p>');
+
+        const ws = new dom.window.djust.LiveViewWebSocket();
+        ws.connect('ws://localhost/ws/live/');
+        ws.ws.onopen({ type: 'open' });
+        ws.handleMessage({ type: 'connect', session_id: 'test-session' });
+
+        ws.skipMountHtml = true;
+
+        const statBefore = dom.window.document.getElementById('stat').textContent;
+        const descBefore = dom.window.document.getElementById('desc').textContent;
+
+        ws.handleMessage({
+            type: 'mount',
+            view: 'test.views.TestView',
+            html: '<div id="stat" dj-id="1">42</div><p id="desc" dj-id="2">description</p>',
+            version: 1,
+            has_ids: true,
+        });
+
+        // Content should not change during pre-rendered mount
+        expect(dom.window.document.getElementById('stat').textContent).toBe(statBefore);
+        expect(dom.window.document.getElementById('desc').textContent).toBe(descBefore);
+    });
+});


### PR DESCRIPTION
## Summary

- When a page is pre-rendered via HTTP GET, the WebSocket mount calls `reinitAfterDOMUpdate()` synchronously after stamping `dj-id` attributes
- This triggers a full DOM traversal for event binding, forcing a browser layout recalculation
- The recalculation causes a visible flash where elements (e.g., large stat values) briefly render at wrong sizes

## Fix

Wrap `reinitAfterDOMUpdate()` in `requestAnimationFrame()` for pre-rendered mounts, deferring event binding to after the browser's next paint. Falls back to synchronous call in environments without `requestAnimationFrame` (JSDOM tests).

## Test plan

- [x] All 1016 JS tests pass (including dj-cloak tests)
- [x] `npm test` passes
- [x] Pre-commit hooks pass (build-js, eslint, npm test)
- [ ] Manual: visit scaffold dashboard, verify no layout shift on stat values

Fixes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)