### PR TITLE
fix: sync input .value from value attribute after VDOM patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sync input `.value` from attribute after innerHTML/VDOM patch** — When navigating backward in a multi-step wizard, text input values were not visually restored even though the server sent correct VDOM patches. `setAttribute('value', x)` only updates the HTML attribute (defaultValue), not the `.value` DOM property. Now syncs `.value` from the attribute in `preserveFormValues()`, broadcast patches, and `morphElement()`. Skips focused inputs, checkboxes, radios, and file inputs. ([#625](https://github.com/djust-org/djust/pull/625), fixes [#624](https://github.com/djust-org/djust/issues/624))
+
 ## [0.4.0] - 2026-03-27
 
 ### Security

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -283,13 +283,7 @@ function handleServerResponse(data, eventName, triggerElement) {
                     root.querySelectorAll('textarea').forEach(el => {
                         el.value = el.textContent || '';
                     });
-                    root.querySelectorAll('input').forEach(el => {
-                        if (el.type === 'checkbox' || el.type === 'radio') return;
-                        const attrVal = el.getAttribute('value');
-                        if (attrVal !== null && el.value !== attrVal) {
-                            el.value = attrVal;
-                        }
-                    });
+                    syncInputValues(root);
                 }
             }
 
@@ -4587,6 +4581,29 @@ let _isBroadcastUpdate = false;
  *
  * Matching strategy: id → name → positional index within container.
  */
+
+/**
+ * Sync input .value from value attribute for non-focused inputs.
+ *
+ * After innerHTML replacement or VDOM SetAttr/Replace patches,
+ * setAttribute('value', x) updates the HTML attribute (defaultValue)
+ * but NOT the .value DOM property on previously-rendered inputs.
+ * Setting .value here ensures the displayed value matches the server.
+ *
+ * Skips focused inputs (user is actively typing), checkboxes, radios,
+ * and file inputs (whose .value is read-only for security reasons).
+ */
+function syncInputValues(container) {
+    container.querySelectorAll('input').forEach(el => {
+        if (el === document.activeElement) return;
+        if (el.type === 'checkbox' || el.type === 'radio' || el.type === 'file') return;
+        const attrVal = el.getAttribute('value');
+        if (attrVal !== null && el.value !== attrVal) {
+            el.value = attrVal;
+        }
+    });
+}
+
 function preserveFormValues(container, updateFn) {
     const active = document.activeElement;
     let saved = null;
@@ -4636,22 +4653,7 @@ function preserveFormValues(container, updateFn) {
         el.value = el.textContent || '';
     });
 
-    // Sync input .value from value attribute for non-focused inputs.
-    //
-    // After innerHTML replacement or VDOM SetAttr/Replace patches,
-    // setAttribute('value', x) updates the HTML attribute (defaultValue)
-    // but NOT the .value DOM property on previously-rendered inputs.
-    // This means navigating back to a wizard step shows stale values.
-    // Setting .value here ensures the displayed value matches the server.
-    // We skip the focused element — its value is preserved above.
-    container.querySelectorAll('input').forEach(el => {
-        if (el === document.activeElement) return;
-        if (el.type === 'checkbox' || el.type === 'radio') return;
-        const attrVal = el.getAttribute('value');
-        if (attrVal !== null && el.value !== attrVal) {
-            el.value = attrVal;
-        }
-    });
+    syncInputValues(container);
 
     // Restore the focused element's value
     if (saved) {
@@ -4876,7 +4878,7 @@ function morphElement(existing, desired) {
     // not the .value DOM property on previously-rendered inputs.
     if (existing.tagName === 'INPUT' && !skipValue &&
         existing.type !== 'checkbox' && existing.type !== 'radio' &&
-        existing !== document.activeElement) {
+        existing.type !== 'file' && existing !== document.activeElement) {
         const attrVal = existing.getAttribute('value');
         if (attrVal !== null && existing.value !== attrVal) {
             existing.value = attrVal;
@@ -5123,6 +5125,7 @@ window.djust._applySinglePatch = applySinglePatch;
 window.djust._stampDjIds = _stampDjIds;
 window.djust._getNodeByPath = getNodeByPath;
 window.djust.createNodeFromVNode = createNodeFromVNode;
+window.djust.syncInputValues = syncInputValues;
 window.djust.preserveFormValues = preserveFormValues;
 window.djust.saveFocusState = saveFocusState;
 window.djust.restoreFocusState = restoreFocusState;

--- a/tests/js/preserve_form_values.test.js
+++ b/tests/js/preserve_form_values.test.js
@@ -280,4 +280,97 @@ describe('preserveFormValues', () => {
             expect(restored.checked).toBe(true);
         });
     });
+
+    describe('input .value syncing from value attribute (issue #624)', () => {
+        it('should sync input .value from attribute after innerHTML replacement', () => {
+            const container = document.createElement('div');
+            container.innerHTML = '<input id="name" value="Alice">';
+            document.body.appendChild(container);
+
+            // Simulate wizard back-navigation: server sends a new innerHTML
+            // with the previously entered value in the value attribute
+            preserveFormValues(container, () => {
+                container.innerHTML = '<input id="name" value="Mendez">';
+            });
+
+            const input = container.querySelector('#name');
+            // .value must match the attribute, not be empty
+            expect(input.value).toBe('Mendez');
+        });
+
+        it('should sync multiple inputs after innerHTML replacement', () => {
+            const container = document.createElement('div');
+            container.innerHTML = '<input id="first" value=""><input id="last" value="">';
+            document.body.appendChild(container);
+
+            preserveFormValues(container, () => {
+                container.innerHTML = '<input id="first" value="John"><input id="last" value="Doe">';
+            });
+
+            expect(container.querySelector('#first').value).toBe('John');
+            expect(container.querySelector('#last').value).toBe('Doe');
+        });
+
+        it('should skip focused input (user is actively typing)', () => {
+            const container = document.createElement('div');
+            container.innerHTML = '<input id="name" value="server">';
+            document.body.appendChild(container);
+
+            const input = container.querySelector('#name');
+            input.value = 'user is typing';
+            input.focus();
+
+            preserveFormValues(container, () => {
+                container.innerHTML = '<input id="name" value="server-updated">';
+            });
+
+            const restored = container.querySelector('#name');
+            // Should have the USER's value, not the server's attribute
+            expect(restored.value).toBe('user is typing');
+        });
+
+        it('should skip checkbox and radio inputs', () => {
+            const container = document.createElement('div');
+            container.innerHTML = '<input type="checkbox" id="cb" value="yes"><input type="radio" id="rd" value="opt1"><input id="text" value="hello">';
+            document.body.appendChild(container);
+
+            preserveFormValues(container, () => {
+                container.innerHTML = '<input type="checkbox" id="cb" value="yes"><input type="radio" id="rd" value="opt1"><input id="text" value="world">';
+            });
+
+            // Text input should have .value synced
+            expect(container.querySelector('#text').value).toBe('world');
+            // Checkbox/radio .value should NOT be touched by syncInputValues
+            // (they use .checked, not .value for state)
+            expect(container.querySelector('#cb').type).toBe('checkbox');
+            expect(container.querySelector('#rd').type).toBe('radio');
+        });
+
+        it('should skip file inputs (read-only .value)', () => {
+            const container = document.createElement('div');
+            container.innerHTML = '<input type="file" id="upload">';
+            document.body.appendChild(container);
+
+            preserveFormValues(container, () => {
+                container.innerHTML = '<input type="file" id="upload">';
+            });
+
+            // File input should not throw or be modified
+            expect(container.querySelector('#upload').value).toBe('');
+        });
+
+        it('should not sync when value attribute is absent', () => {
+            const container = document.createElement('div');
+            container.innerHTML = '<input id="name">';
+            document.body.appendChild(container);
+
+            preserveFormValues(container, () => {
+                // No value attribute at all
+                container.innerHTML = '<input id="name">';
+            });
+
+            // Should remain empty — no attribute to sync from
+            expect(container.querySelector('#name').value).toBe('');
+        });
+    });
 });


### PR DESCRIPTION
## Problem

When navigating backward in a multi-step wizard (or any LiveView with multiple render states), text input values that were previously entered do not visually restore — even though the server sends the correct VDOM patches.

**Root cause**: After `innerHTML` replacement or VDOM `SetAttr`/`Replace` patches, `element.setAttribute('value', x)` updates the HTML attribute (i.e. `defaultValue`) but **not** the `.value` DOM property. Browsers only honour the `value` attribute on element creation; after that, only `element.value = x` updates what's displayed.

DOM evidence:
```js
input.getAttribute('value')  // "Mendez" ✅  set correctly by djust patch
input.value                  // ""        ❌  .value property not updated
```

## Fix

djust already applies this pattern for `<textarea>` (syncing `.value` from `textContent` after `updateFn()`). This PR extends the same fix to `<input>` elements in three call sites:

1. **`preserveFormValues()`** — after `updateFn()` for normal VDOM patches
2. **Broadcast patch handler** — after broadcast updates  
3. **`morphElement()`** — after DOM morphing

Skips the focused element (user is actively typing), checkboxes, and radio buttons.

## Tests

All 26 `preserve_form_values` + `form-recovery` tests pass. No pre-existing test regressions.

Closes #624