### PR TITLE
fix: dj-patch on <a> tags uses href when attribute value is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`dj-patch` on `<a>` tags uses href when attribute value is empty** — Boolean `dj-patch` on anchor elements (`<a href="?tab=docs" dj-patch>`) was resolving to the current URL instead of the href destination. Now falls back to `el.getAttribute('href')` when `dj-patch` is empty and the element is `<a>`. ([#640](https://github.com/djust-org/djust/pull/640))
+
 - **Normalize Model instances in `render_full_template` before passing to Rust** — Django FK fields are class-level descriptors not present in `__dict__`. Rust's `FromPyObject` extracts `__dict__` which has `claimant_id=1` (raw FK int) instead of the related object. Now always calls `normalize_django_value()` on pre-serialized context so FK relationships are resolved via `getattr()` and traversable with dot notation (`{{ claim.claimant.first_name }}`). ([#639](https://github.com/djust-org/djust/pull/639))
 
 - **Render Django Form/BoundField to SafeString HTML in template context** — `{{ form.field_name }}` rendered as empty string because the Rust renderer extracted `Form.__dict__` which doesn't contain computed `BoundField` attributes. Now pre-renders Form and BoundField objects to SafeString HTML via `widget.render()` in all four code paths (serialization, template serialization, template rendering, and LiveView state sync). ([#631](https://github.com/djust-org/djust/pull/631), fixes [#621](https://github.com/djust-org/djust/issues/621))

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -6964,7 +6964,15 @@ window.djust.getActiveStreams = getActiveStreams;
             if (el.tagName !== 'SELECT' && el.tagName !== 'INPUT') {
                 el.addEventListener('click', function (e) {
                     e.preventDefault();
-                    _executePatch(el, el.getAttribute('dj-patch'));
+                    // When dj-patch is used as a boolean attribute on <a> tags
+                    // (e.g. <a href="?tab=docs" dj-patch>), the attribute value
+                    // is "" and the navigation target is the href.  Fall back to
+                    // href so the link destination is respected.
+                    var patchValue = el.getAttribute('dj-patch');
+                    if (!patchValue && el.tagName === 'A') {
+                        patchValue = el.getAttribute('href') || '';
+                    }
+                    _executePatch(el, patchValue);
                 });
             }
         });

--- a/python/djust/static/djust/src/18-navigation.js
+++ b/python/djust/static/djust/src/18-navigation.js
@@ -248,7 +248,15 @@
             if (el.tagName !== 'SELECT' && el.tagName !== 'INPUT') {
                 el.addEventListener('click', function (e) {
                     e.preventDefault();
-                    _executePatch(el, el.getAttribute('dj-patch'));
+                    // When dj-patch is used as a boolean attribute on <a> tags
+                    // (e.g. <a href="?tab=docs" dj-patch>), the attribute value
+                    // is "" and the navigation target is the href.  Fall back to
+                    // href so the link destination is respected.
+                    var patchValue = el.getAttribute('dj-patch');
+                    if (!patchValue && el.tagName === 'A') {
+                        patchValue = el.getAttribute('href') || '';
+                    }
+                    _executePatch(el, patchValue);
                 });
             }
         });

--- a/tests/js/navigation.test.js
+++ b/tests/js/navigation.test.js
@@ -297,6 +297,54 @@ describe('navigation', () => {
         });
     });
 
+    describe('dj-patch boolean on <a> tags (PR #640)', () => {
+        it('boolean dj-patch on <a> falls back to href', () => {
+            const wsMock = { viewMounted: true, ws: { readyState: 1 }, sendMessage: () => {} };
+            const { document, historyCalls } = createNavSourceEnv(
+                '<a id="tab-docs" href="?tab=documents" dj-patch>Documents</a>',
+                wsMock
+            );
+
+            document.defaultView.djust.navigation.bindDirectives();
+            document.getElementById('tab-docs').click();
+
+            expect(historyCalls.length).toBe(1);
+            const pushed = new URL(historyCalls[0].url);
+            expect(pushed.searchParams.get('tab')).toBe('documents');
+        });
+
+        it('boolean dj-patch on <a> uses href, not current URL', () => {
+            const wsMock = { viewMounted: true, ws: { readyState: 1 }, sendMessage: () => {} };
+            const { document, historyCalls } = createNavSourceEnv(
+                '<a id="tab-summary" href="?tab=summary" dj-patch>Summary</a>' +
+                '<a id="tab-docs" href="?tab=documents" dj-patch>Documents</a>',
+                wsMock
+            );
+
+            document.defaultView.djust.navigation.bindDirectives();
+            // Click "Documents" — should navigate to ?tab=documents, not stay on current URL
+            document.getElementById('tab-docs').click();
+
+            expect(historyCalls.length).toBe(1);
+            expect(new URL(historyCalls[0].url).searchParams.get('tab')).toBe('documents');
+        });
+
+        it('explicit dj-patch value still takes priority over href', () => {
+            const wsMock = { viewMounted: true, ws: { readyState: 1 }, sendMessage: () => {} };
+            const { document, historyCalls } = createNavSourceEnv(
+                '<a id="link" href="/ignore/" dj-patch="?filter=active">Active</a>',
+                wsMock
+            );
+
+            document.defaultView.djust.navigation.bindDirectives();
+            document.getElementById('link').click();
+
+            expect(historyCalls.length).toBe(1);
+            const pushed = new URL(historyCalls[0].url);
+            expect(pushed.searchParams.get('filter')).toBe('active');
+        });
+    });
+
     describe('_routeMap', () => {
         it('is initialized as an object', () => {
             const { window } = createEnv();


### PR DESCRIPTION
## Summary

When `dj-patch` is used as a boolean attribute on `<a>` elements:

```html
<a href="?tab=documents" dj-patch>Documents</a>
```

`el.getAttribute('dj-patch')` returns `""` (empty string). `_executePatch` was called with `patchValue=""` which resolved to the **current URL**, so tab clicks always sent the current URL's params instead of the href destination. All `url_change` events had `params: {tab: "documents"}` regardless of which tab was clicked — server always rendered the same tab → 0 patches → tabs appeared completely broken.

## Root Cause

`_executePatch(el, el.getAttribute('dj-patch'))` at line 251 — the attribute value is empty for boolean usage, and there was no fallback to `href`.

## Fix

Fall back to `el.getAttribute('href')` when `dj-patch` is empty and the element is an `<a>` tag. Preserves existing behaviour for explicit values (`dj-patch="?filter=active"`) while making the boolean pattern work:

```html
<a href="?tab=summary" dj-patch>Summary</a>   <!-- params: {tab: "summary"} ✓ -->
<a href="?tab=documents" dj-patch>Documents</a> <!-- params: {tab: "documents"} ✓ -->
```

## Test Plan

- All 2458 tests pass (including npm test)
- Manually verified tab switching works from any starting tab