### PR TITLE
fix: auto-switch to full HTML on heavy structural url_change patches

### DIFF
--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -2377,9 +2377,29 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 self.view_instance._force_full_html = False
                 patches = None
 
+            # Auto-detect heavy structural changes that cause VDOM drift (#641).
+            # When a url_change produces many RemoveChild/InsertChild patches
+            # (e.g. tab switching that replaces entire content areas), applying
+            # them via the patcher can leave the DOM in an inconsistent state
+            # with mismatched dj-id attributes, causing a client-side remount.
+            # Sending full HTML instead avoids this entirely.
             if patches is not None:
                 if isinstance(patches, str):
                     patches = json.loads(patches)
+                structural_ops = sum(
+                    1
+                    for p in patches
+                    if p.get("type") in ("RemoveChild", "InsertChild", "ReplaceChild")
+                )
+                if structural_ops > 5:
+                    logger.info(
+                        "handle_url_change: %d structural patches detected — "
+                        "switching to full HTML to avoid VDOM drift",
+                        structural_ops,
+                    )
+                    patches = None
+
+            if patches is not None:
                 await self._send_update(patches=patches, version=version, event_name="url_change")
             else:
                 html = await sync_to_async(self.view_instance._strip_comments_and_whitespace)(html)


### PR DESCRIPTION
## Summary

Fixes #641 — VDOM node ID drift when dj-patch navigation replaces large content areas.

### Root Cause (diagnosed)

When `handle_url_change` produces 15+ patches for a tab switch (RemoveChild × 8, InsertChild × 7), the client-side patcher applies them but the resulting DOM has mismatched `dj-id` attributes. After multiple tab round-trips, the patcher targets wrong nodes, causing empty content or visual corruption. The client detects the inconsistency and triggers a full remount (visible flicker, version counter resets to 1).

### Fix

In `handle_url_change`, after `render_with_diff()` returns patches, count structural operations (RemoveChild/InsertChild/ReplaceChild). If > 5, automatically switch to full HTML instead of patches:

```python
structural_ops = sum(
    1 for p in patches
    if p.get("type") in ("RemoveChild", "InsertChild", "ReplaceChild")
)
if structural_ops > 5:
    patches = None  # send full HTML instead
```

### Threshold

- Simple class/text changes: 1-6 patches (all SetAttr/SetText) → patches preserved
- Tab content swap: 10-20 patches with structural ops → full HTML
- The threshold of 5 was chosen empirically from the NYC Claims claim detail view (6-tab page)

### Impact

Views no longer need `self._force_full_html = True` in `handle_params()` for tab switching. The framework handles it automatically. Normal event handlers (button clicks, form inputs) continue to use efficient patches.

### Diagnostics performed

- Rust diff engine: works correctly in isolation (SetAttr patches for class changes)
- Python state sync: sends correct state to Rust via incremental `_sync_state_to_rust`
- The bug was NOT in diff computation — patches were generated (15 patches). The bug was in patch APPLICATION: applying heavy structural patches to a pre-rendered DOM leaves dj-id attributes inconsistent.