### PR TITLE
feat: standalone {% live_field %} template tag for non-wizard forms (#650)

### DIFF
--- a/python/djust/templatetags/live_tags.py
+++ b/python/djust/templatetags/live_tags.py
@@ -10,17 +10,108 @@ Usage:
     <!-- Render entire form -->
     {% live_form view %}
 
-    <!-- Render single field -->
+    <!-- Render single field (view-based, with FormMixin) -->
     {% live_field view "field_name" %}
 
     <!-- Render with options -->
     {% live_field view "email" label="Email Address" wrapper_class="custom-class" %}
+
+    <!-- Standalone field (no view required) -->
+    {% live_field "text" handler="set_note_subject" value=note_form_subject placeholder="Brief subject line..." %}
+    {% live_field "textarea" handler="set_note_body" value=note_form_body rows="4" %}
+    {% live_field "select" handler="set_note_type" value=note_form_type choices=note_type_choices %}
 """
 
 from django import template
+from django.utils.html import escape
+from django.utils.safestring import mark_safe
 from typing import Any
 
 register = template.Library()
+
+# Field types that use <input> with dj-input
+_INPUT_TYPES = frozenset({"text", "password", "email", "number", "tel", "url"})
+
+# All recognised standalone field type names (used to disambiguate the
+# one-positional-arg form from the two-positional-arg view-based form).
+_STANDALONE_FIELD_TYPES = _INPUT_TYPES | frozenset({"textarea", "select"})
+
+
+def _get_field_css_class() -> str:
+    """Return the CSS class for form fields from djust config, falling back to 'form-input'."""
+    try:
+        from djust.config import config
+
+        css_class = config.get_framework_class("field_class")
+        if css_class:
+            return css_class
+    except Exception:
+        pass
+    return "form-input"
+
+
+def _build_attr_string(attrs: dict) -> str:
+    """Build a safely-escaped HTML attribute string from a dict.
+
+    Values are escaped; keys are assumed to be safe (developer-provided
+    attribute names like ``placeholder``, ``rows``, ``id``).
+    """
+    parts: list[str] = []
+    for key, value in attrs.items():
+        if value is None:
+            continue
+        # Boolean / valueless attributes (e.g. required="")
+        escaped = escape(str(value))
+        parts.append(f'{key}="{escaped}"')
+    return " ".join(parts)
+
+
+def _render_standalone_field(field_type: str, **kwargs) -> str:
+    """Render a standalone ``<input>``, ``<textarea>``, or ``<select>`` element."""
+    handler = kwargs.pop("handler", "")
+    value = kwargs.pop("value", "")
+    choices = kwargs.pop("choices", None)
+    css_class = _get_field_css_class()
+
+    if value is None:
+        value = ""
+
+    if field_type == "textarea":
+        attrs: dict[str, Any] = {"class": css_class}
+        if handler:
+            attrs["dj-input"] = handler
+        # Merge extra kwargs (rows, id, placeholder, etc.)
+        attrs.update(kwargs)
+        attr_str = _build_attr_string(attrs)
+        escaped_value = escape(str(value))
+        return mark_safe(f"<textarea {attr_str}>{escaped_value}</textarea>")
+
+    if field_type == "select":
+        attrs = {"class": css_class}
+        if handler:
+            attrs["dj-change"] = handler
+        attrs.update(kwargs)
+        attr_str = _build_attr_string(attrs)
+
+        options_html = ""
+        if choices:
+            for choice_value, choice_label in choices:
+                escaped_cv = escape(str(choice_value))
+                escaped_cl = escape(str(choice_label))
+                selected = " selected" if str(choice_value) == str(value) else ""
+                options_html += f'<option value="{escaped_cv}"{selected}>{escaped_cl}</option>'
+
+        return mark_safe(f"<select {attr_str}>{options_html}</select>")
+
+    # Default: <input> types (text, password, email, number, tel, url)
+    attrs = {"class": css_class, "type": field_type}
+    if handler:
+        attrs["dj-input"] = handler
+    if value:
+        attrs["value"] = str(value)
+    attrs.update(kwargs)
+    attr_str = _build_attr_string(attrs)
+    return mark_safe(f"<input {attr_str}>")
 
 
 @register.simple_tag
@@ -55,34 +146,47 @@ def live_form(view, **kwargs):
 
 
 @register.simple_tag
-def live_field(view, field_name: str, **kwargs):
+def live_field(*args, **kwargs):
     """
-    Render a single form field automatically using the configured CSS framework.
+    Render a form field — either view-based or standalone.
 
-    Args:
-        view: The LiveView instance (must use FormMixin)
-        field_name: Name of the field to render
-        **kwargs: Rendering options passed to as_live_field()
-            - framework: Override the configured CSS framework
-            - render_labels: Whether to render field labels (default: True)
-            - render_help_text: Whether to render help text (default: True)
-            - render_errors: Whether to render errors (default: True)
-            - auto_validate: Whether to add validation on change (default: True)
-            - wrapper_class: Custom wrapper class for the field
-            - label: Custom label text
-
-    Returns:
-        HTML string for the field
-
-    Example:
-        {% load live_tags %}
+    **View-based** (two positional args, requires FormMixin):
         {% live_field view "email" %}
         {% live_field view "password" label="Custom Password Label" %}
-    """
-    if not hasattr(view, "as_live_field"):
-        return "<!-- ERROR: View does not have as_live_field() method. Did you use FormMixin? -->"
 
-    return view.as_live_field(field_name, **kwargs)
+    **Standalone** (one positional arg, field type string):
+        {% live_field "text" handler="set_name" value=name_val placeholder="Name..." %}
+        {% live_field "textarea" handler="set_body" value=body_val rows="4" %}
+        {% live_field "select" handler="set_type" value=type_val choices=type_choices %}
+        {% live_field "password" handler="set_pw" placeholder="Enter password..." %}
+
+    Standalone mode renders ``<input>``, ``<textarea>``, or ``<select>`` elements
+    with the appropriate ``dj-input`` / ``dj-change`` binding and CSS class from
+    the djust config (falling back to ``"form-input"``).
+
+    Supported input types: text, password, email, number, tel, url.
+    Extra kwargs are passed through as HTML attributes.
+    """
+    # --- Dispatch: standalone vs view-based ---
+    if len(args) == 1 and isinstance(args[0], str) and args[0] in _STANDALONE_FIELD_TYPES:
+        return _render_standalone_field(args[0], **kwargs)
+
+    # View-based: (view, field_name)
+    if len(args) >= 2:
+        view, field_name = args[0], args[1]
+        if not hasattr(view, "as_live_field"):
+            return (
+                "<!-- ERROR: View does not have as_live_field() method. Did you use FormMixin? -->"
+            )
+        return view.as_live_field(field_name, **kwargs)
+
+    # Single arg that isn't a recognised field type — assume it's a view missing field_name
+    if len(args) == 1:
+        return (
+            "<!-- ERROR: live_field requires either a field type string or (view, field_name) -->"
+        )
+
+    return "<!-- ERROR: live_field requires at least one argument -->"
 
 
 @register.simple_tag

--- a/python/tests/test_live_field_tag.py
+++ b/python/tests/test_live_field_tag.py
@@ -1,0 +1,281 @@
+"""
+Tests for the standalone {% live_field %} template tag.
+
+Covers: text input, textarea, select with choices, password, custom attrs,
+default CSS class fallback, CSS class from djust config, and the view-based
+backward-compatible dispatch.
+"""
+
+import django
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": ":memory:",
+            }
+        },
+        INSTALLED_APPS=[
+            "django.contrib.contenttypes",
+            "django.contrib.auth",
+        ],
+        DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+    )
+    django.setup()
+
+from django.template import Template, Context
+from django.utils.safestring import mark_safe
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def render_tag(tag_content: str, context_dict: dict | None = None) -> str:
+    """Render a template snippet that loads live_tags and uses the given tag."""
+    tpl = Template("{% load live_tags %}" + tag_content)
+    ctx = Context(context_dict or {})
+    return tpl.render(ctx).strip()
+
+
+class FakeView:
+    """Minimal stand-in for a FormMixin view used by the view-based live_field."""
+
+    def __init__(self, html="<input>"):
+        self._html = html
+
+    def as_live_field(self, field_name, **kwargs):
+        return mark_safe(self._html)
+
+
+# ---------------------------------------------------------------------------
+# Text input
+# ---------------------------------------------------------------------------
+
+
+class TestTextInput:
+    def test_basic_text_input(self):
+        html = render_tag(
+            '{% live_field "text" handler="set_name" value="Alice" placeholder="Name..." %}'
+        )
+        assert "<input " in html
+        assert 'type="text"' in html
+        assert 'dj-input="set_name"' in html
+        assert 'value="Alice"' in html
+        assert 'placeholder="Name..."' in html
+
+    def test_text_input_escapes_value(self):
+        html = render_tag(
+            '{% live_field "text" handler="h" value=val %}',
+            {"val": "<script>alert(1)</script>"},
+        )
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_text_input_empty_value_omits_attr(self):
+        html = render_tag('{% live_field "text" handler="h" %}')
+        # No value="" attribute when value is empty/unset
+        assert "value=" not in html
+
+
+# ---------------------------------------------------------------------------
+# Password
+# ---------------------------------------------------------------------------
+
+
+class TestPasswordInput:
+    def test_password_type(self):
+        html = render_tag('{% live_field "password" handler="set_pw" placeholder="Enter..." %}')
+        assert 'type="password"' in html
+        assert 'dj-input="set_pw"' in html
+        assert 'placeholder="Enter..."' in html
+
+
+# ---------------------------------------------------------------------------
+# Textarea
+# ---------------------------------------------------------------------------
+
+
+class TestTextarea:
+    def test_textarea_rendering(self):
+        html = render_tag('{% live_field "textarea" handler="set_body" value="Hello" rows="4" %}')
+        assert "<textarea " in html
+        assert "</textarea>" in html
+        assert 'dj-input="set_body"' in html
+        assert 'rows="4"' in html
+        assert ">Hello</textarea>" in html
+
+    def test_textarea_escapes_value(self):
+        html = render_tag(
+            '{% live_field "textarea" handler="h" value=val %}',
+            {"val": "<b>bold</b>"},
+        )
+        assert "<b>" not in html
+        assert "&lt;b&gt;bold&lt;/b&gt;" in html
+
+    def test_textarea_empty_value(self):
+        html = render_tag('{% live_field "textarea" handler="h" %}')
+        assert "></textarea>" in html
+
+
+# ---------------------------------------------------------------------------
+# Select
+# ---------------------------------------------------------------------------
+
+
+class TestSelect:
+    def test_select_with_choices(self):
+        choices = [("GENERAL", "General"), ("PHONE", "Phone Call")]
+        html = render_tag(
+            '{% live_field "select" handler="set_type" value=val choices=choices %}',
+            {"val": "GENERAL", "choices": choices},
+        )
+        assert "<select " in html
+        assert "</select>" in html
+        assert 'dj-change="set_type"' in html
+        assert 'value="GENERAL" selected' in html
+        assert ">General</option>" in html
+        assert 'value="PHONE"' in html
+        assert ">Phone Call</option>" in html
+        # PHONE should NOT be selected
+        assert 'value="PHONE" selected' not in html
+
+    def test_select_escapes_labels(self):
+        choices = [("x", '<img src=x onerror="alert(1)">')]
+        html = render_tag(
+            '{% live_field "select" handler="h" choices=choices %}',
+            {"choices": choices},
+        )
+        assert "<img" not in html
+        assert "&lt;img" in html
+
+    def test_select_no_choices(self):
+        html = render_tag('{% live_field "select" handler="h" %}')
+        assert "<select " in html
+        assert "</select>" in html
+
+
+# ---------------------------------------------------------------------------
+# Extra kwargs pass-through
+# ---------------------------------------------------------------------------
+
+
+class TestExtraAttrs:
+    def test_custom_id(self):
+        html = render_tag('{% live_field "text" handler="h" id="my-field" %}')
+        assert 'id="my-field"' in html
+
+    def test_required_attr(self):
+        html = render_tag('{% live_field "text" handler="h" required="" %}')
+        assert 'required=""' in html
+
+    def test_multiple_custom_attrs(self):
+        html = render_tag(
+            '{% live_field "email" handler="h" id="email-input" autocomplete="off" %}'
+        )
+        assert 'id="email-input"' in html
+        assert 'autocomplete="off"' in html
+
+
+# ---------------------------------------------------------------------------
+# CSS class
+# ---------------------------------------------------------------------------
+
+
+class TestCSSClass:
+    def test_default_css_class_fallback(self):
+        """When djust config is unavailable, falls back to 'form-input'."""
+        # We mock the import to simulate config not being available
+        import djust.templatetags.live_tags as mod
+
+        original = mod._get_field_css_class
+
+        def _mock():
+            return "form-input"
+
+        mod._get_field_css_class = _mock
+        try:
+            html = render_tag('{% live_field "text" handler="h" %}')
+            assert 'class="form-input"' in html
+        finally:
+            mod._get_field_css_class = original
+
+    def test_css_class_from_config(self):
+        """When djust config returns a class, it is used."""
+        import djust.templatetags.live_tags as mod
+
+        original = mod._get_field_css_class
+
+        def _mock():
+            return "form-control"
+
+        mod._get_field_css_class = _mock
+        try:
+            html = render_tag('{% live_field "text" handler="h" %}')
+            assert 'class="form-control"' in html
+        finally:
+            mod._get_field_css_class = original
+
+    def test_css_class_on_textarea(self):
+        html = render_tag('{% live_field "textarea" handler="h" %}')
+        assert 'class="' in html
+
+    def test_css_class_on_select(self):
+        html = render_tag('{% live_field "select" handler="h" %}')
+        assert 'class="' in html
+
+
+# ---------------------------------------------------------------------------
+# View-based backward compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestViewBasedDispatch:
+    def test_view_based_still_works(self):
+        """The (view, field_name) form should still dispatch to as_live_field()."""
+        view = FakeView(html='<input type="email" name="email">')
+        html = render_tag(
+            "{% live_field view 'email' %}",
+            {"view": view},
+        )
+        assert 'type="email"' in html
+        assert 'name="email"' in html
+
+    def test_view_without_method(self):
+        html = render_tag(
+            "{% live_field obj 'field' %}",
+            {"obj": object()},
+        )
+        assert "ERROR" in html
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_no_handler(self):
+        """Field without handler should still render, just no dj-input."""
+        html = render_tag('{% live_field "text" value="x" %}')
+        assert "<input " in html
+        assert "dj-input" not in html
+
+    def test_none_value_treated_as_empty(self):
+        html = render_tag(
+            '{% live_field "text" handler="h" value=val %}',
+            {"val": None},
+        )
+        assert "value=" not in html
+
+    def test_select_none_value(self):
+        choices = [("a", "A")]
+        html = render_tag(
+            '{% live_field "select" handler="h" value=val choices=choices %}',
+            {"val": None, "choices": choices},
+        )
+        # None won't match "a", so no selected
+        assert "selected" not in html


### PR DESCRIPTION
## Problem

`WizardMixin` + `as_live_field()` renders form fields with proper CSS classes and `dj-input`/`dj-change` bindings for multi-step wizards. But non-wizard forms (modals, inline panels, settings) have no equivalent — developers write raw `<input class="form-input">` and forget the class or use inconsistent bindings.

## Solution

Extend the existing `{% live_field %}` template tag to support a standalone mode (no view/form required):

```html
{% load live_tags %}

{% live_field "text" handler="set_subject" value=form_subject placeholder="Subject..." %}
{% live_field "textarea" handler="set_body" value=form_body rows="4" %}
{% live_field "select" handler="set_type" value=form_type choices=type_choices %}
```

Renders:
```html
<input class="form-input" type="text" dj-input="set_subject" value="..." placeholder="Subject...">
<textarea class="form-input" dj-input="set_body" rows="4">...</textarea>
<select class="form-input" dj-change="set_type">
  <option value="GENERAL" selected>General</option>
  ...
</select>
```

## Details

- Dispatch by argument type: string field type → standalone, view object → legacy `as_live_field()`
- CSS class from `config.get_framework_class("field_class")`, fallback `"form-input"`
- Text types use `dj-input`, select uses `dj-change`
- All values escaped via `django.utils.html.escape` — no XSS
- Extra kwargs pass through as HTML attributes

## Tests

22 new tests: text, textarea, select with choices, password, XSS escaping, custom attrs, CSS class config, backward compat with view-based usage. Full existing suite (2530 tests) passes.

Closes #650