### PR TITLE
docs(website): link JS Commands and dj-paste guides from nav and index

### DIFF
--- a/docs/website/_config.yaml
+++ b/docs/website/_config.yaml
@@ -131,6 +131,16 @@ navigation:
         file: guides/hooks.md
         order: 6
         level: intermediate
+      - title: JS Commands
+        slug: js-commands
+        file: guides/js-commands.md
+        order: 6.5
+        level: intermediate
+      - title: Paste Events
+        slug: dj-paste
+        file: guides/dj-paste.md
+        order: 6.6
+        level: intermediate
       - title: Model Binding
         slug: model-binding
         file: guides/model-binding.md

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -41,7 +41,14 @@ How to build specific features.
 | **[Flash Messages](guides/flash-messages.md)**         | Transient notifications with `put_flash` (Phoenix-style)  |
 | **[Presence](guides/presence.md)**                     | Track online users, live cursors, typing indicators       |
 | **[Uploads](guides/uploads.md)**                       | Chunked binary file uploads via WebSocket                 |
+| **[Paste Events](guides/dj-paste.md)**                 | `dj-paste` — structured clipboard payloads + upload routing |
 | **[Loading States](guides/loading-states.md)**         | Spinners, skeleton screens, disabled states               |
+
+### Client-Side Commands
+
+|                                                        |                                                           |
+| ------------------------------------------------------ | --------------------------------------------------------- |
+| **[JS Commands](guides/js-commands.md)**               | `show`, `hide`, `toggle`, `add_class`, `transition`, `push`, … — client-side DOM ops with Phoenix LV 1.0 parity |
 
 ### Navigation
 


### PR DESCRIPTION
## Summary

PR #672 (JS Commands) and PR #671 (dj-paste) both shipped full guide markdown under \`docs/website/guides/\` — but neither was wired into the website navigation. The files existed on disk but \`_config.yaml\` (sidebar) and \`index.md\` (landing page) didn't reference them, so visitors couldn't find the docs.

## Changes

### \`_config.yaml\`
Adds two new children to the Guides navigation group, between Hooks and Model Binding:

- **JS Commands** → \`guides/js-commands.md\` (order 6.5, intermediate)
- **Paste Events** → \`guides/dj-paste.md\` (order 6.6, intermediate)

### \`index.md\`
- Adds a row for **Paste Events** to the existing **Real-Time Features** table.
- Adds a new **Client-Side Commands** subsection under Guides with a prominent row for **JS Commands** — the topic is its own category (optimistic UI, DOM ops without server round-trips) and deserves a distinct bucket rather than being buried in Real-Time Features.

## Not changed

- The guide markdown itself — both files already exist with full command references, examples, and cross-links from \`docs/website/guides/dj-paste.md\` and \`docs/website/guides/js-commands.md\`.
- Pre-existing orphan guides (flash-messages.md, on-mount-hooks.md, djust-deploy.md, template-cheatsheet.md) that are listed in index.md but missing from \`_config.yaml\` — those predate my changes and are out of scope for this fix.

## Test plan

- [x] Both new guide files exist on disk (\`ls docs/website/guides/js-commands.md docs/website/guides/dj-paste.md\`)
- [x] \`_config.yaml\` is valid YAML (pre-commit passed)
- [x] Pre-commit hooks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)