### PR TITLE
docs(tutorials): document bubble placement outside dj-root (#699)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Tutorial bubble must be placed outside `dj-root` ([#699](https://github.com/djust-org/djust/issues/699))** — If the `{% tutorial_bubble %}` tag is placed inside the `dj-root` container, morphdom recovery (which replaces the entire `dj-root` content on patch failure) destroys the bubble mid-tour, causing it to silently disappear. The tutorials guide now has a dedicated "Bubble Placement" section explaining the requirement, why it exists, and correct/incorrect examples. The simplest-possible example at the top of the guide is updated to show the bubble outside `dj-root`. The `tutorial_bubble` template tag docstring is also updated with this requirement.
+
 - **`data-*` attribute naming convention documented in Events guide ([#623](https://github.com/djust-org/djust/issues/623))** — How `data-foo-bar` on an HTML element maps to `foo_bar` in the event handler's kwargs was undocumented. The Events guide now has a dedicated "Data Attribute Naming Convention" section covering: the dash-to-underscore rule, client-side type-hint suffixes (`:int`, `:float`, `:bool`, `:json`, `:list`), server-side Python type-hint coercion, the `dj-value-*` alternative, which internal `data-*` attributes are excluded, and a quick-reference table.
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,7 +67,7 @@ This roadmap outlines what has been built, what is actively being worked on, and
 | ~~**P1**~~ | ~~`get_context_data` includes non-serializable class attrs, corrupting state (#694)~~ ✅ | ~~MRO walker adds class attrs to context; serializer converts to strings~~ | v0.4.2 |
 | **P1** | `@background` should natively support `async def` handlers (#697) | Coroutine detection is a fragile workaround — decorator should handle it properly | v0.4.2 |
 | **P2** | `_flush_pending_push_events` callback not wired on WS reconnect (#698) | Push commands in background tasks may silently queue after reconnect | v0.4.2 |
-| **P3** | docs: tutorial bubble must be outside `dj-root` (#699) | Morphdom recovery wipes bubble if inside LiveView container — undocumented | v0.4.2 |
+| ~~**P3**~~ | ~~docs: tutorial bubble must be outside `dj-root` (#699)~~ ✅ | ~~Morphdom recovery wipes bubble if inside LiveView container — undocumented~~ | ~~v0.4.2~~ |
 | **P2** | push_commands-only handlers should auto-skip VDOM re-render (#700) | Unnecessary re-renders cause patch failures + morphdom recovery during tours | v0.4.2 |
 | **P2** | Fold `djust-auth` + `djust-tenants` into core ([ADR-007](docs/adr/007-package-taxonomy-and-consolidation.md) Phase 1) | Eliminate theoretical-audience package fragmentation; extras pattern + compat shim | v0.5.0 |
 | **P2** | Fold `djust-theming` into core ([ADR-007](docs/adr/007-package-taxonomy-and-consolidation.md) Phase 2) | Unified CSS/theming story with core; compat shim for plain-Django users | v0.5.1 |

--- a/docs/website/guides/tutorials.md
+++ b/docs/website/guides/tutorials.md
@@ -42,12 +42,15 @@ class OnboardingView(TutorialMixin, LiveView):
 <!-- onboarding.html -->
 {% load djust_tutorials %}
 
-<button dj-click="start_tutorial">Take the tour</button>
+<div dj-root dj-view="myapp.views.OnboardingView">
+    <button dj-click="start_tutorial">Take the tour</button>
 
-<nav id="nav-dashboard">...</nav>
-<button id="btn-new-project">New project</button>
-<form id="project-form">...</form>
+    <nav id="nav-dashboard">...</nav>
+    <button id="btn-new-project">New project</button>
+    <form id="project-form">...</form>
+</div>
 
+<!-- Bubble MUST be outside dj-root (see Bubble Placement below) -->
 {% tutorial_bubble %}
 ```
 
@@ -277,6 +280,43 @@ The framework doesn't ship CSS — styling is the app's responsibility. Here's a
 ```
 
 Apps using djust-theming get the bubble styled automatically via the `config.get_framework_class()` integration (coming as a follow-up).
+
+## Bubble placement
+
+The `{% tutorial_bubble %}` tag **must be placed outside the `dj-root` container**, not inside it.
+
+### Why
+
+When a VDOM patch fails, djust's morphdom recovery replaces the **entire** content of the `dj-root` element with a fresh server render. If the bubble is inside `dj-root`, the recovery wipe destroys it mid-step — the tour silently disappears and the user sees nothing. Because the bubble is marked `dj-update="ignore"`, it survives normal patches, but morphdom recovery bypasses `dj-update` attributes entirely.
+
+### How the bubble still works outside the LiveView container
+
+The bubble's Skip and Close buttons use plain `onclick` handlers that dispatch a `tour:hide` CustomEvent on `document`. They don't use `dj-click` (which requires being inside a `dj-root`), so they work correctly from anywhere in the DOM. The `tour:narrate` event that drives the bubble is also dispatched with `bubbles: true` and caught at `document` level.
+
+### Correct placement
+
+```html
+<div dj-root dj-view="myapp.views.OnboardingView">
+    <button dj-click="start_tutorial">Take the tour</button>
+    <nav id="nav-dashboard">...</nav>
+    <!-- All LiveView content inside dj-root -->
+</div>
+
+<!-- Bubble OUTSIDE dj-root — survives morphdom recovery -->
+{% tutorial_bubble %}
+```
+
+### Incorrect placement
+
+```html
+<div dj-root dj-view="myapp.views.OnboardingView">
+    <button dj-click="start_tutorial">Take the tour</button>
+    <nav id="nav-dashboard">...</nav>
+
+    <!-- WRONG: morphdom recovery will wipe this -->
+    {% tutorial_bubble %}
+</div>
+```
 
 ## Patterns
 

--- a/python/djust/templatetags/djust_tutorials.py
+++ b/python/djust/templatetags/djust_tutorials.py
@@ -40,6 +40,16 @@ def tutorial_bubble(
     """
     Render the tutorial narration bubble container element.
 
+    .. important::
+
+        The bubble **must be placed outside** the ``dj-root`` container.
+        If placed inside, morphdom recovery (which replaces the entire
+        ``dj-root`` content on patch failure) will destroy the bubble
+        mid-tour, causing the tour to silently disappear. The bubble's
+        Skip/Close buttons use ``onclick`` → ``tour:hide`` (not
+        ``dj-click``), so they work correctly outside the LiveView
+        container.
+
     The element is a floating ``<div>`` that starts hidden and becomes
     visible when the tutorial dispatches a ``tour:narrate`` (or custom)
     CustomEvent. The client-side listener in ``src/28-tutorial-bubble.js``


### PR DESCRIPTION
## Summary

- Add "Bubble Placement" section to the tutorials guide explaining that `{% tutorial_bubble %}` must be placed outside the `dj-root` container, with correct/incorrect examples and rationale (morphdom recovery wipes `dj-root` content on patch failure)
- Fix the simplest-possible example at the top of the guide to show the bubble outside `dj-root`
- Update the `tutorial_bubble` template tag docstring in `djust_tutorials.py` with placement requirement

## Test plan

- [ ] Verify tutorials guide renders correctly with the new section
- [ ] Confirm correct/incorrect code examples are clear and accurate
- [ ] Verify CHANGELOG and ROADMAP entries are accurate

Closes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>