### PR TITLE
fix(rust-bridge): cascade change detection to derived context sub-objects (#703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Derived context vars synced when parent instance attr mutated in-place ([#703](https://github.com/djust-org/djust/issues/703))** — `_sync_state_to_rust()` now collects `id()`s of all sub-objects reachable from changed instance attrs and includes any derived context var whose `id()` appears in that set. Previously, context vars computed in `get_context_data()` that returned sub-objects of a mutated dict (e.g., `wizard_step_data.get("person", {})`) were skipped because their `id()` was unchanged, causing templates to render stale data. Depth-capped at 8 with cycle detection. 9 new regression tests.
+
 - **`as_live_field()` now respects `widget.input_type` override for `type` attribute ([#683](https://github.com/djust-org/djust/issues/683) re-open)** — The initial #683 fix merged `widget.attrs` but `type` was still ignored because Django moves `type=` from `attrs` into `widget.input_type` during widget `__init__`. `_get_field_type()` now checks `widget.input_type` against the widget class's default and uses the override when they differ (e.g. `TextInput(attrs={"type": "tel"})` sets `input_type="tel"`). 4 new regression tests covering `type="tel"`, `type="url"`, `type="search"`, and the default `type="text"` fallback.
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,7 +69,7 @@ This roadmap outlines what has been built, what is actively being worked on, and
 | ~~**P2**~~ | ~~`_flush_pending_push_events` callback not wired on WS reconnect (#698)~~ ✅ | ~~Push commands in background tasks may silently queue after reconnect~~ | v0.4.2 |
 | ~~**P3**~~ | ~~docs: tutorial bubble must be outside `dj-root` (#699)~~ ✅ | ~~Morphdom recovery wipes bubble if inside LiveView container — undocumented~~ | v0.4.2 |
 | ~~**P2**~~ | ~~push_commands-only handlers should auto-skip VDOM re-render (#700)~~ ✅ | ~~Unnecessary re-renders cause patch failures + morphdom recovery during tours~~ | v0.4.2 |
-| **P1** | Derived context vars stale under incremental Rust sync (#703) | `id()` optimization skips sub-objects of mutated dicts — templates render stale data | v0.4.2 |
+| ~~**P1**~~ | ~~Derived context vars stale under incremental Rust sync (#703)~~ ✅ | ~~`id()` optimization skips sub-objects of mutated dicts — templates render stale data~~ | v0.4.2 |
 | **P2** | Fold `djust-auth` + `djust-tenants` into core ([ADR-007](docs/adr/007-package-taxonomy-and-consolidation.md) Phase 1) | Eliminate theoretical-audience package fragmentation; extras pattern + compat shim | v0.5.0 |
 | **P2** | Fold `djust-theming` into core ([ADR-007](docs/adr/007-package-taxonomy-and-consolidation.md) Phase 2) | Unified CSS/theming story with core; compat shim for plain-Django users | v0.5.1 |
 | **P2** | Fold `djust-components` into core ([ADR-007](docs/adr/007-package-taxonomy-and-consolidation.md) Phase 3) | Largest fold — 64K LOC — dedicated release window in v0.5.2 | v0.5.2 |

--- a/python/djust/mixins/rust_bridge.py
+++ b/python/djust/mixins/rust_bridge.py
@@ -84,6 +84,30 @@ def _collect_safe_keys(
     return safe_keys
 
 
+def _collect_sub_ids(value, collected, visited=None, depth=0):
+    """Collect id() of all objects reachable from *value* (dicts, lists, tuples).
+
+    Used by ``_sync_state_to_rust`` to detect derived context variables that
+    share an inner object with a changed instance attribute.  Depth-capped at
+    8 and cycle-safe via a *visited* set.
+    """
+    if depth > 8:
+        return
+    if visited is None:
+        visited = set()
+    value_id = id(value)
+    if value_id in visited:
+        return
+    visited.add(value_id)
+    collected.add(value_id)
+    if isinstance(value, dict):
+        for v in value.values():
+            _collect_sub_ids(v, collected, visited, depth + 1)
+    elif isinstance(value, (list, tuple)):
+        for v in value:
+            _collect_sub_ids(v, collected, visited, depth + 1)
+
+
 class RustBridgeMixin:
     """Rust integration: _initialize_rust_view, _sync_state_to_rust."""
 
@@ -248,6 +272,15 @@ class RustBridgeMixin:
 
             # Determine which context to send to Rust
             if prev_refs:
+                # Collect sub-object ids from changed values so derived context
+                # vars that share an inner object are detected (see #703).
+                changed_sub_ids = set()
+                if changed_keys:
+                    for key in changed_keys:
+                        val = full_context.get(key)
+                        if val is not None:
+                            _collect_sub_ids(val, changed_sub_ids)
+
                 # Incremental: only send values that actually changed
                 context = {}
                 for key, value in full_context.items():
@@ -259,6 +292,8 @@ class RustBridgeMixin:
                         context[key] = value  # TypedState with dirty flag
                     elif id(value) != prev_refs.get(key):
                         context[key] = value  # different object reference
+                    elif changed_sub_ids and id(value) in changed_sub_ids:
+                        context[key] = value  # sub-object of a changed value (#703)
                     # else: unchanged — Rust already has it
             else:
                 # First render: send everything

--- a/python/tests/test_changed_tracking.py
+++ b/python/tests/test_changed_tracking.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 from django.test import RequestFactory
 
 from djust import LiveView
+from djust.mixins.rust_bridge import _collect_sub_ids
 from djust.websocket import _snapshot_assigns, _compute_changed_keys
 
 
@@ -381,3 +382,182 @@ class TestContextAlwaysComplete:
         for key in ("a", "b", "c"):
             assert key in ctx1
             assert key in ctx2
+
+
+# ---------------------------------------------------------------------------
+# _collect_sub_ids helper
+# ---------------------------------------------------------------------------
+
+
+class TestCollectSubIds:
+    """Unit tests for the _collect_sub_ids helper."""
+
+    def test_flat_dict(self):
+        """Collects id of dict and its values."""
+        inner = {"a": 1}
+        d = {"key": inner}
+        collected = set()
+        _collect_sub_ids(d, collected)
+        assert id(d) in collected
+        assert id(inner) in collected
+
+    def test_nested_list(self):
+        """Collects ids through lists."""
+        inner = [1, 2]
+        outer = {"items": inner}
+        collected = set()
+        _collect_sub_ids(outer, collected)
+        assert id(inner) in collected
+
+    def test_circular_reference_does_not_hang(self):
+        """Self-referencing dict terminates without error."""
+        d = {}
+        d["self"] = d
+        collected = set()
+        _collect_sub_ids(d, collected)  # should not hang
+        assert id(d) in collected
+
+    def test_depth_limit_respected(self):
+        """Nesting deeper than 8 levels is not traversed."""
+        # Build a chain of 12 nested dicts
+        leaf = {"leaf": True}
+        current = leaf
+        for _ in range(12):
+            current = {"child": current}
+
+        collected = set()
+        _collect_sub_ids(current, collected)
+        # The leaf at depth 13 should NOT be collected (depth cap is 8)
+        assert id(leaf) not in collected
+
+    def test_empty_value(self):
+        """Non-container scalar doesn't recurse but is collected."""
+        collected = set()
+        _collect_sub_ids(42, collected)
+        assert id(42) in collected
+
+
+# ---------------------------------------------------------------------------
+# Derived context sub-object sync (#703)
+# ---------------------------------------------------------------------------
+
+
+class DerivedContextView(LiveView):
+    """View that exposes a sub-object of a mutated dict as a derived context var."""
+
+    template = "<div dj-root>{{ person_data.first_name }}</div>"
+
+    def mount(self, request, **kwargs):
+        self.wizard_step_data = {}
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Returns the same inner dict object — same id() — on every call
+        context["person_data"] = self.wizard_step_data.get("person", {})
+        return context
+
+
+class DerivedListView(LiveView):
+    """View that exposes a list element sub-object as a derived context var."""
+
+    template = "<div dj-root>{{ first_item.name }}</div>"
+
+    def mount(self, request, **kwargs):
+        self.items = [{"name": "original"}]
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["first_item"] = self.items[0] if self.items else {}
+        return context
+
+
+class TestDerivedContextSubObjectSync:
+    """Test that derived context vars sharing sub-objects with changed attrs are synced."""
+
+    def test_derived_dict_synced_when_parent_mutated_in_place(self, mock_request):
+        """Core bug: person_data shares an inner dict with wizard_step_data."""
+        view = DerivedContextView()
+        view.mount(mock_request)
+
+        mock_rust = Mock()
+        view._rust_view = mock_rust
+
+        # First render — sends everything
+        view._sync_state_to_rust()
+
+        # Simulate in-place mutation (like a form validation handler)
+        view.wizard_step_data["person"] = {"first_name": "Alice"}
+        view._changed_keys = {"wizard_step_data"}
+
+        view._sync_state_to_rust()
+        second_call = mock_rust.update_state.call_args[0][0]
+
+        # Both the parent AND the derived var must be synced
+        assert "wizard_step_data" in second_call
+        assert "person_data" in second_call
+
+    def test_derived_list_element_synced_when_parent_mutated(self, mock_request):
+        """List element sub-object synced when parent list item is mutated."""
+        view = DerivedListView()
+        view.mount(mock_request)
+
+        mock_rust = Mock()
+        view._rust_view = mock_rust
+
+        # First render
+        view._sync_state_to_rust()
+
+        # Mutate the inner dict in-place
+        view.items[0]["name"] = "updated"
+        view._changed_keys = {"items"}
+
+        view._sync_state_to_rust()
+        second_call = mock_rust.update_state.call_args[0][0]
+
+        assert "items" in second_call
+        assert "first_item" in second_call
+
+    def test_no_overhead_when_changed_keys_empty(self, mock_request):
+        """When _changed_keys is None/empty, changed_sub_ids stays empty — no extra work.
+
+        We use CounterView (immutable int state) to avoid the dict id() instability
+        that mutable containers introduce through normalize_django_value.
+        """
+        view = CounterView()
+        view.mount(mock_request)
+
+        mock_rust = Mock()
+        view._rust_view = mock_rust
+
+        # First render
+        view._sync_state_to_rust()
+
+        # No changes — simulate a server push with no _changed_keys
+        view._changed_keys = None
+        view._sync_state_to_rust()
+        second_call = mock_rust.update_state.call_args[0][0]
+
+        # count is an int (immutable, same id) — should not be sent
+        assert "count" not in second_call
+
+    def test_unchanged_parent_does_not_cascade(self, mock_request):
+        """When parent is NOT in _changed_keys, derived var is not force-synced."""
+        view = DerivedContextView()
+        view.mount(mock_request)
+
+        mock_rust = Mock()
+        view._rust_view = mock_rust
+
+        # First render
+        view.wizard_step_data["person"] = {"first_name": "Bob"}
+        view._sync_state_to_rust()
+
+        # Mark some other key as changed, not wizard_step_data
+        view._changed_keys = {"some_other_key"}
+        view.some_other_key = "new"
+
+        view._sync_state_to_rust()
+        second_call = mock_rust.update_state.call_args[0][0]
+
+        # person_data should NOT be in second_call since its parent didn't change
+        assert "person_data" not in second_call


### PR DESCRIPTION
## Summary

- **Fixes #703** — derived context vars computed in `get_context_data()` that return sub-objects of a mutated instance attr (same `id()`) were silently skipped by the incremental Rust sync, causing templates to render stale data.
- Adds `_collect_sub_ids()` helper to walk dicts/lists/tuples reachable from changed values and collect their `id()`s. Depth-capped at 8, cycle-safe.
- Adds one new `elif` branch in `_sync_state_to_rust()` that catches context vars whose `id()` matches a sub-object of a changed key.
- 9 new regression tests covering: dict/list sub-object propagation, circular reference safety, depth limit, no-overhead when `_changed_keys` is empty, and unchanged parent does not cascade.

## Test plan

- [x] `pytest python/tests/test_changed_tracking.py -v` — 31/31 pass (9 new)
- [x] `pytest python/ -q` — 2181 passed, 0 failed
- [x] Pre-commit hooks pass (ruff, ruff-format, bandit, detect-secrets)
- [x] Pre-push hooks pass (full test suite)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)