### PR TITLE
fix: v0.4.3 tech-debt round 3

### DIFF
--- a/crates/djust_templates/src/filters.rs
+++ b/crates/djust_templates/src/filters.rs
@@ -645,12 +645,23 @@ fn format_filesize(bytes: i64) -> String {
     }
 }
 
+/// Format a datetime or date string using Django-style format codes.
+///
+/// Supported input formats:
+/// - RFC 3339 datetime: "2026-04-14T12:00:00Z", "2026-04-14T12:00:00+05:00"
+/// - ISO 8601 date only: "2026-04-14" (DateField values — pinned to midnight UTC)
+///
+/// Not yet supported (Django's `|date` filter accepts these in Python):
+/// - Python datetime.date / datetime.datetime objects (handled before Rust via serialization)
+/// - Epoch timestamps as integers
+/// - Locale-specific string formats (e.g., "March 15, 2026")
+///
+/// Note: bare date inputs pinned to midnight UTC will show "00:00" for time format
+/// codes like "H:i". This matches Django's behavior with DateField values.
 fn format_date(datetime_str: &str, format_str: &str) -> Result<String> {
-    // Parse ISO datetime string. Try full datetime first, then fall back
-    // to date-only parsing for DateField values like "2026-03-15" (#719).
     let dt = DateTime::parse_from_rfc3339(datetime_str)
         .or_else(|_| {
-            // Try date-only: "2026-03-15" → midnight UTC
+            // Try date-only: "2026-03-15" → midnight UTC (#719)
             chrono::NaiveDate::parse_from_str(datetime_str.trim(), "%Y-%m-%d")
                 .map(|d| d.and_hms_opt(0, 0, 0).unwrap().and_utc().fixed_offset())
         })
@@ -1730,6 +1741,27 @@ mod tests {
 
         let result = apply_filter("date", &value, Some("F j")).unwrap();
         assert_eq!(result.to_string(), "March 15");
+    }
+
+    #[test]
+    fn test_date_filter_invalid_input() {
+        // #725: Invalid date strings return original value (Django convention),
+        // not an error. The date filter gracefully degrades.
+        let invalid_date = Value::String("2026-13-45".to_string());
+        let result = apply_filter("date", &invalid_date, Some("Y-m-d")).unwrap();
+        assert_eq!(result.to_string(), "2026-13-45");
+
+        let not_a_date = Value::String("not-a-date".to_string());
+        let result = apply_filter("date", &not_a_date, Some("Y-m-d")).unwrap();
+        assert_eq!(result.to_string(), "not-a-date");
+
+        let empty = Value::String("".to_string());
+        let result = apply_filter("date", &empty, Some("Y-m-d")).unwrap();
+        assert_eq!(result.to_string(), "");
+
+        let partial = Value::String("2026-03".to_string());
+        let result = apply_filter("date", &partial, Some("Y-m-d")).unwrap();
+        assert_eq!(result.to_string(), "2026-03");
     }
 
     #[test]

--- a/crates/djust_templates/src/renderer.rs
+++ b/crates/djust_templates/src/renderer.rs
@@ -367,11 +367,7 @@ fn render_node_with_loader<L: TemplateLoader>(
 
             match token {
                 Some(t) => {
-                    let escaped = t
-                        .replace('&', "&amp;")
-                        .replace('"', "&quot;")
-                        .replace('<', "&lt;")
-                        .replace('>', "&gt;");
+                    let escaped = filters::html_escape(&t);
                     Ok(format!(
                         "<input type=\"hidden\" name=\"csrfmiddlewaretoken\" value=\"{escaped}\">"
                     ))

--- a/python/djust/mixins/request.py
+++ b/python/djust/mixins/request.py
@@ -5,6 +5,7 @@ RequestMixin - HTTP GET/POST request handling for LiveView.
 import json
 import logging
 import time
+from contextlib import contextmanager
 
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.utils.decorators import method_decorator
@@ -25,15 +26,13 @@ logger = logging.getLogger(__name__)
 class RequestMixin:
     """HTTP handling: get, post."""
 
-    from contextlib import contextmanager
-
     @contextmanager
     def _processor_context(self, request):
         """Temporarily inject context processor output as instance attributes.
 
-        Used by both GET and POST paths to ensure auth context (user, perms,
-        messages) is available during template rendering. Cleanup is guaranteed
-        via the context manager pattern. (#717)
+        Used by the POST (HTTP fallback) path to ensure auth context (user,
+        perms, messages) is available during template rendering. Cleanup is
+        guaranteed via the context manager pattern. (#717)
         """
         processor_output = self._apply_context_processors({}, request)
         injected_keys = []


### PR DESCRIPTION
## Summary

Batch of 5 small tech-debt fixes from v0.4.3 code reviews (PRs #720, #721):

- **#722**: Use `filters::html_escape()` for CSRF token in `renderer.rs` instead of manual `.replace()` chain (also adds single-quote escaping)
- **#723**: Move `contextmanager` import from class body to module level in `request.py`
- **#724**: Fix `_processor_context` docstring — says "POST path" instead of incorrectly claiming "both GET and POST"
- **#725**: Add negative tests for `|date` filter — 4 tests covering invalid dates, non-date strings, empty strings, partial dates
- **#726**: Add doc comment to `format_date()` documenting supported vs unsupported Django date input types

Closes #722, Closes #723, Closes #724, Closes #725, Closes #726

## Test plan

- [x] `cargo test -p djust_templates` — 233 tests pass (including 4 new negative tests)
- [x] `pytest python/tests/test_http_fallback_auth.py python/tests/test_date_format_injection.py` — 8 tests pass
- [x] cargo clippy clean
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)