### PR TITLE
fix: VDOM path traversal skips regular HTML comments

### DIFF
--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -4331,9 +4331,13 @@ function getNodeByPath(path, djustId = null) {
                 // JS \s includes \u00A0, so we use an explicit ASCII whitespace pattern instead.
                 return (/[^ \t\n\r\f]/.test(child.textContent));
             }
-            // Include comment nodes — the Rust VDOM parser preserves <!--dj-if-->
-            // placeholders and counts them when computing child indices (#559).
-            if (child.nodeType === Node.COMMENT_NODE) return true;
+            // Only include <!--dj-if--> placeholder comments — the Rust VDOM
+            // parser preserves these for diffing stability (#559) but drops
+            // all other HTML comments. Regular comments (<!-- Hero Section -->
+            // etc.) must be excluded to keep path indices aligned.
+            if (child.nodeType === Node.COMMENT_NODE) {
+                return child.textContent.trim() === 'dj-if';
+            }
             return false;
         });
 

--- a/python/djust/static/djust/src/12-vdom-patch.js
+++ b/python/djust/static/djust/src/12-vdom-patch.js
@@ -155,9 +155,13 @@ function getNodeByPath(path, djustId = null) {
                 // JS \s includes \u00A0, so we use an explicit ASCII whitespace pattern instead.
                 return (/[^ \t\n\r\f]/.test(child.textContent));
             }
-            // Include comment nodes — the Rust VDOM parser preserves <!--dj-if-->
-            // placeholders and counts them when computing child indices (#559).
-            if (child.nodeType === Node.COMMENT_NODE) return true;
+            // Only include <!--dj-if--> placeholder comments — the Rust VDOM
+            // parser preserves these for diffing stability (#559) but drops
+            // all other HTML comments. Regular comments (<!-- Hero Section -->
+            // etc.) must be excluded to keep path indices aligned.
+            if (child.nodeType === Node.COMMENT_NODE) {
+                return child.textContent.trim() === 'dj-if';
+            }
             return false;
         });
 

--- a/tests/js/vdom_patch_errors.test.js
+++ b/tests/js/vdom_patch_errors.test.js
@@ -203,4 +203,100 @@ describe('VDOM patch error messages', () => {
         const thrownError = errors.find(e => e.includes('Error applying patch'));
         expect(thrownError).toBeUndefined();
     });
+
+    it('skips regular HTML comments in path traversal (only counts dj-if comments)', () => {
+        // Regression test: the Rust VDOM parser drops regular HTML comments
+        // but preserves <!--dj-if--> placeholders. The JS patcher must match
+        // this behavior when computing child indices, otherwise paths computed
+        // by the Rust diff point to wrong nodes.
+        const dom = new JSDOM(
+            '<!DOCTYPE html><html><body>' +
+            '<div dj-root dj-liveview-root dj-view="test.View">' +
+            '<!-- Hero Section -->' +
+            '<section id="hero">Hero</section>' +
+            '<!-- Main Content -->' +
+            '<main id="content"><div id="counter">0</div></main>' +
+            '</div></body></html>',
+            { url: 'http://localhost', runScripts: 'dangerously' }
+        );
+
+        if (!dom.window.CSS) dom.window.CSS = {};
+        if (!dom.window.CSS.escape) {
+            dom.window.CSS.escape = (v) => String(v).replace(/([^\w-])/g, '\\$1');
+        }
+        dom.window.DEBUG_MODE = false;
+        dom.window.console.warn = () => {};
+        dom.window.console.error = () => {};
+        dom.window.console.log = () => {};
+
+        const sentMessages = [];
+        dom.window.WebSocket = class MockWebSocket {
+            constructor() {
+                this.readyState = 1;
+                this._sent = sentMessages;
+                Promise.resolve().then(() => { if (this.onopen) this.onopen({}); });
+            }
+            send(msg) { this._sent.push(JSON.parse(msg)); }
+            close() {}
+        };
+
+        dom.window.eval(clientCode);
+
+        // Rust VDOM sees: [0]=<section>, [1]=<main> (comments dropped)
+        // Path [1, 0, 0] should reach the text "0" inside #counter
+        const patches = [
+            { type: 'SetText', path: [1, 0, 0], text: '1' }
+        ];
+
+        const result = dom.window.applyPatches(patches);
+        expect(result).toBe(true);
+
+        const counter = dom.window.document.getElementById('counter');
+        expect(counter.textContent).toBe('1');
+    });
+
+    it('still counts dj-if placeholder comments in path traversal', () => {
+        const dom = new JSDOM(
+            '<!DOCTYPE html><html><body>' +
+            '<div dj-root dj-liveview-root dj-view="test.View">' +
+            '<!--dj-if-->' +
+            '<p id="visible">shown</p>' +
+            '</div></body></html>',
+            { url: 'http://localhost', runScripts: 'dangerously' }
+        );
+
+        if (!dom.window.CSS) dom.window.CSS = {};
+        if (!dom.window.CSS.escape) {
+            dom.window.CSS.escape = (v) => String(v).replace(/([^\w-])/g, '\\$1');
+        }
+        dom.window.DEBUG_MODE = false;
+        dom.window.console.warn = () => {};
+        dom.window.console.error = () => {};
+        dom.window.console.log = () => {};
+
+        const sentMessages = [];
+        dom.window.WebSocket = class MockWebSocket {
+            constructor() {
+                this.readyState = 1;
+                this._sent = sentMessages;
+                Promise.resolve().then(() => { if (this.onopen) this.onopen({}); });
+            }
+            send(msg) { this._sent.push(JSON.parse(msg)); }
+            close() {}
+        };
+
+        dom.window.eval(clientCode);
+
+        // <!--dj-if--> counts as child [0], <p> is child [1]
+        // Path [1, 0] should reach the text "shown" inside <p>
+        const patches = [
+            { type: 'SetText', path: [1, 0], text: 'updated' }
+        ];
+
+        const result = dom.window.applyPatches(patches);
+        expect(result).toBe(true);
+
+        const p = dom.window.document.getElementById('visible');
+        expect(p.textContent).toBe('updated');
+    });
 });


### PR DESCRIPTION
Fixes #729

## Summary

- VDOM path-based node traversal was counting ALL HTML comment nodes as children, but the Rust VDOM parser only preserves `<!--dj-if-->` placeholder comments — regular comments like `<!-- Hero Section -->` are dropped
- This caused path index misalignment: Rust computes path `[1]` meaning "second significant child" but the browser's `childNodes` filter included regular comments, making `[1]` point to a comment node instead of the expected element
- The djust.org `/examples/` page counter increment failed with `SetText: node not found at path=1/0/1/0/1/0/0/0/0/0` because the template has `<!-- Hero Section -->` and `<!-- Main Content -->` comments as direct children of `dj-root`

**Fix**: Change the comment node filter in `getNodeByPath()` from `return true` (all comments) to `return child.textContent.trim() === 'dj-if'` (only framework placeholders), matching the Rust parser's behavior.

## Test plan

- [x] 1,126 JS tests pass (1,124 existing + 2 new)
- [x] New test: regular HTML comments skipped in path traversal
- [x] New test: `<!--dj-if-->` placeholder comments still counted
- [x] Verified on live djust.org/examples/ that the comment nodes cause the path mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)