### PR TITLE
perf: event delegation — eliminate post-patch DOM scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **VDOM patch path traversal skips regular HTML comments ([#729](https://github.com/djust-org/djust/issues/729))** — The JS patcher was counting all HTML comment nodes during path traversal, but the Rust VDOM parser only preserves `<!--dj-if-->` placeholders. This caused every page with HTML comments in `dj-root` to fail VDOM patching and fall back to full HTML recovery.
+
+- **Scroll to top on `dj-navigate` live_redirect** — `handleLiveRedirect()` now scrolls to the top of the page (or to anchor if URL has a hash) after `pushState`.
+
+### Changed
+
+- **Event delegation replaces per-element binding ([#730](https://github.com/djust-org/djust/issues/730))** — `bindLiveViewEvents()` no longer scans the DOM after every VDOM patch. Instead, one listener per event type is installed on the `dj-root` element via delegation (`e.target.closest('[dj-click]')`). This reduces client-side post-patch handling from ~56ms to ~30ms on large pages. Per-element rate limiting preserved via WeakMap.
+
+### Added
+
+- **Per-phase Rust timing in `render_with_diff()` ([#730](https://github.com/djust-org/djust/issues/730))** — Instrumentation measuring template render, html5ever parse, VDOM diff, and HTML serialization. Exposed to Python via `get_render_timing()` and propagated to WebSocket response performance metadata.
+
 ## [0.4.3] - 2026-04-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "0.4.3-rc.1"
+version = "0.4.3"
 dependencies = [
  "ahash",
  "criterion",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "0.4.3-rc.1"
+version = "0.4.3"
 dependencies = [
  "ahash",
  "criterion",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "0.4.3-rc.1"
+version = "0.4.3"
 dependencies = [
  "bincode",
  "criterion",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "0.4.3-rc.1"
+version = "0.4.3"
 dependencies = [
  "ahash",
  "chrono",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "0.4.3-rc.1"
+version = "0.4.3"
 dependencies = [
  "ahash",
  "criterion",

--- a/crates/djust_live/src/lib.rs
+++ b/crates/djust_live/src/lib.rs
@@ -72,6 +72,17 @@ struct SerializableViewState {
     timestamp: f64, // Unix timestamp for session age tracking
 }
 
+/// Per-phase timing from render_with_diff()
+#[derive(Debug, Clone)]
+struct RenderTiming {
+    render_ms: f64,
+    parse_ms: f64,
+    diff_ms: f64,
+    serialize_ms: f64,
+    total_ms: f64,
+    html_len: usize,
+}
+
 /// A LiveView component that manages state and rendering (Rust backend)
 #[pyclass(name = "RustLiveView")]
 pub struct RustLiveViewBackend {
@@ -86,6 +97,8 @@ pub struct RustLiveViewBackend {
     template_dirs: Vec<PathBuf>,
     /// Keys whose values should skip auto-escaping (SafeString from Python)
     safe_keys: HashSet<String>,
+    /// Per-phase timing from the last render_with_diff() call
+    last_render_timing: Option<RenderTiming>,
 }
 
 #[pymethods]
@@ -105,6 +118,7 @@ impl RustLiveViewBackend {
                 .map(PathBuf::from)
                 .collect(),
             safe_keys: HashSet::new(),
+            last_render_timing: None,
         }
     }
 
@@ -170,6 +184,10 @@ impl RustLiveViewBackend {
     /// Render and compute diff from last render
     /// Returns a tuple of (html, patches_json, version)
     fn render_with_diff(&mut self) -> PyResult<(String, Option<String>, u64)> {
+        use std::time::Instant;
+
+        let t_start = Instant::now();
+
         // Get template from cache or parse and cache it
         let template_arc = if let Some(cached) = TEMPLATE_CACHE.get(&self.template_source) {
             cached.clone()
@@ -185,19 +203,24 @@ impl RustLiveViewBackend {
             context.mark_safe(key.clone());
         }
 
-        // Use template loader for {% include %} support
+        // Phase 1: Template render
+        let t_render_start = Instant::now();
         let loader = FilesystemTemplateLoader::new(self.template_dirs.clone());
         let html = template_arc.render_with_loader(&context, &loader)?;
+        let render_ms = t_render_start.elapsed().as_secs_f64() * 1000.0;
 
-        // Parse new HTML to VDOM
+        // Phase 2: HTML parse to VDOM
+        let t_parse_start = Instant::now();
         let mut new_vdom = if self.last_vdom.is_some() {
             parse_html_continue(&html)
         } else {
             parse_html(&html)
         }
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        let parse_ms = t_parse_start.elapsed().as_secs_f64() * 1000.0;
 
-        // Compute diff if we have a previous render
+        // Phase 3: VDOM diff
+        let t_diff_start = Instant::now();
         let patches =
             if let Some(old_vdom) = &self.last_vdom {
                 let patches = diff(old_vdom, &new_vdom);
@@ -212,9 +235,24 @@ impl RustLiveViewBackend {
             } else {
                 None
             };
+        let diff_ms = t_diff_start.elapsed().as_secs_f64() * 1000.0;
 
-        // Serialize VDOM back to HTML with dj-id attributes
+        // Phase 4: HTML serialization
+        let t_serial_start = Instant::now();
         let hydrated_html = new_vdom.to_html();
+        let serialize_ms = t_serial_start.elapsed().as_secs_f64() * 1000.0;
+
+        let total_ms = t_start.elapsed().as_secs_f64() * 1000.0;
+
+        // Store timing for Python to read
+        self.last_render_timing = Some(RenderTiming {
+            render_ms,
+            parse_ms,
+            diff_ms,
+            serialize_ms,
+            total_ms,
+            html_len: html.len(),
+        });
 
         self.last_vdom = Some(new_vdom);
         self.version += 1;
@@ -224,6 +262,10 @@ impl RustLiveViewBackend {
 
     /// Render and return patches as MessagePack bytes
     fn render_binary_diff(&mut self, py: Python) -> PyResult<(String, Option<PyObject>, u64)> {
+        use std::time::Instant;
+
+        let t_start = Instant::now();
+
         // Get template from cache or parse and cache it
         let template_arc = if let Some(cached) = TEMPLATE_CACHE.get(&self.template_source) {
             cached.clone()
@@ -239,41 +281,57 @@ impl RustLiveViewBackend {
             context.mark_safe(key.clone());
         }
 
-        // Use template loader for {% include %} support
+        // Phase 1: Template render
+        let t_render_start = Instant::now();
         let loader = FilesystemTemplateLoader::new(self.template_dirs.clone());
         let html = template_arc.render_with_loader(&context, &loader)?;
+        let render_ms = t_render_start.elapsed().as_secs_f64() * 1000.0;
 
-        // IMPORTANT: Use parse_html_continue() for subsequent renders to avoid ID collisions
+        // Phase 2: HTML parse to VDOM
+        let t_parse_start = Instant::now();
         let mut new_vdom = if self.last_vdom.is_some() {
             parse_html_continue(&html)
         } else {
             parse_html(&html)
         }
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        let parse_ms = t_parse_start.elapsed().as_secs_f64() * 1000.0;
 
+        // Phase 3: VDOM diff
+        let t_diff_start = Instant::now();
         let patches_bytes = if let Some(old_vdom) = &self.last_vdom {
             let patches = diff(old_vdom, &new_vdom);
-            // Sync old IDs to matched new VDOM elements (see render_with_diff)
             sync_ids(old_vdom, &mut new_vdom);
             if !patches.is_empty() {
                 let bytes = rmp_serde::to_vec(&patches)
                     .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
                 Some(PyBytes::new(py, &bytes).into())
             } else {
-                // 0-change diff: return empty msgpack array so Python can
-                // distinguish "no changes" from "first render" (which is None).
                 let empty: Vec<djust_vdom::Patch> = Vec::new();
                 let bytes = rmp_serde::to_vec(&empty)
                     .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
                 Some(PyBytes::new(py, &bytes).into())
             }
         } else {
-            // First render — no previous VDOM to diff against
             None
         };
+        let diff_ms = t_diff_start.elapsed().as_secs_f64() * 1000.0;
 
-        // Serialize VDOM back to HTML with dj-id attributes for reliable patch targeting
+        // Phase 4: HTML serialization
+        let t_serial_start = Instant::now();
         let hydrated_html = new_vdom.to_html();
+        let serialize_ms = t_serial_start.elapsed().as_secs_f64() * 1000.0;
+
+        let total_ms = t_start.elapsed().as_secs_f64() * 1000.0;
+
+        self.last_render_timing = Some(RenderTiming {
+            render_ms,
+            parse_ms,
+            diff_ms,
+            serialize_ms,
+            total_ms,
+            html_len: html.len(),
+        });
 
         self.last_vdom = Some(new_vdom);
         self.version += 1;
@@ -348,6 +406,22 @@ impl RustLiveViewBackend {
             timestamp: serializable.timestamp,
             template_dirs: Vec::new(),
             safe_keys: HashSet::new(),
+            last_render_timing: None,
+        })
+    }
+
+    /// Get per-phase timing from the last render_with_diff() call.
+    /// Returns a dict with render_ms, parse_ms, diff_ms, serialize_ms, total_ms, html_len.
+    fn get_render_timing(&self) -> Option<HashMap<String, f64>> {
+        self.last_render_timing.as_ref().map(|t| {
+            let mut m = HashMap::new();
+            m.insert("render_ms".to_string(), t.render_ms);
+            m.insert("parse_ms".to_string(), t.parse_ms);
+            m.insert("diff_ms".to_string(), t.diff_ms);
+            m.insert("serialize_ms".to_string(), t.serialize_ms);
+            m.insert("total_ms".to_string(), t.total_ms);
+            m.insert("html_len".to_string(), t.html_len as f64);
+            m
         })
     }
 

--- a/docs/performance/2026-04-15-vdom-patch-perf.md
+++ b/docs/performance/2026-04-15-vdom-patch-perf.md
@@ -1,0 +1,170 @@
+# VDOM Patch Performance Investigation (2026-04-15)
+
+## Problem
+
+On the djust.org `/examples/` page (974-line template, 17 demo sections, 304KB rendered HTML), clicking the "Increment" button on the counter demo took **~250ms** end-to-end. The counter also failed on the first click, falling back to full HTML recovery.
+
+Two issues were identified:
+
+1. **VDOM patch failure**: The Rust VDOM parser drops regular HTML comments (`<!-- Hero Section -->`) from the tree, but the JS patcher was counting them during path traversal, causing index misalignment. Every patch failed and triggered full HTML recovery.
+
+2. **Slow post-patch DOM scanning**: After every patch, `bindLiveViewEvents()` scanned the entire DOM with `querySelectorAll('*')` to find and bind `dj-*` interactive elements — O(all_elements) per update on a page with 5000+ nodes.
+
+## Investigation
+
+### Profiling methodology
+
+Added `Instant::now()` timing instrumentation to `render_with_diff()` in `crates/djust_live/src/lib.rs`, measuring four phases:
+- Template render (`render_with_loader`)
+- HTML parse (html5ever `parse_html_continue`)
+- VDOM diff + `sync_ids`
+- HTML serialization (`to_html`)
+
+Timings are exposed to Python via `get_render_timing()` and propagated to the WebSocket response `performance` metadata, visible in the browser console.
+
+Client-side timing measured via WebSocket `send`/`onmessage` instrumentation in the browser.
+
+### Server-side breakdown (Rust)
+
+| Phase | Time | % of Rust total |
+|-------|------|-----------------|
+| Template render | 1.0ms | 5% |
+| **html5ever parse** | **16.0ms** | **73%** |
+| VDOM diff | 0.4ms | 2% |
+| HTML serialize | 4.0ms | 18% |
+| **Rust total** | **22ms** | |
+
+Key insight: The VDOM diff itself is fast (0.4ms). The bottleneck is html5ever parsing 304KB of HTML on every event, even when only one text node changed. Template rendering and diffing are negligible.
+
+### Client-side breakdown (before optimization)
+
+| Phase | Time |
+|-------|------|
+| `bindLiveViewEvents()` DOM scan | ~25ms |
+| `updateHooks()` + `bindModelElements()` | ~15ms |
+| Patch application | ~5ms |
+| Focus save/restore | ~5ms |
+| Other (loading manager, scroll) | ~6ms |
+| **Client total** | **~56ms** |
+
+## Fixes
+
+### PR #728: VDOM comment node path fix
+
+**Root cause**: `getNodeByPath()` in `12-vdom-patch.js` included ALL comment nodes when filtering children for path traversal (line 160: `if (child.nodeType === Node.COMMENT_NODE) return true`). The Rust VDOM parser only preserves `<!--dj-if-->` placeholder comments — all other HTML comments are dropped (`parser.rs:381`).
+
+**Fix**: Changed the comment filter to only count `dj-if` placeholders:
+```js
+if (child.nodeType === Node.COMMENT_NODE) {
+    return child.textContent.trim() === 'dj-if';
+}
+```
+
+**Impact**: Patches work correctly on any page with HTML comments. Previously, every page with comments in `dj-root` had broken VDOM patching and fell back to full HTML recovery.
+
+### PR #731: Event delegation + instrumentation
+
+Three changes:
+
+#### 1. Rust timing instrumentation
+
+Added per-phase `Instant::now()` measurements to `render_with_diff()` and `render_binary_diff()` in `crates/djust_live/src/lib.rs`. Exposed via `get_render_timing()` Python method and WebSocket `performance.timing` metadata.
+
+#### 2. Event delegation
+
+Replaced per-element event binding with event delegation. Instead of scanning the DOM after every VDOM patch to find and bind `dj-*` elements, install ONE listener per event type on the `dj-root` element at startup.
+
+**Delegated events** (via `e.target.closest()`):
+- click (`dj-click`, `dj-copy`)
+- submit (`dj-submit`)
+- change (`dj-change`)
+- input (`dj-input` — per-element rate limiting via WeakMap)
+- keydown/keyup (`dj-keydown`, `dj-keyup`)
+- paste (`dj-paste`)
+- focusin/focusout (`dj-focus`, `dj-blur`)
+
+**Still per-element** (non-delegable):
+- `dj-poll` (custom interval timer)
+- `dj-mounted` (fire-once lifecycle)
+- `dj-window-*`/`dj-document-*`, `dj-click-away`, `dj-shortcut` (already delegated)
+
+**Teardown**: Uses `AbortController` to cleanly remove old listeners before reinstalling after TurboNav navigation.
+
+**Body guard**: Delegation only installs on `[dj-view]`/`[dj-root]` elements, never on `document.body` fallback. This prevents double events when navigating from a non-LiveView page back to a LiveView page via TurboNav (body persists across page swaps).
+
+#### 3. Targeted CSS selectors (intermediate step, superseded by delegation)
+
+Replaced `querySelectorAll('*')` with targeted attribute selectors for the remaining per-element scanning (scoped listeners, poll, mounted). This only affects the non-delegated events.
+
+## Results
+
+### End-to-end performance (djust.org /examples/ counter, localhost, 20 samples)
+
+| Metric | Before | After | Improvement |
+|--------|--------|-------|-------------|
+| **Total E2E (avg)** | **250ms** | **71ms** | **3.5x** |
+| Total E2E (p50) | — | 76ms | — |
+| Total E2E (p95) | — | 82ms | — |
+| E2E range | 45–250ms | 70–84ms | **17x tighter** |
+| Server total | 177ms* | 34ms | 5.2x |
+| Client handling | 56ms | 30ms | 1.9x |
+
+*The 177ms "before" measurement included cold-start overhead. Stable server time was ~50ms before optimization, reduced to 34ms after.
+
+### Server-side breakdown (after)
+
+| Phase | Time |
+|-------|------|
+| Handler (`self.count += 1`) | 0.5ms |
+| Python context prep | 0.5ms |
+| Rust render+parse+diff+serialize | 22ms |
+| Python overhead (serialization, sync_to_async) | ~12ms |
+| **Server total** | **34ms** |
+
+### Client-side breakdown (after)
+
+| Phase | Time |
+|-------|------|
+| Patch application | ~5ms |
+| Post-patch hooks/model/loading scans | ~15ms |
+| Focus save/restore | ~5ms |
+| Other | ~5ms |
+| **Client total** | **~30ms** |
+
+The `bindLiveViewEvents()` DOM scan cost dropped from ~25ms to ~0ms (delegation = no scanning).
+
+## Remaining optimization targets
+
+For further improvement beyond 71ms:
+
+| Target | Current cost | Potential savings | Complexity |
+|--------|-------------|-------------------|------------|
+| html5ever parse (skip `dj-update="ignore"` sections) | 16ms | ~8ms | Medium |
+| HTML serialize (skip unchanged subtrees) | 4ms | ~2ms | Medium |
+| Python context serialization | 12ms | ~5ms | Low |
+| Post-patch hook/model scanning | 15ms | ~10ms | Medium |
+| **Total potential** | | **~25ms** | |
+
+Target achievable E2E: **~45ms** (from current 71ms).
+
+## Files modified
+
+### PR #728
+- `python/djust/static/djust/src/12-vdom-patch.js` — Comment node filter fix
+- `python/djust/static/djust/client.js` — Rebuilt
+- `tests/js/vdom_patch_errors.test.js` — 2 new regression tests
+
+### PR #731
+- `crates/djust_live/src/lib.rs` — Rust timing instrumentation
+- `python/djust/mixins/template.py` — Capture `_rust_render_timing`
+- `python/djust/websocket.py` — Propagate `rust_timing` to response metadata
+- `python/djust/static/djust/src/09-event-binding.js` — Event delegation refactor
+- `python/djust/static/djust/client.js` — Rebuilt
+- `tests/js/double_bind.test.js` — Updated for delegation model
+- `tests/js/event-listener-dedup.test.js` — Updated for delegation model
+- `tests/js/dj-copy.test.js` — Updated for delegation model
+
+## Issues
+
+- #729 — VDOM patch fails on pages with HTML comments in templates
+- #730 — VDOM render+diff takes 176ms for single-variable change on large templates

--- a/python/djust/mixins/template.py
+++ b/python/djust/mixins/template.py
@@ -541,6 +541,9 @@ Object.assign(window.handlerMetadata, {json.dumps(metadata)});
         result = self._rust_view.render_with_diff()
         html, patches_json, version = result
 
+        # Capture per-phase Rust timing (render, parse, diff, serialize)
+        self._rust_render_timing = self._rust_view.get_render_timing()
+
         logger.debug(
             "[LiveView] Rendered HTML length: %d chars, starts with: %s...",
             len(html),

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -7222,6 +7222,17 @@ window.djust.getActiveStreams = getActiveStreams;
         const method = data.replace ? 'replaceState' : 'pushState';
         window.history[method]({ djust: true, redirect: true }, '', newUrl.toString());
 
+        // Scroll to top on navigation (or to anchor if present)
+        var hash = newUrl.hash;
+        if (hash) {
+            var target = document.querySelector(hash);
+            if (target) {
+                target.scrollIntoView({ behavior: 'instant' });
+            }
+        } else {
+            window.scrollTo({ top: 0, behavior: 'instant' });
+        }
+
         // Clear the prefetch set so links on the new view are re-eligible for prefetching
         window.djust._prefetch?.clear();
 

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -3288,15 +3288,27 @@ async function _handleDjKeyboard(element, e, eventType) {
 
 /**
  * Install ONE delegated listener per DOM event type on the given root element.
- * Idempotent — checks root._djustDelegated to avoid double-installing.
+ * Idempotent — uses AbortController to tear down old listeners before
+ * installing new ones, preventing double-firing after TurboNav navigation.
  * @param {HTMLElement} root - The LiveView root element to delegate from
  */
 function installDelegatedListeners(root) {
-    if (root._djustDelegated) return;
-    root._djustDelegated = true;
+    // Tear down previous delegated listeners (if any) to prevent double-firing
+    // after TurboNav morphs the page content while preserving the root element.
+    if (root._djustDelegateAbort) {
+        root._djustDelegateAbort.abort();
+    }
+    var controller = new AbortController();
+    root._djustDelegateAbort = controller;
+    var opts = { signal: controller.signal };
+
+    // Helper: addEventListener with abort signal for clean teardown
+    function on(event, handler) {
+        root.addEventListener(event, handler, opts);
+    }
 
     // click → dj-copy (client-only) first, then dj-click
-    root.addEventListener('click', function(e) {
+    on('click', function(e) {
         var copyEl = e.target.closest('[dj-copy]');
         if (copyEl) {
             _handleDjCopy(copyEl, e);
@@ -3312,7 +3324,7 @@ function installDelegatedListeners(root) {
     });
 
     // submit → dj-submit
-    root.addEventListener('submit', function(e) {
+    on('submit', function(e) {
         var submitEl = e.target.closest('[dj-submit]');
         if (submitEl) {
             _handleDjSubmit(submitEl, e);
@@ -3320,7 +3332,7 @@ function installDelegatedListeners(root) {
     });
 
     // change → dj-change
-    root.addEventListener('change', function(e) {
+    on('change', function(e) {
         var changeEl = e.target.closest('[dj-change]');
         if (changeEl) {
             // Rate-limit per element using WeakMap
@@ -3331,7 +3343,7 @@ function installDelegatedListeners(root) {
     });
 
     // input → dj-input (with smart rate limiting)
-    root.addEventListener('input', function(e) {
+    on('input', function(e) {
         var inputEl = e.target.closest('[dj-input]');
         if (inputEl) {
             // Get or create rate-limited wrapper for this element
@@ -3393,7 +3405,7 @@ function installDelegatedListeners(root) {
     });
 
     // keydown → dj-keydown
-    root.addEventListener('keydown', function(e) {
+    on('keydown', function(e) {
         var keyEl = e.target.closest('[dj-keydown]');
         if (keyEl) {
             var rawHandler = function(ev) { return _handleDjKeyboard(keyEl, ev, 'keydown'); };
@@ -3403,7 +3415,7 @@ function installDelegatedListeners(root) {
     });
 
     // keyup → dj-keyup
-    root.addEventListener('keyup', function(e) {
+    on('keyup', function(e) {
         var keyEl = e.target.closest('[dj-keyup]');
         if (keyEl) {
             var rawHandler = function(ev) { return _handleDjKeyboard(keyEl, ev, 'keyup'); };
@@ -3423,7 +3435,7 @@ function installDelegatedListeners(root) {
     });
 
     // paste → dj-paste
-    root.addEventListener('paste', function(e) {
+    on('paste', function(e) {
         var pasteEl = e.target.closest('[dj-paste]');
         if (pasteEl) {
             _handleDjPaste(pasteEl, e);
@@ -3431,7 +3443,7 @@ function installDelegatedListeners(root) {
     });
 
     // focusin → dj-focus (focusin bubbles, focus doesn't)
-    root.addEventListener('focusin', function(e) {
+    on('focusin', function(e) {
         var focusEl = e.target.closest('[dj-focus]');
         if (focusEl) {
             _handleDjFocus(focusEl, e);
@@ -3439,7 +3451,7 @@ function installDelegatedListeners(root) {
     });
 
     // focusout → dj-blur (focusout bubbles, blur doesn't)
-    root.addEventListener('focusout', function(e) {
+    on('focusout', function(e) {
         var blurEl = e.target.closest('[dj-blur]');
         if (blurEl) {
             _handleDjBlur(blurEl, e);

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -4331,9 +4331,13 @@ function getNodeByPath(path, djustId = null) {
                 // JS \s includes \u00A0, so we use an explicit ASCII whitespace pattern instead.
                 return (/[^ \t\n\r\f]/.test(child.textContent));
             }
-            // Include comment nodes — the Rust VDOM parser preserves <!--dj-if-->
-            // placeholders and counts them when computing child indices (#559).
-            if (child.nodeType === Node.COMMENT_NODE) return true;
+            // Only include <!--dj-if--> placeholder comments — the Rust VDOM
+            // parser preserves these for diffing stability (#559) but drops
+            // all other HTML comments. Regular comments (<!-- Hero Section -->
+            // etc.) must be excluded to keep path indices aligned.
+            if (child.nodeType === Node.COMMENT_NODE) {
+                return child.textContent.trim() === 'dj-if';
+            }
             return false;
         });
 

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -2799,19 +2799,27 @@ function _applyDisableWith(element) {
     element.disabled = true;
 }
 
-function bindLiveViewEvents() {
+function bindLiveViewEvents(scope) {
+    const root = scope || document;
+
     // Bind upload handlers (dj-upload, dj-upload-drop, dj-upload-preview)
     if (window.djust.uploads) {
-        window.djust.uploads.bindHandlers();
+        window.djust.uploads.bindHandlers(scope);
     }
 
     // Bind navigation directives (dj-patch, dj-navigate)
     if (window.djust.navigation) {
-        window.djust.navigation.bindDirectives();
+        window.djust.navigation.bindDirectives(scope);
     }
 
-    // Find all interactive elements
-    const allElements = document.querySelectorAll('*');
+    // Find interactive elements via targeted attribute selectors instead of
+    // scanning all elements. This is O(interactive) instead of O(all_elements).
+    const djSelector = '[dj-click],[dj-change],[dj-input],[dj-submit],' +
+        '[dj-focus],[dj-blur],[dj-keydown],[dj-keyup],[dj-mouseenter],' +
+        '[dj-mouseleave],[dj-scroll],[dj-mounted],[dj-paste],[dj-poll],' +
+        '[dj-viewport-enter],[dj-viewport-leave],[dj-disable-with],' +
+        '[dj-copy],[dj-click-away],[dj-shortcut],[dj-auto-recover]';
+    const allElements = root.querySelectorAll(djSelector);
     allElements.forEach(element => {
         // Handle dj-click events
         const clickHandler = element.getAttribute('dj-click');
@@ -3358,17 +3366,20 @@ function bindLiveViewEvents() {
     ];
     const scopedEventTypes = ['keydown', 'keyup', 'click', 'scroll', 'resize'];
 
-    // Collect all elements that have any dj-window-* or dj-document-* attributes
-    // by scanning once through allElements (already queried above).
+    // Collect elements with dj-window-*/dj-document-* attributes.
+    // These have dynamic attribute names (e.g. dj-window-keydown.escape)
+    // that CSS selectors can't match, so we scan all elements within root.
+    // This is a small scan since most pages have 0-5 scoped listener elements.
+    const scopedElements = root.querySelectorAll('*');
     for (const { prefix, target } of scopedPrefixes) {
         for (const evtType of scopedEventTypes) {
             // scroll and resize only make sense on window
             if (target === document && (evtType === 'scroll' || evtType === 'resize')) continue;
 
             const attrBase = prefix + evtType;
-            // Scan all elements for attributes starting with this prefix+eventType
+            // Scan elements for attributes starting with this prefix+eventType
             // (covers both exact matches and key-modifier variants like dj-window-keydown.escape)
-            allElements.forEach(element => {
+            scopedElements.forEach(element => {
                 for (const attr of element.attributes) {
                     if (!attr.name.startsWith(attrBase)) continue;
                     const bindType = attr.name; // e.g. 'dj-window-keydown' or 'dj-window-keydown.escape'
@@ -3644,14 +3655,23 @@ function clearOptimisticState(eventName) {
 // will scroll again — correct behavior for newly inserted content.
 const _scrolledElements = new WeakSet();
 
-function reinitAfterDOMUpdate() {
+function reinitAfterDOMUpdate(scope) {
     initReactCounters();
     initTodoItems();
-    bindLiveViewEvents();
+    bindLiveViewEvents(scope);
+    if (window.djust.mountHooks) {
+        // updateHooks scans for [dj-hook] — scope it too
+        const hookRoot = scope || getLiveViewRoot();
+        hookRoot.querySelectorAll('[dj-hook]').forEach(el => {
+            // Delegate to the hook system's per-element logic
+            if (window.djust.mountHooks) window.djust.mountHooks(el);
+        });
+    }
     updateHooks();
 
     // dj-scroll-into-view: auto-scroll elements into view after DOM updates
-    document.querySelectorAll('[dj-scroll-into-view]').forEach(el => {
+    const scrollRoot = scope || document;
+    scrollRoot.querySelectorAll('[dj-scroll-into-view]').forEach(el => {
         if (_scrolledElements.has(el)) return;
         _scrolledElements.add(el);
 

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -2809,7 +2809,8 @@ function _applyDisableWith(element) {
 const _inputRateLimitState = new WeakMap();
 const _changeRateLimitState = new WeakMap();
 const _clickRateLimitState = new WeakMap();
-const _keyboardRateLimitState = new WeakMap();
+const _keydownRateLimitState = new WeakMap();
+const _keyupRateLimitState = new WeakMap();
 
 // Helper: Extract field name from element attributes
 // Priority: data-field (explicit) > name (standard) > id (fallback)
@@ -3409,28 +3410,18 @@ function installDelegatedListeners(root) {
         var keyEl = e.target.closest('[dj-keydown]');
         if (keyEl) {
             var rawHandler = function(ev) { return _handleDjKeyboard(keyEl, ev, 'keydown'); };
-            var wrapped = _getOrCreateRateLimitedHandler(_keyboardRateLimitState, keyEl, 'keydown', rawHandler);
+            var wrapped = _getOrCreateRateLimitedHandler(_keydownRateLimitState, keyEl, 'keydown', rawHandler);
             wrapped(e);
         }
     });
 
-    // keyup → dj-keyup
+    // keyup → dj-keyup (separate WeakMap from keydown to avoid handler collision)
     on('keyup', function(e) {
         var keyEl = e.target.closest('[dj-keyup]');
         if (keyEl) {
             var rawHandler = function(ev) { return _handleDjKeyboard(keyEl, ev, 'keyup'); };
-            // keyup shares the keyboard state map but different element keys won't collide
-            // since WeakMap is keyed by element object
-            var state = _keyboardRateLimitState.get(keyEl);
-            if (!state) {
-                var wrappedKu = _applyRateLimitAttrs(keyEl, rawHandler);
-                if (wrappedKu === rawHandler && window.djust.rateLimit) {
-                    wrappedKu = window.djust.rateLimit.wrapWithRateLimit(keyEl, 'keyup', rawHandler);
-                }
-                _keyboardRateLimitState.set(keyEl, { wrapped: wrappedKu });
-                state = _keyboardRateLimitState.get(keyEl);
-            }
-            state.wrapped(e);
+            var wrapped = _getOrCreateRateLimitedHandler(_keyupRateLimitState, keyEl, 'keyup', rawHandler);
+            wrapped(e);
         }
     });
 
@@ -7225,9 +7216,14 @@ window.djust.getActiveStreams = getActiveStreams;
         // Scroll to top on navigation (or to anchor if present)
         var hash = newUrl.hash;
         if (hash) {
-            var target = document.querySelector(hash);
-            if (target) {
-                target.scrollIntoView({ behavior: 'instant' });
+            try {
+                var target = document.querySelector(hash);
+                if (target) {
+                    target.scrollIntoView({ behavior: 'instant' });
+                }
+            } catch (_e) {
+                // Malformed hash (e.g. "#foo[bar]") — fall through to scroll top
+                window.scrollTo({ top: 0, behavior: 'instant' });
             }
         } else {
             window.scrollTo({ top: 0, behavior: 'instant' });

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -2799,8 +2799,660 @@ function _applyDisableWith(element) {
     element.disabled = true;
 }
 
+// ============================================================================
+// Delegated Event Handlers
+// ============================================================================
+
+// WeakMaps to store per-element rate limit state for delegated events.
+// Since delegation means we don't have a closure per element, we use
+// WeakMaps to associate rate-limited wrappers with their elements.
+const _inputRateLimitState = new WeakMap();
+const _changeRateLimitState = new WeakMap();
+const _clickRateLimitState = new WeakMap();
+const _keyboardRateLimitState = new WeakMap();
+
+// Helper: Extract field name from element attributes
+// Priority: data-field (explicit) > name (standard) > id (fallback)
+function getFieldName(element) {
+    if (element.dataset && element.dataset.field) {
+        return element.dataset.field;
+    }
+    if (element.name) {
+        return element.name;
+    }
+    if (element.id) {
+        // Strip common prefixes like 'id_' (Django convention)
+        return element.id.replace(/^id_/, '');
+    }
+    return null;
+}
+
+/**
+ * Build standard form event params with component context.
+ * Used by change, input, blur, focus event handlers.
+ * @param {HTMLElement} element - Form element that triggered the event
+ * @param {any} value - Current value of the field
+ * @returns {Object} - Params object with value, field, and optional component_id
+ */
+function buildFormEventParams(element, value) {
+    const fieldName = getFieldName(element);
+    const params = { value, field: fieldName };
+    // Merge dj-value-* attributes from the triggering element
+    Object.assign(params, collectDjValues(element));
+    addEventContext(params, element);
+    return params;
+}
+
+/**
+ * Get or create a rate-limited handler wrapper for an element.
+ * @param {WeakMap} stateMap - WeakMap storing per-element rate limit state
+ * @param {HTMLElement} element - Element to get/create wrapper for
+ * @param {string} eventType - Event type (for server rate limit lookup)
+ * @param {Function} rawHandler - The raw (unwrapped) handler function
+ * @returns {Function} - Rate-limited wrapper or raw handler
+ */
+function _getOrCreateRateLimitedHandler(stateMap, element, eventType, rawHandler) {
+    let state = stateMap.get(element);
+    if (state) return state.wrapped;
+
+    // Create rate-limited wrapper for this element
+    let wrapped = _applyRateLimitAttrs(element, rawHandler);
+    if (wrapped === rawHandler && window.djust.rateLimit) {
+        wrapped = window.djust.rateLimit.wrapWithRateLimit(element, eventType, rawHandler);
+    }
+    stateMap.set(element, { wrapped });
+    return wrapped;
+}
+
+/**
+ * Handle dj-click events via delegation.
+ * @param {HTMLElement} element - Element with dj-click attribute
+ * @param {Event} e - The original click event
+ */
+async function _handleDjClick(element, e) {
+    e.preventDefault();
+
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // Read attribute at fire time so morphElement attribute updates take effect
+    const rawClickValue = element.getAttribute('dj-click') || '';
+
+    // dj-confirm: show confirmation dialog before executing commands/events
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    // JS Commands: synchronously check whether the attribute is a
+    // JSON command chain. If so, fire-and-forget the chain (push
+    // ops still round-trip, but we don't block the rest of this
+    // handler on them). A plain event name falls through to the
+    // normal dj-click path without adding an `await` boundary,
+    // so synchronous expectations on dj-disable-with and friends
+    // continue to hold.
+    if (window.djust.js) {
+        const _ops = window.djust.js._parseCommandValue(rawClickValue);
+        if (_ops) {
+            window.djust.js._executeOps(_ops, element);
+            return;
+        }
+    }
+
+    const parsed = parseEventHandler(rawClickValue);
+
+    // dj-disable-with: disable and show loading text
+    _applyDisableWith(element);
+
+    // Apply optimistic update if specified
+    let optimisticUpdateId = null;
+    if (window.djust.optimistic) {
+        optimisticUpdateId = window.djust.optimistic.applyOptimisticUpdate(element, parsed.name);
+    }
+
+    // Extract all data-* attributes with type coercion support
+    const params = extractTypedParams(element);
+
+    // Add positional arguments from handler syntax if present
+    // e.g., dj-click="set_period('month')" -> params._args = ['month']
+    if (parsed.args.length > 0) {
+        params._args = parsed.args;
+    }
+
+    addEventContext(params, element);
+
+    // Pass target element and optimistic update ID
+    params._targetElement = element;
+    params._optimisticUpdateId = optimisticUpdateId;
+
+    // Handle dj-target for scoped updates
+    const targetSelector = element.getAttribute('dj-target');
+    if (targetSelector) {
+        params._djTargetSelector = targetSelector;
+    }
+
+    await handleEvent(parsed.name, params);
+}
+
+/**
+ * Handle dj-copy — client-side clipboard copy (no server round-trip).
+ * @param {HTMLElement} element - Element with dj-copy attribute
+ * @param {Event} e - The original click event
+ */
+function _handleDjCopy(element, e) {
+    e.preventDefault();
+    // Read attribute at click time (not bind time) so morph updates take effect
+    var currentValue = element.getAttribute('dj-copy');
+    if (!currentValue) return;
+
+    // Selector-based copy: if value starts with #, . or [, try querySelector
+    var textToCopy = currentValue;
+    if (currentValue.charAt(0) === '#' || currentValue.charAt(0) === '.' || currentValue.charAt(0) === '[') {
+        try {
+            var target = document.querySelector(currentValue);
+            if (target) {
+                textToCopy = target.textContent;
+            }
+        } catch (err) {
+            // Invalid selector — fall back to literal copy
+        }
+    }
+
+    navigator.clipboard.writeText(textToCopy).then(function() {
+        // CSS class feedback: add class and remove after 2s
+        var cssClass = element.getAttribute('dj-copy-class') || 'dj-copied';
+        element.classList.add(cssClass);
+        setTimeout(function() { element.classList.remove(cssClass); }, 2000);
+
+        // Text feedback: custom or default "Copied!"
+        var feedbackText = element.getAttribute('dj-copy-feedback') || 'Copied!';
+        var original = element.textContent;
+        element.textContent = feedbackText;
+        setTimeout(function() { element.textContent = original; }, 1500);
+
+        // Optional server event for analytics
+        var copyEvent = element.getAttribute('dj-copy-event');
+        if (copyEvent) {
+            handleEvent(copyEvent, { text: textToCopy });
+        }
+    });
+}
+
+/**
+ * Handle dj-submit events on forms via delegation.
+ * @param {HTMLElement} element - Form element with dj-submit attribute
+ * @param {Event} e - The original submit event
+ */
+async function _handleDjSubmit(element, e) {
+    e.preventDefault();
+
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // dj-confirm: show confirmation dialog before sending event
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    // Read attribute at fire time so morphElement attribute updates take effect
+    const submitHandler = element.getAttribute('dj-submit');
+
+    // dj-disable-with: disable submit buttons within the form
+    const submitBtns = element.querySelectorAll('button[type="submit"][dj-disable-with]');
+    submitBtns.forEach(btn => _applyDisableWith(btn));
+    // Also check the submitter if it has dj-disable-with
+    if (e.submitter && e.submitter.hasAttribute('dj-disable-with')) {
+        _applyDisableWith(e.submitter);
+    }
+
+    const formData = new FormData(element);
+    const params = Object.fromEntries(formData.entries());
+
+    // Merge dj-value-* attributes from the form element
+    Object.assign(params, collectDjValues(element));
+
+    addEventContext(params, element);
+
+    // _target: include submitter name if available
+    params._target = (e.submitter && (e.submitter.name || e.submitter.id)) || null;
+
+    // Pass target element for optimistic updates (Phase 3)
+    params._targetElement = element;
+
+    await handleEvent(submitHandler, params);
+}
+
+/**
+ * Handle dj-change events via delegation.
+ * @param {HTMLElement} element - Element with dj-change attribute
+ * @param {Event} e - The original change event
+ */
+async function _handleDjChange(element, e) {
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // dj-confirm: show confirmation dialog before sending event
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    // Read and parse attribute at fire time
+    const changeHandler = element.getAttribute('dj-change');
+    const parsedChange = parseEventHandler(changeHandler);
+
+    const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
+    const params = buildFormEventParams(e.target, value);
+
+    // Add positional arguments from handler syntax if present
+    // e.g., dj-change="toggle_todo(3)" -> params._args = [3]
+    if (parsedChange.args.length > 0) {
+        params._args = parsedChange.args;
+    }
+
+    // _target: include triggering field's name (or id, or null)
+    params._target = e.target.name || e.target.id || null;
+
+    // Add target element for loading state (consistent with other handlers)
+    params._targetElement = e.target;
+
+    // Handle dj-target for scoped updates
+    const targetSelector = element.getAttribute('dj-target');
+    if (targetSelector) {
+        params._djTargetSelector = targetSelector;
+    }
+
+    if (globalThis.djustDebug) {
+        console.log(`[LiveView] dj-change handler: value="${value}", params=`, params);
+    }
+    await handleEvent(parsedChange.name, params);
+}
+
+/**
+ * Handle dj-input events via delegation.
+ * @param {HTMLElement} element - Element with dj-input attribute
+ * @param {Event} e - The original input event
+ */
+async function _handleDjInput(element, e) {
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // dj-confirm: show confirmation dialog before sending event
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    // Read and parse attribute at fire time
+    const inputHandler = element.getAttribute('dj-input');
+    const parsedInput = parseEventHandler(inputHandler);
+
+    const params = buildFormEventParams(e.target, e.target.value);
+    if (parsedInput.args.length > 0) {
+        params._args = parsedInput.args;
+    }
+
+    // _target: include triggering field's name (or id, or null)
+    params._target = e.target.name || e.target.id || null;
+
+    await handleEvent(parsedInput.name, params);
+}
+
+/**
+ * Handle dj-blur events via delegation (using focusout which bubbles).
+ * @param {HTMLElement} element - Element with dj-blur attribute
+ * @param {Event} e - The original focusout event
+ */
+async function _handleDjBlur(element, e) {
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // dj-confirm: show confirmation dialog before sending event
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    // Read and parse attribute at fire time
+    const blurHandler = element.getAttribute('dj-blur');
+    const parsedBlur = parseEventHandler(blurHandler);
+
+    const params = buildFormEventParams(e.target, e.target.value);
+    if (parsedBlur.args.length > 0) {
+        params._args = parsedBlur.args;
+    }
+    await handleEvent(parsedBlur.name, params);
+}
+
+/**
+ * Handle dj-focus events via delegation (using focusin which bubbles).
+ * @param {HTMLElement} element - Element with dj-focus attribute
+ * @param {Event} e - The original focusin event
+ */
+async function _handleDjFocus(element, e) {
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // dj-confirm: show confirmation dialog before sending event
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    // Read and parse attribute at fire time
+    const focusHandler = element.getAttribute('dj-focus');
+    const parsedFocus = parseEventHandler(focusHandler);
+
+    const params = buildFormEventParams(e.target, e.target.value);
+    if (parsedFocus.args.length > 0) {
+        params._args = parsedFocus.args;
+    }
+    await handleEvent(parsedFocus.name, params);
+}
+
+/**
+ * Handle dj-paste events via delegation.
+ * Extracts structured clipboard payload (plain text, rich HTML, files)
+ * and sends it to the server as a single event call.
+ * @param {HTMLElement} element - Element with dj-paste attribute
+ * @param {Event} e - The original paste event
+ */
+async function _handleDjPaste(element, e) {
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // dj-confirm: show confirmation dialog before sending event
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    // Read and parse attribute at fire time
+    const pasteHandler = element.getAttribute('dj-paste');
+    const parsedPaste = parseEventHandler(pasteHandler);
+
+    const clipboardData = e.clipboardData || window.clipboardData;
+    if (!clipboardData) {
+        // No clipboard data available — let the default paste happen
+        return;
+    }
+
+    // Build structured payload: text, html, and file metadata.
+    // The actual file bytes are NOT sent in this event — that would
+    // blow the WS frame budget. Instead, set a dj-upload slot on
+    // the element and UploadMixin will pick up any files from the
+    // clipboard files list via the existing upload pipeline.
+    let text = '';
+    let html = '';
+    const files = [];
+    try {
+        text = clipboardData.getData('text/plain') || '';
+    } catch (err) { /* older browsers */ }
+    try {
+        html = clipboardData.getData('text/html') || '';
+    } catch (err) { /* older browsers */ }
+    if (clipboardData.files) {
+        for (let i = 0; i < clipboardData.files.length; i++) {
+            const f = clipboardData.files[i];
+            files.push({
+                name: f.name || 'clipboard-paste',
+                type: f.type || '',
+                size: f.size || 0,
+            });
+        }
+    }
+
+    // If the element has an upload slot configured, route pasted
+    // files through the upload pipeline (image paste → chat, etc).
+    // We route BEFORE sending the server event so the handler can
+    // react to both the metadata and the pending upload in one tick.
+    if (files.length > 0 && window.djust && window.djust.uploads && element.getAttribute('dj-upload')) {
+        try {
+            await window.djust.uploads.queueClipboardFiles(element, clipboardData.files);
+        } catch (err) {
+            if (globalThis.djustDebug) console.log('[LiveView] dj-paste: upload route failed', err);
+        }
+    }
+
+    const params = {
+        text: text,
+        html: html,
+        has_files: files.length > 0,
+        files: files,
+    };
+    if (parsedPaste.args.length > 0) {
+        params._args = parsedPaste.args;
+    }
+
+    // Suppress the default paste only when the element opts in
+    // with dj-paste-suppress. Otherwise let the browser also
+    // insert into the input so hybrid UIs still feel natural.
+    if (element.hasAttribute('dj-paste-suppress')) {
+        e.preventDefault();
+    }
+
+    await handleEvent(parsedPaste.name, params);
+}
+
+/**
+ * Handle dj-keydown / dj-keyup events via delegation.
+ * @param {HTMLElement} element - Element with dj-keydown or dj-keyup attribute
+ * @param {Event} e - The original keyboard event
+ * @param {string} eventType - 'keydown' or 'keyup'
+ */
+async function _handleDjKeyboard(element, e, eventType) {
+    // Read attribute at fire time
+    const keyHandler = element.getAttribute('dj-' + eventType);
+    if (!keyHandler) return;
+
+    // Check for key modifiers (e.g. dj-keydown.enter)
+    const modifiers = keyHandler.split('.');
+    const handlerName = modifiers[0];
+    const requiredKey = modifiers.length > 1 ? modifiers[1] : null;
+
+    if (requiredKey) {
+        if (requiredKey === 'enter' && e.key !== 'Enter') return;
+        if (requiredKey === 'escape' && e.key !== 'Escape') return;
+        if (requiredKey === 'space' && e.key !== ' ') return;
+        // Add more key mappings as needed
+    }
+
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // dj-confirm: show confirmation dialog before sending event
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    const fieldName = getFieldName(e.target);
+    const params = {
+        key: e.key,
+        code: e.code,
+        value: e.target.value,
+        field: fieldName
+    };
+
+    // Merge dj-value-* attributes from the element
+    Object.assign(params, collectDjValues(element));
+
+    addEventContext(params, e.target);
+
+    // Add target element and handle dj-target
+    params._targetElement = e.target;
+    const targetSelector = element.getAttribute('dj-target');
+    if (targetSelector) {
+        params._djTargetSelector = targetSelector;
+    }
+
+    await handleEvent(handlerName, params);
+}
+
+// ============================================================================
+// Event Delegation
+// ============================================================================
+
+/**
+ * Install ONE delegated listener per DOM event type on the given root element.
+ * Idempotent — checks root._djustDelegated to avoid double-installing.
+ * @param {HTMLElement} root - The LiveView root element to delegate from
+ */
+function installDelegatedListeners(root) {
+    if (root._djustDelegated) return;
+    root._djustDelegated = true;
+
+    // click → dj-copy (client-only) first, then dj-click
+    root.addEventListener('click', function(e) {
+        var copyEl = e.target.closest('[dj-copy]');
+        if (copyEl) {
+            _handleDjCopy(copyEl, e);
+            return;
+        }
+        var clickEl = e.target.closest('[dj-click]');
+        if (clickEl) {
+            // Rate-limit per element using WeakMap
+            var rawHandler = function(ev) { return _handleDjClick(clickEl, ev); };
+            var wrapped = _getOrCreateRateLimitedHandler(_clickRateLimitState, clickEl, 'click', rawHandler);
+            wrapped(e);
+        }
+    });
+
+    // submit → dj-submit
+    root.addEventListener('submit', function(e) {
+        var submitEl = e.target.closest('[dj-submit]');
+        if (submitEl) {
+            _handleDjSubmit(submitEl, e);
+        }
+    });
+
+    // change → dj-change
+    root.addEventListener('change', function(e) {
+        var changeEl = e.target.closest('[dj-change]');
+        if (changeEl) {
+            // Rate-limit per element using WeakMap
+            var rawHandler = function(ev) { return _handleDjChange(changeEl, ev); };
+            var wrapped = _getOrCreateRateLimitedHandler(_changeRateLimitState, changeEl, 'change', rawHandler);
+            wrapped(e);
+        }
+    });
+
+    // input → dj-input (with smart rate limiting)
+    root.addEventListener('input', function(e) {
+        var inputEl = e.target.closest('[dj-input]');
+        if (inputEl) {
+            // Get or create rate-limited wrapper for this element
+            var state = _inputRateLimitState.get(inputEl);
+            if (!state) {
+                // Build the raw handler
+                var rawHandler = function(ev) { return _handleDjInput(inputEl, ev); };
+
+                // Determine rate limit strategy
+                var inputType = inputEl.type || inputEl.tagName.toLowerCase();
+                var rateLimit = Object.prototype.hasOwnProperty.call(DEFAULT_RATE_LIMITS, inputType) ? DEFAULT_RATE_LIMITS[inputType] : { type: 'debounce', ms: 300 };
+
+                // Check for explicit overrides: dj-* attributes take precedence
+                if (inputEl.hasAttribute('dj-debounce')) {
+                    var djVal = inputEl.getAttribute('dj-debounce');
+                    if (djVal === 'blur') {
+                        rateLimit.type = 'blur';
+                        rateLimit.ms = 0;
+                    } else {
+                        rateLimit.type = 'debounce';
+                        rateLimit.ms = parseInt(djVal, 10);
+                    }
+                } else if (inputEl.hasAttribute('dj-throttle')) {
+                    rateLimit.type = 'throttle';
+                    rateLimit.ms = parseInt(inputEl.getAttribute('dj-throttle'), 10);
+                } else if (inputEl.hasAttribute('data-debounce')) {
+                    rateLimit.type = 'debounce';
+                    rateLimit.ms = parseInt(inputEl.getAttribute('data-debounce'));
+                } else if (inputEl.hasAttribute('data-throttle')) {
+                    rateLimit.type = 'throttle';
+                    rateLimit.ms = parseInt(inputEl.getAttribute('data-throttle'));
+                }
+
+                // Apply rate limiting wrapper
+                var wrapped;
+                if (rateLimit.type === 'blur') {
+                    // dj-debounce="blur": defer until element loses focus
+                    var latestArgs = null;
+                    wrapped = function() {
+                        latestArgs = arguments;
+                    };
+                    inputEl.addEventListener('blur', function() {
+                        if (latestArgs !== null) {
+                            rawHandler.apply(null, latestArgs);
+                            latestArgs = null;
+                        }
+                    });
+                } else if (rateLimit.type === 'throttle') {
+                    wrapped = throttle(rawHandler, rateLimit.ms);
+                } else {
+                    wrapped = debounce(rawHandler, rateLimit.ms);
+                }
+
+                state = { wrapped: wrapped };
+                _inputRateLimitState.set(inputEl, state);
+            }
+            state.wrapped(e);
+        }
+    });
+
+    // keydown → dj-keydown
+    root.addEventListener('keydown', function(e) {
+        var keyEl = e.target.closest('[dj-keydown]');
+        if (keyEl) {
+            var rawHandler = function(ev) { return _handleDjKeyboard(keyEl, ev, 'keydown'); };
+            var wrapped = _getOrCreateRateLimitedHandler(_keyboardRateLimitState, keyEl, 'keydown', rawHandler);
+            wrapped(e);
+        }
+    });
+
+    // keyup → dj-keyup
+    root.addEventListener('keyup', function(e) {
+        var keyEl = e.target.closest('[dj-keyup]');
+        if (keyEl) {
+            var rawHandler = function(ev) { return _handleDjKeyboard(keyEl, ev, 'keyup'); };
+            // keyup shares the keyboard state map but different element keys won't collide
+            // since WeakMap is keyed by element object
+            var state = _keyboardRateLimitState.get(keyEl);
+            if (!state) {
+                var wrappedKu = _applyRateLimitAttrs(keyEl, rawHandler);
+                if (wrappedKu === rawHandler && window.djust.rateLimit) {
+                    wrappedKu = window.djust.rateLimit.wrapWithRateLimit(keyEl, 'keyup', rawHandler);
+                }
+                _keyboardRateLimitState.set(keyEl, { wrapped: wrappedKu });
+                state = _keyboardRateLimitState.get(keyEl);
+            }
+            state.wrapped(e);
+        }
+    });
+
+    // paste → dj-paste
+    root.addEventListener('paste', function(e) {
+        var pasteEl = e.target.closest('[dj-paste]');
+        if (pasteEl) {
+            _handleDjPaste(pasteEl, e);
+        }
+    });
+
+    // focusin → dj-focus (focusin bubbles, focus doesn't)
+    root.addEventListener('focusin', function(e) {
+        var focusEl = e.target.closest('[dj-focus]');
+        if (focusEl) {
+            _handleDjFocus(focusEl, e);
+        }
+    });
+
+    // focusout → dj-blur (focusout bubbles, blur doesn't)
+    root.addEventListener('focusout', function(e) {
+        var blurEl = e.target.closest('[dj-blur]');
+        if (blurEl) {
+            _handleDjBlur(blurEl, e);
+        }
+    });
+}
+
 function bindLiveViewEvents(scope) {
-    const root = scope || document;
+    const root = scope || getLiveViewRoot() || document;
+
+    // Install delegated listeners ONCE on the LiveView root
+    const liveRoot = getLiveViewRoot();
+    if (liveRoot) installDelegatedListeners(liveRoot);
 
     // Bind upload handlers (dj-upload, dj-upload-drop, dj-upload-preview)
     if (window.djust.uploads) {
@@ -2812,521 +3464,12 @@ function bindLiveViewEvents(scope) {
         window.djust.navigation.bindDirectives(scope);
     }
 
-    // Find interactive elements via targeted attribute selectors instead of
-    // scanning all elements. This is O(interactive) instead of O(all_elements).
-    const djSelector = '[dj-click],[dj-change],[dj-input],[dj-submit],' +
-        '[dj-focus],[dj-blur],[dj-keydown],[dj-keyup],[dj-mouseenter],' +
-        '[dj-mouseleave],[dj-scroll],[dj-mounted],[dj-paste],[dj-poll],' +
-        '[dj-viewport-enter],[dj-viewport-leave],[dj-disable-with],' +
-        '[dj-copy],[dj-click-away],[dj-shortcut],[dj-auto-recover]';
-    const allElements = root.querySelectorAll(djSelector);
-    allElements.forEach(element => {
-        // Handle dj-click events
-        const clickHandler = element.getAttribute('dj-click');
-        if (clickHandler && !_isHandlerBound(element, 'click')) {
-            _markHandlerBound(element, 'click');
-
-            const clickHandlerFn = async (e) => {
-                e.preventDefault();
-
-                // dj-lock: skip if already locked
-                if (_checkAndLock(element)) return;
-
-                // Read attribute at fire time so morphElement attribute updates take effect
-                const rawClickValue = element.getAttribute('dj-click') || '';
-
-                // dj-confirm: show confirmation dialog before executing commands/events
-                if (!checkDjConfirm(element)) {
-                    return; // User cancelled
-                }
-
-                // JS Commands: synchronously check whether the attribute is a
-                // JSON command chain. If so, fire-and-forget the chain (push
-                // ops still round-trip, but we don't block the rest of this
-                // handler on them). A plain event name falls through to the
-                // normal dj-click path without adding an `await` boundary,
-                // so synchronous expectations on dj-disable-with and friends
-                // continue to hold.
-                if (window.djust.js) {
-                    const _ops = window.djust.js._parseCommandValue(rawClickValue);
-                    if (_ops) {
-                        window.djust.js._executeOps(_ops, element);
-                        return;
-                    }
-                }
-
-                const parsed = parseEventHandler(rawClickValue);
-
-                // dj-disable-with: disable and show loading text
-                _applyDisableWith(element);
-
-                // Apply optimistic update if specified
-                let optimisticUpdateId = null;
-                if (window.djust.optimistic) {
-                    optimisticUpdateId = window.djust.optimistic.applyOptimisticUpdate(e.currentTarget, parsed.name);
-                }
-
-                // Extract all data-* attributes with type coercion support
-                const params = extractTypedParams(element);
-
-                // Add positional arguments from handler syntax if present
-                // e.g., dj-click="set_period('month')" -> params._args = ['month']
-                if (parsed.args.length > 0) {
-                    params._args = parsed.args;
-                }
-
-                addEventContext(params, e.currentTarget);
-
-                // Pass target element and optimistic update ID
-                params._targetElement = e.currentTarget;
-                params._optimisticUpdateId = optimisticUpdateId;
-
-                // Handle dj-target for scoped updates
-                const targetSelector = element.getAttribute('dj-target');
-                if (targetSelector) {
-                    params._djTargetSelector = targetSelector;
-                }
-
-                await handleEvent(parsed.name, params);
-            };
-
-            // Apply dj-debounce/dj-throttle HTML attributes first, then server rate limit
-            let wrappedHandler = _applyRateLimitAttrs(element, clickHandlerFn);
-            if (wrappedHandler === clickHandlerFn && window.djust.rateLimit) {
-                wrappedHandler = window.djust.rateLimit.wrapWithRateLimit(element, 'click', clickHandlerFn);
-            }
-
-            element.addEventListener('click', wrappedHandler);
-        }
-
-        // Handle dj-copy — client-side clipboard copy (no server round-trip)
-        if (element.getAttribute('dj-copy') && !_isHandlerBound(element, 'copy')) {
-            _markHandlerBound(element, 'copy');
-            element.addEventListener('click', function(e) {
-                e.preventDefault();
-                // Read attribute at click time (not bind time) so morph updates take effect
-                var currentValue = element.getAttribute('dj-copy');
-                if (!currentValue) return;
-
-                // Selector-based copy: if value starts with #, . or [, try querySelector
-                var textToCopy = currentValue;
-                if (currentValue.charAt(0) === '#' || currentValue.charAt(0) === '.' || currentValue.charAt(0) === '[') {
-                    try {
-                        var target = document.querySelector(currentValue);
-                        if (target) {
-                            textToCopy = target.textContent;
-                        }
-                    } catch (err) {
-                        // Invalid selector — fall back to literal copy
-                    }
-                }
-
-                navigator.clipboard.writeText(textToCopy).then(function() {
-                    // CSS class feedback: add class and remove after 2s
-                    var cssClass = element.getAttribute('dj-copy-class') || 'dj-copied';
-                    element.classList.add(cssClass);
-                    setTimeout(function() { element.classList.remove(cssClass); }, 2000);
-
-                    // Text feedback: custom or default "Copied!"
-                    var feedbackText = element.getAttribute('dj-copy-feedback') || 'Copied!';
-                    var original = element.textContent;
-                    element.textContent = feedbackText;
-                    setTimeout(function() { element.textContent = original; }, 1500);
-
-                    // Optional server event for analytics
-                    var copyEvent = element.getAttribute('dj-copy-event');
-                    if (copyEvent) {
-                        handleEvent(copyEvent, { text: textToCopy });
-                    }
-                });
-            });
-        }
-
-        // Handle dj-submit events on forms
-        const submitHandler = element.getAttribute('dj-submit');
-        if (submitHandler && !_isHandlerBound(element, 'submit')) {
-            _markHandlerBound(element, 'submit');
-            element.addEventListener('submit', async (e) => {
-                e.preventDefault();
-
-                // dj-lock: skip if already locked
-                if (_checkAndLock(e.target)) return;
-
-                // dj-confirm: show confirmation dialog before sending event
-                if (!checkDjConfirm(e.target)) {
-                    return; // User cancelled
-                }
-
-                // dj-disable-with: disable submit buttons within the form
-                const submitBtns = e.target.querySelectorAll('button[type="submit"][dj-disable-with]');
-                submitBtns.forEach(btn => _applyDisableWith(btn));
-                // Also check the submitter if it has dj-disable-with
-                if (e.submitter && e.submitter.hasAttribute('dj-disable-with')) {
-                    _applyDisableWith(e.submitter);
-                }
-
-                const formData = new FormData(e.target);
-                const params = Object.fromEntries(formData.entries());
-
-                // Merge dj-value-* attributes from the form element
-                Object.assign(params, collectDjValues(e.target));
-
-                addEventContext(params, e.target);
-
-                // _target: include submitter name if available
-                params._target = (e.submitter && (e.submitter.name || e.submitter.id)) || null;
-
-                // Pass target element for optimistic updates (Phase 3)
-                params._targetElement = e.target;
-
-                await handleEvent(submitHandler, params);
-            });
-        }
-
-        // Helper: Extract field name from element attributes
-        // Priority: data-field (explicit) > name (standard) > id (fallback)
-        function getFieldName(element) {
-            if (element.dataset.field) {
-                return element.dataset.field;
-            }
-            if (element.name) {
-                return element.name;
-            }
-            if (element.id) {
-                // Strip common prefixes like 'id_' (Django convention)
-                return element.id.replace(/^id_/, '');
-            }
-            return null;
-        }
-
-        /**
-         * Build standard form event params with component context.
-         * Used by change, input, blur, focus event handlers.
-         * @param {HTMLElement} element - Form element that triggered the event
-         * @param {any} value - Current value of the field
-         * @returns {Object} - Params object with value, field, and optional component_id
-         */
-        function buildFormEventParams(element, value) {
-            const fieldName = getFieldName(element);
-            const params = { value, field: fieldName };
-            // Merge dj-value-* attributes from the triggering element
-            Object.assign(params, collectDjValues(element));
-            addEventContext(params, element);
-            return params;
-        }
-
-        // Handle dj-change events
-        const changeHandler = element.getAttribute('dj-change');
-        if (changeHandler && !_isHandlerBound(element, 'change')) {
-            _markHandlerBound(element, 'change');
-            // Parse handler string to extract function name and arguments
-            const parsedChange = parseEventHandler(changeHandler);
-
-            const changeHandlerFn = async (e) => {
-                // dj-lock: skip if already locked
-                if (_checkAndLock(element)) return;
-
-                // dj-confirm: show confirmation dialog before sending event
-                if (!checkDjConfirm(element)) {
-                    return; // User cancelled
-                }
-
-                const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
-                const params = buildFormEventParams(e.target, value);
-
-                // Add positional arguments from handler syntax if present
-                // e.g., dj-change="toggle_todo(3)" -> params._args = [3]
-                if (parsedChange.args.length > 0) {
-                    params._args = parsedChange.args;
-                }
-
-                // _target: include triggering field's name (or id, or null)
-                params._target = e.target.name || e.target.id || null;
-
-                // Add target element for loading state (consistent with other handlers)
-                params._targetElement = e.target;
-
-                // Handle dj-target for scoped updates
-                const targetSelector = element.getAttribute('dj-target');
-                if (targetSelector) {
-                    params._djTargetSelector = targetSelector;
-                }
-
-                if (globalThis.djustDebug) {
-                    console.log(`[LiveView] dj-change handler: value="${value}", params=`, params);
-                }
-                await handleEvent(parsedChange.name, params);
-            };
-
-            // Apply dj-debounce/dj-throttle HTML attributes first, then server rate limit
-            let wrappedChangeHandler = _applyRateLimitAttrs(element, changeHandlerFn);
-            if (wrappedChangeHandler === changeHandlerFn && window.djust.rateLimit) {
-                wrappedChangeHandler = window.djust.rateLimit.wrapWithRateLimit(element, 'change', changeHandlerFn);
-            }
-
-            element.addEventListener('change', wrappedChangeHandler);
-        }
-
-        // Handle dj-input events (with smart debouncing/throttling)
-        const inputHandler = element.getAttribute('dj-input');
-        if (inputHandler && !_isHandlerBound(element, 'input')) {
-            _markHandlerBound(element, 'input');
-            // Parse handler string to extract function name and arguments
-            const parsedInput = parseEventHandler(inputHandler);
-
-            // Determine rate limit strategy
-            const inputType = element.type || element.tagName.toLowerCase();
-            const rateLimit = Object.prototype.hasOwnProperty.call(DEFAULT_RATE_LIMITS, inputType) ? DEFAULT_RATE_LIMITS[inputType] : { type: 'debounce', ms: 300 };
-
-            // Check for explicit overrides: dj-* attributes take precedence
-            if (element.hasAttribute('dj-debounce')) {
-                const djVal = element.getAttribute('dj-debounce');
-                if (djVal === 'blur') {
-                    rateLimit.type = 'blur';
-                    rateLimit.ms = 0;
-                } else {
-                    rateLimit.type = 'debounce';
-                    rateLimit.ms = parseInt(djVal, 10);
-                }
-            } else if (element.hasAttribute('dj-throttle')) {
-                rateLimit.type = 'throttle';
-                rateLimit.ms = parseInt(element.getAttribute('dj-throttle'), 10);
-            } else if (element.hasAttribute('data-debounce')) {
-                rateLimit.type = 'debounce';
-                rateLimit.ms = parseInt(element.getAttribute('data-debounce'));
-            } else if (element.hasAttribute('data-throttle')) {
-                rateLimit.type = 'throttle';
-                rateLimit.ms = parseInt(element.getAttribute('data-throttle'));
-            }
-
-            const handler = async (e) => {
-                // dj-lock: skip if already locked
-                if (_checkAndLock(element)) return;
-
-                // dj-confirm: show confirmation dialog before sending event
-                if (!checkDjConfirm(element)) {
-                    return; // User cancelled
-                }
-
-                const params = buildFormEventParams(e.target, e.target.value);
-                if (parsedInput.args.length > 0) {
-                    params._args = parsedInput.args;
-                }
-
-                // _target: include triggering field's name (or id, or null)
-                params._target = e.target.name || e.target.id || null;
-
-                await handleEvent(parsedInput.name, params);
-            };
-
-            // Apply rate limiting wrapper
-            let wrappedHandler;
-            if (rateLimit.type === 'blur') {
-                // dj-debounce="blur": defer until element loses focus
-                let latestArgs = null;
-                wrappedHandler = function (...args) {
-                    latestArgs = args;
-                };
-                element.addEventListener('blur', function () {
-                    if (latestArgs !== null) {
-                        handler(...latestArgs);
-                        latestArgs = null;
-                    }
-                });
-            } else if (rateLimit.type === 'throttle') {
-                wrappedHandler = throttle(handler, rateLimit.ms);
-            } else {
-                wrappedHandler = debounce(handler, rateLimit.ms);
-            }
-
-            element.addEventListener('input', wrappedHandler);
-        }
-
-        // Handle dj-blur events
-        const blurHandler = element.getAttribute('dj-blur');
-        if (blurHandler && !_isHandlerBound(element, 'blur')) {
-            _markHandlerBound(element, 'blur');
-            const parsedBlur = parseEventHandler(blurHandler);
-            element.addEventListener('blur', async (e) => {
-                // dj-lock: skip if already locked
-                if (_checkAndLock(element)) return;
-
-                // dj-confirm: show confirmation dialog before sending event
-                if (!checkDjConfirm(element)) {
-                    return; // User cancelled
-                }
-
-                const params = buildFormEventParams(e.target, e.target.value);
-                if (parsedBlur.args.length > 0) {
-                    params._args = parsedBlur.args;
-                }
-                await handleEvent(parsedBlur.name, params);
-            });
-        }
-
-        // Handle dj-focus events
-        const focusHandler = element.getAttribute('dj-focus');
-        if (focusHandler && !_isHandlerBound(element, 'focus')) {
-            _markHandlerBound(element, 'focus');
-            const parsedFocus = parseEventHandler(focusHandler);
-            element.addEventListener('focus', async (e) => {
-                // dj-lock: skip if already locked
-                if (_checkAndLock(element)) return;
-
-                // dj-confirm: show confirmation dialog before sending event
-                if (!checkDjConfirm(element)) {
-                    return; // User cancelled
-                }
-
-                const params = buildFormEventParams(e.target, e.target.value);
-                if (parsedFocus.args.length > 0) {
-                    params._args = parsedFocus.args;
-                }
-                await handleEvent(parsedFocus.name, params);
-            });
-        }
-
-        // Handle dj-paste events
-        // Extracts structured clipboard payload (plain text, rich HTML, files)
-        // and sends it to the server as a single event call.
-        const pasteHandler = element.getAttribute('dj-paste');
-        if (pasteHandler && !_isHandlerBound(element, 'paste')) {
-            _markHandlerBound(element, 'paste');
-            const parsedPaste = parseEventHandler(pasteHandler);
-            element.addEventListener('paste', async (e) => {
-                // dj-lock: skip if already locked
-                if (_checkAndLock(element)) return;
-
-                // dj-confirm: show confirmation dialog before sending event
-                if (!checkDjConfirm(element)) {
-                    return; // User cancelled
-                }
-
-                const clipboardData = e.clipboardData || window.clipboardData;
-                if (!clipboardData) {
-                    // No clipboard data available — let the default paste happen
-                    return;
-                }
-
-                // Build structured payload: text, html, and file metadata.
-                // The actual file bytes are NOT sent in this event — that would
-                // blow the WS frame budget. Instead, set a dj-upload slot on
-                // the element and UploadMixin will pick up any files from the
-                // clipboard files list via the existing upload pipeline.
-                let text = '';
-                let html = '';
-                const files = [];
-                try {
-                    text = clipboardData.getData('text/plain') || '';
-                } catch (err) { /* older browsers */ }
-                try {
-                    html = clipboardData.getData('text/html') || '';
-                } catch (err) { /* older browsers */ }
-                if (clipboardData.files) {
-                    for (let i = 0; i < clipboardData.files.length; i++) {
-                        const f = clipboardData.files[i];
-                        files.push({
-                            name: f.name || 'clipboard-paste',
-                            type: f.type || '',
-                            size: f.size || 0,
-                        });
-                    }
-                }
-
-                // If the element has an upload slot configured, route pasted
-                // files through the upload pipeline (image paste → chat, etc).
-                // We route BEFORE sending the server event so the handler can
-                // react to both the metadata and the pending upload in one tick.
-                if (files.length > 0 && window.djust && window.djust.uploads && element.getAttribute('dj-upload')) {
-                    try {
-                        await window.djust.uploads.queueClipboardFiles(element, clipboardData.files);
-                    } catch (err) {
-                        if (globalThis.djustDebug) console.log('[LiveView] dj-paste: upload route failed', err);
-                    }
-                }
-
-                const params = {
-                    text: text,
-                    html: html,
-                    has_files: files.length > 0,
-                    files: files,
-                };
-                if (parsedPaste.args.length > 0) {
-                    params._args = parsedPaste.args;
-                }
-
-                // Suppress the default paste only when the element opts in
-                // with dj-paste-suppress. Otherwise let the browser also
-                // insert into the input so hybrid UIs still feel natural.
-                if (element.hasAttribute('dj-paste-suppress')) {
-                    e.preventDefault();
-                }
-
-                await handleEvent(parsedPaste.name, params);
-            });
-        }
-
-        // Handle dj-keydown / dj-keyup events
-        ['keydown', 'keyup'].forEach(eventType => {
-            const keyHandler = element.getAttribute(`dj-${eventType}`);
-            if (keyHandler && !_isHandlerBound(element, eventType)) {
-                _markHandlerBound(element, eventType);
-
-                const keyHandlerFn = async (e) => {
-                    // Check for key modifiers (e.g. dj-keydown.enter)
-                    const modifiers = keyHandler.split('.');
-                    const handlerName = modifiers[0];
-                    const requiredKey = modifiers.length > 1 ? modifiers[1] : null;
-
-                    if (requiredKey) {
-                        if (requiredKey === 'enter' && e.key !== 'Enter') return;
-                        if (requiredKey === 'escape' && e.key !== 'Escape') return;
-                        if (requiredKey === 'space' && e.key !== ' ') return;
-                        // Add more key mappings as needed
-                    }
-
-                    // dj-lock: skip if already locked
-                    if (_checkAndLock(element)) return;
-
-                    // dj-confirm: show confirmation dialog before sending event
-                    if (!checkDjConfirm(element)) {
-                        return; // User cancelled
-                    }
-
-                    const fieldName = getFieldName(e.target);
-                    const params = {
-                        key: e.key,
-                        code: e.code,
-                        value: e.target.value,
-                        field: fieldName
-                    };
-
-                    // Merge dj-value-* attributes from the element
-                    Object.assign(params, collectDjValues(element));
-
-                    addEventContext(params, e.target);
-
-                    // Add target element and handle dj-target
-                    params._targetElement = e.target;
-                    const targetSelector = element.getAttribute('dj-target');
-                    if (targetSelector) {
-                        params._djTargetSelector = targetSelector;
-                    }
-
-                    await handleEvent(handlerName, params);
-                };
-
-                // Apply dj-debounce/dj-throttle HTML attributes first, then server rate limit
-                let wrappedKeyHandler = _applyRateLimitAttrs(element, keyHandlerFn);
-                if (wrappedKeyHandler === keyHandlerFn && window.djust.rateLimit) {
-                    wrappedKeyHandler = window.djust.rateLimit.wrapWithRateLimit(element, eventType, keyHandlerFn);
-                }
-
-                element.addEventListener(eventType, wrappedKeyHandler);
-            }
-        });
-
-        // Handle dj-poll — declarative polling
+    // === Per-element scanning section (only for non-delegable events) ===
+
+    // dj-poll needs per-element interval setup
+    const pollSelector = '[dj-poll]';
+    const pollElements = root.querySelectorAll(pollSelector);
+    pollElements.forEach(element => {
         const pollHandler = element.getAttribute('dj-poll');
         if (pollHandler && !_isHandlerBound(element, 'poll')) {
             _markHandlerBound(element, 'poll');
@@ -3843,6 +3986,7 @@ function _processFormRecovery() {
 // Export for testing and for createNodeFromVNode to mark VDOM-created elements as bound
 window.djust.bindLiveViewEvents = bindLiveViewEvents;
 window.djust.reinitAfterDOMUpdate = reinitAfterDOMUpdate;
+window.djust.installDelegatedListeners = installDelegatedListeners;
 window.djust._isHandlerBound = _isHandlerBound;
 window.djust._markHandlerBound = _markHandlerBound;
 window.djust._processAutoRecover = _processAutoRecover;

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -3462,8 +3462,11 @@ function installDelegatedListeners(root) {
 function bindLiveViewEvents(scope) {
     const root = scope || getLiveViewRoot() || document;
 
-    // Install delegated listeners ONCE on the LiveView root
-    const liveRoot = getLiveViewRoot();
+    // Install delegated listeners on the LiveView root element.
+    // Only install on actual [dj-view]/[dj-root] elements, NOT on document.body
+    // fallback — body persists across TurboNav page swaps, causing duplicate
+    // events when navigating away from a LiveView page and back.
+    const liveRoot = document.querySelector('[dj-view]') || document.querySelector('[dj-root]');
     if (liveRoot) installDelegatedListeners(liveRoot);
 
     // Bind upload handlers (dj-upload, dj-upload-drop, dj-upload-preview)

--- a/python/djust/static/djust/src/09-event-binding.js
+++ b/python/djust/static/djust/src/09-event-binding.js
@@ -668,15 +668,27 @@ async function _handleDjKeyboard(element, e, eventType) {
 
 /**
  * Install ONE delegated listener per DOM event type on the given root element.
- * Idempotent — checks root._djustDelegated to avoid double-installing.
+ * Idempotent — uses AbortController to tear down old listeners before
+ * installing new ones, preventing double-firing after TurboNav navigation.
  * @param {HTMLElement} root - The LiveView root element to delegate from
  */
 function installDelegatedListeners(root) {
-    if (root._djustDelegated) return;
-    root._djustDelegated = true;
+    // Tear down previous delegated listeners (if any) to prevent double-firing
+    // after TurboNav morphs the page content while preserving the root element.
+    if (root._djustDelegateAbort) {
+        root._djustDelegateAbort.abort();
+    }
+    var controller = new AbortController();
+    root._djustDelegateAbort = controller;
+    var opts = { signal: controller.signal };
+
+    // Helper: addEventListener with abort signal for clean teardown
+    function on(event, handler) {
+        root.addEventListener(event, handler, opts);
+    }
 
     // click → dj-copy (client-only) first, then dj-click
-    root.addEventListener('click', function(e) {
+    on('click', function(e) {
         var copyEl = e.target.closest('[dj-copy]');
         if (copyEl) {
             _handleDjCopy(copyEl, e);
@@ -692,7 +704,7 @@ function installDelegatedListeners(root) {
     });
 
     // submit → dj-submit
-    root.addEventListener('submit', function(e) {
+    on('submit', function(e) {
         var submitEl = e.target.closest('[dj-submit]');
         if (submitEl) {
             _handleDjSubmit(submitEl, e);
@@ -700,7 +712,7 @@ function installDelegatedListeners(root) {
     });
 
     // change → dj-change
-    root.addEventListener('change', function(e) {
+    on('change', function(e) {
         var changeEl = e.target.closest('[dj-change]');
         if (changeEl) {
             // Rate-limit per element using WeakMap
@@ -711,7 +723,7 @@ function installDelegatedListeners(root) {
     });
 
     // input → dj-input (with smart rate limiting)
-    root.addEventListener('input', function(e) {
+    on('input', function(e) {
         var inputEl = e.target.closest('[dj-input]');
         if (inputEl) {
             // Get or create rate-limited wrapper for this element
@@ -773,7 +785,7 @@ function installDelegatedListeners(root) {
     });
 
     // keydown → dj-keydown
-    root.addEventListener('keydown', function(e) {
+    on('keydown', function(e) {
         var keyEl = e.target.closest('[dj-keydown]');
         if (keyEl) {
             var rawHandler = function(ev) { return _handleDjKeyboard(keyEl, ev, 'keydown'); };
@@ -783,7 +795,7 @@ function installDelegatedListeners(root) {
     });
 
     // keyup → dj-keyup
-    root.addEventListener('keyup', function(e) {
+    on('keyup', function(e) {
         var keyEl = e.target.closest('[dj-keyup]');
         if (keyEl) {
             var rawHandler = function(ev) { return _handleDjKeyboard(keyEl, ev, 'keyup'); };
@@ -803,7 +815,7 @@ function installDelegatedListeners(root) {
     });
 
     // paste → dj-paste
-    root.addEventListener('paste', function(e) {
+    on('paste', function(e) {
         var pasteEl = e.target.closest('[dj-paste]');
         if (pasteEl) {
             _handleDjPaste(pasteEl, e);
@@ -811,7 +823,7 @@ function installDelegatedListeners(root) {
     });
 
     // focusin → dj-focus (focusin bubbles, focus doesn't)
-    root.addEventListener('focusin', function(e) {
+    on('focusin', function(e) {
         var focusEl = e.target.closest('[dj-focus]');
         if (focusEl) {
             _handleDjFocus(focusEl, e);
@@ -819,7 +831,7 @@ function installDelegatedListeners(root) {
     });
 
     // focusout → dj-blur (focusout bubbles, blur doesn't)
-    root.addEventListener('focusout', function(e) {
+    on('focusout', function(e) {
         var blurEl = e.target.closest('[dj-blur]');
         if (blurEl) {
             _handleDjBlur(blurEl, e);

--- a/python/djust/static/djust/src/09-event-binding.js
+++ b/python/djust/static/djust/src/09-event-binding.js
@@ -189,7 +189,8 @@ function _applyDisableWith(element) {
 const _inputRateLimitState = new WeakMap();
 const _changeRateLimitState = new WeakMap();
 const _clickRateLimitState = new WeakMap();
-const _keyboardRateLimitState = new WeakMap();
+const _keydownRateLimitState = new WeakMap();
+const _keyupRateLimitState = new WeakMap();
 
 // Helper: Extract field name from element attributes
 // Priority: data-field (explicit) > name (standard) > id (fallback)
@@ -789,28 +790,18 @@ function installDelegatedListeners(root) {
         var keyEl = e.target.closest('[dj-keydown]');
         if (keyEl) {
             var rawHandler = function(ev) { return _handleDjKeyboard(keyEl, ev, 'keydown'); };
-            var wrapped = _getOrCreateRateLimitedHandler(_keyboardRateLimitState, keyEl, 'keydown', rawHandler);
+            var wrapped = _getOrCreateRateLimitedHandler(_keydownRateLimitState, keyEl, 'keydown', rawHandler);
             wrapped(e);
         }
     });
 
-    // keyup → dj-keyup
+    // keyup → dj-keyup (separate WeakMap from keydown to avoid handler collision)
     on('keyup', function(e) {
         var keyEl = e.target.closest('[dj-keyup]');
         if (keyEl) {
             var rawHandler = function(ev) { return _handleDjKeyboard(keyEl, ev, 'keyup'); };
-            // keyup shares the keyboard state map but different element keys won't collide
-            // since WeakMap is keyed by element object
-            var state = _keyboardRateLimitState.get(keyEl);
-            if (!state) {
-                var wrappedKu = _applyRateLimitAttrs(keyEl, rawHandler);
-                if (wrappedKu === rawHandler && window.djust.rateLimit) {
-                    wrappedKu = window.djust.rateLimit.wrapWithRateLimit(keyEl, 'keyup', rawHandler);
-                }
-                _keyboardRateLimitState.set(keyEl, { wrapped: wrappedKu });
-                state = _keyboardRateLimitState.get(keyEl);
-            }
-            state.wrapped(e);
+            var wrapped = _getOrCreateRateLimitedHandler(_keyupRateLimitState, keyEl, 'keyup', rawHandler);
+            wrapped(e);
         }
     });
 

--- a/python/djust/static/djust/src/09-event-binding.js
+++ b/python/djust/static/djust/src/09-event-binding.js
@@ -179,8 +179,660 @@ function _applyDisableWith(element) {
     element.disabled = true;
 }
 
+// ============================================================================
+// Delegated Event Handlers
+// ============================================================================
+
+// WeakMaps to store per-element rate limit state for delegated events.
+// Since delegation means we don't have a closure per element, we use
+// WeakMaps to associate rate-limited wrappers with their elements.
+const _inputRateLimitState = new WeakMap();
+const _changeRateLimitState = new WeakMap();
+const _clickRateLimitState = new WeakMap();
+const _keyboardRateLimitState = new WeakMap();
+
+// Helper: Extract field name from element attributes
+// Priority: data-field (explicit) > name (standard) > id (fallback)
+function getFieldName(element) {
+    if (element.dataset && element.dataset.field) {
+        return element.dataset.field;
+    }
+    if (element.name) {
+        return element.name;
+    }
+    if (element.id) {
+        // Strip common prefixes like 'id_' (Django convention)
+        return element.id.replace(/^id_/, '');
+    }
+    return null;
+}
+
+/**
+ * Build standard form event params with component context.
+ * Used by change, input, blur, focus event handlers.
+ * @param {HTMLElement} element - Form element that triggered the event
+ * @param {any} value - Current value of the field
+ * @returns {Object} - Params object with value, field, and optional component_id
+ */
+function buildFormEventParams(element, value) {
+    const fieldName = getFieldName(element);
+    const params = { value, field: fieldName };
+    // Merge dj-value-* attributes from the triggering element
+    Object.assign(params, collectDjValues(element));
+    addEventContext(params, element);
+    return params;
+}
+
+/**
+ * Get or create a rate-limited handler wrapper for an element.
+ * @param {WeakMap} stateMap - WeakMap storing per-element rate limit state
+ * @param {HTMLElement} element - Element to get/create wrapper for
+ * @param {string} eventType - Event type (for server rate limit lookup)
+ * @param {Function} rawHandler - The raw (unwrapped) handler function
+ * @returns {Function} - Rate-limited wrapper or raw handler
+ */
+function _getOrCreateRateLimitedHandler(stateMap, element, eventType, rawHandler) {
+    let state = stateMap.get(element);
+    if (state) return state.wrapped;
+
+    // Create rate-limited wrapper for this element
+    let wrapped = _applyRateLimitAttrs(element, rawHandler);
+    if (wrapped === rawHandler && window.djust.rateLimit) {
+        wrapped = window.djust.rateLimit.wrapWithRateLimit(element, eventType, rawHandler);
+    }
+    stateMap.set(element, { wrapped });
+    return wrapped;
+}
+
+/**
+ * Handle dj-click events via delegation.
+ * @param {HTMLElement} element - Element with dj-click attribute
+ * @param {Event} e - The original click event
+ */
+async function _handleDjClick(element, e) {
+    e.preventDefault();
+
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // Read attribute at fire time so morphElement attribute updates take effect
+    const rawClickValue = element.getAttribute('dj-click') || '';
+
+    // dj-confirm: show confirmation dialog before executing commands/events
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    // JS Commands: synchronously check whether the attribute is a
+    // JSON command chain. If so, fire-and-forget the chain (push
+    // ops still round-trip, but we don't block the rest of this
+    // handler on them). A plain event name falls through to the
+    // normal dj-click path without adding an `await` boundary,
+    // so synchronous expectations on dj-disable-with and friends
+    // continue to hold.
+    if (window.djust.js) {
+        const _ops = window.djust.js._parseCommandValue(rawClickValue);
+        if (_ops) {
+            window.djust.js._executeOps(_ops, element);
+            return;
+        }
+    }
+
+    const parsed = parseEventHandler(rawClickValue);
+
+    // dj-disable-with: disable and show loading text
+    _applyDisableWith(element);
+
+    // Apply optimistic update if specified
+    let optimisticUpdateId = null;
+    if (window.djust.optimistic) {
+        optimisticUpdateId = window.djust.optimistic.applyOptimisticUpdate(element, parsed.name);
+    }
+
+    // Extract all data-* attributes with type coercion support
+    const params = extractTypedParams(element);
+
+    // Add positional arguments from handler syntax if present
+    // e.g., dj-click="set_period('month')" -> params._args = ['month']
+    if (parsed.args.length > 0) {
+        params._args = parsed.args;
+    }
+
+    addEventContext(params, element);
+
+    // Pass target element and optimistic update ID
+    params._targetElement = element;
+    params._optimisticUpdateId = optimisticUpdateId;
+
+    // Handle dj-target for scoped updates
+    const targetSelector = element.getAttribute('dj-target');
+    if (targetSelector) {
+        params._djTargetSelector = targetSelector;
+    }
+
+    await handleEvent(parsed.name, params);
+}
+
+/**
+ * Handle dj-copy — client-side clipboard copy (no server round-trip).
+ * @param {HTMLElement} element - Element with dj-copy attribute
+ * @param {Event} e - The original click event
+ */
+function _handleDjCopy(element, e) {
+    e.preventDefault();
+    // Read attribute at click time (not bind time) so morph updates take effect
+    var currentValue = element.getAttribute('dj-copy');
+    if (!currentValue) return;
+
+    // Selector-based copy: if value starts with #, . or [, try querySelector
+    var textToCopy = currentValue;
+    if (currentValue.charAt(0) === '#' || currentValue.charAt(0) === '.' || currentValue.charAt(0) === '[') {
+        try {
+            var target = document.querySelector(currentValue);
+            if (target) {
+                textToCopy = target.textContent;
+            }
+        } catch (err) {
+            // Invalid selector — fall back to literal copy
+        }
+    }
+
+    navigator.clipboard.writeText(textToCopy).then(function() {
+        // CSS class feedback: add class and remove after 2s
+        var cssClass = element.getAttribute('dj-copy-class') || 'dj-copied';
+        element.classList.add(cssClass);
+        setTimeout(function() { element.classList.remove(cssClass); }, 2000);
+
+        // Text feedback: custom or default "Copied!"
+        var feedbackText = element.getAttribute('dj-copy-feedback') || 'Copied!';
+        var original = element.textContent;
+        element.textContent = feedbackText;
+        setTimeout(function() { element.textContent = original; }, 1500);
+
+        // Optional server event for analytics
+        var copyEvent = element.getAttribute('dj-copy-event');
+        if (copyEvent) {
+            handleEvent(copyEvent, { text: textToCopy });
+        }
+    });
+}
+
+/**
+ * Handle dj-submit events on forms via delegation.
+ * @param {HTMLElement} element - Form element with dj-submit attribute
+ * @param {Event} e - The original submit event
+ */
+async function _handleDjSubmit(element, e) {
+    e.preventDefault();
+
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // dj-confirm: show confirmation dialog before sending event
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    // Read attribute at fire time so morphElement attribute updates take effect
+    const submitHandler = element.getAttribute('dj-submit');
+
+    // dj-disable-with: disable submit buttons within the form
+    const submitBtns = element.querySelectorAll('button[type="submit"][dj-disable-with]');
+    submitBtns.forEach(btn => _applyDisableWith(btn));
+    // Also check the submitter if it has dj-disable-with
+    if (e.submitter && e.submitter.hasAttribute('dj-disable-with')) {
+        _applyDisableWith(e.submitter);
+    }
+
+    const formData = new FormData(element);
+    const params = Object.fromEntries(formData.entries());
+
+    // Merge dj-value-* attributes from the form element
+    Object.assign(params, collectDjValues(element));
+
+    addEventContext(params, element);
+
+    // _target: include submitter name if available
+    params._target = (e.submitter && (e.submitter.name || e.submitter.id)) || null;
+
+    // Pass target element for optimistic updates (Phase 3)
+    params._targetElement = element;
+
+    await handleEvent(submitHandler, params);
+}
+
+/**
+ * Handle dj-change events via delegation.
+ * @param {HTMLElement} element - Element with dj-change attribute
+ * @param {Event} e - The original change event
+ */
+async function _handleDjChange(element, e) {
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // dj-confirm: show confirmation dialog before sending event
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    // Read and parse attribute at fire time
+    const changeHandler = element.getAttribute('dj-change');
+    const parsedChange = parseEventHandler(changeHandler);
+
+    const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
+    const params = buildFormEventParams(e.target, value);
+
+    // Add positional arguments from handler syntax if present
+    // e.g., dj-change="toggle_todo(3)" -> params._args = [3]
+    if (parsedChange.args.length > 0) {
+        params._args = parsedChange.args;
+    }
+
+    // _target: include triggering field's name (or id, or null)
+    params._target = e.target.name || e.target.id || null;
+
+    // Add target element for loading state (consistent with other handlers)
+    params._targetElement = e.target;
+
+    // Handle dj-target for scoped updates
+    const targetSelector = element.getAttribute('dj-target');
+    if (targetSelector) {
+        params._djTargetSelector = targetSelector;
+    }
+
+    if (globalThis.djustDebug) {
+        console.log(`[LiveView] dj-change handler: value="${value}", params=`, params);
+    }
+    await handleEvent(parsedChange.name, params);
+}
+
+/**
+ * Handle dj-input events via delegation.
+ * @param {HTMLElement} element - Element with dj-input attribute
+ * @param {Event} e - The original input event
+ */
+async function _handleDjInput(element, e) {
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // dj-confirm: show confirmation dialog before sending event
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    // Read and parse attribute at fire time
+    const inputHandler = element.getAttribute('dj-input');
+    const parsedInput = parseEventHandler(inputHandler);
+
+    const params = buildFormEventParams(e.target, e.target.value);
+    if (parsedInput.args.length > 0) {
+        params._args = parsedInput.args;
+    }
+
+    // _target: include triggering field's name (or id, or null)
+    params._target = e.target.name || e.target.id || null;
+
+    await handleEvent(parsedInput.name, params);
+}
+
+/**
+ * Handle dj-blur events via delegation (using focusout which bubbles).
+ * @param {HTMLElement} element - Element with dj-blur attribute
+ * @param {Event} e - The original focusout event
+ */
+async function _handleDjBlur(element, e) {
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // dj-confirm: show confirmation dialog before sending event
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    // Read and parse attribute at fire time
+    const blurHandler = element.getAttribute('dj-blur');
+    const parsedBlur = parseEventHandler(blurHandler);
+
+    const params = buildFormEventParams(e.target, e.target.value);
+    if (parsedBlur.args.length > 0) {
+        params._args = parsedBlur.args;
+    }
+    await handleEvent(parsedBlur.name, params);
+}
+
+/**
+ * Handle dj-focus events via delegation (using focusin which bubbles).
+ * @param {HTMLElement} element - Element with dj-focus attribute
+ * @param {Event} e - The original focusin event
+ */
+async function _handleDjFocus(element, e) {
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // dj-confirm: show confirmation dialog before sending event
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    // Read and parse attribute at fire time
+    const focusHandler = element.getAttribute('dj-focus');
+    const parsedFocus = parseEventHandler(focusHandler);
+
+    const params = buildFormEventParams(e.target, e.target.value);
+    if (parsedFocus.args.length > 0) {
+        params._args = parsedFocus.args;
+    }
+    await handleEvent(parsedFocus.name, params);
+}
+
+/**
+ * Handle dj-paste events via delegation.
+ * Extracts structured clipboard payload (plain text, rich HTML, files)
+ * and sends it to the server as a single event call.
+ * @param {HTMLElement} element - Element with dj-paste attribute
+ * @param {Event} e - The original paste event
+ */
+async function _handleDjPaste(element, e) {
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // dj-confirm: show confirmation dialog before sending event
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    // Read and parse attribute at fire time
+    const pasteHandler = element.getAttribute('dj-paste');
+    const parsedPaste = parseEventHandler(pasteHandler);
+
+    const clipboardData = e.clipboardData || window.clipboardData;
+    if (!clipboardData) {
+        // No clipboard data available — let the default paste happen
+        return;
+    }
+
+    // Build structured payload: text, html, and file metadata.
+    // The actual file bytes are NOT sent in this event — that would
+    // blow the WS frame budget. Instead, set a dj-upload slot on
+    // the element and UploadMixin will pick up any files from the
+    // clipboard files list via the existing upload pipeline.
+    let text = '';
+    let html = '';
+    const files = [];
+    try {
+        text = clipboardData.getData('text/plain') || '';
+    } catch (err) { /* older browsers */ }
+    try {
+        html = clipboardData.getData('text/html') || '';
+    } catch (err) { /* older browsers */ }
+    if (clipboardData.files) {
+        for (let i = 0; i < clipboardData.files.length; i++) {
+            const f = clipboardData.files[i];
+            files.push({
+                name: f.name || 'clipboard-paste',
+                type: f.type || '',
+                size: f.size || 0,
+            });
+        }
+    }
+
+    // If the element has an upload slot configured, route pasted
+    // files through the upload pipeline (image paste → chat, etc).
+    // We route BEFORE sending the server event so the handler can
+    // react to both the metadata and the pending upload in one tick.
+    if (files.length > 0 && window.djust && window.djust.uploads && element.getAttribute('dj-upload')) {
+        try {
+            await window.djust.uploads.queueClipboardFiles(element, clipboardData.files);
+        } catch (err) {
+            if (globalThis.djustDebug) console.log('[LiveView] dj-paste: upload route failed', err);
+        }
+    }
+
+    const params = {
+        text: text,
+        html: html,
+        has_files: files.length > 0,
+        files: files,
+    };
+    if (parsedPaste.args.length > 0) {
+        params._args = parsedPaste.args;
+    }
+
+    // Suppress the default paste only when the element opts in
+    // with dj-paste-suppress. Otherwise let the browser also
+    // insert into the input so hybrid UIs still feel natural.
+    if (element.hasAttribute('dj-paste-suppress')) {
+        e.preventDefault();
+    }
+
+    await handleEvent(parsedPaste.name, params);
+}
+
+/**
+ * Handle dj-keydown / dj-keyup events via delegation.
+ * @param {HTMLElement} element - Element with dj-keydown or dj-keyup attribute
+ * @param {Event} e - The original keyboard event
+ * @param {string} eventType - 'keydown' or 'keyup'
+ */
+async function _handleDjKeyboard(element, e, eventType) {
+    // Read attribute at fire time
+    const keyHandler = element.getAttribute('dj-' + eventType);
+    if (!keyHandler) return;
+
+    // Check for key modifiers (e.g. dj-keydown.enter)
+    const modifiers = keyHandler.split('.');
+    const handlerName = modifiers[0];
+    const requiredKey = modifiers.length > 1 ? modifiers[1] : null;
+
+    if (requiredKey) {
+        if (requiredKey === 'enter' && e.key !== 'Enter') return;
+        if (requiredKey === 'escape' && e.key !== 'Escape') return;
+        if (requiredKey === 'space' && e.key !== ' ') return;
+        // Add more key mappings as needed
+    }
+
+    // dj-lock: skip if already locked
+    if (_checkAndLock(element)) return;
+
+    // dj-confirm: show confirmation dialog before sending event
+    if (!checkDjConfirm(element)) {
+        return; // User cancelled
+    }
+
+    const fieldName = getFieldName(e.target);
+    const params = {
+        key: e.key,
+        code: e.code,
+        value: e.target.value,
+        field: fieldName
+    };
+
+    // Merge dj-value-* attributes from the element
+    Object.assign(params, collectDjValues(element));
+
+    addEventContext(params, e.target);
+
+    // Add target element and handle dj-target
+    params._targetElement = e.target;
+    const targetSelector = element.getAttribute('dj-target');
+    if (targetSelector) {
+        params._djTargetSelector = targetSelector;
+    }
+
+    await handleEvent(handlerName, params);
+}
+
+// ============================================================================
+// Event Delegation
+// ============================================================================
+
+/**
+ * Install ONE delegated listener per DOM event type on the given root element.
+ * Idempotent — checks root._djustDelegated to avoid double-installing.
+ * @param {HTMLElement} root - The LiveView root element to delegate from
+ */
+function installDelegatedListeners(root) {
+    if (root._djustDelegated) return;
+    root._djustDelegated = true;
+
+    // click → dj-copy (client-only) first, then dj-click
+    root.addEventListener('click', function(e) {
+        var copyEl = e.target.closest('[dj-copy]');
+        if (copyEl) {
+            _handleDjCopy(copyEl, e);
+            return;
+        }
+        var clickEl = e.target.closest('[dj-click]');
+        if (clickEl) {
+            // Rate-limit per element using WeakMap
+            var rawHandler = function(ev) { return _handleDjClick(clickEl, ev); };
+            var wrapped = _getOrCreateRateLimitedHandler(_clickRateLimitState, clickEl, 'click', rawHandler);
+            wrapped(e);
+        }
+    });
+
+    // submit → dj-submit
+    root.addEventListener('submit', function(e) {
+        var submitEl = e.target.closest('[dj-submit]');
+        if (submitEl) {
+            _handleDjSubmit(submitEl, e);
+        }
+    });
+
+    // change → dj-change
+    root.addEventListener('change', function(e) {
+        var changeEl = e.target.closest('[dj-change]');
+        if (changeEl) {
+            // Rate-limit per element using WeakMap
+            var rawHandler = function(ev) { return _handleDjChange(changeEl, ev); };
+            var wrapped = _getOrCreateRateLimitedHandler(_changeRateLimitState, changeEl, 'change', rawHandler);
+            wrapped(e);
+        }
+    });
+
+    // input → dj-input (with smart rate limiting)
+    root.addEventListener('input', function(e) {
+        var inputEl = e.target.closest('[dj-input]');
+        if (inputEl) {
+            // Get or create rate-limited wrapper for this element
+            var state = _inputRateLimitState.get(inputEl);
+            if (!state) {
+                // Build the raw handler
+                var rawHandler = function(ev) { return _handleDjInput(inputEl, ev); };
+
+                // Determine rate limit strategy
+                var inputType = inputEl.type || inputEl.tagName.toLowerCase();
+                var rateLimit = Object.prototype.hasOwnProperty.call(DEFAULT_RATE_LIMITS, inputType) ? DEFAULT_RATE_LIMITS[inputType] : { type: 'debounce', ms: 300 };
+
+                // Check for explicit overrides: dj-* attributes take precedence
+                if (inputEl.hasAttribute('dj-debounce')) {
+                    var djVal = inputEl.getAttribute('dj-debounce');
+                    if (djVal === 'blur') {
+                        rateLimit.type = 'blur';
+                        rateLimit.ms = 0;
+                    } else {
+                        rateLimit.type = 'debounce';
+                        rateLimit.ms = parseInt(djVal, 10);
+                    }
+                } else if (inputEl.hasAttribute('dj-throttle')) {
+                    rateLimit.type = 'throttle';
+                    rateLimit.ms = parseInt(inputEl.getAttribute('dj-throttle'), 10);
+                } else if (inputEl.hasAttribute('data-debounce')) {
+                    rateLimit.type = 'debounce';
+                    rateLimit.ms = parseInt(inputEl.getAttribute('data-debounce'));
+                } else if (inputEl.hasAttribute('data-throttle')) {
+                    rateLimit.type = 'throttle';
+                    rateLimit.ms = parseInt(inputEl.getAttribute('data-throttle'));
+                }
+
+                // Apply rate limiting wrapper
+                var wrapped;
+                if (rateLimit.type === 'blur') {
+                    // dj-debounce="blur": defer until element loses focus
+                    var latestArgs = null;
+                    wrapped = function() {
+                        latestArgs = arguments;
+                    };
+                    inputEl.addEventListener('blur', function() {
+                        if (latestArgs !== null) {
+                            rawHandler.apply(null, latestArgs);
+                            latestArgs = null;
+                        }
+                    });
+                } else if (rateLimit.type === 'throttle') {
+                    wrapped = throttle(rawHandler, rateLimit.ms);
+                } else {
+                    wrapped = debounce(rawHandler, rateLimit.ms);
+                }
+
+                state = { wrapped: wrapped };
+                _inputRateLimitState.set(inputEl, state);
+            }
+            state.wrapped(e);
+        }
+    });
+
+    // keydown → dj-keydown
+    root.addEventListener('keydown', function(e) {
+        var keyEl = e.target.closest('[dj-keydown]');
+        if (keyEl) {
+            var rawHandler = function(ev) { return _handleDjKeyboard(keyEl, ev, 'keydown'); };
+            var wrapped = _getOrCreateRateLimitedHandler(_keyboardRateLimitState, keyEl, 'keydown', rawHandler);
+            wrapped(e);
+        }
+    });
+
+    // keyup → dj-keyup
+    root.addEventListener('keyup', function(e) {
+        var keyEl = e.target.closest('[dj-keyup]');
+        if (keyEl) {
+            var rawHandler = function(ev) { return _handleDjKeyboard(keyEl, ev, 'keyup'); };
+            // keyup shares the keyboard state map but different element keys won't collide
+            // since WeakMap is keyed by element object
+            var state = _keyboardRateLimitState.get(keyEl);
+            if (!state) {
+                var wrappedKu = _applyRateLimitAttrs(keyEl, rawHandler);
+                if (wrappedKu === rawHandler && window.djust.rateLimit) {
+                    wrappedKu = window.djust.rateLimit.wrapWithRateLimit(keyEl, 'keyup', rawHandler);
+                }
+                _keyboardRateLimitState.set(keyEl, { wrapped: wrappedKu });
+                state = _keyboardRateLimitState.get(keyEl);
+            }
+            state.wrapped(e);
+        }
+    });
+
+    // paste → dj-paste
+    root.addEventListener('paste', function(e) {
+        var pasteEl = e.target.closest('[dj-paste]');
+        if (pasteEl) {
+            _handleDjPaste(pasteEl, e);
+        }
+    });
+
+    // focusin → dj-focus (focusin bubbles, focus doesn't)
+    root.addEventListener('focusin', function(e) {
+        var focusEl = e.target.closest('[dj-focus]');
+        if (focusEl) {
+            _handleDjFocus(focusEl, e);
+        }
+    });
+
+    // focusout → dj-blur (focusout bubbles, blur doesn't)
+    root.addEventListener('focusout', function(e) {
+        var blurEl = e.target.closest('[dj-blur]');
+        if (blurEl) {
+            _handleDjBlur(blurEl, e);
+        }
+    });
+}
+
 function bindLiveViewEvents(scope) {
-    const root = scope || document;
+    const root = scope || getLiveViewRoot() || document;
+
+    // Install delegated listeners ONCE on the LiveView root
+    const liveRoot = getLiveViewRoot();
+    if (liveRoot) installDelegatedListeners(liveRoot);
 
     // Bind upload handlers (dj-upload, dj-upload-drop, dj-upload-preview)
     if (window.djust.uploads) {
@@ -192,521 +844,12 @@ function bindLiveViewEvents(scope) {
         window.djust.navigation.bindDirectives(scope);
     }
 
-    // Find interactive elements via targeted attribute selectors instead of
-    // scanning all elements. This is O(interactive) instead of O(all_elements).
-    const djSelector = '[dj-click],[dj-change],[dj-input],[dj-submit],' +
-        '[dj-focus],[dj-blur],[dj-keydown],[dj-keyup],[dj-mouseenter],' +
-        '[dj-mouseleave],[dj-scroll],[dj-mounted],[dj-paste],[dj-poll],' +
-        '[dj-viewport-enter],[dj-viewport-leave],[dj-disable-with],' +
-        '[dj-copy],[dj-click-away],[dj-shortcut],[dj-auto-recover]';
-    const allElements = root.querySelectorAll(djSelector);
-    allElements.forEach(element => {
-        // Handle dj-click events
-        const clickHandler = element.getAttribute('dj-click');
-        if (clickHandler && !_isHandlerBound(element, 'click')) {
-            _markHandlerBound(element, 'click');
-
-            const clickHandlerFn = async (e) => {
-                e.preventDefault();
-
-                // dj-lock: skip if already locked
-                if (_checkAndLock(element)) return;
-
-                // Read attribute at fire time so morphElement attribute updates take effect
-                const rawClickValue = element.getAttribute('dj-click') || '';
-
-                // dj-confirm: show confirmation dialog before executing commands/events
-                if (!checkDjConfirm(element)) {
-                    return; // User cancelled
-                }
-
-                // JS Commands: synchronously check whether the attribute is a
-                // JSON command chain. If so, fire-and-forget the chain (push
-                // ops still round-trip, but we don't block the rest of this
-                // handler on them). A plain event name falls through to the
-                // normal dj-click path without adding an `await` boundary,
-                // so synchronous expectations on dj-disable-with and friends
-                // continue to hold.
-                if (window.djust.js) {
-                    const _ops = window.djust.js._parseCommandValue(rawClickValue);
-                    if (_ops) {
-                        window.djust.js._executeOps(_ops, element);
-                        return;
-                    }
-                }
-
-                const parsed = parseEventHandler(rawClickValue);
-
-                // dj-disable-with: disable and show loading text
-                _applyDisableWith(element);
-
-                // Apply optimistic update if specified
-                let optimisticUpdateId = null;
-                if (window.djust.optimistic) {
-                    optimisticUpdateId = window.djust.optimistic.applyOptimisticUpdate(e.currentTarget, parsed.name);
-                }
-
-                // Extract all data-* attributes with type coercion support
-                const params = extractTypedParams(element);
-
-                // Add positional arguments from handler syntax if present
-                // e.g., dj-click="set_period('month')" -> params._args = ['month']
-                if (parsed.args.length > 0) {
-                    params._args = parsed.args;
-                }
-
-                addEventContext(params, e.currentTarget);
-
-                // Pass target element and optimistic update ID
-                params._targetElement = e.currentTarget;
-                params._optimisticUpdateId = optimisticUpdateId;
-
-                // Handle dj-target for scoped updates
-                const targetSelector = element.getAttribute('dj-target');
-                if (targetSelector) {
-                    params._djTargetSelector = targetSelector;
-                }
-
-                await handleEvent(parsed.name, params);
-            };
-
-            // Apply dj-debounce/dj-throttle HTML attributes first, then server rate limit
-            let wrappedHandler = _applyRateLimitAttrs(element, clickHandlerFn);
-            if (wrappedHandler === clickHandlerFn && window.djust.rateLimit) {
-                wrappedHandler = window.djust.rateLimit.wrapWithRateLimit(element, 'click', clickHandlerFn);
-            }
-
-            element.addEventListener('click', wrappedHandler);
-        }
-
-        // Handle dj-copy — client-side clipboard copy (no server round-trip)
-        if (element.getAttribute('dj-copy') && !_isHandlerBound(element, 'copy')) {
-            _markHandlerBound(element, 'copy');
-            element.addEventListener('click', function(e) {
-                e.preventDefault();
-                // Read attribute at click time (not bind time) so morph updates take effect
-                var currentValue = element.getAttribute('dj-copy');
-                if (!currentValue) return;
-
-                // Selector-based copy: if value starts with #, . or [, try querySelector
-                var textToCopy = currentValue;
-                if (currentValue.charAt(0) === '#' || currentValue.charAt(0) === '.' || currentValue.charAt(0) === '[') {
-                    try {
-                        var target = document.querySelector(currentValue);
-                        if (target) {
-                            textToCopy = target.textContent;
-                        }
-                    } catch (err) {
-                        // Invalid selector — fall back to literal copy
-                    }
-                }
-
-                navigator.clipboard.writeText(textToCopy).then(function() {
-                    // CSS class feedback: add class and remove after 2s
-                    var cssClass = element.getAttribute('dj-copy-class') || 'dj-copied';
-                    element.classList.add(cssClass);
-                    setTimeout(function() { element.classList.remove(cssClass); }, 2000);
-
-                    // Text feedback: custom or default "Copied!"
-                    var feedbackText = element.getAttribute('dj-copy-feedback') || 'Copied!';
-                    var original = element.textContent;
-                    element.textContent = feedbackText;
-                    setTimeout(function() { element.textContent = original; }, 1500);
-
-                    // Optional server event for analytics
-                    var copyEvent = element.getAttribute('dj-copy-event');
-                    if (copyEvent) {
-                        handleEvent(copyEvent, { text: textToCopy });
-                    }
-                });
-            });
-        }
-
-        // Handle dj-submit events on forms
-        const submitHandler = element.getAttribute('dj-submit');
-        if (submitHandler && !_isHandlerBound(element, 'submit')) {
-            _markHandlerBound(element, 'submit');
-            element.addEventListener('submit', async (e) => {
-                e.preventDefault();
-
-                // dj-lock: skip if already locked
-                if (_checkAndLock(e.target)) return;
-
-                // dj-confirm: show confirmation dialog before sending event
-                if (!checkDjConfirm(e.target)) {
-                    return; // User cancelled
-                }
-
-                // dj-disable-with: disable submit buttons within the form
-                const submitBtns = e.target.querySelectorAll('button[type="submit"][dj-disable-with]');
-                submitBtns.forEach(btn => _applyDisableWith(btn));
-                // Also check the submitter if it has dj-disable-with
-                if (e.submitter && e.submitter.hasAttribute('dj-disable-with')) {
-                    _applyDisableWith(e.submitter);
-                }
-
-                const formData = new FormData(e.target);
-                const params = Object.fromEntries(formData.entries());
-
-                // Merge dj-value-* attributes from the form element
-                Object.assign(params, collectDjValues(e.target));
-
-                addEventContext(params, e.target);
-
-                // _target: include submitter name if available
-                params._target = (e.submitter && (e.submitter.name || e.submitter.id)) || null;
-
-                // Pass target element for optimistic updates (Phase 3)
-                params._targetElement = e.target;
-
-                await handleEvent(submitHandler, params);
-            });
-        }
-
-        // Helper: Extract field name from element attributes
-        // Priority: data-field (explicit) > name (standard) > id (fallback)
-        function getFieldName(element) {
-            if (element.dataset.field) {
-                return element.dataset.field;
-            }
-            if (element.name) {
-                return element.name;
-            }
-            if (element.id) {
-                // Strip common prefixes like 'id_' (Django convention)
-                return element.id.replace(/^id_/, '');
-            }
-            return null;
-        }
-
-        /**
-         * Build standard form event params with component context.
-         * Used by change, input, blur, focus event handlers.
-         * @param {HTMLElement} element - Form element that triggered the event
-         * @param {any} value - Current value of the field
-         * @returns {Object} - Params object with value, field, and optional component_id
-         */
-        function buildFormEventParams(element, value) {
-            const fieldName = getFieldName(element);
-            const params = { value, field: fieldName };
-            // Merge dj-value-* attributes from the triggering element
-            Object.assign(params, collectDjValues(element));
-            addEventContext(params, element);
-            return params;
-        }
-
-        // Handle dj-change events
-        const changeHandler = element.getAttribute('dj-change');
-        if (changeHandler && !_isHandlerBound(element, 'change')) {
-            _markHandlerBound(element, 'change');
-            // Parse handler string to extract function name and arguments
-            const parsedChange = parseEventHandler(changeHandler);
-
-            const changeHandlerFn = async (e) => {
-                // dj-lock: skip if already locked
-                if (_checkAndLock(element)) return;
-
-                // dj-confirm: show confirmation dialog before sending event
-                if (!checkDjConfirm(element)) {
-                    return; // User cancelled
-                }
-
-                const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
-                const params = buildFormEventParams(e.target, value);
-
-                // Add positional arguments from handler syntax if present
-                // e.g., dj-change="toggle_todo(3)" -> params._args = [3]
-                if (parsedChange.args.length > 0) {
-                    params._args = parsedChange.args;
-                }
-
-                // _target: include triggering field's name (or id, or null)
-                params._target = e.target.name || e.target.id || null;
-
-                // Add target element for loading state (consistent with other handlers)
-                params._targetElement = e.target;
-
-                // Handle dj-target for scoped updates
-                const targetSelector = element.getAttribute('dj-target');
-                if (targetSelector) {
-                    params._djTargetSelector = targetSelector;
-                }
-
-                if (globalThis.djustDebug) {
-                    console.log(`[LiveView] dj-change handler: value="${value}", params=`, params);
-                }
-                await handleEvent(parsedChange.name, params);
-            };
-
-            // Apply dj-debounce/dj-throttle HTML attributes first, then server rate limit
-            let wrappedChangeHandler = _applyRateLimitAttrs(element, changeHandlerFn);
-            if (wrappedChangeHandler === changeHandlerFn && window.djust.rateLimit) {
-                wrappedChangeHandler = window.djust.rateLimit.wrapWithRateLimit(element, 'change', changeHandlerFn);
-            }
-
-            element.addEventListener('change', wrappedChangeHandler);
-        }
-
-        // Handle dj-input events (with smart debouncing/throttling)
-        const inputHandler = element.getAttribute('dj-input');
-        if (inputHandler && !_isHandlerBound(element, 'input')) {
-            _markHandlerBound(element, 'input');
-            // Parse handler string to extract function name and arguments
-            const parsedInput = parseEventHandler(inputHandler);
-
-            // Determine rate limit strategy
-            const inputType = element.type || element.tagName.toLowerCase();
-            const rateLimit = Object.prototype.hasOwnProperty.call(DEFAULT_RATE_LIMITS, inputType) ? DEFAULT_RATE_LIMITS[inputType] : { type: 'debounce', ms: 300 };
-
-            // Check for explicit overrides: dj-* attributes take precedence
-            if (element.hasAttribute('dj-debounce')) {
-                const djVal = element.getAttribute('dj-debounce');
-                if (djVal === 'blur') {
-                    rateLimit.type = 'blur';
-                    rateLimit.ms = 0;
-                } else {
-                    rateLimit.type = 'debounce';
-                    rateLimit.ms = parseInt(djVal, 10);
-                }
-            } else if (element.hasAttribute('dj-throttle')) {
-                rateLimit.type = 'throttle';
-                rateLimit.ms = parseInt(element.getAttribute('dj-throttle'), 10);
-            } else if (element.hasAttribute('data-debounce')) {
-                rateLimit.type = 'debounce';
-                rateLimit.ms = parseInt(element.getAttribute('data-debounce'));
-            } else if (element.hasAttribute('data-throttle')) {
-                rateLimit.type = 'throttle';
-                rateLimit.ms = parseInt(element.getAttribute('data-throttle'));
-            }
-
-            const handler = async (e) => {
-                // dj-lock: skip if already locked
-                if (_checkAndLock(element)) return;
-
-                // dj-confirm: show confirmation dialog before sending event
-                if (!checkDjConfirm(element)) {
-                    return; // User cancelled
-                }
-
-                const params = buildFormEventParams(e.target, e.target.value);
-                if (parsedInput.args.length > 0) {
-                    params._args = parsedInput.args;
-                }
-
-                // _target: include triggering field's name (or id, or null)
-                params._target = e.target.name || e.target.id || null;
-
-                await handleEvent(parsedInput.name, params);
-            };
-
-            // Apply rate limiting wrapper
-            let wrappedHandler;
-            if (rateLimit.type === 'blur') {
-                // dj-debounce="blur": defer until element loses focus
-                let latestArgs = null;
-                wrappedHandler = function (...args) {
-                    latestArgs = args;
-                };
-                element.addEventListener('blur', function () {
-                    if (latestArgs !== null) {
-                        handler(...latestArgs);
-                        latestArgs = null;
-                    }
-                });
-            } else if (rateLimit.type === 'throttle') {
-                wrappedHandler = throttle(handler, rateLimit.ms);
-            } else {
-                wrappedHandler = debounce(handler, rateLimit.ms);
-            }
-
-            element.addEventListener('input', wrappedHandler);
-        }
-
-        // Handle dj-blur events
-        const blurHandler = element.getAttribute('dj-blur');
-        if (blurHandler && !_isHandlerBound(element, 'blur')) {
-            _markHandlerBound(element, 'blur');
-            const parsedBlur = parseEventHandler(blurHandler);
-            element.addEventListener('blur', async (e) => {
-                // dj-lock: skip if already locked
-                if (_checkAndLock(element)) return;
-
-                // dj-confirm: show confirmation dialog before sending event
-                if (!checkDjConfirm(element)) {
-                    return; // User cancelled
-                }
-
-                const params = buildFormEventParams(e.target, e.target.value);
-                if (parsedBlur.args.length > 0) {
-                    params._args = parsedBlur.args;
-                }
-                await handleEvent(parsedBlur.name, params);
-            });
-        }
-
-        // Handle dj-focus events
-        const focusHandler = element.getAttribute('dj-focus');
-        if (focusHandler && !_isHandlerBound(element, 'focus')) {
-            _markHandlerBound(element, 'focus');
-            const parsedFocus = parseEventHandler(focusHandler);
-            element.addEventListener('focus', async (e) => {
-                // dj-lock: skip if already locked
-                if (_checkAndLock(element)) return;
-
-                // dj-confirm: show confirmation dialog before sending event
-                if (!checkDjConfirm(element)) {
-                    return; // User cancelled
-                }
-
-                const params = buildFormEventParams(e.target, e.target.value);
-                if (parsedFocus.args.length > 0) {
-                    params._args = parsedFocus.args;
-                }
-                await handleEvent(parsedFocus.name, params);
-            });
-        }
-
-        // Handle dj-paste events
-        // Extracts structured clipboard payload (plain text, rich HTML, files)
-        // and sends it to the server as a single event call.
-        const pasteHandler = element.getAttribute('dj-paste');
-        if (pasteHandler && !_isHandlerBound(element, 'paste')) {
-            _markHandlerBound(element, 'paste');
-            const parsedPaste = parseEventHandler(pasteHandler);
-            element.addEventListener('paste', async (e) => {
-                // dj-lock: skip if already locked
-                if (_checkAndLock(element)) return;
-
-                // dj-confirm: show confirmation dialog before sending event
-                if (!checkDjConfirm(element)) {
-                    return; // User cancelled
-                }
-
-                const clipboardData = e.clipboardData || window.clipboardData;
-                if (!clipboardData) {
-                    // No clipboard data available — let the default paste happen
-                    return;
-                }
-
-                // Build structured payload: text, html, and file metadata.
-                // The actual file bytes are NOT sent in this event — that would
-                // blow the WS frame budget. Instead, set a dj-upload slot on
-                // the element and UploadMixin will pick up any files from the
-                // clipboard files list via the existing upload pipeline.
-                let text = '';
-                let html = '';
-                const files = [];
-                try {
-                    text = clipboardData.getData('text/plain') || '';
-                } catch (err) { /* older browsers */ }
-                try {
-                    html = clipboardData.getData('text/html') || '';
-                } catch (err) { /* older browsers */ }
-                if (clipboardData.files) {
-                    for (let i = 0; i < clipboardData.files.length; i++) {
-                        const f = clipboardData.files[i];
-                        files.push({
-                            name: f.name || 'clipboard-paste',
-                            type: f.type || '',
-                            size: f.size || 0,
-                        });
-                    }
-                }
-
-                // If the element has an upload slot configured, route pasted
-                // files through the upload pipeline (image paste → chat, etc).
-                // We route BEFORE sending the server event so the handler can
-                // react to both the metadata and the pending upload in one tick.
-                if (files.length > 0 && window.djust && window.djust.uploads && element.getAttribute('dj-upload')) {
-                    try {
-                        await window.djust.uploads.queueClipboardFiles(element, clipboardData.files);
-                    } catch (err) {
-                        if (globalThis.djustDebug) console.log('[LiveView] dj-paste: upload route failed', err);
-                    }
-                }
-
-                const params = {
-                    text: text,
-                    html: html,
-                    has_files: files.length > 0,
-                    files: files,
-                };
-                if (parsedPaste.args.length > 0) {
-                    params._args = parsedPaste.args;
-                }
-
-                // Suppress the default paste only when the element opts in
-                // with dj-paste-suppress. Otherwise let the browser also
-                // insert into the input so hybrid UIs still feel natural.
-                if (element.hasAttribute('dj-paste-suppress')) {
-                    e.preventDefault();
-                }
-
-                await handleEvent(parsedPaste.name, params);
-            });
-        }
-
-        // Handle dj-keydown / dj-keyup events
-        ['keydown', 'keyup'].forEach(eventType => {
-            const keyHandler = element.getAttribute(`dj-${eventType}`);
-            if (keyHandler && !_isHandlerBound(element, eventType)) {
-                _markHandlerBound(element, eventType);
-
-                const keyHandlerFn = async (e) => {
-                    // Check for key modifiers (e.g. dj-keydown.enter)
-                    const modifiers = keyHandler.split('.');
-                    const handlerName = modifiers[0];
-                    const requiredKey = modifiers.length > 1 ? modifiers[1] : null;
-
-                    if (requiredKey) {
-                        if (requiredKey === 'enter' && e.key !== 'Enter') return;
-                        if (requiredKey === 'escape' && e.key !== 'Escape') return;
-                        if (requiredKey === 'space' && e.key !== ' ') return;
-                        // Add more key mappings as needed
-                    }
-
-                    // dj-lock: skip if already locked
-                    if (_checkAndLock(element)) return;
-
-                    // dj-confirm: show confirmation dialog before sending event
-                    if (!checkDjConfirm(element)) {
-                        return; // User cancelled
-                    }
-
-                    const fieldName = getFieldName(e.target);
-                    const params = {
-                        key: e.key,
-                        code: e.code,
-                        value: e.target.value,
-                        field: fieldName
-                    };
-
-                    // Merge dj-value-* attributes from the element
-                    Object.assign(params, collectDjValues(element));
-
-                    addEventContext(params, e.target);
-
-                    // Add target element and handle dj-target
-                    params._targetElement = e.target;
-                    const targetSelector = element.getAttribute('dj-target');
-                    if (targetSelector) {
-                        params._djTargetSelector = targetSelector;
-                    }
-
-                    await handleEvent(handlerName, params);
-                };
-
-                // Apply dj-debounce/dj-throttle HTML attributes first, then server rate limit
-                let wrappedKeyHandler = _applyRateLimitAttrs(element, keyHandlerFn);
-                if (wrappedKeyHandler === keyHandlerFn && window.djust.rateLimit) {
-                    wrappedKeyHandler = window.djust.rateLimit.wrapWithRateLimit(element, eventType, keyHandlerFn);
-                }
-
-                element.addEventListener(eventType, wrappedKeyHandler);
-            }
-        });
-
-        // Handle dj-poll — declarative polling
+    // === Per-element scanning section (only for non-delegable events) ===
+
+    // dj-poll needs per-element interval setup
+    const pollSelector = '[dj-poll]';
+    const pollElements = root.querySelectorAll(pollSelector);
+    pollElements.forEach(element => {
         const pollHandler = element.getAttribute('dj-poll');
         if (pollHandler && !_isHandlerBound(element, 'poll')) {
             _markHandlerBound(element, 'poll');
@@ -1223,6 +1366,7 @@ function _processFormRecovery() {
 // Export for testing and for createNodeFromVNode to mark VDOM-created elements as bound
 window.djust.bindLiveViewEvents = bindLiveViewEvents;
 window.djust.reinitAfterDOMUpdate = reinitAfterDOMUpdate;
+window.djust.installDelegatedListeners = installDelegatedListeners;
 window.djust._isHandlerBound = _isHandlerBound;
 window.djust._markHandlerBound = _markHandlerBound;
 window.djust._processAutoRecover = _processAutoRecover;

--- a/python/djust/static/djust/src/09-event-binding.js
+++ b/python/djust/static/djust/src/09-event-binding.js
@@ -179,19 +179,27 @@ function _applyDisableWith(element) {
     element.disabled = true;
 }
 
-function bindLiveViewEvents() {
+function bindLiveViewEvents(scope) {
+    const root = scope || document;
+
     // Bind upload handlers (dj-upload, dj-upload-drop, dj-upload-preview)
     if (window.djust.uploads) {
-        window.djust.uploads.bindHandlers();
+        window.djust.uploads.bindHandlers(scope);
     }
 
     // Bind navigation directives (dj-patch, dj-navigate)
     if (window.djust.navigation) {
-        window.djust.navigation.bindDirectives();
+        window.djust.navigation.bindDirectives(scope);
     }
 
-    // Find all interactive elements
-    const allElements = document.querySelectorAll('*');
+    // Find interactive elements via targeted attribute selectors instead of
+    // scanning all elements. This is O(interactive) instead of O(all_elements).
+    const djSelector = '[dj-click],[dj-change],[dj-input],[dj-submit],' +
+        '[dj-focus],[dj-blur],[dj-keydown],[dj-keyup],[dj-mouseenter],' +
+        '[dj-mouseleave],[dj-scroll],[dj-mounted],[dj-paste],[dj-poll],' +
+        '[dj-viewport-enter],[dj-viewport-leave],[dj-disable-with],' +
+        '[dj-copy],[dj-click-away],[dj-shortcut],[dj-auto-recover]';
+    const allElements = root.querySelectorAll(djSelector);
     allElements.forEach(element => {
         // Handle dj-click events
         const clickHandler = element.getAttribute('dj-click');
@@ -738,17 +746,20 @@ function bindLiveViewEvents() {
     ];
     const scopedEventTypes = ['keydown', 'keyup', 'click', 'scroll', 'resize'];
 
-    // Collect all elements that have any dj-window-* or dj-document-* attributes
-    // by scanning once through allElements (already queried above).
+    // Collect elements with dj-window-*/dj-document-* attributes.
+    // These have dynamic attribute names (e.g. dj-window-keydown.escape)
+    // that CSS selectors can't match, so we scan all elements within root.
+    // This is a small scan since most pages have 0-5 scoped listener elements.
+    const scopedElements = root.querySelectorAll('*');
     for (const { prefix, target } of scopedPrefixes) {
         for (const evtType of scopedEventTypes) {
             // scroll and resize only make sense on window
             if (target === document && (evtType === 'scroll' || evtType === 'resize')) continue;
 
             const attrBase = prefix + evtType;
-            // Scan all elements for attributes starting with this prefix+eventType
+            // Scan elements for attributes starting with this prefix+eventType
             // (covers both exact matches and key-modifier variants like dj-window-keydown.escape)
-            allElements.forEach(element => {
+            scopedElements.forEach(element => {
                 for (const attr of element.attributes) {
                     if (!attr.name.startsWith(attrBase)) continue;
                     const bindType = attr.name; // e.g. 'dj-window-keydown' or 'dj-window-keydown.escape'
@@ -1024,14 +1035,23 @@ function clearOptimisticState(eventName) {
 // will scroll again — correct behavior for newly inserted content.
 const _scrolledElements = new WeakSet();
 
-function reinitAfterDOMUpdate() {
+function reinitAfterDOMUpdate(scope) {
     initReactCounters();
     initTodoItems();
-    bindLiveViewEvents();
+    bindLiveViewEvents(scope);
+    if (window.djust.mountHooks) {
+        // updateHooks scans for [dj-hook] — scope it too
+        const hookRoot = scope || getLiveViewRoot();
+        hookRoot.querySelectorAll('[dj-hook]').forEach(el => {
+            // Delegate to the hook system's per-element logic
+            if (window.djust.mountHooks) window.djust.mountHooks(el);
+        });
+    }
     updateHooks();
 
     // dj-scroll-into-view: auto-scroll elements into view after DOM updates
-    document.querySelectorAll('[dj-scroll-into-view]').forEach(el => {
+    const scrollRoot = scope || document;
+    scrollRoot.querySelectorAll('[dj-scroll-into-view]').forEach(el => {
         if (_scrolledElements.has(el)) return;
         _scrolledElements.add(el);
 

--- a/python/djust/static/djust/src/09-event-binding.js
+++ b/python/djust/static/djust/src/09-event-binding.js
@@ -842,8 +842,11 @@ function installDelegatedListeners(root) {
 function bindLiveViewEvents(scope) {
     const root = scope || getLiveViewRoot() || document;
 
-    // Install delegated listeners ONCE on the LiveView root
-    const liveRoot = getLiveViewRoot();
+    // Install delegated listeners on the LiveView root element.
+    // Only install on actual [dj-view]/[dj-root] elements, NOT on document.body
+    // fallback — body persists across TurboNav page swaps, causing duplicate
+    // events when navigating away from a LiveView page and back.
+    const liveRoot = document.querySelector('[dj-view]') || document.querySelector('[dj-root]');
     if (liveRoot) installDelegatedListeners(liveRoot);
 
     // Bind upload handlers (dj-upload, dj-upload-drop, dj-upload-preview)

--- a/python/djust/static/djust/src/12-vdom-patch.js
+++ b/python/djust/static/djust/src/12-vdom-patch.js
@@ -155,9 +155,13 @@ function getNodeByPath(path, djustId = null) {
                 // JS \s includes \u00A0, so we use an explicit ASCII whitespace pattern instead.
                 return (/[^ \t\n\r\f]/.test(child.textContent));
             }
-            // Include comment nodes — the Rust VDOM parser preserves <!--dj-if-->
-            // placeholders and counts them when computing child indices (#559).
-            if (child.nodeType === Node.COMMENT_NODE) return true;
+            // Only include <!--dj-if--> placeholder comments — the Rust VDOM
+            // parser preserves these for diffing stability (#559) but drops
+            // all other HTML comments. Regular comments (<!-- Hero Section -->
+            // etc.) must be excluded to keep path indices aligned.
+            if (child.nodeType === Node.COMMENT_NODE) {
+                return child.textContent.trim() === 'dj-if';
+            }
             return false;
         });
 

--- a/python/djust/static/djust/src/18-navigation.js
+++ b/python/djust/static/djust/src/18-navigation.js
@@ -78,6 +78,17 @@
         const method = data.replace ? 'replaceState' : 'pushState';
         window.history[method]({ djust: true, redirect: true }, '', newUrl.toString());
 
+        // Scroll to top on navigation (or to anchor if present)
+        var hash = newUrl.hash;
+        if (hash) {
+            var target = document.querySelector(hash);
+            if (target) {
+                target.scrollIntoView({ behavior: 'instant' });
+            }
+        } else {
+            window.scrollTo({ top: 0, behavior: 'instant' });
+        }
+
         // Clear the prefetch set so links on the new view are re-eligible for prefetching
         window.djust._prefetch?.clear();
 

--- a/python/djust/static/djust/src/18-navigation.js
+++ b/python/djust/static/djust/src/18-navigation.js
@@ -81,9 +81,14 @@
         // Scroll to top on navigation (or to anchor if present)
         var hash = newUrl.hash;
         if (hash) {
-            var target = document.querySelector(hash);
-            if (target) {
-                target.scrollIntoView({ behavior: 'instant' });
+            try {
+                var target = document.querySelector(hash);
+                if (target) {
+                    target.scrollIntoView({ behavior: 'instant' });
+                }
+            } catch (_e) {
+                // Malformed hash (e.g. "#foo[bar]") — fall through to scroll top
+                window.scrollTo({ top: 0, behavior: 'instant' });
             }
         } else {
             window.scrollTo({ top: 0, behavior: 'instant' });

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -1995,6 +1995,12 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                                     # VDOM diffing, even though they share one thread hop.
                                     batch_node.metadata["context_prep_ms"] = ctx_ms
                                     batch_node.metadata["vdom_diff_ms"] = diff_ms
+                                    # Per-phase Rust timing (template render, HTML parse, VDOM diff, serialize)
+                                    rust_timing = getattr(
+                                        self.view_instance, "_rust_render_timing", None
+                                    )
+                                    if rust_timing:
+                                        batch_node.metadata["rust_timing"] = rust_timing
                                     tracker.track_context_size(context)
 
                                     patch_list = None  # Initialize for later use

--- a/tests/js/dj-copy.test.js
+++ b/tests/js/dj-copy.test.js
@@ -107,9 +107,12 @@ describe('dj-copy', () => {
         window.djust.bindLiveViewEvents();
 
         const link = document.querySelector('[dj-copy]');
+        const root = document.querySelector('[dj-root]');
 
+        // With event delegation, preventDefault is called by the root-level
+        // handler. Listen on the root (after the delegated handler) to verify.
         let defaultPrevented = false;
-        link.addEventListener('click', (e) => {
+        root.addEventListener('click', (e) => {
             defaultPrevented = e.defaultPrevented;
         });
 

--- a/tests/js/double_bind.test.js
+++ b/tests/js/double_bind.test.js
@@ -55,22 +55,21 @@ describe('Double bind prevention on VDOM-inserted elements', () => {
         extraElements = [];
     });
 
-    it('bindLiveViewEvents attaches click listener to VDOM-created elements', () => {
-        // createNodeFromVNode must NOT pre-mark elements as bound.
-        // bindLiveViewEvents() must attach the listener on first call.
+    it('bindLiveViewEvents installs delegated click listener on root (not per-element)', () => {
+        // With event delegation, bindLiveViewEvents installs ONE click listener
+        // on the root element, not per-element listeners.
         const elem = window.djust.createNodeFromVNode({
             tag: 'button',
             attrs: { 'dj-click': 'delete_todo(1)', 'data-dj-id': 'b-new-1' },
             children: [{ tag: '', attrs: {}, children: [], text: 'Delete' }],
         });
 
-        // Insert into DOM so querySelectorAll finds it — without this the test passes
-        // trivially because bindLiveViewEvents() never sees the detached element.
-        window.document.body.appendChild(elem);
+        // Insert into DOM so delegation can find it via closest().
+        const root = window.document.getElementById('root');
+        root.appendChild(elem);
         extraElements.push(elem);
 
-        // Wrap addEventListener AFTER insertion so we only count calls made by
-        // bindLiveViewEvents(), not any calls made during createNodeFromVNode.
+        // No per-element click listeners should be added
         let addEventCount = 0;
         const origAddEvent = elem.addEventListener.bind(elem);
         elem.addEventListener = function(type, ...args) {
@@ -78,18 +77,17 @@ describe('Double bind prevention on VDOM-inserted elements', () => {
             return origAddEvent(type, ...args);
         };
 
-        // First call: element is in DOM and unbound — should bind it exactly once.
         window.djust.bindLiveViewEvents();
-        expect(addEventCount).toBe(1);
+        // With delegation, no per-element click listeners — count stays 0
+        expect(addEventCount).toBe(0);
 
-        // Second call: WeakMap prevents double-binding — count must not increase.
-        window.djust.bindLiveViewEvents();
-        expect(addEventCount).toBe(1);
+        // But the root should have a delegated listener (verified by _djustDelegated flag)
+        expect(root._djustDelegated).toBe(true);
     });
 
-    it('bindLiveViewEvents binds click handler on VDOM-inserted elements exactly once', () => {
-        // createNodeFromVNode no longer pre-marks elements; bindLiveViewEvents
-        // is responsible for binding and deduplicating via WeakMap.
+    it('VDOM-inserted elements are handled by delegation without per-element listeners', () => {
+        // With event delegation, replaced elements are automatically handled
+        // by the root-level listener — no per-element binding needed.
         const newBtn = window.djust.createNodeFromVNode({
             tag: 'button',
             attrs: { 'dj-click': 'delete_todo(1)', 'data-dj-id': 'b2' },
@@ -106,13 +104,13 @@ describe('Double bind prevention on VDOM-inserted elements', () => {
             return origAddEvent(type, ...args);
         };
 
-        // First call: should bind the listener (count = 1)
+        // Delegation means no per-element click listeners are added
         window.djust.bindLiveViewEvents();
-        expect(addEventCount).toBe(1);
+        expect(addEventCount).toBe(0);
 
-        // Second call: element already bound via WeakMap, no double-bind (count stays 1)
+        // Multiple calls still don't add per-element listeners
         window.djust.bindLiveViewEvents();
-        expect(addEventCount).toBe(1);
+        expect(addEventCount).toBe(0);
     });
 
     it('bindLiveViewEvents does not double-bind elements already in the DOM', () => {
@@ -136,7 +134,7 @@ describe('Double bind prevention on VDOM-inserted elements', () => {
         expect(addEventCount).toBe(countAfterFirst);
     });
 
-    it('binds handlers for other event types (submit, change) without double-binding', () => {
+    it('submit and change events use delegation — no per-element listeners added', () => {
         const form = window.djust.createNodeFromVNode({
             tag: 'form', attrs: { 'dj-submit': 'save' }, children: [],
         });
@@ -144,10 +142,10 @@ describe('Double bind prevention on VDOM-inserted elements', () => {
             tag: 'input', attrs: { 'dj-change': 'validate', type: 'text', name: 'email' }, children: [],
         });
 
-        // Insert into DOM — without this, querySelectorAll never finds the elements
-        // and the counts trivially stay 0 regardless of WeakMap deduplication.
-        window.document.body.appendChild(form);
-        window.document.body.appendChild(input);
+        // Insert into DOM inside the root so delegation finds them
+        const root = window.document.getElementById('root');
+        root.appendChild(form);
+        root.appendChild(input);
         extraElements.push(form, input);
 
         // Verify attributes are set correctly
@@ -168,15 +166,18 @@ describe('Double bind prevention on VDOM-inserted elements', () => {
             return origInputAdd(type, ...args);
         };
 
-        // First call: elements are in DOM and unbound — should bind each once.
+        // With delegation, no per-element submit/change listeners are added
         window.djust.bindLiveViewEvents();
-        expect(submitCount).toBe(1);
-        expect(changeCount).toBe(1);
+        expect(submitCount).toBe(0);
+        expect(changeCount).toBe(0);
 
-        // Second call: WeakMap prevents double-binding — counts must not increase.
+        // Multiple calls still don't add per-element listeners
         window.djust.bindLiveViewEvents();
-        expect(submitCount).toBe(1);
-        expect(changeCount).toBe(1);
+        expect(submitCount).toBe(0);
+        expect(changeCount).toBe(0);
+
+        // Root has delegated listeners installed
+        expect(root._djustDelegated).toBe(true);
     });
 
     it('createNodeFromVNode sets dj-click as DOM attribute', () => {

--- a/tests/js/double_bind.test.js
+++ b/tests/js/double_bind.test.js
@@ -81,8 +81,8 @@ describe('Double bind prevention on VDOM-inserted elements', () => {
         // With delegation, no per-element click listeners — count stays 0
         expect(addEventCount).toBe(0);
 
-        // But the root should have a delegated listener (verified by _djustDelegated flag)
-        expect(root._djustDelegated).toBe(true);
+        // But the root should have a delegated listener (verified by _djustDelegateAbort flag)
+        expect(root._djustDelegateAbort).toBeTruthy();
     });
 
     it('VDOM-inserted elements are handled by delegation without per-element listeners', () => {
@@ -177,7 +177,7 @@ describe('Double bind prevention on VDOM-inserted elements', () => {
         expect(changeCount).toBe(0);
 
         // Root has delegated listeners installed
-        expect(root._djustDelegated).toBe(true);
+        expect(root._djustDelegateAbort).toBeTruthy();
     });
 
     it('createNodeFromVNode sets dj-click as DOM attribute', () => {

--- a/tests/js/event-listener-dedup.test.js
+++ b/tests/js/event-listener-dedup.test.js
@@ -159,7 +159,7 @@ describe('Event listener deduplication (issue #315)', () => {
             expect(bindCount).toBe(0);
 
             // Root has delegation installed
-            expect(root._djustDelegated).toBe(true);
+            expect(root._djustDelegateAbort).toBeTruthy();
         });
     });
 

--- a/tests/js/event-listener-dedup.test.js
+++ b/tests/js/event-listener-dedup.test.js
@@ -132,7 +132,7 @@ describe('Event listener deduplication (issue #315)', () => {
             expect(bindCount).toBe(0);
         });
 
-        it('element inserted via createNodeFromVNode gets bound by bindLiveViewEvents', () => {
+        it('VDOM-inserted elements use delegation — no per-element click listeners', () => {
             const root = window.document.getElementById('root');
 
             const newBtn = window.djust.createNodeFromVNode({
@@ -149,14 +149,17 @@ describe('Event listener deduplication (issue #315)', () => {
                 return origAdd(type, ...args);
             };
 
-            // First call should bind it
+            // With delegation, no per-element click listeners are added
             window.djust.bindLiveViewEvents();
-            expect(bindCount).toBe(1);
+            expect(bindCount).toBe(0);
 
-            // Subsequent calls must not double-bind
+            // Multiple calls still add no per-element listeners
             window.djust.bindLiveViewEvents();
             window.djust.bindLiveViewEvents();
-            expect(bindCount).toBe(1);
+            expect(bindCount).toBe(0);
+
+            // Root has delegation installed
+            expect(root._djustDelegated).toBe(true);
         });
     });
 

--- a/tests/js/vdom_patch_errors.test.js
+++ b/tests/js/vdom_patch_errors.test.js
@@ -203,4 +203,100 @@ describe('VDOM patch error messages', () => {
         const thrownError = errors.find(e => e.includes('Error applying patch'));
         expect(thrownError).toBeUndefined();
     });
+
+    it('skips regular HTML comments in path traversal (only counts dj-if comments)', () => {
+        // Regression test: the Rust VDOM parser drops regular HTML comments
+        // but preserves <!--dj-if--> placeholders. The JS patcher must match
+        // this behavior when computing child indices, otherwise paths computed
+        // by the Rust diff point to wrong nodes.
+        const dom = new JSDOM(
+            '<!DOCTYPE html><html><body>' +
+            '<div dj-root dj-liveview-root dj-view="test.View">' +
+            '<!-- Hero Section -->' +
+            '<section id="hero">Hero</section>' +
+            '<!-- Main Content -->' +
+            '<main id="content"><div id="counter">0</div></main>' +
+            '</div></body></html>',
+            { url: 'http://localhost', runScripts: 'dangerously' }
+        );
+
+        if (!dom.window.CSS) dom.window.CSS = {};
+        if (!dom.window.CSS.escape) {
+            dom.window.CSS.escape = (v) => String(v).replace(/([^\w-])/g, '\\$1');
+        }
+        dom.window.DEBUG_MODE = false;
+        dom.window.console.warn = () => {};
+        dom.window.console.error = () => {};
+        dom.window.console.log = () => {};
+
+        const sentMessages = [];
+        dom.window.WebSocket = class MockWebSocket {
+            constructor() {
+                this.readyState = 1;
+                this._sent = sentMessages;
+                Promise.resolve().then(() => { if (this.onopen) this.onopen({}); });
+            }
+            send(msg) { this._sent.push(JSON.parse(msg)); }
+            close() {}
+        };
+
+        dom.window.eval(clientCode);
+
+        // Rust VDOM sees: [0]=<section>, [1]=<main> (comments dropped)
+        // Path [1, 0, 0] should reach the text "0" inside #counter
+        const patches = [
+            { type: 'SetText', path: [1, 0, 0], text: '1' }
+        ];
+
+        const result = dom.window.applyPatches(patches);
+        expect(result).toBe(true);
+
+        const counter = dom.window.document.getElementById('counter');
+        expect(counter.textContent).toBe('1');
+    });
+
+    it('still counts dj-if placeholder comments in path traversal', () => {
+        const dom = new JSDOM(
+            '<!DOCTYPE html><html><body>' +
+            '<div dj-root dj-liveview-root dj-view="test.View">' +
+            '<!--dj-if-->' +
+            '<p id="visible">shown</p>' +
+            '</div></body></html>',
+            { url: 'http://localhost', runScripts: 'dangerously' }
+        );
+
+        if (!dom.window.CSS) dom.window.CSS = {};
+        if (!dom.window.CSS.escape) {
+            dom.window.CSS.escape = (v) => String(v).replace(/([^\w-])/g, '\\$1');
+        }
+        dom.window.DEBUG_MODE = false;
+        dom.window.console.warn = () => {};
+        dom.window.console.error = () => {};
+        dom.window.console.log = () => {};
+
+        const sentMessages = [];
+        dom.window.WebSocket = class MockWebSocket {
+            constructor() {
+                this.readyState = 1;
+                this._sent = sentMessages;
+                Promise.resolve().then(() => { if (this.onopen) this.onopen({}); });
+            }
+            send(msg) { this._sent.push(JSON.parse(msg)); }
+            close() {}
+        };
+
+        dom.window.eval(clientCode);
+
+        // <!--dj-if--> counts as child [0], <p> is child [1]
+        // Path [1, 0] should reach the text "shown" inside <p>
+        const patches = [
+            { type: 'SetText', path: [1, 0], text: 'updated' }
+        ];
+
+        const result = dom.window.applyPatches(patches);
+        expect(result).toBe(true);
+
+        const p = dom.window.document.getElementById('visible');
+        expect(p.textContent).toBe('updated');
+    });
 });


### PR DESCRIPTION
Fixes #729, fixes #730

## Summary

Three performance fixes and one bug fix that reduce end-to-end event latency from **250ms to 62ms** on the djust.org /examples/ page (304KB HTML, 17 demo sections):

### Bug fix
- **VDOM comment node path fix (#729)**: JS patcher counted all HTML comments during path traversal, but Rust VDOM only preserves `<!--dj-if-->` placeholders. Pages with HTML comments had 100% patch failure rate, falling back to full HTML recovery.

### Performance
- **Event delegation (#730)**: Replace per-element `addEventListener` binding with one delegated listener per event type on `dj-root`. Eliminates DOM scanning after every patch. Client handling: 56ms → 30ms.
- **Rust render timing instrumentation (#730)**: Per-phase `Instant::now()` in `render_with_diff()` — template render, html5ever parse, VDOM diff, HTML serialize. Revealed html5ever parse (16ms) is the main Rust cost, not diffing (0.4ms).
- **Scroll to top on dj-navigate**: `handleLiveRedirect()` now scrolls to top after `pushState`.

### TurboNav fixes (discovered during testing)
- **AbortController teardown**: Prevents double event firing after TurboNav navigation by cleanly removing old delegated listeners before reinstalling.
- **Skip body delegation**: Only installs delegation on `[dj-view]`/`[dj-root]`, never on `document.body` fallback (body persists across TurboNav page swaps).

## Performance results (DEBUG=False, localhost, 20 samples)

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Total E2E (avg) | 250ms | 62ms | **4x faster** |
| Total E2E (p50) | — | 64ms | — |
| Total E2E (p95) | — | 70ms | — |
| Client handling | 56ms | 24ms | 2.3x faster |
| Server total | 50ms | 34ms | 1.5x faster |

## Test plan

- [x] 1,126 JS tests pass (86 test files)
- [x] 42 Rust VDOM tests pass
- [x] All pre-push hooks pass (pytest, cargo test, cargo audit)
- [x] Browser-tested: increment, TurboNav round-trip, no double events
- [x] Self-review: no security issues, delegation params correct
- [x] Security check: all 6 checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)