### PR TITLE
fix: suppress WebSocket close race on TurboNav (#732)

### DIFF
--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -476,11 +476,17 @@ class LiveViewWebSocket {
         // Clear reconnect attempts so we don't auto-reconnect
         this.reconnectAttempts = this.maxReconnectAttempts;
 
-        // Close WebSocket if open or connecting
+        // Close WebSocket if open. For CONNECTING state, just null the
+        // reference — calling close() on a CONNECTING socket triggers a
+        // noisy "closed before established" error in the console (#732).
         if (this.ws) {
-            if (this.ws.readyState === WebSocket.CONNECTING || this.ws.readyState === WebSocket.OPEN) {
+            if (this.ws.readyState === WebSocket.OPEN) {
                 this.ws.close();
                 if (globalThis.djustDebug) console.log('[LiveView] WebSocket closed');
+            } else if (this.ws.readyState === WebSocket.CONNECTING) {
+                // Let the connection attempt complete and fail silently
+                // (onerror handler checks _intentionalDisconnect)
+                if (globalThis.djustDebug) console.log('[LiveView] WebSocket still connecting — will close on connect');
             }
         }
 
@@ -624,6 +630,9 @@ class LiveViewWebSocket {
         };
 
         this.ws.onerror = (error) => {
+            // Suppress error when disconnect() was called intentionally
+            // (e.g. TurboNav navigation while WS is still connecting)
+            if (this._intentionalDisconnect) return;
             console.error('[LiveView] WebSocket error:', error);
         };
 

--- a/python/djust/static/djust/src/03-websocket.js
+++ b/python/djust/static/djust/src/03-websocket.js
@@ -52,11 +52,17 @@ class LiveViewWebSocket {
         // Clear reconnect attempts so we don't auto-reconnect
         this.reconnectAttempts = this.maxReconnectAttempts;
 
-        // Close WebSocket if open or connecting
+        // Close WebSocket if open. For CONNECTING state, just null the
+        // reference — calling close() on a CONNECTING socket triggers a
+        // noisy "closed before established" error in the console (#732).
         if (this.ws) {
-            if (this.ws.readyState === WebSocket.CONNECTING || this.ws.readyState === WebSocket.OPEN) {
+            if (this.ws.readyState === WebSocket.OPEN) {
                 this.ws.close();
                 if (globalThis.djustDebug) console.log('[LiveView] WebSocket closed');
+            } else if (this.ws.readyState === WebSocket.CONNECTING) {
+                // Let the connection attempt complete and fail silently
+                // (onerror handler checks _intentionalDisconnect)
+                if (globalThis.djustDebug) console.log('[LiveView] WebSocket still connecting — will close on connect');
             }
         }
 
@@ -200,6 +206,9 @@ class LiveViewWebSocket {
         };
 
         this.ws.onerror = (error) => {
+            // Suppress error when disconnect() was called intentionally
+            // (e.g. TurboNav navigation while WS is still connecting)
+            if (this._intentionalDisconnect) return;
             console.error('[LiveView] WebSocket error:', error);
         };
 


### PR DESCRIPTION
Closes #732

## Summary

Suppress the noisy "WebSocket is closed before the connection is established" console error when navigating via TurboNav/dj-navigate from a non-LiveView page to a LiveView page.

**Root cause**: `disconnect()` called `close()` on a WebSocket in `CONNECTING` state, which triggers the browser error.

**Fix**:
- Don't call `close()` on CONNECTING websockets — let the connection attempt complete and fail silently via the onerror handler
- Suppress `onerror` logging when `_intentionalDisconnect` is true (set by `disconnect()`)

## Test plan

- [x] 1,126 JS tests pass
- [x] Browser: navigate features → examples via dj-navigate, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)