### PR TITLE
feat: djust.observability foundation (Phase 7.0)

### DIFF
--- a/python/djust/observability/__init__.py
+++ b/python/djust/observability/__init__.py
@@ -1,0 +1,37 @@
+"""
+AI-observability module for djust. Exposes live LiveView state via
+HTTP endpoints so the djust Python MCP (running in a separate process
+from Django) can introspect sessions, tracebacks, timings, and logs
+without shared memory.
+
+Security: all endpoints are DEBUG-gated + localhost-only. This matches
+django-debug-toolbar's model. In production (DEBUG=False), the URL
+include registers no routes and the module is effectively inert.
+
+Usage (from a project's urls.py):
+
+    from django.conf import settings
+    if settings.DEBUG:
+        urlpatterns = [
+            path("_djust/", include("djust.observability.urls")),
+            # ... your routes
+        ]
+
+Subsequent Phase 7.x items add endpoints under the base
+"/_djust/observability/" prefix. This module provides only the
+foundation (registry + middleware + base URL include).
+"""
+
+from djust.observability.registry import (
+    get_registered_session_count,
+    get_view_for_session,
+    register_view,
+    unregister_view,
+)
+
+__all__ = [
+    "get_registered_session_count",
+    "get_view_for_session",
+    "register_view",
+    "unregister_view",
+]

--- a/python/djust/observability/middleware.py
+++ b/python/djust/observability/middleware.py
@@ -1,0 +1,56 @@
+"""
+Localhost-only gate for the observability endpoint.
+
+These endpoints expose live server state (view assigns, tracebacks,
+SQL queries, logs). In DEBUG mode that's acceptable for developer
+introspection but we don't want them reachable from the LAN even if
+DEBUG slips through to a non-production environment.
+
+The check runs for every request whose path starts with the
+OBSERVABILITY_URL_PREFIX. Non-localhost clients get a 403 regardless
+of ALLOWED_HOSTS.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.http import HttpResponseForbidden
+
+logger = logging.getLogger("djust.observability")
+
+OBSERVABILITY_URL_PREFIX = "/_djust/observability/"
+
+_LOCALHOST_ADDRS = {"127.0.0.1", "::1", "localhost"}
+
+
+def _client_ip(request) -> str:
+    """Extract the client IP. In dev this is reliable (no proxy chain)."""
+    return request.META.get("REMOTE_ADDR", "")
+
+
+def is_localhost(request) -> bool:
+    """True iff the request came from loopback."""
+    return _client_ip(request) in _LOCALHOST_ADDRS
+
+
+class LocalhostOnlyObservabilityMiddleware:
+    """Reject non-localhost requests to /_djust/observability/.
+
+    Install in MIDDLEWARE **before** any auth middleware so unauthenticated
+    but localhost-origin MCP calls succeed (auth isn't the security
+    boundary here; network location is).
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.path.startswith(OBSERVABILITY_URL_PREFIX) and not is_localhost(request):
+            logger.warning(
+                "Rejected observability request from non-localhost: path=%s ip=%s",
+                request.path,
+                _client_ip(request),
+            )
+            return HttpResponseForbidden("Observability endpoints are localhost-only.")
+        return self.get_response(request)

--- a/python/djust/observability/registry.py
+++ b/python/djust/observability/registry.py
@@ -1,0 +1,50 @@
+"""
+Session → LiveView instance registry.
+
+Threadsafe. Uses a WeakValueDictionary so entries evaporate when the
+view instance is garbage-collected — prevents the registry from
+growing unboundedly if consumers forget to call unregister_view().
+"""
+
+from __future__ import annotations
+
+import threading
+import weakref
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from djust.live_view import LiveView
+
+
+_registry: "weakref.WeakValueDictionary[str, LiveView]" = weakref.WeakValueDictionary()
+_lock = threading.Lock()
+
+
+def register_view(session_id: str, view: "LiveView") -> None:
+    """Add a session→view mapping. Called by LiveViewConsumer after mount."""
+    with _lock:
+        _registry[session_id] = view
+
+
+def unregister_view(session_id: str) -> None:
+    """Remove a session from the registry. Called on disconnect."""
+    with _lock:
+        _registry.pop(session_id, None)
+
+
+def get_view_for_session(session_id: str) -> Optional["LiveView"]:
+    """Return the view bound to session_id, or None if not registered."""
+    with _lock:
+        return _registry.get(session_id)
+
+
+def get_registered_session_count() -> int:
+    """Number of sessions currently in the registry. Test + debug helper."""
+    with _lock:
+        return len(_registry)
+
+
+def _clear_registry() -> None:
+    """Test-only: wipe the registry. Not exported from __init__."""
+    with _lock:
+        _registry.clear()

--- a/python/djust/observability/urls.py
+++ b/python/djust/observability/urls.py
@@ -1,0 +1,22 @@
+"""
+Observability URL patterns. Include via:
+
+    urlpatterns = [
+        path("_djust/observability/", include("djust.observability.urls")),
+        ...
+    ]
+
+Each Phase 7.x PR adds more routes below `health`. Routes are
+additionally DEBUG-gated at the view level so a stray include in a
+production config still refuses to serve data.
+"""
+
+from django.urls import path
+
+from djust.observability.views import health
+
+app_name = "djust_observability"
+
+urlpatterns = [
+    path("health/", health, name="health"),
+]

--- a/python/djust/observability/views.py
+++ b/python/djust/observability/views.py
@@ -1,0 +1,43 @@
+"""
+Base view helpers for observability endpoints. Each Phase 7.x PR adds
+endpoint handlers here; this file initially ships only the `health`
+endpoint so the foundation PR is independently verifiable.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.http import HttpResponse, JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_GET
+
+from djust.observability.registry import get_registered_session_count
+
+
+def _debug_gate():
+    """Return a 404-style response if DEBUG is off — mirrors how Django
+    hides debug URLs in production. We return 404 rather than 403 so
+    the endpoint's existence isn't disclosed.
+    """
+    return HttpResponse(status=404)
+
+
+@csrf_exempt
+@require_GET
+def health(request):
+    """Liveness probe. Returns the registry size + DEBUG flag.
+
+    `curl http://127.0.0.1:8000/_djust/observability/health/` during
+    live-verification. Returns:
+
+        {"ok": true, "debug": true, "registered_sessions": 0}
+    """
+    if not settings.DEBUG:
+        return _debug_gate()
+    return JsonResponse(
+        {
+            "ok": True,
+            "debug": settings.DEBUG,
+            "registered_sessions": get_registered_session_count(),
+        }
+    )

--- a/python/djust/tests/test_observability_foundation.py
+++ b/python/djust/tests/test_observability_foundation.py
@@ -1,0 +1,173 @@
+"""
+Tests for Phase 7.0 observability foundation: session registry,
+localhost-only middleware, and health endpoint.
+"""
+
+from __future__ import annotations
+
+import gc
+
+import pytest
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+
+from djust.observability import (
+    get_registered_session_count,
+    get_view_for_session,
+    register_view,
+    unregister_view,
+)
+from djust.observability.middleware import (
+    LocalhostOnlyObservabilityMiddleware,
+    is_localhost,
+)
+from djust.observability.registry import _clear_registry
+from djust.observability.views import health
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """Ensure each test starts with an empty registry."""
+    _clear_registry()
+    yield
+    _clear_registry()
+
+
+class _FakeView:
+    """Stand-in for a LiveView — registry only cares about object identity."""
+
+    def __init__(self, name="fake"):
+        self.name = name
+
+
+# --- Registry --------------------------------------------------------------
+
+
+def test_register_and_lookup():
+    view = _FakeView()
+    register_view("session-1", view)
+    assert get_view_for_session("session-1") is view
+
+
+def test_unregister_removes_entry():
+    view = _FakeView()
+    register_view("session-1", view)
+    unregister_view("session-1")
+    assert get_view_for_session("session-1") is None
+
+
+def test_unregister_missing_session_noop():
+    unregister_view("never-registered")  # Must not raise.
+
+
+def test_registered_count_tracks_inserts_and_removes():
+    assert get_registered_session_count() == 0
+    v1, v2 = _FakeView(), _FakeView()
+    register_view("a", v1)
+    register_view("b", v2)
+    assert get_registered_session_count() == 2
+    unregister_view("a")
+    assert get_registered_session_count() == 1
+
+
+def test_registry_holds_weak_references():
+    """Entry must evaporate when the view is GC'd — guards against leaks
+    if consumers forget to call unregister_view()."""
+    view = _FakeView()
+    register_view("ephemeral", view)
+    assert get_view_for_session("ephemeral") is view
+    del view
+    gc.collect()
+    assert get_view_for_session("ephemeral") is None
+
+
+def test_re_register_replaces_entry():
+    v1, v2 = _FakeView("first"), _FakeView("second")
+    register_view("same-session", v1)
+    register_view("same-session", v2)
+    assert get_view_for_session("same-session") is v2
+
+
+# --- Middleware ------------------------------------------------------------
+
+
+def _dummy_get_response(request):
+    return HttpResponse("ok")
+
+
+def test_localhost_middleware_allows_127_0_0_1():
+    rf = RequestFactory()
+    req = rf.get("/_djust/observability/health/", REMOTE_ADDR="127.0.0.1")
+    mw = LocalhostOnlyObservabilityMiddleware(_dummy_get_response)
+    resp = mw(req)
+    assert resp.status_code == 200
+
+
+def test_localhost_middleware_allows_ipv6_loopback():
+    rf = RequestFactory()
+    req = rf.get("/_djust/observability/health/", REMOTE_ADDR="::1")
+    mw = LocalhostOnlyObservabilityMiddleware(_dummy_get_response)
+    assert mw(req).status_code == 200
+
+
+def test_localhost_middleware_rejects_lan_address():
+    rf = RequestFactory()
+    req = rf.get("/_djust/observability/health/", REMOTE_ADDR="192.168.1.5")
+    mw = LocalhostOnlyObservabilityMiddleware(_dummy_get_response)
+    resp = mw(req)
+    assert resp.status_code == 403
+    assert b"localhost-only" in resp.content
+
+
+def test_localhost_middleware_ignores_non_observability_paths():
+    """Requests to other paths flow through regardless of IP."""
+    rf = RequestFactory()
+    req = rf.get("/some/other/path/", REMOTE_ADDR="192.168.1.5")
+    mw = LocalhostOnlyObservabilityMiddleware(_dummy_get_response)
+    assert mw(req).status_code == 200
+
+
+def test_is_localhost_helper():
+    rf = RequestFactory()
+    assert is_localhost(rf.get("/", REMOTE_ADDR="127.0.0.1"))
+    assert is_localhost(rf.get("/", REMOTE_ADDR="::1"))
+    assert not is_localhost(rf.get("/", REMOTE_ADDR="10.0.0.1"))
+    assert not is_localhost(rf.get("/", REMOTE_ADDR=""))
+
+
+# --- Health endpoint -------------------------------------------------------
+
+
+@override_settings(DEBUG=True)
+def test_health_endpoint_debug_on():
+    rf = RequestFactory()
+    resp = health(rf.get("/_djust/observability/health/"))
+    assert resp.status_code == 200
+    import json
+
+    data = json.loads(resp.content)
+    assert data["ok"] is True
+    assert data["debug"] is True
+    assert data["registered_sessions"] == 0
+
+
+@override_settings(DEBUG=True)
+def test_health_reports_registered_session_count():
+    # Hold strong references so the weakref registry keeps the entries.
+    views = [_FakeView(), _FakeView()]
+    register_view("a", views[0])
+    register_view("b", views[1])
+    rf = RequestFactory()
+    resp = health(rf.get("/_djust/observability/health/"))
+    import json
+
+    data = json.loads(resp.content)
+    assert data["registered_sessions"] == 2
+
+
+@override_settings(DEBUG=False)
+def test_health_endpoint_debug_off_returns_404():
+    """In production the endpoint should 404 — don't leak its existence."""
+    rf = RequestFactory()
+    resp = health(rf.get("/_djust/observability/health/"))
+    assert resp.status_code == 404

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -954,6 +954,17 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
 
     async def disconnect(self, close_code):
         """Handle WebSocket disconnection"""
+        # Release observability registry entry first — it's weakly-held
+        # anyway but explicit cleanup avoids a brief stale entry window.
+        session_id = getattr(self, "session_id", None)
+        if session_id:
+            try:
+                from djust.observability.registry import unregister_view
+
+                unregister_view(session_id)
+            except Exception:  # noqa: BLE001
+                pass  # Observability never blocks shutdown.
+
         # Release IP connection slot
         client_ip = getattr(self, "_client_ip", None)
         if client_ip:
@@ -1246,6 +1257,17 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             self.view_instance._websocket_query_string = self.scope.get("query_string", b"").decode(
                 "utf-8"
             )
+
+            # Register this view in the observability session registry so the
+            # djust MCP can introspect live state via its HTTP endpoints.
+            # Registry uses weakrefs — no leak if unregister is missed.
+            try:
+                from djust.observability.registry import register_view
+
+                register_view(self.session_id, self.view_instance)
+            except Exception as e:  # noqa: BLE001
+                # Observability must never break a WS connection.
+                logger.warning("Failed to register view in observability registry: %s", e)
 
             # Join per-view channel group for server-push
             from .push import view_group_name


### PR DESCRIPTION
## Summary

Adds the cross-process HTTP-endpoint infrastructure that Phase 7.1–7.6 build on. djust Python MCP runs as a separate process from the Django dev server, so it can't see in-memory state directly — this PR exposes a DEBUG-gated, localhost-only \`/_djust/observability/\` URL include that the MCP will query for live view state, tracebacks, logs, SQL queries, and handler timings.

**Security model** (mirrors django-debug-toolbar):
- Routes only register when \`settings.DEBUG = True\`
- \`LocalhostOnlyObservabilityMiddleware\` rejects non-\`127.0.0.1\`/\`::1\` with 403
- All view handlers 404 (not 403) when DEBUG=False so their existence isn't leaked
- CSRF-exempt GETs (data fetch, not mutations)

### Foundation pieces
- \`observability/registry.py\` — threadsafe \`WeakValueDictionary\` session_id → LiveView
- \`observability/middleware.py\` — \`LocalhostOnlyObservabilityMiddleware\`
- \`observability/views.py\` — base \`health\` endpoint + \`_debug_gate()\` helper
- \`observability/urls.py\` — \`app_name=djust_observability\` include
- \`observability/__init__.py\` — re-exports registry API
- \`websocket.py\` — \`LiveViewConsumer.connect()\` / \`disconnect()\` register/unregister the view; try/except so observability never breaks a WS connection

### Installation

Users add to their project \`urls.py\`:
\`\`\`python
if settings.DEBUG:
    urlpatterns = [
        path(\"_djust/observability/\", include(\"djust.observability.urls\")),
        ...
    ]
\`\`\`

And add to \`MIDDLEWARE\`:
\`\`\`python
MIDDLEWARE = [
    \"djust.observability.middleware.LocalhostOnlyObservabilityMiddleware\",
    ...
]
\`\`\`

## Test plan

- [x] 14 unit tests: registry lifecycle (incl weakref eviction), middleware ACL (loopback allow, LAN deny, non-observability paths pass-through), health endpoint under DEBUG on/off — \`pytest python/djust/tests/test_observability_foundation.py\` all passing
- [ ] Manual: install on demo_project, curl \`http://127.0.0.1:8002/_djust/observability/health/\` → \`{\"ok\": true, \"debug\": true, \"registered_sessions\": 0}\`
- [ ] Manual: open /examples/ in browser, re-curl, see \`registered_sessions: 1\`
- [ ] Manual: curl from a non-loopback interface → 403

## What's next

Phase 7.1 (\`get_view_assigns\`) builds on this — new endpoint in \`observability/views.py\`, new route in \`urls.py\`, matching MCP tool in \`djust.mcp\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)