### PR TITLE
feat: get_view_assigns endpoint + MCP tool (Phase 7.1)

### DIFF
--- a/python/djust/mcp/server.py
+++ b/python/djust/mcp/server.py
@@ -219,6 +219,69 @@ def create_server():
             }
         )
 
+    # === Observability tools ===
+    #
+    # These call the dev server's /_djust/observability/ endpoints (installed
+    # in the project's urls.py as `djust.observability.urls`). Cross-process
+    # because djust MCP runs in a separate process from the Django server.
+    #
+    # The base URL defaults to http://127.0.0.1:8000 and can be overridden via
+    # the DJUST_DEV_SERVER_URL env var for non-standard ports.
+
+    @mcp.tool()
+    def get_view_assigns(session_id: str) -> str:
+        """Read the live LiveView's public state (self.* non-underscore attrs).
+
+        Args:
+            session_id: WebSocket session id from the connect frame's
+                `session_id` field. Persistent per WS connection.
+
+        Returns JSON: {session_id, view_class, view_module, assigns} where
+        `assigns` is the serializable {attr: value} dict of the view.
+
+        Requires djust.observability.urls included in the project's urls.py
+        with DEBUG=True. Complements the client-side `djust_state_diff`
+        from djust-browser-mcp — this reads the actual server-side source
+        of truth rather than inferred client state.
+        """
+        import os
+
+        try:
+            import requests
+        except ImportError:
+            return json.dumps({"error": "`requests` package not installed in the MCP environment"})
+
+        base = os.environ.get("DJUST_DEV_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
+        url = f"{base}/_djust/observability/view_assigns/"
+        try:
+            r = requests.get(url, params={"session_id": session_id}, timeout=5)
+        except requests.RequestException as e:
+            return json.dumps(
+                {
+                    "error": f"request failed: {e}",
+                    "hint": (
+                        f"Is the dev server running? Tried {url}. Set "
+                        "DJUST_DEV_SERVER_URL env var for non-8000 ports."
+                    ),
+                }
+            )
+        if r.status_code == 404:
+            return json.dumps(
+                {
+                    "error": f"session {session_id} not registered or endpoint disabled",
+                    "status": 404,
+                    "hint": (
+                        "Check that (a) settings.DEBUG=True, (b) the project "
+                        "urls.py includes `path('_djust/observability/', "
+                        "include('djust.observability.urls'))`, and (c) a "
+                        "WebSocket connection is open for this session."
+                    ),
+                }
+            )
+        if r.status_code != 200:
+            return json.dumps({"error": r.text, "status": r.status_code})
+        return r.text
+
     # === Runtime tools ===
 
     @mcp.tool()

--- a/python/djust/observability/urls.py
+++ b/python/djust/observability/urls.py
@@ -13,10 +13,11 @@ production config still refuses to serve data.
 
 from django.urls import path
 
-from djust.observability.views import health
+from djust.observability.views import health, view_assigns
 
 app_name = "djust_observability"
 
 urlpatterns = [
     path("health/", health, name="health"),
+    path("view_assigns/", view_assigns, name="view_assigns"),
 ]

--- a/python/djust/observability/views.py
+++ b/python/djust/observability/views.py
@@ -6,12 +6,19 @@ endpoint so the foundation PR is independently verifiable.
 
 from __future__ import annotations
 
+import logging
+
 from django.conf import settings
 from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
 
-from djust.observability.registry import get_registered_session_count
+from djust.observability.registry import (
+    get_registered_session_count,
+    get_view_for_session,
+)
+
+logger = logging.getLogger("djust.observability")
 
 
 def _debug_gate():
@@ -39,5 +46,59 @@ def health(request):
             "ok": True,
             "debug": settings.DEBUG,
             "registered_sessions": get_registered_session_count(),
+        }
+    )
+
+
+@csrf_exempt
+@require_GET
+def view_assigns(request):
+    """Return the mounted LiveView's public state for a session.
+
+    Query params:
+        session_id (required): session uuid from the WS handshake ack.
+
+    Response (200):
+        {"session_id": "...", "view_class": "CounterView", "assigns": {...}}
+
+    Response (400): session_id missing.
+    Response (404): DEBUG=False, or session not registered.
+    """
+    if not settings.DEBUG:
+        return _debug_gate()
+
+    session_id = request.GET.get("session_id", "").strip()
+    if not session_id:
+        return JsonResponse(
+            {"error": "session_id query param required"},
+            status=400,
+        )
+
+    view = get_view_for_session(session_id)
+    if view is None:
+        return JsonResponse(
+            {"error": f"no view registered for session {session_id}"},
+            status=404,
+        )
+
+    try:
+        assigns = view.get_state()
+    except Exception as e:  # noqa: BLE001
+        # get_state raises TypeError on non-serializable values in DEBUG.
+        # Observability must still return something useful — fall back to
+        # a best-effort shallow dict of repr()s.
+        logger.warning("view.get_state() failed for session %s: %s", session_id, e)
+        assigns = {
+            k: repr(v)[:200]
+            for k, v in view.__dict__.items()
+            if not k.startswith("_") and not callable(v)
+        }
+
+    return JsonResponse(
+        {
+            "session_id": session_id,
+            "view_class": view.__class__.__name__,
+            "view_module": view.__class__.__module__,
+            "assigns": assigns,
         }
     )

--- a/python/djust/tests/test_observability_view_assigns.py
+++ b/python/djust/tests/test_observability_view_assigns.py
@@ -1,0 +1,103 @@
+"""
+Tests for Phase 7.1 — /_djust/observability/view_assigns/ endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.test import RequestFactory, override_settings
+
+from djust.observability.registry import _clear_registry, register_view
+from djust.observability.views import view_assigns
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    _clear_registry()
+    yield
+    _clear_registry()
+
+
+class _FakeView:
+    """Stand-in matching the contract get_state() expects."""
+
+    def __init__(self, count=0, label="test"):
+        self.count = count
+        self.label = label
+        # Private attrs should NOT appear in output.
+        self._websocket_session_id = "abc"
+        self._private = "hidden"
+
+    def get_state(self):
+        return {k: v for k, v in self.__dict__.items() if not k.startswith("_") and not callable(v)}
+
+
+class _ExplodingView(_FakeView):
+    def get_state(self):
+        raise TypeError("boom — non-serializable value")
+
+
+@override_settings(DEBUG=True)
+def test_view_assigns_returns_state_for_registered_session():
+    view = _FakeView(count=7, label="counter")
+    register_view("session-1", view)
+
+    rf = RequestFactory()
+    resp = view_assigns(rf.get("/?session_id=session-1"))
+    assert resp.status_code == 200
+
+    data = json.loads(resp.content)
+    assert data["session_id"] == "session-1"
+    assert data["view_class"] == "_FakeView"
+    assert data["assigns"] == {"count": 7, "label": "counter"}
+
+
+@override_settings(DEBUG=True)
+def test_view_assigns_excludes_private_and_callable_attrs():
+    view = _FakeView()
+    register_view("s", view)
+
+    rf = RequestFactory()
+    resp = view_assigns(rf.get("/?session_id=s"))
+    data = json.loads(resp.content)
+    assert "_private" not in data["assigns"]
+    assert "_websocket_session_id" not in data["assigns"]
+
+
+@override_settings(DEBUG=True)
+def test_view_assigns_400_when_session_id_missing():
+    rf = RequestFactory()
+    resp = view_assigns(rf.get("/"))
+    assert resp.status_code == 400
+
+
+@override_settings(DEBUG=True)
+def test_view_assigns_404_when_session_unknown():
+    rf = RequestFactory()
+    resp = view_assigns(rf.get("/?session_id=never-registered"))
+    assert resp.status_code == 404
+
+
+@override_settings(DEBUG=False)
+def test_view_assigns_404_when_debug_off():
+    view = _FakeView()
+    register_view("s", view)
+    rf = RequestFactory()
+    resp = view_assigns(rf.get("/?session_id=s"))
+    assert resp.status_code == 404
+
+
+@override_settings(DEBUG=True)
+def test_view_assigns_falls_back_when_get_state_raises():
+    """If get_state() can't serialize, return repr()s instead of 500."""
+    view = _ExplodingView(count=42)
+    register_view("s", view)
+    rf = RequestFactory()
+    resp = view_assigns(rf.get("/?session_id=s"))
+    assert resp.status_code == 200
+    data = json.loads(resp.content)
+    # Fallback is repr()'d strings — count=42 becomes "42"
+    assert "count" in data["assigns"]
+    assert data["assigns"]["count"] == "42"


### PR DESCRIPTION
## Summary

First real consumer of the Phase 7.0 observability foundation. Reads live server-side \`self.*\` from the mounted LiveView bound to a session via a DEBUG+localhost HTTP endpoint, surfaces it through a new MCP tool.

### Server side
- \`GET /_djust/observability/view_assigns/?session_id=X\` → \`{session_id, view_class, view_module, assigns}\`
- \`assigns\` is the output of \`LiveView.get_state()\` (same public-attr serialization djust uses for client-state transport)
- Graceful fallback to \`repr()\` dict if \`get_state()\` raises on non-serializable attrs — observability must remain useful even when the target view has a bug

### MCP side
- New \"Observability tools\" section in \`djust/mcp/server.py\`
- \`get_view_assigns(session_id)\` — HTTP call via \`requests\` with helpful hints when dev server isn't reachable or endpoint isn't wired in urls.py
- \`DJUST_DEV_SERVER_URL\` env var for non-8000 ports

### Why this matters

Complements browser-mcp's \`djust_state_diff\` which can only observe client-side *inferred* state (vdom_version, bound_events, loading). This tool reads the actual **source of truth**: \`self.count\`, \`self.todos\`, whatever the view holds.

## Test plan

- [x] 6 new unit tests — happy path, private-attr exclusion, 400/404 error cases, DEBUG=False 404, get_state() fallback. All 20 observability tests pass.
- [ ] Manual: wire \`djust.observability.urls\` into demo_project, click increment on /examples/, call \`get_view_assigns\` with the session_id from WS connect frame → \`{count: N}\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)