### PR TITLE
feat: get_last_traceback — ring-buffered exception capture (Phase 7.2)

### DIFF
--- a/python/djust/mcp/server.py
+++ b/python/djust/mcp/server.py
@@ -282,6 +282,44 @@ def create_server():
             return json.dumps({"error": r.text, "status": r.status_code})
         return r.text
 
+    @mcp.tool()
+    def get_last_traceback(n: int = 1) -> str:
+        """Read the most-recent captured server-side Python exceptions.
+
+        Args:
+            n: How many entries to return (newest first). Defaults to 1,
+                capped at 50 (ring-buffer size).
+
+        Returns JSON: {count, entries: [{timestamp_ms, exception_type,
+        message, view_class, event_name, traceback, ...}]}.
+
+        Captures flow through djust's single `handle_exception()` entry
+        point — every handler / mount / render error lands in the ring
+        buffer. Single biggest lever for blind debugging: eliminates
+        "can you check the terminal for a traceback?".
+        """
+        import os
+
+        try:
+            import requests
+        except ImportError:
+            return json.dumps({"error": "`requests` package not installed in the MCP environment"})
+
+        base = os.environ.get("DJUST_DEV_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
+        url = f"{base}/_djust/observability/last_traceback/"
+        try:
+            r = requests.get(url, params={"n": n}, timeout=5)
+        except requests.RequestException as e:
+            return json.dumps(
+                {
+                    "error": f"request failed: {e}",
+                    "hint": f"Is the dev server running? Tried {url}.",
+                }
+            )
+        if r.status_code != 200:
+            return json.dumps({"error": r.text, "status": r.status_code})
+        return r.text
+
     # === Runtime tools ===
 
     @mcp.tool()

--- a/python/djust/observability/tracebacks.py
+++ b/python/djust/observability/tracebacks.py
@@ -1,0 +1,69 @@
+"""
+Ring-buffered exception capture.
+
+Populated from `djust.security.error_handling.handle_exception()`, which
+is the single entry point every consumer / view / actor error flows
+through. The MCP reads this via /_djust/observability/last_traceback/.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import traceback
+from collections import deque
+from typing import Any, Dict, List, Optional
+
+_MAX_ENTRIES = 50
+
+_buffer: "deque[Dict[str, Any]]" = deque(maxlen=_MAX_ENTRIES)
+_lock = threading.Lock()
+
+
+def record_traceback(
+    exception: BaseException,
+    *,
+    error_type: str = "default",
+    event_name: Optional[str] = None,
+    view_class: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> None:
+    """Push a captured exception onto the ring buffer.
+
+    Called from `handle_exception()` so every djust-managed exception
+    lands here exactly once. Safe to call concurrently.
+    """
+    with _lock:
+        _buffer.append(
+            {
+                "timestamp_ms": int(time.time() * 1000),
+                "exception_type": type(exception).__name__,
+                "exception_module": type(exception).__module__,
+                "message": str(exception),
+                "error_type": error_type,
+                "event_name": event_name,
+                "view_class": view_class,
+                "session_id": session_id,
+                "traceback": "".join(traceback.format_exception(exception)),
+            }
+        )
+
+
+def get_recent_tracebacks(n: int = 1) -> List[Dict[str, Any]]:
+    """Return up to the last `n` entries, newest first."""
+    with _lock:
+        items = list(_buffer)
+    items.reverse()
+    return items[:n]
+
+
+def get_buffer_size() -> int:
+    """Current buffer length. Diagnostic helper."""
+    with _lock:
+        return len(_buffer)
+
+
+def _clear_tracebacks() -> None:
+    """Test-only reset."""
+    with _lock:
+        _buffer.clear()

--- a/python/djust/observability/urls.py
+++ b/python/djust/observability/urls.py
@@ -13,11 +13,12 @@ production config still refuses to serve data.
 
 from django.urls import path
 
-from djust.observability.views import health, view_assigns
+from djust.observability.views import health, last_traceback, view_assigns
 
 app_name = "djust_observability"
 
 urlpatterns = [
     path("health/", health, name="health"),
     path("view_assigns/", view_assigns, name="view_assigns"),
+    path("last_traceback/", last_traceback, name="last_traceback"),
 ]

--- a/python/djust/observability/views.py
+++ b/python/djust/observability/views.py
@@ -17,6 +17,7 @@ from djust.observability.registry import (
     get_registered_session_count,
     get_view_for_session,
 )
+from djust.observability.tracebacks import get_recent_tracebacks
 
 logger = logging.getLogger("djust.observability")
 
@@ -102,3 +103,31 @@ def view_assigns(request):
             "assigns": assigns,
         }
     )
+
+
+@csrf_exempt
+@require_GET
+def last_traceback(request):
+    """Return the most-recent N captured exceptions (newest first).
+
+    Query params:
+        n (optional): how many entries to return. Defaults to 1. Capped
+            at the ring buffer's size.
+
+    Each entry: {timestamp_ms, exception_type, exception_module, message,
+    error_type, event_name, view_class, session_id, traceback}.
+
+    Captures flow through `handle_exception()` — the single entry point
+    for djust-managed errors. Every handler / mount / render error ends
+    up here.
+    """
+    if not settings.DEBUG:
+        return _debug_gate()
+
+    try:
+        n = int(request.GET.get("n", "1"))
+    except (TypeError, ValueError):
+        n = 1
+    n = max(1, min(n, 50))
+
+    return JsonResponse({"count": n, "entries": get_recent_tracebacks(n)})

--- a/python/djust/security/error_handling.py
+++ b/python/djust/security/error_handling.py
@@ -229,6 +229,21 @@ def handle_exception(
     if logger is None:
         logger = logging_module.getLogger("djust.security")
 
+    # Capture for observability ring buffer (AI introspection via the
+    # djust Python MCP). Best-effort — must not break error handling
+    # itself if the observability module is somehow broken.
+    try:
+        from djust.observability.tracebacks import record_traceback
+
+        record_traceback(
+            exception,
+            error_type=error_type,
+            event_name=event_name,
+            view_class=view_class,
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
     # Build context for logging — sanitize to break taint chain from caller inputs.
     from .log_sanitizer import sanitize_for_log
 

--- a/python/djust/tests/test_observability_tracebacks.py
+++ b/python/djust/tests/test_observability_tracebacks.py
@@ -1,0 +1,155 @@
+"""
+Tests for Phase 7.2 — traceback ring buffer + /last_traceback/ endpoint.
+Also verifies that djust.security.error_handling.handle_exception()
+pushes into the buffer automatically.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.test import RequestFactory, override_settings
+
+from djust.observability.tracebacks import (
+    _clear_tracebacks,
+    get_buffer_size,
+    get_recent_tracebacks,
+    record_traceback,
+)
+from djust.observability.views import last_traceback
+
+
+@pytest.fixture(autouse=True)
+def clean_buffer():
+    _clear_tracebacks()
+    yield
+    _clear_tracebacks()
+
+
+def _make_exc():
+    try:
+        raise ValueError("boom — test exception")
+    except ValueError as e:
+        return e
+
+
+# --- Buffer primitives -----------------------------------------------------
+
+
+def test_record_and_retrieve():
+    exc = _make_exc()
+    record_traceback(exc, error_type="event", event_name="increment", view_class="CounterView")
+    entries = get_recent_tracebacks(1)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["exception_type"] == "ValueError"
+    assert "boom" in entry["message"]
+    assert entry["error_type"] == "event"
+    assert entry["event_name"] == "increment"
+    assert entry["view_class"] == "CounterView"
+    assert "boom" in entry["traceback"]
+
+
+def test_buffer_preserves_newest_first():
+    for i in range(3):
+        try:
+            raise RuntimeError(f"err-{i}")
+        except RuntimeError as e:
+            record_traceback(e)
+    recent = get_recent_tracebacks(3)
+    assert [e["message"] for e in recent] == ["err-2", "err-1", "err-0"]
+
+
+def test_buffer_caps_at_50():
+    for i in range(60):
+        try:
+            raise RuntimeError(f"err-{i}")
+        except RuntimeError as e:
+            record_traceback(e)
+    assert get_buffer_size() == 50
+    recent = get_recent_tracebacks(60)
+    # Only the last 50 remain; entries 0..9 are gone.
+    assert len(recent) == 50
+    assert recent[0]["message"] == "err-59"
+    assert recent[-1]["message"] == "err-10"
+
+
+def test_empty_buffer_returns_empty_list():
+    assert get_recent_tracebacks(5) == []
+
+
+# --- Endpoint --------------------------------------------------------------
+
+
+@override_settings(DEBUG=True)
+def test_endpoint_returns_recent():
+    exc = _make_exc()
+    record_traceback(exc, event_name="click", view_class="MyView")
+    rf = RequestFactory()
+    resp = last_traceback(rf.get("/?n=1"))
+    assert resp.status_code == 200
+    data = json.loads(resp.content)
+    assert data["count"] == 1
+    assert len(data["entries"]) == 1
+    assert data["entries"][0]["exception_type"] == "ValueError"
+
+
+@override_settings(DEBUG=True)
+def test_endpoint_defaults_n_to_1():
+    for i in range(3):
+        try:
+            raise KeyError(f"k{i}")
+        except KeyError as e:
+            record_traceback(e)
+    rf = RequestFactory()
+    resp = last_traceback(rf.get("/"))
+    data = json.loads(resp.content)
+    assert len(data["entries"]) == 1
+    assert "k2" in data["entries"][0]["message"]
+
+
+@override_settings(DEBUG=True)
+def test_endpoint_handles_bad_n():
+    """Non-int n silently falls back to 1 rather than 500ing."""
+    rf = RequestFactory()
+    resp = last_traceback(rf.get("/?n=abc"))
+    assert resp.status_code == 200
+    data = json.loads(resp.content)
+    assert data["count"] == 1
+
+
+@override_settings(DEBUG=True)
+def test_endpoint_caps_n_at_50():
+    rf = RequestFactory()
+    resp = last_traceback(rf.get("/?n=9999"))
+    data = json.loads(resp.content)
+    assert data["count"] == 50
+
+
+@override_settings(DEBUG=False)
+def test_endpoint_404_when_debug_off():
+    rf = RequestFactory()
+    resp = last_traceback(rf.get("/"))
+    assert resp.status_code == 404
+
+
+# --- Integration with handle_exception ------------------------------------
+
+
+def test_handle_exception_populates_buffer():
+    """Any djust-managed exception should land in the ring buffer."""
+    from djust.security.error_handling import handle_exception
+
+    exc = _make_exc()
+    handle_exception(
+        exc,
+        error_type="event",
+        event_name="increment",
+        view_class="CounterView",
+    )
+    entries = get_recent_tracebacks(1)
+    assert len(entries) == 1
+    assert entries[0]["exception_type"] == "ValueError"
+    assert entries[0]["event_name"] == "increment"
+    assert entries[0]["view_class"] == "CounterView"


### PR DESCRIPTION
## Summary

Third of the server-visibility trio. Exposes the N most-recent Python exceptions from the dev server so the AI agent can diagnose failed handlers without terminal access. **Single biggest lever for blind debugging.**

### Framework side
- \`observability/tracebacks.py\` — threadsafe \`deque(maxlen=50)\` ring buffer
- Hooks into \`djust.security.error_handling.handle_exception()\` — the single entry point every mount / event / render error flows through. One insertion covers all paths. Wrapped in try/except so observability never disturbs error handling itself.
- \`GET /_djust/observability/last_traceback/?n=N\` — newest-first, n clamped to [1,50]

### MCP side
- New \`get_last_traceback(n=1)\` tool

## Test plan

- [x] 10 new unit tests: buffer primitives (record, ordering, 50-cap, empty-safe), endpoint (n default, n cap, bad-n fallback, DEBUG=False 404), and handle_exception integration test. 30 observability tests total pass.
- [ ] Manual: add a handler that raises ValueError('boom'), click it, call get_last_traceback → traceback with 'boom' in message

🤖 Generated with [Claude Code](https://claude.com/claude-code)