### PR TITLE
feat(demo): wire djust.observability into demo_project

### DIFF
--- a/examples/demo_project/demo_project/settings.py
+++ b/examples/demo_project/demo_project/settings.py
@@ -57,6 +57,9 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    # Observability localhost-gate — must come early so it rejects LAN
+    # requests before any downstream middleware can do work.
+    'djust.observability.middleware.LocalhostOnlyObservabilityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/examples/demo_project/demo_project/urls.py
+++ b/examples/demo_project/demo_project/urls.py
@@ -2,6 +2,7 @@
 URL configuration for demo_project.
 """
 
+from django.conf import settings
 from django.contrib import admin
 from django.urls import path, include
 
@@ -17,6 +18,17 @@ urlpatterns = [
     # PWA — service worker must be at root scope for full-site coverage
     path('sw.js', service_worker_view, name='service-worker'),
     path('manifest.json', manifest_view, name='pwa-manifest'),
+]
+
+# AI observability endpoints — DEBUG-gated, localhost-only (enforced by
+# LocalhostOnlyObservabilityMiddleware). djust Python MCP calls these to
+# introspect live state without sharing process memory with the dev server.
+if settings.DEBUG:
+    urlpatterns += [
+        path('_djust/observability/', include('djust.observability.urls')),
+    ]
+
+urlpatterns += [
 
     # New organized apps
     path('', include('djust_homepage.urls')),       # Homepage and embedded demos


### PR DESCRIPTION
## Summary

Activates the Phase 7.0–7.3 observability infrastructure in the dogfooding demo — serves as the canonical integration example for downstream users.

- \`MIDDLEWARE\`: \`LocalhostOnlyObservabilityMiddleware\` placed right after \`SecurityMiddleware\`
- \`urls.py\`: \`include('djust.observability.urls')\` at \`/_djust/observability/\` gated by \`settings.DEBUG\`

## Live-verified end-to-end

\`\`\`bash
curl http://127.0.0.1:8002/_djust/observability/health/
# {\"ok\": true, \"debug\": true, \"registered_sessions\": 1}

curl '.../view_assigns/?session_id=80de38fc-...'
# {view_class: \"DemosIndexShadcnView\", assigns: {counter: \"1\", ...}}

curl '.../log/?level=WARNING&limit=3'
# {count: 1, entries: [...]}
\`\`\`

## Finding from live-verify

When a view has \`self.request = <WSGIRequest>\` (common pattern), \`LiveView.get_state()\` raises in DEBUG. The \`view_assigns\` endpoint's fallback path engages and returns \`repr()\` strings for **all** attrs instead of only the bad ones. Actionable follow-up: make the fallback per-attr, or add a \`skip_nonserializable=True\` mode to \`get_state()\`. Not blocking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)