### PR TITLE
fix: view_assigns uses per-attr fallback instead of all-or-nothing

### DIFF
--- a/python/djust/observability/views.py
+++ b/python/djust/observability/views.py
@@ -6,21 +6,70 @@ endpoint so the foundation PR is independently verifiable.
 
 from __future__ import annotations
 
-import logging
-
 from django.conf import settings
 from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
 
+from djust.observability.log_handler import get_recent_logs
 from djust.observability.registry import (
     get_registered_session_count,
     get_view_for_session,
 )
-from djust.observability.log_handler import get_recent_logs
 from djust.observability.tracebacks import get_recent_tracebacks
 
-logger = logging.getLogger("djust.observability")
+
+def _is_jsonable(value):
+    """Last-resort serializability check when the view doesn't expose
+    `_is_serializable`. Cheap for small values; we tolerate the cost
+    because observability endpoints aren't hot paths."""
+    import json
+
+    try:
+        json.dumps(value)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def _lenient_assigns(view):
+    """Serialize public attrs one-by-one with per-attr fallback.
+
+    Why not just call `view.get_state()`? In DEBUG mode that raises on
+    the first non-serializable attr, forcing an all-or-nothing choice.
+    A common pattern (`self.request = request` stored during mount)
+    then loses the other 95% of legitimate state to a blanket repr.
+
+    This walker keeps JSON-serializable values as themselves and tags
+    each non-serializable one with `{_repr, _type}` so the agent can
+    see at a glance which attrs fell back and why.
+
+    Uses the view's own `_is_serializable` when available (matches the
+    framework's definition) and falls back to a direct json.dumps probe
+    for anything that doesn't expose it (e.g. test doubles).
+    """
+    checker = getattr(view, "_is_serializable", None)
+
+    def _safe_check(val):
+        if checker is not None:
+            try:
+                return bool(checker(val))
+            except Exception:  # noqa: BLE001
+                return False
+        return _is_jsonable(val)
+
+    assigns = {}
+    for key, value in view.__dict__.items():
+        if key.startswith("_") or callable(value):
+            continue
+        if _safe_check(value):
+            assigns[key] = value
+        else:
+            assigns[key] = {
+                "_repr": repr(value)[:200],
+                "_type": type(value).__name__,
+            }
+    return assigns
 
 
 def _debug_gate():
@@ -83,18 +132,7 @@ def view_assigns(request):
             status=404,
         )
 
-    try:
-        assigns = view.get_state()
-    except Exception as e:  # noqa: BLE001
-        # get_state raises TypeError on non-serializable values in DEBUG.
-        # Observability must still return something useful — fall back to
-        # a best-effort shallow dict of repr()s.
-        logger.warning("view.get_state() failed for session %s: %s", session_id, e)
-        assigns = {
-            k: repr(v)[:200]
-            for k, v in view.__dict__.items()
-            if not k.startswith("_") and not callable(v)
-        }
+    assigns = _lenient_assigns(view)
 
     return JsonResponse(
         {

--- a/python/djust/tests/test_observability_view_assigns.py
+++ b/python/djust/tests/test_observability_view_assigns.py
@@ -34,8 +34,31 @@ class _FakeView:
         return {k: v for k, v in self.__dict__.items() if not k.startswith("_") and not callable(v)}
 
 
-class _ExplodingView(_FakeView):
+class _FakeViewWithNonSerializable(_FakeView):
+    """Has an attribute the framework considers non-serializable (like a
+    live request or DB connection). Represents the DEBUG-mode common case.
+    """
+
+    def __init__(self):
+        super().__init__(count=42, label="mixed")
+        # Something that mimics a WSGIRequest — an object the framework's
+        # _is_serializable will reject.
+        self.request = object()
+
+    def _is_serializable(self, value):
+        # Mirror LiveView's semantics: reject objects of bare `object` type
+        # (non-JSON-serializable) but accept the ints/strs/lists/dicts.
+        try:
+            import json
+
+            json.dumps(value)
+            return True
+        except (TypeError, ValueError):
+            return False
+
     def get_state(self):
+        # Would raise in real LiveView when DEBUG=True because of self.request;
+        # here we delegate to the framework-style check via super-equivalent.
         raise TypeError("boom — non-serializable value")
 
 
@@ -90,14 +113,24 @@ def test_view_assigns_404_when_debug_off():
 
 
 @override_settings(DEBUG=True)
-def test_view_assigns_falls_back_when_get_state_raises():
-    """If get_state() can't serialize, return repr()s instead of 500."""
-    view = _ExplodingView(count=42)
+def test_view_assigns_per_attr_fallback_keeps_serializable_native():
+    """Partial serializability: good attrs stay native, bad ones get tagged.
+
+    Previously any non-serializable attr forced an all-or-nothing blanket
+    repr that lost all native values. Now each attr is handled independently.
+    """
+    view = _FakeViewWithNonSerializable()
     register_view("s", view)
     rf = RequestFactory()
     resp = view_assigns(rf.get("/?session_id=s"))
     assert resp.status_code == 200
     data = json.loads(resp.content)
-    # Fallback is repr()'d strings — count=42 becomes "42"
-    assert "count" in data["assigns"]
-    assert data["assigns"]["count"] == "42"
+    # Serializable attrs stay as their actual values.
+    assert data["assigns"]["count"] == 42
+    assert data["assigns"]["label"] == "mixed"
+    # Non-serializable attr is tagged {_repr, _type} so the caller can see
+    # at a glance that it fell back.
+    request_field = data["assigns"]["request"]
+    assert isinstance(request_field, dict)
+    assert request_field["_type"] == "object"
+    assert "_repr" in request_field


### PR DESCRIPTION
## Summary

Follow-up to the live-verify finding from Phase 7.1 (PR #746).

When a view stores a non-serializable attribute (e.g. \`self.request = request\` during mount — a common LiveView pattern), \`get_state()\` raises \`TypeError\` in DEBUG. The original \`view_assigns\` fallback responded with a blanket \`repr()\` of every attr, losing all native values for attrs that were perfectly fine.

### Before
\`\`\`json
{\"counter\": \"1\", \"dropdown_open\": \"False\", \"request\": \"<WSGIRequest...>\"}
\`\`\`

### After
\`\`\`json
{
  \"counter\": 1,
  \"dropdown_open\": false,
  \"request\": {\"_repr\": \"<WSGIRequest: GET '/'>\", \"_type\": \"WSGIRequest\"}
}
\`\`\`

## Implementation

\`_lenient_assigns(view)\` walks \`view.__dict__\` once, per-attr checks:
1. Prefer the view's own \`_is_serializable\` (matches framework semantics)
2. Fall back to a \`json.dumps\` probe for test doubles or non-LiveView subclasses

Non-serializable attrs get tagged \`{_repr, _type}\` rather than silently dropped, so the agent can see exactly which attrs fell back.

## Test plan

- [x] Unit tests updated — new \`test_view_assigns_per_attr_fallback_keeps_serializable_native\`
- [x] Live re-verified on demo_project — DemosIndexShadcnView session shows native \`counter: 1\` + tagged \`request: {_repr, _type: \"WSGIRequest\"}\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)