### PR TITLE
feat: get_handler_timings — per-handler percentile stats (Phase 7.4)

### DIFF
--- a/python/djust/mcp/server.py
+++ b/python/djust/mcp/server.py
@@ -283,6 +283,52 @@ def create_server():
         return r.text
 
     @mcp.tool()
+    def get_handler_timings(handler_name: str = "", since_ms: int = 0) -> str:
+        """Per-handler percentile stats over the rolling sample window.
+
+        Args:
+            handler_name: Filter to one handler name. If multiple views
+                expose the same handler name, each view appears as its
+                own row. Empty string = no filter.
+            since_ms: Only include samples with timestamp > since_ms.
+                Default 0 = whole rolling window (last 100 samples per
+                handler).
+
+        Returns JSON: {count, stats:[{view_class, handler_name, count,
+        min_ms, max_ms, avg_ms, p50_ms, p90_ms, p99_ms}]}.
+
+        Rows sorted by p90 descending, so the slowest handlers surface
+        first. Catches "this handler got slow" regressions without
+        running a load test.
+        """
+        import os
+
+        try:
+            import requests
+        except ImportError:
+            return json.dumps({"error": "`requests` package not installed in the MCP environment"})
+
+        base = os.environ.get("DJUST_DEV_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
+        url = f"{base}/_djust/observability/handler_timings/"
+        params = {}
+        if handler_name:
+            params["handler_name"] = handler_name
+        if since_ms:
+            params["since_ms"] = since_ms
+        try:
+            r = requests.get(url, params=params, timeout=5)
+        except requests.RequestException as e:
+            return json.dumps(
+                {
+                    "error": f"request failed: {e}",
+                    "hint": f"Is the dev server running? Tried {url}.",
+                }
+            )
+        if r.status_code != 200:
+            return json.dumps({"error": r.text, "status": r.status_code})
+        return r.text
+
+    @mcp.tool()
     def tail_server_log(since_ms: int = 0, level: str = "INFO", limit: int = 500) -> str:
         """Read buffered Django/djust log records from the dev server.
 

--- a/python/djust/observability/timings.py
+++ b/python/djust/observability/timings.py
@@ -1,0 +1,100 @@
+"""
+Per-handler timing samples + aggregation.
+
+Populated by LiveViewConsumer at every handler invocation (sync or
+async, view-level or component-level). The MCP reads aggregated
+percentiles via /_djust/observability/handler_timings/.
+"""
+
+from __future__ import annotations
+
+import statistics
+import threading
+from collections import defaultdict, deque
+from typing import Any, Dict, List, Optional, Tuple
+
+_MAX_SAMPLES_PER_HANDLER = 100
+
+# Map (view_class, handler_name) → deque of (timestamp_ms, duration_ms).
+_samples: "defaultdict[Tuple[str, str], deque[Tuple[int, float]]]" = defaultdict(
+    lambda: deque(maxlen=_MAX_SAMPLES_PER_HANDLER)
+)
+_lock = threading.Lock()
+
+
+def record_handler_timing(view_class: str, handler_name: str, duration_ms: float) -> None:
+    """Push a single handler execution sample onto the rolling window."""
+    import time
+
+    ts = int(time.time() * 1000)
+    with _lock:
+        _samples[(view_class, handler_name)].append((ts, float(duration_ms)))
+
+
+def _percentile(values: List[float], pct: float) -> float:
+    """Return the approximate pct (0..100) percentile. Uses linear
+    interpolation between sorted samples — matches numpy's 'linear'
+    default. Empty list → 0.0.
+    """
+    if not values:
+        return 0.0
+    s = sorted(values)
+    if len(s) == 1:
+        return s[0]
+    k = (len(s) - 1) * (pct / 100.0)
+    lo = int(k)
+    hi = min(lo + 1, len(s) - 1)
+    frac = k - lo
+    return s[lo] + (s[hi] - s[lo]) * frac
+
+
+def get_timing_stats(
+    handler_name: Optional[str] = None,
+    since_ms: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Aggregate samples into per-handler stats.
+
+    Args:
+        handler_name: If set, only return stats for handlers with this
+            exact name. Otherwise return one row per (view_class,
+            handler_name) pair seen.
+        since_ms: If set, only include samples with timestamp > since_ms.
+    """
+    with _lock:
+        snapshot = {k: list(v) for k, v in _samples.items()}
+
+    rows = []
+    for (view_class, h_name), sample_list in snapshot.items():
+        if handler_name and h_name != handler_name:
+            continue
+        durations = [d for (ts, d) in sample_list if since_ms is None or ts > since_ms]
+        if not durations:
+            continue
+        rows.append(
+            {
+                "view_class": view_class,
+                "handler_name": h_name,
+                "count": len(durations),
+                "min_ms": +round(min(durations), 3),
+                "max_ms": +round(max(durations), 3),
+                "avg_ms": +round(statistics.fmean(durations), 3),
+                "p50_ms": +round(_percentile(durations, 50), 3),
+                "p90_ms": +round(_percentile(durations, 90), 3),
+                "p99_ms": +round(_percentile(durations, 99), 3),
+            }
+        )
+    # Slowest p90 first — surfaces the most-suspicious handlers.
+    rows.sort(key=lambda r: r["p90_ms"], reverse=True)
+    return rows
+
+
+def get_sample_total() -> int:
+    """Total samples across all handlers. Diagnostic helper."""
+    with _lock:
+        return sum(len(v) for v in _samples.values())
+
+
+def _clear_timings() -> None:
+    """Test-only reset."""
+    with _lock:
+        _samples.clear()

--- a/python/djust/observability/urls.py
+++ b/python/djust/observability/urls.py
@@ -14,6 +14,7 @@ production config still refuses to serve data.
 from django.urls import path
 
 from djust.observability.views import (
+    handler_timings,
     health,
     last_traceback,
     log_tail,
@@ -27,4 +28,5 @@ urlpatterns = [
     path("view_assigns/", view_assigns, name="view_assigns"),
     path("last_traceback/", last_traceback, name="last_traceback"),
     path("log/", log_tail, name="log"),
+    path("handler_timings/", handler_timings, name="handler_timings"),
 ]

--- a/python/djust/observability/views.py
+++ b/python/djust/observability/views.py
@@ -16,6 +16,7 @@ from djust.observability.registry import (
     get_registered_session_count,
     get_view_for_session,
 )
+from djust.observability.timings import get_timing_stats
 from djust.observability.tracebacks import get_recent_tracebacks
 
 
@@ -211,3 +212,33 @@ def log_tail(request):
             "entries": entries,
         }
     )
+
+
+@csrf_exempt
+@require_GET
+def handler_timings(request):
+    """Return per-handler percentile stats over the rolling sample window.
+
+    Query params:
+        handler_name (optional): filter to a single handler name. If
+            multiple views expose handlers with the same name, each
+            appears as its own row.
+        since_ms (optional): only include samples with timestamp > since_ms.
+
+    Each row: {view_class, handler_name, count, min_ms, max_ms, avg_ms,
+    p50_ms, p90_ms, p99_ms}. Sorted by p90 descending so the slowest
+    handlers are first.
+    """
+    if not settings.DEBUG:
+        return _debug_gate()
+
+    handler_name = request.GET.get("handler_name", "").strip() or None
+
+    since_ms_raw = request.GET.get("since_ms", "").strip()
+    try:
+        since_ms = int(since_ms_raw) if since_ms_raw else None
+    except ValueError:
+        since_ms = None
+
+    rows = get_timing_stats(handler_name=handler_name, since_ms=since_ms)
+    return JsonResponse({"count": len(rows), "stats": rows})

--- a/python/djust/tests/test_observability_timings.py
+++ b/python/djust/tests/test_observability_timings.py
@@ -1,0 +1,152 @@
+"""
+Tests for Phase 7.4 — handler timing ring buffer + /handler_timings/ endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.test import RequestFactory, override_settings
+
+from djust.observability.timings import (
+    _clear_timings,
+    _percentile,
+    get_sample_total,
+    get_timing_stats,
+    record_handler_timing,
+)
+from djust.observability.views import handler_timings as handler_timings_view
+
+
+@pytest.fixture(autouse=True)
+def clean_timings():
+    _clear_timings()
+    yield
+    _clear_timings()
+
+
+# --- Buffer / aggregation --------------------------------------------------
+
+
+def test_record_and_single_handler_stats():
+    for d in [10, 12, 14, 9, 11]:
+        record_handler_timing("CounterView", "increment", d)
+    rows = get_timing_stats()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["view_class"] == "CounterView"
+    assert row["handler_name"] == "increment"
+    assert row["count"] == 5
+    assert row["min_ms"] == 9
+    assert row["max_ms"] == 14
+    assert row["avg_ms"] == pytest.approx(11.2, abs=0.01)
+
+
+def test_multiple_handlers_separate_rows():
+    record_handler_timing("A", "one", 1)
+    record_handler_timing("A", "two", 10)
+    record_handler_timing("B", "one", 100)
+    rows = get_timing_stats()
+    # Three distinct (view_class, handler) pairs.
+    assert len(rows) == 3
+
+
+def test_handler_name_filter():
+    record_handler_timing("A", "one", 1)
+    record_handler_timing("A", "two", 10)
+    record_handler_timing("B", "one", 100)
+    rows = get_timing_stats(handler_name="one")
+    # Both views with a handler named "one" — not the "two" row.
+    assert {r["view_class"] for r in rows} == {"A", "B"}
+    assert all(r["handler_name"] == "one" for r in rows)
+
+
+def test_p90_sorting_slowest_first():
+    for d in [1, 1, 1, 1, 1]:
+        record_handler_timing("Fast", "h", d)
+    for d in [50, 60, 70, 80, 90]:
+        record_handler_timing("Slow", "h", d)
+    rows = get_timing_stats()
+    assert rows[0]["view_class"] == "Slow"
+    assert rows[1]["view_class"] == "Fast"
+
+
+def test_since_ms_filter():
+    import time
+
+    record_handler_timing("A", "h", 10)
+    time.sleep(0.01)
+    cutoff = int(time.time() * 1000)
+    time.sleep(0.01)
+    record_handler_timing("A", "h", 20)
+    rows = get_timing_stats(since_ms=cutoff)
+    assert len(rows) == 1
+    assert rows[0]["count"] == 1
+    assert rows[0]["avg_ms"] == 20
+
+
+def test_sample_cap_per_handler():
+    """Buffer evicts oldest when more than 100 samples arrive."""
+    for i in range(120):
+        record_handler_timing("A", "h", float(i))
+    assert get_sample_total() == 100
+    rows = get_timing_stats()
+    # Only the last 100 samples remain (20..119).
+    assert rows[0]["count"] == 100
+    assert rows[0]["min_ms"] == 20
+    assert rows[0]["max_ms"] == 119
+
+
+def test_percentile_interpolation():
+    assert _percentile([], 50) == 0.0
+    assert _percentile([7], 50) == 7
+    # [1,2,3,4,5] — p50 is the median (3). p90 is linear interp between
+    # indices 3.6 and 4 → 4 + 0.6*(5-4) = 4.6.
+    assert _percentile([1, 2, 3, 4, 5], 50) == 3
+    assert _percentile([1, 2, 3, 4, 5], 90) == pytest.approx(4.6, abs=0.01)
+
+
+def test_empty_buffer_returns_empty_stats():
+    assert get_timing_stats() == []
+
+
+# --- Endpoint --------------------------------------------------------------
+
+
+@override_settings(DEBUG=True)
+def test_endpoint_returns_stats():
+    for d in [1, 2, 3]:
+        record_handler_timing("CounterView", "increment", d)
+    rf = RequestFactory()
+    resp = handler_timings_view(rf.get("/"))
+    assert resp.status_code == 200
+    data = json.loads(resp.content)
+    assert data["count"] == 1
+    assert data["stats"][0]["handler_name"] == "increment"
+
+
+@override_settings(DEBUG=True)
+def test_endpoint_handler_name_filter():
+    record_handler_timing("A", "one", 5)
+    record_handler_timing("A", "two", 15)
+    rf = RequestFactory()
+    resp = handler_timings_view(rf.get("/?handler_name=one"))
+    data = json.loads(resp.content)
+    assert data["count"] == 1
+    assert data["stats"][0]["handler_name"] == "one"
+
+
+@override_settings(DEBUG=True)
+def test_endpoint_handles_bad_since_ms():
+    record_handler_timing("A", "h", 1)
+    rf = RequestFactory()
+    resp = handler_timings_view(rf.get("/?since_ms=not-a-number"))
+    assert resp.status_code == 200
+
+
+@override_settings(DEBUG=False)
+def test_endpoint_404_when_debug_off():
+    rf = RequestFactory()
+    resp = handler_timings_view(rf.get("/"))
+    assert resp.status_code == 404

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -1818,6 +1818,18 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         time.perf_counter() - handler_start
                     ) * 1000  # Convert to ms
 
+                    # Observability: record the component-handler duration
+                    # for percentile stats. Best-effort — never disturbs
+                    # handler execution.
+                    try:
+                        from djust.observability.timings import record_handler_timing
+
+                        record_handler_timing(
+                            target_view.__class__.__name__, event_name, timing["handler"]
+                        )
+                    except Exception:  # noqa: BLE001
+                        pass
+
                     # ADR-002 Phase 1b/1c follow-up: propagate component events
                     # to parent LiveView waiters. Without this, a tutorial step
                     # that uses `wait_for="component_handler"` on a LiveView
@@ -1898,6 +1910,17 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         timing["handler"] = (
                             time.perf_counter() - handler_start
                         ) * 1000  # Convert to ms
+
+                        # Observability: record the view-handler duration
+                        # for percentile stats. Best-effort.
+                        try:
+                            from djust.observability.timings import record_handler_timing
+
+                            record_handler_timing(
+                                target_view.__class__.__name__, event_name, timing["handler"]
+                            )
+                        except Exception:  # noqa: BLE001
+                            pass
 
                         # ADR-002 Phase 1b: resolve any pending wait_for_event
                         # waiters on the target view whose event_name matches.

--- a/uv.lock
+++ b/uv.lock
@@ -711,7 +711,7 @@ wheels = [
 
 [[package]]
 name = "djust"
-version = "0.4.3rc1"
+version = "0.4.5rc1"
 source = { editable = "." }
 dependencies = [
     { name = "channels", extra = ["daphne"] },


### PR DESCRIPTION
## Summary

Rolling 100-sample-per-handler window → min/max/avg/p50/p90/p99 stats. Catches \"this handler got slow\" regressions without running a load test.

### Framework
- \`observability/timings.py\` — \`defaultdict\` of \`deque(maxlen=100)\` keyed by \`(view_class, handler_name)\`
- \`websocket.py\` — record at both call sites (view + component path), reusing the existing \`timing[\"handler\"]\` measurement; zero extra perf_counter calls
- \`GET /handler_timings/?handler_name=&since_ms=\` returns rows sorted by p90 descending

### MCP
- \`get_handler_timings(handler_name=\"\", since_ms=0)\` tool

## Test plan

- [x] 12 new unit tests; 53 observability tests total pass
- [ ] Manual: click increment 20x on demo_project, curl \`/handler_timings/\` → see count=20 distribution for increment

🤖 Generated with [Claude Code](https://claude.com/claude-code)