### PR TITLE
feat: get_sql_queries_since — per-event SQL capture (Phase 7.5)

### DIFF
--- a/python/djust/mcp/server.py
+++ b/python/djust/mcp/server.py
@@ -329,6 +329,56 @@ def create_server():
         return r.text
 
     @mcp.tool()
+    def get_sql_queries_since(
+        since_ms: int = 0,
+        session_id: str = "",
+        handler_name: str = "",
+        limit: int = 500,
+    ) -> str:
+        """Captured SQL queries, scoped to an event handler when filtered.
+
+        Each query is tagged with the session_id + handler_name that fired
+        it, so you can ask "what SQL did the increment handler just run?"
+        and get a clean answer — including N+1 patterns that are almost
+        always the reason a handler got slow.
+
+        Args:
+            since_ms: only queries with timestamp > since_ms.
+            session_id: filter to one session.
+            handler_name: filter to one handler.
+            limit: max rows (default + cap: 500).
+
+        Returns JSON: {count, since_ms, entries:[{timestamp_ms, sql,
+        params, duration_ms, stack_top, session_id, handler_name, ...}]}.
+        """
+        import os
+
+        try:
+            import requests
+        except ImportError:
+            return json.dumps({"error": "`requests` package not installed in the MCP environment"})
+
+        base = os.environ.get("DJUST_DEV_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
+        url = f"{base}/_djust/observability/sql_queries/"
+        params = {"since_ms": since_ms, "limit": limit}
+        if session_id:
+            params["session_id"] = session_id
+        if handler_name:
+            params["handler_name"] = handler_name
+        try:
+            r = requests.get(url, params=params, timeout=5)
+        except requests.RequestException as e:
+            return json.dumps(
+                {
+                    "error": f"request failed: {e}",
+                    "hint": f"Is the dev server running? Tried {url}.",
+                }
+            )
+        if r.status_code != 200:
+            return json.dumps({"error": r.text, "status": r.status_code})
+        return r.text
+
+    @mcp.tool()
     def tail_server_log(since_ms: int = 0, level: str = "INFO", limit: int = 500) -> str:
         """Read buffered Django/djust log records from the dev server.
 

--- a/python/djust/observability/sql.py
+++ b/python/djust/observability/sql.py
@@ -1,0 +1,151 @@
+"""
+Per-event SQL query capture.
+
+When enabled via `capture_for_event()`, a `django.db.connection.execute_wrapper`
+intercepts every query fired during handler execution and tags it with
+`(session_id, event_id, handler_name)`. The MCP reads the aggregated
+log via `/_djust/observability/sql_queries/`.
+
+Unlike Django's own `connection.queries`, this buffer survives across
+requests + is event-scoped — so the agent can ask "what SQL did the
+increment handler just run?" and get a clean answer.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import traceback
+from collections import deque
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Optional
+
+_MAX_ENTRIES = 500
+
+_buffer: "deque[Dict[str, Any]]" = deque(maxlen=_MAX_ENTRIES)
+_lock = threading.Lock()
+
+# Per-thread active scope — lets nested wrappers know the current tags.
+_active = threading.local()
+
+
+def _get_active() -> Optional[Dict[str, Any]]:
+    return getattr(_active, "scope", None)
+
+
+def _push_entry(entry: Dict[str, Any]) -> None:
+    with _lock:
+        _buffer.append(entry)
+
+
+def _short_stack_top() -> str:
+    """Grab the top frame OUTSIDE djust itself so the log points at the
+    caller's code (where the query was issued from), not at Django or
+    this module."""
+    stack = traceback.extract_stack(limit=30)
+    # Walk outermost-first, find the first frame that's NOT in djust,
+    # Django, or observability itself.
+    for frame in stack[:-4]:  # skip the wrapper frames themselves
+        fname = frame.filename
+        if "/djust/" in fname and "/site-packages/django" not in fname:
+            continue
+        if "/site-packages/django" in fname:
+            continue
+        if fname.endswith("sql.py"):
+            continue
+        return f"{frame.filename}:{frame.lineno} in {frame.name}"
+    # Fallback: the deepest non-wrapper frame.
+    if len(stack) >= 2:
+        f = stack[-2]
+        return f"{f.filename}:{f.lineno} in {f.name}"
+    return ""
+
+
+def _execute_wrapper(execute, sql, params, many, context):
+    """Django execute_wrapper — called for every query while installed."""
+    scope = _get_active()
+    if scope is None:
+        # Not in a capture scope (e.g. a stray query outside event dispatch).
+        # Still record it so the buffer stays honest about global activity.
+        scope = {"session_id": None, "event_id": None, "handler_name": None}
+
+    t0 = time.perf_counter()
+    try:
+        return execute(sql, params, many, context)
+    finally:
+        duration_ms = (time.perf_counter() - t0) * 1000
+        _push_entry(
+            {
+                "timestamp_ms": int(time.time() * 1000),
+                "session_id": scope.get("session_id"),
+                "event_id": scope.get("event_id"),
+                "handler_name": scope.get("handler_name"),
+                "sql": sql if isinstance(sql, str) else str(sql),
+                "params": list(params) if params is not None else None,
+                "many": bool(many),
+                "duration_ms": +round(duration_ms, 3),
+                "stack_top": _short_stack_top(),
+            }
+        )
+
+
+@contextmanager
+def capture_for_event(
+    session_id: Optional[str] = None,
+    event_id: Optional[str] = None,
+    handler_name: Optional[str] = None,
+) -> Iterator[None]:
+    """Install the wrapper for the duration of a handler invocation.
+
+    Nested scopes are supported — the outermost scope's tags stick until
+    it exits. (Most handlers don't nest; the protection is defensive.)
+    """
+    # Lazy import so djust.observability can be used without Django.
+    try:
+        from django.db import connection
+    except Exception:  # noqa: BLE001
+        yield
+        return
+
+    prev_scope = getattr(_active, "scope", None)
+    _active.scope = {
+        "session_id": session_id,
+        "event_id": event_id,
+        "handler_name": handler_name,
+    }
+    try:
+        with connection.execute_wrapper(_execute_wrapper):
+            yield
+    finally:
+        _active.scope = prev_scope
+
+
+def get_queries_since(
+    since_ms: int = 0,
+    session_id: Optional[str] = None,
+    handler_name: Optional[str] = None,
+    limit: int = 500,
+) -> List[Dict[str, Any]]:
+    """Return captured queries matching the filters. Newest-last so
+    chronological reading works naturally."""
+    with _lock:
+        entries = list(_buffer)
+    filtered = [
+        e
+        for e in entries
+        if e["timestamp_ms"] > since_ms
+        and (session_id is None or e["session_id"] == session_id)
+        and (handler_name is None or e["handler_name"] == handler_name)
+    ]
+    return filtered[-limit:]
+
+
+def get_buffer_size() -> int:
+    with _lock:
+        return len(_buffer)
+
+
+def _clear_queries() -> None:
+    """Test-only reset."""
+    with _lock:
+        _buffer.clear()

--- a/python/djust/observability/urls.py
+++ b/python/djust/observability/urls.py
@@ -18,6 +18,7 @@ from djust.observability.views import (
     health,
     last_traceback,
     log_tail,
+    sql_queries,
     view_assigns,
 )
 
@@ -29,4 +30,5 @@ urlpatterns = [
     path("last_traceback/", last_traceback, name="last_traceback"),
     path("log/", log_tail, name="log"),
     path("handler_timings/", handler_timings, name="handler_timings"),
+    path("sql_queries/", sql_queries, name="sql_queries"),
 ]

--- a/python/djust/observability/views.py
+++ b/python/djust/observability/views.py
@@ -16,6 +16,7 @@ from djust.observability.registry import (
     get_registered_session_count,
     get_view_for_session,
 )
+from djust.observability.sql import get_queries_since
 from djust.observability.timings import get_timing_stats
 from djust.observability.tracebacks import get_recent_tracebacks
 
@@ -242,3 +243,50 @@ def handler_timings(request):
 
     rows = get_timing_stats(handler_name=handler_name, since_ms=since_ms)
     return JsonResponse({"count": len(rows), "stats": rows})
+
+
+@csrf_exempt
+@require_GET
+def sql_queries(request):
+    """Return captured SQL queries, filtered by session/handler/since_ms.
+
+    Query params:
+        session_id: filter to one session
+        handler_name: filter to one handler
+        since_ms: only queries with timestamp > since_ms
+        limit: max rows returned (default 500)
+
+    Each entry: {timestamp_ms, session_id, event_id, handler_name, sql,
+    params, many, duration_ms, stack_top}. Entries chronological.
+    """
+    if not settings.DEBUG:
+        return _debug_gate()
+
+    session_id = request.GET.get("session_id", "").strip() or None
+    handler_name = request.GET.get("handler_name", "").strip() or None
+
+    try:
+        since_ms = int(request.GET.get("since_ms", "0"))
+    except (TypeError, ValueError):
+        since_ms = 0
+    try:
+        limit = int(request.GET.get("limit", "500"))
+    except (TypeError, ValueError):
+        limit = 500
+    limit = max(1, min(limit, 500))
+
+    entries = get_queries_since(
+        since_ms=since_ms,
+        session_id=session_id,
+        handler_name=handler_name,
+        limit=limit,
+    )
+    return JsonResponse(
+        {
+            "count": len(entries),
+            "since_ms": since_ms,
+            "session_id": session_id,
+            "handler_name": handler_name,
+            "entries": entries,
+        }
+    )

--- a/python/djust/tests/test_observability_sql.py
+++ b/python/djust/tests/test_observability_sql.py
@@ -1,0 +1,147 @@
+"""
+Tests for Phase 7.5 — SQL query capture + /sql_queries/ endpoint.
+
+Uses Django's test database via django_db fixture so the execute_wrapper
+runs against a real connection.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+from django.db import connection
+from django.test import RequestFactory, override_settings
+
+from djust.observability.sql import (
+    _clear_queries,
+    capture_for_event,
+    get_buffer_size,
+    get_queries_since,
+)
+from djust.observability.views import sql_queries as sql_queries_view
+
+
+@pytest.fixture(autouse=True)
+def clean_buffer():
+    _clear_queries()
+    yield
+    _clear_queries()
+
+
+# --- Capture primitives ----------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_capture_records_queries_with_scope():
+    with capture_for_event(session_id="s-1", handler_name="increment"):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+    entries = get_queries_since()
+    assert len(entries) >= 1
+    entry = next(e for e in entries if "SELECT 1" in e["sql"])
+    assert entry["session_id"] == "s-1"
+    assert entry["handler_name"] == "increment"
+    assert entry["duration_ms"] >= 0
+
+
+@pytest.mark.django_db
+def test_queries_outside_scope_are_tagged_null():
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT 2")
+    # Without capture_for_event, no tags but still NO capture because the
+    # wrapper wasn't installed. Buffer should remain empty.
+    assert get_buffer_size() == 0
+
+
+@pytest.mark.django_db
+def test_capture_scope_restores_on_exit():
+    """After the with-block exits, subsequent queries are NOT captured."""
+    with capture_for_event(session_id="s", handler_name="h"):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+    size_during = get_buffer_size()
+
+    # Outside the context: wrapper is uninstalled, no new entries.
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT 3")
+    assert get_buffer_size() == size_during
+
+
+@pytest.mark.django_db
+def test_since_ms_filter():
+    with capture_for_event(session_id="s", handler_name="h"):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 10")
+    time.sleep(0.01)
+    cutoff = int(time.time() * 1000)
+    time.sleep(0.01)
+    with capture_for_event(session_id="s", handler_name="h"):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 20")
+    recent = get_queries_since(since_ms=cutoff)
+    # Only the 'SELECT 20' query should remain.
+    assert any("20" in e["sql"] for e in recent)
+    assert not any("SELECT 10" in e["sql"] for e in recent)
+
+
+@pytest.mark.django_db
+def test_handler_name_filter():
+    with capture_for_event(session_id="s", handler_name="increment"):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 'inc'")
+    with capture_for_event(session_id="s", handler_name="decrement"):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 'dec'")
+    inc_only = get_queries_since(handler_name="increment")
+    assert all(e["handler_name"] == "increment" for e in inc_only)
+    assert any("inc" in e["sql"] for e in inc_only)
+
+
+@pytest.mark.django_db
+def test_no_wrapper_when_context_inactive():
+    """capture_for_event installs the wrapper only within its scope."""
+    # No active scope at this point.
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT 99")
+    # Nothing captured — execute_wrapper not installed.
+    assert get_buffer_size() == 0
+
+
+# --- Endpoint --------------------------------------------------------------
+
+
+@override_settings(DEBUG=True)
+@pytest.mark.django_db
+def test_endpoint_returns_entries():
+    with capture_for_event(session_id="s", handler_name="h"):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+    rf = RequestFactory()
+    resp = sql_queries_view(rf.get("/"))
+    assert resp.status_code == 200
+    data = json.loads(resp.content)
+    assert data["count"] >= 1
+
+
+@override_settings(DEBUG=True)
+@pytest.mark.django_db
+def test_endpoint_session_filter():
+    with capture_for_event(session_id="sA", handler_name="h"):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+    with capture_for_event(session_id="sB", handler_name="h"):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 2")
+    rf = RequestFactory()
+    resp = sql_queries_view(rf.get("/?session_id=sA"))
+    data = json.loads(resp.content)
+    assert all(e["session_id"] == "sA" for e in data["entries"])
+
+
+@override_settings(DEBUG=False)
+def test_endpoint_404_when_debug_off():
+    rf = RequestFactory()
+    resp = sql_queries_view(rf.get("/"))
+    assert resp.status_code == 404

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -1813,7 +1813,17 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                     # Call component's event handler (supports both sync and async)
                     # This may call send_parent() which triggers handle_component_event()
                     handler_start = time.perf_counter()
-                    await _call_handler(handler, coerced_event_data if coerced_event_data else None)
+                    # Observability: capture SQL queries fired by this handler.
+                    from djust.observability.sql import capture_for_event as _dj_sql_capture
+
+                    with _dj_sql_capture(
+                        session_id=self.session_id,
+                        event_id=f"{self.session_id}:{handler_start}",
+                        handler_name=event_name,
+                    ):
+                        await _call_handler(
+                            handler, coerced_event_data if coerced_event_data else None
+                        )
                     timing["handler"] = (
                         time.perf_counter() - handler_start
                     ) * 1000  # Convert to ms
@@ -1900,13 +1910,23 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
 
                         # Call handler with tracking (supports both sync and async handlers)
                         handler_start = time.perf_counter()
+                        # Observability: capture SQL queries fired by this handler.
+                        from djust.observability.sql import (
+                            capture_for_event as _dj_sql_capture,
+                        )
+
                         with tracker.track(
                             "Event Handler", event_name=event_name, params=coerced_params
                         ):
                             with profiler.profile(profiler.OP_EVENT_HANDLE):
-                                await _call_handler(
-                                    handler, coerced_params if coerced_params else None
-                                )
+                                with _dj_sql_capture(
+                                    session_id=self.session_id,
+                                    event_id=f"{self.session_id}:{handler_start}",
+                                    handler_name=event_name,
+                                ):
+                                    await _call_handler(
+                                        handler, coerced_params if coerced_params else None
+                                    )
                         timing["handler"] = (
                             time.perf_counter() - handler_start
                         ) * 1000  # Convert to ms

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -1816,9 +1816,10 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                     # Observability: capture SQL queries fired by this handler.
                     from djust.observability.sql import capture_for_event as _dj_sql_capture
 
+                    _sid = getattr(self, "session_id", None)
                     with _dj_sql_capture(
-                        session_id=self.session_id,
-                        event_id=f"{self.session_id}:{handler_start}",
+                        session_id=_sid,
+                        event_id=f"{_sid}:{handler_start}" if _sid else None,
                         handler_name=event_name,
                     ):
                         await _call_handler(
@@ -1915,13 +1916,14 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                             capture_for_event as _dj_sql_capture,
                         )
 
+                        _sid = getattr(self, "session_id", None)
                         with tracker.track(
                             "Event Handler", event_name=event_name, params=coerced_params
                         ):
                             with profiler.profile(profiler.OP_EVENT_HANDLE):
                                 with _dj_sql_capture(
-                                    session_id=self.session_id,
-                                    event_id=f"{self.session_id}:{handler_start}",
+                                    session_id=_sid,
+                                    event_id=f"{_sid}:{handler_start}" if _sid else None,
                                     handler_name=event_name,
                                 ):
                                     await _call_handler(


### PR DESCRIPTION
## Summary

Every query fired during handler execution is tagged with \`(session_id, event_id, handler_name)\`. Catches N+1 queries — the single most common cause of slow handlers — in one tool call.

### Framework
- \`observability/sql.py\` — \`capture_for_event()\` contextmanager installs a \`connection.execute_wrapper\` that records \`{sql, params, duration_ms, stack_top}\` + scope tags
- \`websocket.py\` — wrap both handler call sites (view path + component path). Defensive \`getattr(self, \"session_id\", None)\` for test fixtures that construct consumers outside of \`connect()\`
- \`stack_top\` filter skips djust + Django frames so the log points at the ORM callsite

### MCP
- \`get_sql_queries_since(since_ms, session_id, handler_name, limit)\`

### Diagnostic loop
1. \`get_handler_timings\` → which handler got slow  
2. \`get_sql_queries_since(handler_name=X)\` → which query + stack_top  
3. Fix the N+1

## Test plan

- [x] 9 new django_db-backed unit tests (scope install/uninstall, session/handler filters, since_ms, no-wrapper-when-inactive, endpoint variants)
- [x] Full observability suite: 62 tests passing
- [x] Waiter-propagation regression from first attempt (missing session_id on mock consumers) fixed with defensive getattr; pre-push test suite now clean
- [ ] Manual: click a handler that does an ORM read, curl \`/sql_queries/?handler_name=X\` → see the SELECT with duration + stack_top

🤖 Generated with [Claude Code](https://claude.com/claude-code)