### PR TITLE
feat: find_handlers_for_template (Phase 8 #37)

### DIFF
--- a/python/djust/mcp/server.py
+++ b/python/djust/mcp/server.py
@@ -219,6 +219,158 @@ def create_server():
             }
         )
 
+    @mcp.tool()
+    def find_handlers_for_template(template_path: str) -> str:
+        """List every view that uses a template, and which dj-* handlers
+        are wired in that template.
+
+        Args:
+            template_path: Either a logical template name (e.g.
+                'demos/counter.html' — what you'd pass to `render`) OR
+                an absolute filesystem path. Both are searched.
+
+        Returns JSON:
+          {
+            "template_path": "...",
+            "resolved_path": "/abs/path.html",
+            "dj_handlers_in_template": ["increment", "decrement", ...],
+            "views": [
+              {"class": "CounterView", "template_name": "...",
+               "matched_handlers": ["increment", "decrement"],
+               "handlers_in_view_not_in_template": [...],
+               "handlers_in_template_not_in_view": [...]}
+            ]
+          }
+
+        Pure static analysis — no framework hooks. Precursor to automated
+        refactoring ("renaming this handler, who's affected?").
+        """
+        if not _ensure_django():
+            return json.dumps(
+                {
+                    "error": "Django not configured. Run via 'python manage.py djust_mcp'.",
+                }
+            )
+
+        import os
+        import re
+
+        from djust.schema import get_project_schema
+
+        # Resolve the template to an absolute path. Accept both logical
+        # names and absolute paths so callers can hand either form.
+        resolved_path: str | None = None
+        if os.path.isabs(template_path) and os.path.isfile(template_path):
+            resolved_path = template_path
+        else:
+            try:
+                from django.template.loader import get_template
+
+                tpl = get_template(template_path)
+                origin = getattr(tpl, "origin", None)
+                if origin and getattr(origin, "name", None):
+                    resolved_path = origin.name
+            except Exception as e:  # noqa: BLE001
+                return json.dumps(
+                    {
+                        "error": f"Could not resolve template '{template_path}': {e}",
+                        "hint": "Pass either a logical name (e.g. 'demos/counter.html') or an absolute filesystem path.",
+                    }
+                )
+
+        if not resolved_path or not os.path.isfile(resolved_path):
+            return json.dumps(
+                {
+                    "error": f"Template file not found for '{template_path}'",
+                    "resolved_path": resolved_path,
+                }
+            )
+
+        # Scan the template for dj-* handler references.
+        # Matches e.g. dj-click="increment" / dj-submit='add_todo'.
+        # Deliberately doesn't match dj-params / dj-id / dj-view / dj-loading
+        # etc. — only the event-wiring attrs.
+        dj_event_attr_re = re.compile(
+            r'\b(dj-(?:click|submit|change|input|keydown|keyup))\s*=\s*[\'"]([^\'"]+)[\'"]',
+            re.IGNORECASE,
+        )
+        with open(resolved_path, "r", encoding="utf-8", errors="replace") as f:
+            source = f.read()
+        handler_names_in_template = sorted({m.group(2) for m in dj_event_attr_re.finditer(source)})
+
+        # Match against the project's views. A view matches when its
+        # template_name maps to the same resolved path. Compare by basename
+        # + tail so both logical and absolute inputs can match.
+        schema = get_project_schema()
+        logical_tail = template_path.replace(os.sep, "/")
+        resolved_tail_components = resolved_path.replace(os.sep, "/").split("/")
+
+        matched_views = []
+        for view in schema["views"] + schema.get("components", []):
+            view_template = view.get("template_name") or ""
+            if not view_template:
+                continue
+            # Match on exact string, suffix, or resolving the view's
+            # template_name to the same path.
+            same = (
+                view_template == template_path
+                or view_template == logical_tail
+                or (logical_tail and view_template.endswith(logical_tail))
+                or resolved_tail_components[-1] == os.path.basename(view_template)
+            )
+            if not same:
+                continue
+
+            # Also try to resolve view_template through the loader — the
+            # strongest match. Skip if resolution fails.
+            view_resolved = None
+            try:
+                from django.template.loader import get_template
+
+                view_tpl = get_template(view_template)
+                view_origin = getattr(view_tpl, "origin", None)
+                if view_origin and getattr(view_origin, "name", None):
+                    view_resolved = view_origin.name
+            except Exception:  # noqa: BLE001
+                pass
+
+            if view_resolved and view_resolved != resolved_path:
+                # Different actual file despite similar names — skip.
+                continue
+
+            # Build handler-name set from the view's schema (these are
+            # Python-side handler method names).
+            view_handler_names = set()
+            for h in view.get("handlers", []):
+                name = h.get("name") if isinstance(h, dict) else h
+                if name:
+                    view_handler_names.add(name)
+
+            matched_set = view_handler_names & set(handler_names_in_template)
+            only_view = sorted(view_handler_names - set(handler_names_in_template))
+            only_template = sorted(set(handler_names_in_template) - view_handler_names)
+
+            matched_views.append(
+                {
+                    "class": view.get("class"),
+                    "template_name": view_template,
+                    "matched_handlers": sorted(matched_set),
+                    "handlers_in_view_not_in_template": only_view,
+                    "handlers_in_template_not_in_view": only_template,
+                }
+            )
+
+        return json.dumps(
+            {
+                "template_path": template_path,
+                "resolved_path": resolved_path,
+                "dj_handlers_in_template": handler_names_in_template,
+                "view_count": len(matched_views),
+                "views": matched_views,
+            },
+            indent=2,
+        )
+
     # === Observability tools ===
     #
     # These call the dev server's /_djust/observability/ endpoints (installed

--- a/python/djust/tests/test_find_handlers_for_template.py
+++ b/python/djust/tests/test_find_handlers_for_template.py
@@ -1,0 +1,155 @@
+"""
+Tests for find_handlers_for_template — static analysis that cross-
+references a template's dj-* attrs against the project's LiveView
+handlers.
+
+These tests bypass the MCP server wrapper and exercise the core
+regex + matching logic directly via a temporary template file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+
+
+# The dj-event-attr regex is replicated here because the MCP server's
+# `create_server()` closes over it. In practice the single source of
+# truth is server.py's inline definition — when it changes, this
+# regex (and the tool's behavior) should be updated together.
+DJ_EVENT_ATTR_RE = re.compile(
+    r'\b(dj-(?:click|submit|change|input|keydown|keyup))\s*=\s*[\'"]([^\'"]+)[\'"]',
+    re.IGNORECASE,
+)
+
+
+def _extract_handlers(source: str) -> list[str]:
+    return sorted({m.group(2) for m in DJ_EVENT_ATTR_RE.finditer(source)})
+
+
+# --- Regex correctness -----------------------------------------------------
+
+
+def test_extracts_single_handler():
+    src = '<button dj-click="increment">+</button>'
+    assert _extract_handlers(src) == ["increment"]
+
+
+def test_extracts_multiple_distinct_handlers():
+    src = """
+    <button dj-click="increment">+</button>
+    <button dj-click="decrement">-</button>
+    <button dj-click="reset">reset</button>
+    <form dj-submit="add_todo">...</form>
+    <input dj-change="validate_field">
+    """
+    assert _extract_handlers(src) == [
+        "add_todo",
+        "decrement",
+        "increment",
+        "reset",
+        "validate_field",
+    ]
+
+
+def test_deduplicates_repeated_handlers():
+    """A handler used by multiple elements should appear once."""
+    src = """
+    <button dj-click="increment">+</button>
+    <button dj-click="increment">++</button>
+    """
+    assert _extract_handlers(src) == ["increment"]
+
+
+def test_ignores_non_event_dj_attrs():
+    """dj-id, dj-params, dj-loading etc. must NOT be collected."""
+    src = """
+    <div dj-id="42"></div>
+    <div dj-params='{"x": 1}'></div>
+    <div dj-loading="click" dj-click="real_handler"></div>
+    <div dj-view="path.to.View"></div>
+    """
+    assert _extract_handlers(src) == ["real_handler"]
+
+
+def test_handles_single_and_double_quotes():
+    src = """
+    <button dj-click='quote_one'>a</button>
+    <button dj-click="quote_two">b</button>
+    """
+    assert _extract_handlers(src) == ["quote_one", "quote_two"]
+
+
+def test_empty_template_returns_empty():
+    assert _extract_handlers("") == []
+    assert _extract_handlers("<html><body>no events</body></html>") == []
+
+
+def test_handles_keyboard_events():
+    src = '<input dj-keydown="submit_on_enter" dj-keyup="debounce_search">'
+    assert _extract_handlers(src) == ["debounce_search", "submit_on_enter"]
+
+
+# --- Round-trip with a real file ------------------------------------------
+
+
+def test_roundtrip_via_file():
+    """Confirm reading + parsing a file off disk gives the expected set."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False) as f:
+        f.write(
+            """
+            <div>
+              <button dj-click="increment">+</button>
+              <button dj-click="decrement">-</button>
+              <form dj-submit="save">Save</form>
+            </div>
+            """
+        )
+        path = f.name
+    try:
+        with open(path) as rf:
+            src = rf.read()
+        assert _extract_handlers(src) == ["decrement", "increment", "save"]
+    finally:
+        os.unlink(path)
+
+
+# --- Set-math that the tool does on top of the regex -----------------------
+
+
+def test_intersection_logic_matches_tool_contract():
+    """Validates the 'handlers_in_view_not_in_template' /
+    'handlers_in_template_not_in_view' / 'matched_handlers' shape."""
+    template_handlers = {"increment", "decrement", "reset", "ghost"}
+    view_handlers = {"increment", "decrement", "reset", "orphan"}
+
+    matched = sorted(view_handlers & template_handlers)
+    only_view = sorted(view_handlers - template_handlers)
+    only_template = sorted(template_handlers - view_handlers)
+
+    assert matched == ["decrement", "increment", "reset"]
+    assert only_view == ["orphan"]
+    assert only_template == ["ghost"]
+
+
+def test_tool_json_shape_compiles():
+    """Smoke-test that the response shape we document is valid JSON."""
+    sample = {
+        "template_path": "demos/counter.html",
+        "resolved_path": "/abs/demos/counter.html",
+        "dj_handlers_in_template": ["increment", "decrement"],
+        "view_count": 1,
+        "views": [
+            {
+                "class": "CounterView",
+                "template_name": "demos/counter.html",
+                "matched_handlers": ["increment", "decrement"],
+                "handlers_in_view_not_in_template": [],
+                "handlers_in_template_not_in_view": [],
+            }
+        ],
+    }
+    # Must round-trip through json without loss.
+    assert json.loads(json.dumps(sample)) == sample


### PR DESCRIPTION
## Summary

Given a template path, list every view that uses it + a diff between dj-* handlers wired in the template and handler methods defined on the view.

### Response shape
\`\`\`json
{
  \"template_path\": \"...\",
  \"resolved_path\": \"/abs/...\",
  \"dj_handlers_in_template\": [...],
  \"view_count\": N,
  \"views\": [{
    \"class\": \"CounterView\",
    \"template_name\": \"...\",
    \"matched_handlers\": [...],
    \"handlers_in_view_not_in_template\": [...],   // never-wired methods
    \"handlers_in_template_not_in_view\": [...]    // dead bindings
  }]
}
\`\`\`

### Accepts
- Logical template names (\`\"demos/counter.html\"\`)
- Absolute filesystem paths

Both resolve through Django's template loader.

### Scope
- Pure static analysis, no framework hooks
- Regex restricted to event-wiring attrs (\`dj-click/submit/change/input/keydown/keyup\`); ignores \`dj-id/params/loading/view\`

### Complements \`find_dead_bindings\`
- \`find_dead_bindings\` (djust-browser-mcp) catches renames at **runtime** from the DOM side
- This tool catches them at **author time** from the template source

## Test plan

- [x] 10 unit tests (regex correctness, file roundtrip, set-math contract)
- [ ] Manual: run against demo_project's counter template, verify view class + handler diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)