### PR TITLE
feat: reset_view_state — replay mount() on a live view (Phase 11 #42)

### DIFF
--- a/python/djust/mcp/server.py
+++ b/python/djust/mcp/server.py
@@ -527,6 +527,48 @@ def create_server():
         return r.text
 
     @mcp.tool()
+    def reset_view_state(session_id: str) -> str:
+        """Replay `view.mount()` on the registered instance — resets all
+        public attrs back to their post-mount defaults without a page
+        reload.
+
+        Useful between regression-fixture replays: you want the counter
+        at 0 again without closing the WebSocket or losing the login
+        session.
+
+        Does NOT push a fresh render to the client. The caller must
+        trigger one (the next user click re-renders with the reset
+        state).
+
+        Args:
+            session_id: WebSocket session id.
+
+        Returns JSON: {session_id, view_class, assigns_after_reset}.
+        """
+        import os
+
+        try:
+            import requests
+        except ImportError:
+            return json.dumps({"error": "`requests` package not installed in the MCP environment"})
+
+        base = os.environ.get("DJUST_DEV_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
+        url = f"{base}/_djust/observability/reset_view_state/?session_id={session_id}"
+        try:
+            # csrf_exempt on the endpoint — POST with no body is fine.
+            r = requests.post(url, timeout=5)
+        except requests.RequestException as e:
+            return json.dumps(
+                {
+                    "error": f"request failed: {e}",
+                    "hint": f"Is the dev server running? Tried {url}.",
+                }
+            )
+        if r.status_code != 200:
+            return json.dumps({"error": r.text, "status": r.status_code})
+        return r.text
+
+    @mcp.tool()
     def get_handler_timings(handler_name: str = "", since_ms: int = 0) -> str:
         """Per-handler percentile stats over the rolling sample window.
 

--- a/python/djust/observability/urls.py
+++ b/python/djust/observability/urls.py
@@ -18,6 +18,7 @@ from djust.observability.views import (
     health,
     last_traceback,
     log_tail,
+    reset_view_state,
     sql_queries,
     view_assigns,
 )
@@ -31,4 +32,5 @@ urlpatterns = [
     path("log/", log_tail, name="log"),
     path("handler_timings/", handler_timings, name="handler_timings"),
     path("sql_queries/", sql_queries, name="sql_queries"),
+    path("reset_view_state/", reset_view_state, name="reset_view_state"),
 ]

--- a/python/djust/observability/views.py
+++ b/python/djust/observability/views.py
@@ -246,6 +246,86 @@ def handler_timings(request):
 
 
 @csrf_exempt
+def reset_view_state(request):
+    """Replay `view.mount()` on the registered instance — resets all public
+    attrs back to their post-mount values.
+
+    Accepts POST only. Requires the consumer to have stashed
+    `_djust_mount_request` + `_djust_mount_kwargs` (automatic since djust
+    framework Phase 11 #42). Views mounted before this was wired will
+    fail with a 409 and a clear message.
+
+    Does NOT push a fresh render to the connected client — the caller
+    must trigger one (user interaction, force reload). This limitation
+    is acceptable for test-harness / fixture-cleanup use cases.
+
+    Query params:
+        session_id (required)
+
+    Response (200): {session_id, view_class, assigns_after_reset}
+    Response (400): session_id missing
+    Response (404): DEBUG=False, or session not registered
+    Response (405): wrong HTTP method
+    Response (409): mount args not stashed (view predates this feature)
+    Response (500): mount() raised
+    """
+    if not settings.DEBUG:
+        return _debug_gate()
+
+    if request.method != "POST":
+        return JsonResponse({"error": "POST required"}, status=405)
+
+    session_id = request.GET.get("session_id", "").strip()
+    if not session_id:
+        return JsonResponse({"error": "session_id query param required"}, status=400)
+
+    view = get_view_for_session(session_id)
+    if view is None:
+        return JsonResponse(
+            {"error": f"no view registered for session {session_id}"},
+            status=404,
+        )
+
+    mount_request = getattr(view, "_djust_mount_request", None)
+    mount_kwargs = getattr(view, "_djust_mount_kwargs", None)
+    if mount_request is None or mount_kwargs is None:
+        return JsonResponse(
+            {
+                "error": "view was mounted before reset_view_state was wired",
+                "hint": "Reconnect the WebSocket to re-mount under the new consumer.",
+            },
+            status=409,
+        )
+
+    # Clear all public, non-callable attrs. This is the "reset" — mount()
+    # will then repopulate them. Private (_foo) attrs stay so that framework
+    # bookkeeping (websocket_session_id, stashed request, etc.) isn't lost.
+    for key in list(view.__dict__.keys()):
+        if not key.startswith("_") and not callable(getattr(view, key, None)):
+            delattr(view, key)
+
+    try:
+        view.mount(mount_request, **mount_kwargs)
+    except Exception as e:  # noqa: BLE001
+        return JsonResponse(
+            {
+                "error": f"mount() raised: {type(e).__name__}: {e}",
+                "session_id": session_id,
+            },
+            status=500,
+        )
+
+    assigns = _lenient_assigns(view)
+    return JsonResponse(
+        {
+            "session_id": session_id,
+            "view_class": view.__class__.__name__,
+            "assigns_after_reset": assigns,
+        }
+    )
+
+
+@csrf_exempt
 @require_GET
 def sql_queries(request):
     """Return captured SQL queries, filtered by session/handler/since_ms.

--- a/python/djust/tests/test_observability_reset_view.py
+++ b/python/djust/tests/test_observability_reset_view.py
@@ -1,0 +1,139 @@
+"""
+Tests for Phase 11 #42 — /reset_view_state/ endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.test import RequestFactory, override_settings
+
+from djust.observability.registry import _clear_registry, register_view
+from djust.observability.views import reset_view_state
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    _clear_registry()
+    yield
+    _clear_registry()
+
+
+class _FakeView:
+    """Stand-in that behaves like a LiveView for the reset endpoint.
+
+    The endpoint calls `_lenient_assigns(view)` which needs
+    `_is_serializable` or falls back to json.dumps — either works.
+    """
+
+    def __init__(self):
+        self.counter = 0
+        self.label = "initial"
+        self._djust_mount_request = object()
+        self._djust_mount_kwargs = {}
+
+    def mount(self, request, **kwargs):
+        self.counter = 0
+        self.label = "initial"
+
+
+class _ViewMissingMountArgs(_FakeView):
+    def __init__(self):
+        self.counter = 0
+        # Deliberately no _djust_mount_request — simulates a view mounted
+        # before the reset feature was wired.
+
+
+class _ViewMountRaises(_FakeView):
+    def mount(self, request, **kwargs):
+        raise RuntimeError("mount exploded")
+
+
+@override_settings(DEBUG=True)
+def test_reset_restores_state_to_post_mount():
+    view = _FakeView()
+    view.counter = 42
+    view.label = "dirty"
+    register_view("s", view)
+
+    rf = RequestFactory()
+    resp = reset_view_state(rf.post("/?session_id=s"))
+    assert resp.status_code == 200
+    data = json.loads(resp.content)
+    assert data["session_id"] == "s"
+    assert data["view_class"] == "_FakeView"
+    # After reset: counter+label back to mount defaults (0, "initial").
+    assert data["assigns_after_reset"]["counter"] == 0
+    assert data["assigns_after_reset"]["label"] == "initial"
+
+    # Instance state also cleared/remounted.
+    assert view.counter == 0
+    assert view.label == "initial"
+
+
+@override_settings(DEBUG=True)
+def test_reset_preserves_private_attrs():
+    view = _FakeView()
+    view._websocket_session_id = "ws-1"
+    view.counter = 99
+    register_view("s", view)
+
+    rf = RequestFactory()
+    reset_view_state(rf.post("/?session_id=s"))
+    # Private attrs stay (framework bookkeeping isn't disturbed).
+    assert view._websocket_session_id == "ws-1"
+    assert view._djust_mount_request is not None
+
+
+@override_settings(DEBUG=True)
+def test_reset_requires_post():
+    view = _FakeView()
+    register_view("s", view)
+    rf = RequestFactory()
+    resp = reset_view_state(rf.get("/?session_id=s"))
+    assert resp.status_code == 405
+
+
+@override_settings(DEBUG=True)
+def test_reset_400_when_session_id_missing():
+    rf = RequestFactory()
+    resp = reset_view_state(rf.post("/"))
+    assert resp.status_code == 400
+
+
+@override_settings(DEBUG=True)
+def test_reset_404_when_session_unknown():
+    rf = RequestFactory()
+    resp = reset_view_state(rf.post("/?session_id=never"))
+    assert resp.status_code == 404
+
+
+@override_settings(DEBUG=True)
+def test_reset_409_when_mount_args_not_stashed():
+    view = _ViewMissingMountArgs()
+    register_view("s", view)
+    rf = RequestFactory()
+    resp = reset_view_state(rf.post("/?session_id=s"))
+    assert resp.status_code == 409
+    assert b"before reset_view_state was wired" in resp.content
+
+
+@override_settings(DEBUG=True)
+def test_reset_500_when_mount_raises():
+    view = _ViewMountRaises()
+    register_view("s", view)
+    rf = RequestFactory()
+    resp = reset_view_state(rf.post("/?session_id=s"))
+    assert resp.status_code == 500
+    data = json.loads(resp.content)
+    assert "RuntimeError" in data["error"]
+
+
+@override_settings(DEBUG=False)
+def test_reset_404_when_debug_off():
+    view = _FakeView()
+    register_view("s", view)
+    rf = RequestFactory()
+    resp = reset_view_state(rf.post("/?session_id=s"))
+    assert resp.status_code == 404

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -1475,6 +1475,12 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
 
                 # Run synchronous view operations in a thread pool
                 await sync_to_async(self.view_instance.mount)(request, **mount_kwargs)
+                # Stash request + kwargs so observability/reset_view_state/
+                # can replay mount() without page reload. Minor memory cost
+                # (one request ref per live view) in exchange for a cheap
+                # reset primitive.
+                self.view_instance._djust_mount_request = request
+                self.view_instance._djust_mount_kwargs = mount_kwargs
                 self.view_instance._snapshot_user_private_attrs()
         except Exception as e:
             response = handle_exception(


### PR DESCRIPTION
## Summary

Reset public attrs back to post-mount defaults without a page reload. Use case: between regression-fixture replays, bring counter back to 0 without closing the WebSocket or losing the login session.

### Framework
- \`websocket.py\` — stash \`_djust_mount_request\` + \`_djust_mount_kwargs\` on the view at mount time (minor memory cost, one request ref per live view)
- \`POST /_djust/observability/reset_view_state/?session_id=X\` — clears public non-callable attrs, calls \`view.mount(stashed_request, **stashed_kwargs)\`, returns \`{session_id, view_class, assigns_after_reset}\`

### MCP
- \`reset_view_state(session_id)\` tool

### Non-goal
Does NOT push a fresh render to the client. The next click re-renders with the reset state. Acceptable for test-harness / fixture-cleanup use cases.

### Error paths
- 405 non-POST
- 400 session_id missing
- 404 session not registered / DEBUG=False
- 409 view mounted before feature was wired
- 500 mount() raised

## Test plan

- [x] 8 new unit tests covering happy path + all error branches
- [x] 70 observability tests total pass
- [ ] Manual: mount view, increment to 5, call \`reset_view_state\` → counter back to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)