### PR TITLE
feat: eval_handler v1 (Phase 7.6 #35)

### DIFF
--- a/python/djust/mcp/server.py
+++ b/python/djust/mcp/server.py
@@ -527,6 +527,51 @@ def create_server():
         return r.text
 
     @mcp.tool()
+    def eval_handler(session_id: str, handler_name: str, params: dict | None = None) -> str:
+        """Dry-run a handler against a live view's current state.
+
+        Runs `view.<handler_name>(**params)` against the registered
+        view and returns the state delta + handler return value.
+
+        **v1 limitations:**
+        - Side effects (ORM writes, emails, webhooks) are NOT prevented.
+          Use on views with pure state mutations or against a test DB.
+        - Sync handlers only (async returns 400 with a clear message).
+        - No render/patch push — the client won't see the mutation.
+
+        Args:
+            session_id: WebSocket session id.
+            handler_name: method name on the mounted view.
+            params: kwargs dict passed to the handler.
+
+        Returns JSON: {view_class, handler_name, params, before_assigns,
+        after_assigns, delta:{added, removed, modified, change_count},
+        result}.
+        """
+        import os
+
+        try:
+            import requests
+        except ImportError:
+            return json.dumps({"error": "`requests` package not installed in the MCP environment"})
+
+        base = os.environ.get("DJUST_DEV_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
+        url = f"{base}/_djust/observability/eval_handler/?session_id={session_id}"
+        body = {"handler_name": handler_name, "params": params or {}}
+        try:
+            r = requests.post(url, json=body, timeout=10)
+        except requests.RequestException as e:
+            return json.dumps(
+                {
+                    "error": f"request failed: {e}",
+                    "hint": f"Is the dev server running? Tried {url}.",
+                }
+            )
+        if r.status_code != 200:
+            return json.dumps({"error": r.text, "status": r.status_code})
+        return r.text
+
+    @mcp.tool()
     def reset_view_state(session_id: str) -> str:
         """Replay `view.mount()` on the registered instance — resets all
         public attrs back to their post-mount defaults without a page

--- a/python/djust/observability/urls.py
+++ b/python/djust/observability/urls.py
@@ -14,6 +14,7 @@ production config still refuses to serve data.
 from django.urls import path
 
 from djust.observability.views import (
+    eval_handler,
     handler_timings,
     health,
     last_traceback,
@@ -33,4 +34,5 @@ urlpatterns = [
     path("handler_timings/", handler_timings, name="handler_timings"),
     path("sql_queries/", sql_queries, name="sql_queries"),
     path("reset_view_state/", reset_view_state, name="reset_view_state"),
+    path("eval_handler/", eval_handler, name="eval_handler"),
 ]

--- a/python/djust/observability/views.py
+++ b/python/djust/observability/views.py
@@ -326,6 +326,154 @@ def reset_view_state(request):
 
 
 @csrf_exempt
+def eval_handler(request):
+    """Dry-run a handler against the live view's current state.
+
+    POST body (JSON): {handler_name, params?: {}}
+    Query param:       session_id (required)
+
+    Runs `view.<handler_name>(**params)` against the registered view,
+    snapshots state before + after, returns the delta.
+
+    **v1 limitations (explicit non-goals for now):**
+    - No side-effect recording. ORM writes will commit, emails will
+      send, webhooks will fire. Use against views that do pure state
+      mutations, or in a test DB.
+    - Sync handlers only. Async handlers return a 400 with a clear
+      message — running async code from a sync Django view is
+      non-trivial and was deliberately descoped for v1.
+    - No render/patch push to the client. The handler mutates state
+      but the client doesn't see it. Call `reset_view_state` if you
+      need to rewind the view.
+
+    Returns:
+        {session_id, view_class, handler_name,
+         before_assigns, after_assigns,
+         delta: {added, removed, modified: {key: {before, after}}},
+         result: <handler's return value if JSON-serializable>}
+    """
+    if not settings.DEBUG:
+        return _debug_gate()
+
+    if request.method != "POST":
+        return JsonResponse({"error": "POST required"}, status=405)
+
+    session_id = request.GET.get("session_id", "").strip()
+    if not session_id:
+        return JsonResponse({"error": "session_id query param required"}, status=400)
+
+    view = get_view_for_session(session_id)
+    if view is None:
+        return JsonResponse(
+            {"error": f"no view registered for session {session_id}"},
+            status=404,
+        )
+
+    # Parse body.
+    import json as _json
+
+    try:
+        body = _json.loads(request.body.decode("utf-8")) if request.body else {}
+    except (ValueError, UnicodeDecodeError) as e:
+        return JsonResponse({"error": f"invalid JSON body: {e}"}, status=400)
+
+    handler_name = (body.get("handler_name") or "").strip()
+    if not handler_name:
+        return JsonResponse({"error": "body.handler_name required"}, status=400)
+
+    params = body.get("params") or {}
+    if not isinstance(params, dict):
+        return JsonResponse(
+            {"error": "body.params must be a JSON object (or null/absent)"}, status=400
+        )
+
+    handler = getattr(view, handler_name, None)
+    if handler is None or not callable(handler):
+        return JsonResponse(
+            {
+                "error": f"view '{view.__class__.__name__}' has no callable '{handler_name}'",
+                "hint": "Use `get_view_schema` on the djust MCP to see available handler names.",
+            },
+            status=404,
+        )
+
+    # v1: sync handlers only.
+    import inspect as _inspect
+
+    if _inspect.iscoroutinefunction(handler):
+        return JsonResponse(
+            {
+                "error": f"handler '{handler_name}' is async; eval_handler v1 "
+                "only supports sync handlers",
+                "hint": "A future PR will add async support via an async endpoint.",
+            },
+            status=400,
+        )
+
+    before = _lenient_assigns(view)
+
+    try:
+        result = handler(**params) if params else handler()
+    except TypeError as e:
+        # Most common: wrong params. Return with 400 so caller can fix.
+        return JsonResponse(
+            {
+                "error": f"handler call failed: {type(e).__name__}: {e}",
+                "hint": "Check that params match the handler signature (use get_view_schema).",
+                "handler_name": handler_name,
+                "params": params,
+            },
+            status=400,
+        )
+    except Exception as e:  # noqa: BLE001
+        return JsonResponse(
+            {
+                "error": f"handler raised: {type(e).__name__}: {e}",
+                "handler_name": handler_name,
+                "params": params,
+            },
+            status=500,
+        )
+
+    after = _lenient_assigns(view)
+
+    # Compute delta.
+    before_keys = set(before.keys())
+    after_keys = set(after.keys())
+    added = {k: after[k] for k in after_keys - before_keys}
+    removed = {k: before[k] for k in before_keys - after_keys}
+    modified = {}
+    for k in before_keys & after_keys:
+        if _json.dumps(before[k], default=repr) != _json.dumps(after[k], default=repr):
+            modified[k] = {"before": before[k], "after": after[k]}
+
+    # Return value — best-effort serialize.
+    try:
+        _json.dumps(result)
+        safe_result = result
+    except (TypeError, ValueError):
+        safe_result = {"_repr": repr(result)[:200], "_type": type(result).__name__}
+
+    return JsonResponse(
+        {
+            "session_id": session_id,
+            "view_class": view.__class__.__name__,
+            "handler_name": handler_name,
+            "params": params,
+            "before_assigns": before,
+            "after_assigns": after,
+            "delta": {
+                "added": added,
+                "removed": removed,
+                "modified": modified,
+                "change_count": len(added) + len(removed) + len(modified),
+            },
+            "result": safe_result,
+        }
+    )
+
+
+@csrf_exempt
 @require_GET
 def sql_queries(request):
     """Return captured SQL queries, filtered by session/handler/since_ms.

--- a/python/djust/tests/test_observability_eval_handler.py
+++ b/python/djust/tests/test_observability_eval_handler.py
@@ -1,0 +1,178 @@
+"""
+Tests for Phase 7.6 #35 v1 — /eval_handler/ endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.test import RequestFactory, override_settings
+
+from djust.observability.registry import _clear_registry, register_view
+from djust.observability.views import eval_handler
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    _clear_registry()
+    yield
+    _clear_registry()
+
+
+class _FakeCounterView:
+    def __init__(self):
+        self.count = 0
+        self.label = "initial"
+
+    def increment(self):
+        self.count += 1
+        return {"new_count": self.count}
+
+    def add(self, amount: int = 1):
+        self.count += amount
+
+    def set_label(self, value: str = ""):
+        self.label = value
+
+    def explode(self):
+        raise RuntimeError("handler boom")
+
+    async def async_handler(self):  # noqa: RUF029
+        self.count += 1
+
+
+def _post(body: dict, session_id: str = "s"):
+    rf = RequestFactory()
+    return rf.post(
+        f"/?session_id={session_id}",
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+
+
+# --- Happy path -----------------------------------------------------------
+
+
+@override_settings(DEBUG=True)
+def test_eval_returns_delta_and_result():
+    view = _FakeCounterView()
+    register_view("s", view)
+    resp = eval_handler(_post({"handler_name": "increment"}))
+    assert resp.status_code == 200
+    data = json.loads(resp.content)
+    assert data["handler_name"] == "increment"
+    assert data["before_assigns"]["count"] == 0
+    assert data["after_assigns"]["count"] == 1
+    assert data["delta"]["change_count"] == 1
+    assert "count" in data["delta"]["modified"]
+    assert data["delta"]["modified"]["count"] == {"before": 0, "after": 1}
+    assert data["result"] == {"new_count": 1}
+
+
+@override_settings(DEBUG=True)
+def test_eval_passes_params():
+    view = _FakeCounterView()
+    register_view("s", view)
+    resp = eval_handler(_post({"handler_name": "add", "params": {"amount": 5}}))
+    data = json.loads(resp.content)
+    assert data["after_assigns"]["count"] == 5
+    assert data["delta"]["modified"]["count"]["after"] == 5
+
+
+@override_settings(DEBUG=True)
+def test_eval_change_count_zero_when_handler_is_noop():
+    view = _FakeCounterView()
+    register_view("s", view)
+    # set_label to the same value — no state change.
+    resp = eval_handler(_post({"handler_name": "set_label", "params": {"value": "initial"}}))
+    data = json.loads(resp.content)
+    assert data["delta"]["change_count"] == 0
+
+
+# --- Error paths ----------------------------------------------------------
+
+
+@override_settings(DEBUG=True)
+def test_eval_405_for_non_post():
+    view = _FakeCounterView()
+    register_view("s", view)
+    rf = RequestFactory()
+    resp = eval_handler(rf.get("/?session_id=s"))
+    assert resp.status_code == 405
+
+
+@override_settings(DEBUG=True)
+def test_eval_400_when_session_id_missing():
+    resp = eval_handler(_post({"handler_name": "increment"}, session_id=""))
+    assert resp.status_code == 400
+
+
+@override_settings(DEBUG=True)
+def test_eval_404_when_session_unknown():
+    resp = eval_handler(_post({"handler_name": "increment"}, session_id="never"))
+    assert resp.status_code == 404
+
+
+@override_settings(DEBUG=True)
+def test_eval_400_when_handler_name_missing():
+    view = _FakeCounterView()
+    register_view("s", view)
+    resp = eval_handler(_post({}))
+    assert resp.status_code == 400
+
+
+@override_settings(DEBUG=True)
+def test_eval_404_when_handler_doesnt_exist():
+    view = _FakeCounterView()
+    register_view("s", view)
+    resp = eval_handler(_post({"handler_name": "not_a_handler"}))
+    assert resp.status_code == 404
+
+
+@override_settings(DEBUG=True)
+def test_eval_400_when_handler_is_async():
+    view = _FakeCounterView()
+    register_view("s", view)
+    resp = eval_handler(_post({"handler_name": "async_handler"}))
+    assert resp.status_code == 400
+    data = json.loads(resp.content)
+    assert "async" in data["error"]
+
+
+@override_settings(DEBUG=True)
+def test_eval_400_when_params_type_error():
+    """Wrong kwargs should surface as 400 so the caller can fix their call."""
+    view = _FakeCounterView()
+    register_view("s", view)
+    resp = eval_handler(_post({"handler_name": "add", "params": {"wrong_kwarg": 1}}))
+    assert resp.status_code == 400
+
+
+@override_settings(DEBUG=True)
+def test_eval_500_when_handler_raises():
+    view = _FakeCounterView()
+    register_view("s", view)
+    resp = eval_handler(_post({"handler_name": "explode"}))
+    assert resp.status_code == 500
+    data = json.loads(resp.content)
+    assert "RuntimeError" in data["error"]
+
+
+@override_settings(DEBUG=True)
+def test_eval_400_on_invalid_json_body():
+    view = _FakeCounterView()
+    register_view("s", view)
+    rf = RequestFactory()
+    resp = eval_handler(
+        rf.post("/?session_id=s", data=b"not-json", content_type="application/json")
+    )
+    assert resp.status_code == 400
+
+
+@override_settings(DEBUG=False)
+def test_eval_404_when_debug_off():
+    view = _FakeCounterView()
+    register_view("s", view)
+    resp = eval_handler(_post({"handler_name": "increment"}))
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Dry-run a handler against a live LiveView's current state. Returns state delta + return value. Enables property-based testing and \"what would this handler do?\" queries without clicking through a browser.

### Contract
\`\`\`
POST /_djust/observability/eval_handler/?session_id=X
{\"handler_name\": \"...\", \"params\": {...}}
→ {
  view_class, handler_name, params,
  before_assigns, after_assigns,
  delta: {added, removed, modified, change_count},
  result  # handler's return value (or {_repr, _type} if non-serializable)
}
\`\`\`

### MCP
- \`eval_handler(session_id, handler_name, params)\`

### v1 deliberate non-goals

- **No side-effect recording.** ORM writes WILL commit, emails WILL send. Use on views with pure state mutations or against a test DB.
- **Sync handlers only.** Async returns 400 with a clear message.
- **No render/patch push.** Handler mutates state but client doesn't see it. Pair with \`reset_view_state\` to rewind.

All three are documented in the tool description + endpoint docstring so callers aren't surprised. The side-effect-recording v2 is scoped for a follow-up (monkey-patch \`Model.save\` / \`send_mail\` / \`requests.*\`, raise \`DryRunViolation\` on attempt).

## Test plan

- [x] 13 new unit tests — happy paths (delta, params passing, noop), 405, 400 variants (missing session, handler, async, TypeError, bad JSON), 404, 500 (handler raises), DEBUG=False
- [x] 83 observability tests total pass
- [ ] Manual: mount a view, eval_handler(\"increment\") → see count delta before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)