### PR TITLE
fix(observability): log setattr failures in DryRunContext._uninstall (#759)

### DIFF
--- a/python/djust/observability/dry_run.py
+++ b/python/djust/observability/dry_run.py
@@ -37,8 +37,11 @@ Design notes:
 
 from __future__ import annotations
 
+import logging
 import threading
 from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("djust.observability")
 
 
 # Process-wide lock — serializes dry-runs so we never leave a patched
@@ -125,11 +128,22 @@ class DryRunContext:
 
     def _uninstall(self) -> None:
         # Restore in reverse order so nested wrappers don't leak.
+        # We catch+log rather than raise — if ONE restore fails, we still
+        # want to attempt every remaining restore so the smallest number of
+        # patches leak into subsequent requests. But we log at warning so
+        # the failure is visible (silent swallow would leave the process
+        # running with a wrapped Model.save indefinitely — catastrophic
+        # for a dev server).
         for obj, attr, original in reversed(self._patches):
             try:
                 setattr(obj, attr, original)
-            except Exception:
-                pass
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "DryRunContext failed to restore %s.%s: %s",
+                    getattr(obj, "__name__", type(obj).__name__),
+                    attr,
+                    e,
+                )
         self._patches.clear()
 
     def _install_orm(self) -> None:

--- a/python/djust/tests/test_observability_dry_run.py
+++ b/python/djust/tests/test_observability_dry_run.py
@@ -86,6 +86,33 @@ def test_context_unpatch_on_exception():
     assert Model.save is original_save
 
 
+def test_context_uninstall_failure_is_logged_not_swallowed(caplog):
+    """Regression for #759: if setattr fails during uninstall, we log a
+    warning so the failure is visible. Silent swallow would leave the
+    process running with a wrapped Model.save forever.
+    """
+    import logging
+
+    caplog.set_level(logging.WARNING, logger="djust.observability")
+
+    ctx = DryRunContext()
+    ctx.__enter__()
+    try:
+        # Install a single bogus patch entry whose setattr will fail.
+        # frozenset is immutable — setattr raises AttributeError.
+        bogus_target = frozenset([1, 2, 3])
+        ctx._patches.append((bogus_target, "some_attr", "restore_value"))
+    finally:
+        ctx.__exit__(None, None, None)
+
+    # _uninstall should have logged the failure, not silently swallowed.
+    assert any(
+        "failed to restore" in rec.getMessage() for rec in caplog.records
+    ), "DryRunContext._uninstall must log when setattr fails"
+    # And the patch table is cleared regardless.
+    assert ctx._patches == []
+
+
 def test_context_blocks_http_requests():
     try:
         import requests  # noqa: F401


### PR DESCRIPTION
Closes #759.

Replaces silent `except Exception: pass` in `DryRunContext._uninstall` with a `logger.warning` so restore failures are visible. Silent swallow meant a process could run indefinitely with a wrapped `Model.save` — catastrophic for a dev server.

Keeps the per-patch try/except so every remaining restore attempt still runs (we want the fewest patches to leak) — only change is making the failure observable.

## Test

New regression test `test_context_uninstall_failure_is_logged_not_swallowed` installs a bogus frozenset patch entry (setattr raises AttributeError), asserts the warning is logged + patch table is cleared.

12 dry_run tests pass.