### PR TITLE
fix(hotreload): suppress empty-patch broadcasts on unrelated file changes (#763)

### DIFF
--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -767,6 +767,22 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             ref: Event reference number echoed back from the client's request,
                 allowing the client to match responses to sent events (#560).
         """
+        # #763: On hot-reload, suppress empty-patch broadcasts. When an
+        # unrelated Python file changes, re-rendering often produces zero
+        # patches (the file didn't affect the current view's output). The
+        # old code still broadcast a full ~14 KB payload including the
+        # `_debug` state dump to every connected session. Skip it — the
+        # client has nothing to do and the payload is pure noise.
+        # NON-hot-reload empty patches are still sent: user events that
+        # legitimately produce no diff still need an acknowledgment so
+        # the client can clear loading state.
+        if hotreload and patches == []:
+            hotreload_logger.debug(
+                "Suppressing empty-patch hot-reload broadcast (unrelated file: %s)",
+                file_path,
+            )
+            return
+
         # Note: patches=[] (empty list) is valid and should be sent as "patch" type
         # Only patches=None indicates we should send html_update
         if patches is not None:

--- a/python/tests/test_hotreload.py
+++ b/python/tests/test_hotreload.py
@@ -239,11 +239,21 @@ class TestHotReloadMessage:
         assert call_args["file"] == "test.html"
 
     @pytest.mark.asyncio
-    async def test_hotreload_empty_patches_array(self, mock_consumer, mock_view_instance):
-        """Test hot reload when patches array is empty."""
+    async def test_hotreload_empty_patches_array_is_suppressed(
+        self, mock_consumer, mock_view_instance
+    ):
+        """Test hot reload suppresses broadcast when patches array is empty (#763).
+
+        When an unrelated file change produces no patches for the current
+        view, we skip the broadcast entirely rather than sending a ~14 KB
+        empty-patch payload to every connected session.
+
+        NON-empty hot reload patches are still sent (covered by other tests).
+        User-event empty patches are still sent (loading state must clear).
+        """
         mock_consumer.view_instance = mock_view_instance
 
-        # Mock empty patches array (gets parsed but still sent as patch)
+        # Mock empty patches array.
         mock_view_instance.render_with_diff = Mock(return_value=("<html>same</html>", "[]", 1))
 
         with patch.object(mock_consumer, "_clear_template_caches", return_value=1):
@@ -251,16 +261,10 @@ class TestHotReloadMessage:
                 "channels.db.database_sync_to_async",
                 side_effect=lambda f: AsyncMock(return_value=f()),
             ):
-                # Call hotreload
                 await mock_consumer.hotreload({"file": "test.html"})
 
-        # Empty array is still sent as patch (no check after parsing)
-        mock_consumer.send_json.assert_called_once()
-        call_args = mock_consumer.send_json.call_args[0][0]
-
-        assert call_args["type"] == "patch"
-        assert call_args["patches"] == []
-        assert call_args["file"] == "test.html"
+        # Broadcast suppressed — nothing sent to the client.
+        mock_consumer.send_json.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_hotreload_general_exception(self, mock_consumer, mock_view_instance):


### PR DESCRIPTION
Closes #763. When an unrelated Python file changes, the re-render often produces zero patches for the currently-mounted view. The old code still broadcast a ~14 KB payload (empty patches + full `_debug` state dump) to every connected session.

Early-return when `hotreload=True AND patches==[]`. Non-hot-reload empty patches are still sent (user events need a loading-state clear ack).

## Test

Updated existing `test_hotreload_empty_patches_array` (now `_is_suppressed`) to assert `send_json` is NOT called when patches are empty. Full 18-test hotreload suite passes.