### PR TITLE
fix(client): guard 38 unguarded console.log calls (#761)

### DIFF
--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -8,6 +8,21 @@
 window.djust = window.djust || {};
 
 // ============================================================================
+// djLog: debug-gated console.log (#761)
+// ============================================================================
+// Per djust/CLAUDE.md: "No console.log in JS without if (globalThis.djustDebug)
+// guard". Rather than sprinkle that conditional at every callsite, client.js
+// uses djLog which checks the flag once per call. Tree-shakes nothing (we
+// still evaluate the args in the call), but at least the console stays clean
+// when djustDebug is false.
+//
+// console.warn / console.error are NOT guarded — those indicate real problems
+// and should be visible in prod.
+window.djLog = function djLog(...args) {
+    if (globalThis.djustDebug) console.log(...args);
+};
+
+// ============================================================================
 // Double-Load Guard
 // ============================================================================
 // Prevent double execution when client.js is included in both base template
@@ -223,7 +238,7 @@ function handleServerResponse(data, eventName, triggerElement) {
                 expiresAt
             });
             if (globalThis.djustDebug) {
-                console.log(`[LiveView:cache] Cached patches: ${cacheKey} (TTL: ${ttl}s)`);
+                djLog(`[LiveView:cache] Cached patches: ${cacheKey} (TTL: ${ttl}s)`);
             }
             pendingCacheRequests.delete(data.cache_request_id);
         }
@@ -412,7 +427,7 @@ function handleServerResponse(data, eventName, triggerElement) {
                 el.disabled = false;
             });
         } else if (globalThis.djustDebug) {
-            console.log('[LiveView] Keeping loading state — async work pending');
+            djLog('[LiveView] Keeping loading state — async work pending');
         }
         return true;
 
@@ -807,7 +822,7 @@ class LiveViewWebSocket {
                     // all pending event responses arrive.
                     _tickBuffer.push(data);
                     if (globalThis.djustDebug) {
-                        console.log('[LiveView] Buffered %s patch (v%s) — waiting for %d pending event(s)', String(data.source), String(data.version), _pendingEventRefs.size);
+                        djLog('[LiveView] Buffered %s patch (v%s) — waiting for %d pending event(s)', String(data.source), String(data.version), _pendingEventRefs.size);
                     }
                     break;
                 }
@@ -842,7 +857,7 @@ class LiveViewWebSocket {
                 // patches only when ALL pending events have resolved.
                 if (isEventResponse && _pendingEventRefs.size === 0 && _tickBuffer.length > 0) {
                     if (globalThis.djustDebug) {
-                        console.log('[LiveView] Flushing ' + _tickBuffer.length + ' buffered patches');
+                        djLog('[LiveView] Flushing ' + _tickBuffer.length + ' buffered patches');
                     }
                     const buffered = _tickBuffer.splice(0);
                     for (const tickData of buffered) {
@@ -869,7 +884,7 @@ class LiveViewWebSocket {
                 reinitAfterDOMUpdate();
                 if (globalThis.djustDebug) {
                     // codeql[js/log-injection] -- data.version is a server-controlled integer
-                    console.log('[LiveView] DOM recovered via morph, version: %s', String(data.version));
+                    djLog('[LiveView] DOM recovered via morph, version: %s', String(data.version));
                 }
                 break;
             }
@@ -1701,7 +1716,7 @@ function addToCache(cacheKey, value) {
         const oldestKey = resultCache.keys().next().value;
         resultCache.delete(oldestKey);
         if (globalThis.djustDebug) {
-            console.log(`[LiveView:cache] Evicted (LRU): ${oldestKey}`);
+            djLog(`[LiveView:cache] Evicted (LRU): ${oldestKey}`);
         }
     }
 
@@ -1718,7 +1733,7 @@ function setCacheConfig(config) {
     Object.entries(config).forEach(([handlerName, handlerConfig]) => {
         cacheConfig.set(handlerName, handlerConfig);
         if (globalThis.djustDebug) {
-            console.log(`[LiveView:cache] Configured cache for ${handlerName}:`, handlerConfig);
+            djLog(`[LiveView:cache] Configured cache for ${handlerName}:`, handlerConfig);
         }
     });
 }
@@ -1806,7 +1821,7 @@ function clearCache() {
     const size = resultCache.size;
     resultCache.clear();
     if (globalThis.djustDebug) {
-        console.log(`[LiveView:cache] Cleared all ${size} cached entries`);
+        djLog(`[LiveView:cache] Cleared all ${size} cached entries`);
     }
 }
 
@@ -1836,7 +1851,7 @@ function invalidateCache(pattern) {
     }
 
     if (globalThis.djustDebug) {
-        console.log(`[LiveView:cache] Invalidated ${count} entries matching: ${pattern}`);
+        djLog(`[LiveView:cache] Invalidated ${count} entries matching: ${pattern}`);
     }
 
     return count;
@@ -1875,7 +1890,7 @@ class StateBus {
         const oldValue = this.state.get(key);
         this.state.set(key, value);
         if (globalThis.djustDebug) {
-            console.log(`[StateBus] Set: ${key} =`, value, `(was:`, oldValue, `)`);
+            djLog(`[StateBus] Set: ${key} =`, value, `(was:`, oldValue, `)`);
         }
         this.notify(key, value, oldValue);
     }
@@ -1890,14 +1905,14 @@ class StateBus {
         }
         this.subscribers.get(key).add(callback);
         if (globalThis.djustDebug) {
-            console.log(`[StateBus] Subscribed to: ${key} (${this.subscribers.get(key).size} subscribers)`);
+            djLog(`[StateBus] Subscribed to: ${key} (${this.subscribers.get(key).size} subscribers)`);
         }
         return () => {
             const subs = this.subscribers.get(key);
             if (subs) {
                 subs.delete(callback);
                 if (globalThis.djustDebug) {
-                    console.log(`[StateBus] Unsubscribed from: ${key} (${subs.size} remaining)`);
+                    djLog(`[StateBus] Unsubscribed from: ${key} (${subs.size} remaining)`);
                 }
             }
         };
@@ -1906,7 +1921,7 @@ class StateBus {
     notify(key, newValue, oldValue) {
         const callbacks = this.subscribers.get(key) || new Set();
         if (callbacks.size > 0 && globalThis.djustDebug) {
-            console.log(`[StateBus] Notifying ${callbacks.size} subscribers of: ${key}`);
+            djLog(`[StateBus] Notifying ${callbacks.size} subscribers of: ${key}`);
         }
         callbacks.forEach(callback => {
             try {
@@ -1921,7 +1936,7 @@ class StateBus {
         this.state.clear();
         this.subscribers.clear();
         if (globalThis.djustDebug) {
-            console.log('[StateBus] Cleared all state');
+            djLog('[StateBus] Cleared all state');
         }
     }
 
@@ -1953,7 +1968,7 @@ class DraftManager {
                 localStorage.setItem(`djust_draft_${draftKey}`, JSON.stringify(draftData));
 
                 if (globalThis.djustDebug) {
-                    console.log(`[DraftMode] Saved draft: ${draftKey}`, data);
+                    djLog(`[DraftMode] Saved draft: ${draftKey}`, data);
                 }
             } catch (error) {
                 console.error(`[DraftMode] Failed to save draft ${draftKey}:`, error);
@@ -1975,7 +1990,7 @@ class DraftManager {
 
             if (globalThis.djustDebug) {
                 const age = Math.round((Date.now() - draftData.timestamp) / 1000);
-                console.log(`[DraftMode] Loaded draft: ${draftKey} (${age}s old)`, draftData.data);
+                djLog(`[DraftMode] Loaded draft: ${draftKey} (${age}s old)`, draftData.data);
             }
 
             return draftData.data;
@@ -1995,7 +2010,7 @@ class DraftManager {
             localStorage.removeItem(`djust_draft_${draftKey}`);
 
             if (globalThis.djustDebug) {
-                console.log(`[DraftMode] Cleared draft: ${draftKey}`);
+                djLog(`[DraftMode] Cleared draft: ${draftKey}`);
             }
         } catch (error) {
             console.error(`[DraftMode] Failed to clear draft ${draftKey}:`, error);
@@ -2022,7 +2037,7 @@ class DraftManager {
         keys.forEach(key => this.clearDraft(key));
 
         if (globalThis.djustDebug) {
-            console.log(`[DraftMode] Cleared all ${keys.length} drafts`);
+            djLog(`[DraftMode] Cleared all ${keys.length} drafts`);
         }
     }
 }
@@ -2152,7 +2167,7 @@ function _restoreFormData(container, data) {
     });
 
     if (globalThis.djustDebug) {
-        console.log('[DraftMode] Restored form data:', data);
+        djLog('[DraftMode] Restored form data:', data);
     }
 }
 
@@ -3228,7 +3243,7 @@ async function _handleDjChange(element, e) {
     }
 
     if (globalThis.djustDebug) {
-        console.log(`[LiveView] dj-change handler: value="${value}", params=`, params);
+        djLog(`[LiveView] dj-change handler: value="${value}", params=`, params);
     }
     await handleEvent(parsedChange.name, params);
 }
@@ -4134,7 +4149,7 @@ const globalLoadingManager = {
         if (modifiers.length > 0) {
             this.registeredElements.set(element, { eventName, modifiers, originalState });
             if (globalThis.djustDebug) {
-                console.log(`[Loading] Registered element for "${eventName}":`, modifiers);
+                djLog(`[Loading] Registered element for "${eventName}":`, modifiers);
             }
         }
     },
@@ -4178,7 +4193,7 @@ const globalLoadingManager = {
             }
         });
         if (globalThis.djustDebug) {
-            console.log(`[Loading] Scanned ${this.registeredElements.size} elements with dj-loading attributes`);
+            djLog(`[Loading] Scanned ${this.registeredElements.size} elements with dj-loading attributes`);
         }
     },
 
@@ -4192,8 +4207,8 @@ const globalLoadingManager = {
             // Check if trigger element has dj-loading.disable
             const hasDisable = triggerElement.hasAttribute('dj-loading.disable');
             if (globalThis.djustDebug) {
-                console.log(`[Loading] triggerElement:`, triggerElement);
-                console.log(`[Loading] hasAttribute('dj-loading.disable'):`, hasDisable);
+                djLog(`[Loading] triggerElement:`, triggerElement);
+                djLog(`[Loading] hasAttribute('dj-loading.disable'):`, hasDisable);
             }
             if (hasDisable) {
                 triggerElement.disabled = true;
@@ -4210,7 +4225,7 @@ const globalLoadingManager = {
         document.body.classList.add('djust-global-loading');
 
         if (globalThis.djustDebug) {
-            console.log(`[Loading] Started: ${eventName}`);
+            djLog(`[Loading] Started: ${eventName}`);
         }
     },
 
@@ -4237,7 +4252,7 @@ const globalLoadingManager = {
         document.body.classList.remove('djust-global-loading');
 
         if (globalThis.djustDebug) {
-            console.log(`[Loading] Stopped: ${eventName}`);
+            djLog(`[Loading] Stopped: ${eventName}`);
         }
     },
 
@@ -4285,7 +4300,7 @@ function generateCacheRequestId() {
 // Main Event Handler
 async function handleEvent(eventName, params = {}) {
     if (globalThis.djustDebug) {
-        console.log(`[LiveView] Handling event: ${eventName}`, params);
+        djLog(`[LiveView] Handling event: ${eventName}`, params);
     }
 
     // Extract client-only properties before sending to server.
@@ -4347,7 +4362,7 @@ async function handleEvent(eventName, params = {}) {
     if (cached) {
         // Cache hit! Apply cached patches without server round-trip
         if (globalThis.djustDebug) {
-            console.log(`[LiveView:cache] Cache hit: ${cacheKey}`);
+            djLog(`[LiveView:cache] Cache hit: ${cacheKey}`);
         }
 
         // Still show brief loading state for UX consistency
@@ -4365,7 +4380,7 @@ async function handleEvent(eventName, params = {}) {
 
     // Cache miss - need to fetch from server
     if (globalThis.djustDebug && cacheConfig.has(eventName)) {
-        console.log(`[LiveView:cache] Cache miss: ${cacheKey}`);
+        djLog(`[LiveView:cache] Cache miss: ${cacheKey}`);
     }
 
     if (!skipLoading) globalLoadingManager.startLoading(eventName, triggerElement);
@@ -4384,7 +4399,7 @@ async function handleEvent(eventName, params = {}) {
             if (pendingCacheRequests.has(cacheRequestId)) {
                 pendingCacheRequests.delete(cacheRequestId);
                 if (globalThis.djustDebug) {
-                    console.log(`[LiveView:cache] Cleaned up stale pending request: ${cacheRequestId}`);
+                    djLog(`[LiveView:cache] Cleaned up stale pending request: ${cacheRequestId}`);
                 }
             }
         }, PENDING_CACHE_TIMEOUT);
@@ -5278,7 +5293,7 @@ function applyDjUpdateElements(existingRoot, newRoot) {
                         // Clone and append new child
                         existingElement.appendChild(newChild.cloneNode(true));
                         if (globalThis.djustDebug) {
-                            console.log(`[LiveView:dj-update] Appended #${newChild.id} to #${elementId}`);
+                            djLog(`[LiveView:dj-update] Appended #${newChild.id} to #${elementId}`);
                         }
                     }
                 }
@@ -5299,7 +5314,7 @@ function applyDjUpdateElements(existingRoot, newRoot) {
                         // Clone and prepend new child
                         existingElement.insertBefore(newChild.cloneNode(true), firstExisting);
                         if (globalThis.djustDebug) {
-                            console.log(`[LiveView:dj-update] Prepended #${newChild.id} to #${elementId}`);
+                            djLog(`[LiveView:dj-update] Prepended #${newChild.id} to #${elementId}`);
                         }
                     }
                 }
@@ -5309,7 +5324,7 @@ function applyDjUpdateElements(existingRoot, newRoot) {
             case 'ignore':
                 // Don't update this element at all
                 if (globalThis.djustDebug) {
-                    console.log(`[LiveView:dj-update] Ignoring #${elementId}`);
+                    djLog(`[LiveView:dj-update] Ignoring #${elementId}`);
                 }
                 break;
 
@@ -5700,7 +5715,7 @@ function applySinglePatch(patch) {
                     insertTarget = node.parentNode;
                     insertRefChild = node.nextSibling;
                     if (globalThis.djustDebug) {
-                        console.log('[LiveView] InsertChild redirected: non-option child into SELECT parent');
+                        djLog('[LiveView] InsertChild redirected: non-option child into SELECT parent');
                     }
                 } else {
                     if (patch.ref_d) {
@@ -6098,7 +6113,7 @@ const lazyHydrationManager = {
         }
 
         if (globalThis.djustDebug) {
-            console.log(`[LiveView:lazy] Registered element for lazy hydration (mode: ${lazyMode})`, element);
+            djLog(`[LiveView:lazy] Registered element for lazy hydration (mode: ${lazyMode})`, element);
         }
     },
 
@@ -8755,14 +8770,14 @@ window.djust.bindModelElements = bindModelElements;
             // module ordering puts 26-js-commands.js before this file in the
             // build, but be defensive).
             if (globalThis.djustDebug) {
-                console.log('[djust:exec] js commands module not loaded; skipping exec chain');
+                djLog('[djust:exec] js commands module not loaded; skipping exec chain');
             }
             return;
         }
 
         if (!payload || !Array.isArray(payload.ops)) {
             if (globalThis.djustDebug) {
-                console.log('[djust:exec] malformed payload (expected {ops: [...]}):', payload);
+                djLog('[djust:exec] malformed payload (expected {ops: [...]}):', payload);
             }
             return;
         }
@@ -8778,7 +8793,7 @@ window.djust.bindModelElements = bindModelElements;
             // Don't let one bad op break the whole event pipeline. Log in debug
             // mode and swallow — downstream chains keep working.
             if (globalThis.djustDebug) {
-                console.log('[djust:exec] op execution failed:', err);
+                djLog('[djust:exec] op execution failed:', err);
             }
         }
     }

--- a/python/djust/static/djust/debug-panel.js
+++ b/python/djust/static/djust/debug-panel.js
@@ -3968,7 +3968,7 @@
                             this.networkHistory = data.network || [];
                             this.patchHistory = data.patches || [];
                             this.renderTabContent();
-                            console.log('[djust] Debug session imported successfully');
+                            if (globalThis.djustDebug) console.log('[djust] Debug session imported successfully');
                         } catch (err) {
                             console.error('[djust] Failed to import debug session:', err);
                         }
@@ -4001,7 +4001,7 @@
             this.components = null;
             this.variables = {};
 
-            console.log('[djust] Debug panel destroyed');
+            if (globalThis.djustDebug) console.log('[djust] Debug panel destroyed');
         }
     }
 

--- a/python/djust/static/djust/src/00-namespace.js
+++ b/python/djust/static/djust/src/00-namespace.js
@@ -8,6 +8,21 @@
 window.djust = window.djust || {};
 
 // ============================================================================
+// djLog: debug-gated console.log (#761)
+// ============================================================================
+// Per djust/CLAUDE.md: "No console.log in JS without if (globalThis.djustDebug)
+// guard". Rather than sprinkle that conditional at every callsite, client.js
+// uses djLog which checks the flag once per call. Tree-shakes nothing (we
+// still evaluate the args in the call), but at least the console stays clean
+// when djustDebug is false.
+//
+// console.warn / console.error are NOT guarded — those indicate real problems
+// and should be visible in prod.
+window.djLog = function djLog(...args) {
+    if (globalThis.djustDebug) console.log(...args);
+};
+
+// ============================================================================
 // Double-Load Guard
 // ============================================================================
 // Prevent double execution when client.js is included in both base template

--- a/python/djust/static/djust/src/02-response-handler.js
+++ b/python/djust/static/djust/src/02-response-handler.js
@@ -45,7 +45,7 @@ function handleServerResponse(data, eventName, triggerElement) {
                 expiresAt
             });
             if (globalThis.djustDebug) {
-                console.log(`[LiveView:cache] Cached patches: ${cacheKey} (TTL: ${ttl}s)`);
+                djLog(`[LiveView:cache] Cached patches: ${cacheKey} (TTL: ${ttl}s)`);
             }
             pendingCacheRequests.delete(data.cache_request_id);
         }
@@ -234,7 +234,7 @@ function handleServerResponse(data, eventName, triggerElement) {
                 el.disabled = false;
             });
         } else if (globalThis.djustDebug) {
-            console.log('[LiveView] Keeping loading state — async work pending');
+            djLog('[LiveView] Keeping loading state — async work pending');
         }
         return true;
 

--- a/python/djust/static/djust/src/03-websocket.js
+++ b/python/djust/static/djust/src/03-websocket.js
@@ -383,7 +383,7 @@ class LiveViewWebSocket {
                     // all pending event responses arrive.
                     _tickBuffer.push(data);
                     if (globalThis.djustDebug) {
-                        console.log('[LiveView] Buffered %s patch (v%s) — waiting for %d pending event(s)', String(data.source), String(data.version), _pendingEventRefs.size);
+                        djLog('[LiveView] Buffered %s patch (v%s) — waiting for %d pending event(s)', String(data.source), String(data.version), _pendingEventRefs.size);
                     }
                     break;
                 }
@@ -418,7 +418,7 @@ class LiveViewWebSocket {
                 // patches only when ALL pending events have resolved.
                 if (isEventResponse && _pendingEventRefs.size === 0 && _tickBuffer.length > 0) {
                     if (globalThis.djustDebug) {
-                        console.log('[LiveView] Flushing ' + _tickBuffer.length + ' buffered patches');
+                        djLog('[LiveView] Flushing ' + _tickBuffer.length + ' buffered patches');
                     }
                     const buffered = _tickBuffer.splice(0);
                     for (const tickData of buffered) {
@@ -445,7 +445,7 @@ class LiveViewWebSocket {
                 reinitAfterDOMUpdate();
                 if (globalThis.djustDebug) {
                     // codeql[js/log-injection] -- data.version is a server-controlled integer
-                    console.log('[LiveView] DOM recovered via morph, version: %s', String(data.version));
+                    djLog('[LiveView] DOM recovered via morph, version: %s', String(data.version));
                 }
                 break;
             }

--- a/python/djust/static/djust/src/04-cache.js
+++ b/python/djust/static/djust/src/04-cache.js
@@ -42,7 +42,7 @@ function addToCache(cacheKey, value) {
         const oldestKey = resultCache.keys().next().value;
         resultCache.delete(oldestKey);
         if (globalThis.djustDebug) {
-            console.log(`[LiveView:cache] Evicted (LRU): ${oldestKey}`);
+            djLog(`[LiveView:cache] Evicted (LRU): ${oldestKey}`);
         }
     }
 
@@ -59,7 +59,7 @@ function setCacheConfig(config) {
     Object.entries(config).forEach(([handlerName, handlerConfig]) => {
         cacheConfig.set(handlerName, handlerConfig);
         if (globalThis.djustDebug) {
-            console.log(`[LiveView:cache] Configured cache for ${handlerName}:`, handlerConfig);
+            djLog(`[LiveView:cache] Configured cache for ${handlerName}:`, handlerConfig);
         }
     });
 }
@@ -147,7 +147,7 @@ function clearCache() {
     const size = resultCache.size;
     resultCache.clear();
     if (globalThis.djustDebug) {
-        console.log(`[LiveView:cache] Cleared all ${size} cached entries`);
+        djLog(`[LiveView:cache] Cleared all ${size} cached entries`);
     }
 }
 
@@ -177,7 +177,7 @@ function invalidateCache(pattern) {
     }
 
     if (globalThis.djustDebug) {
-        console.log(`[LiveView:cache] Invalidated ${count} entries matching: ${pattern}`);
+        djLog(`[LiveView:cache] Invalidated ${count} entries matching: ${pattern}`);
     }
 
     return count;

--- a/python/djust/static/djust/src/05-state-bus.js
+++ b/python/djust/static/djust/src/05-state-bus.js
@@ -10,7 +10,7 @@ class StateBus {
         const oldValue = this.state.get(key);
         this.state.set(key, value);
         if (globalThis.djustDebug) {
-            console.log(`[StateBus] Set: ${key} =`, value, `(was:`, oldValue, `)`);
+            djLog(`[StateBus] Set: ${key} =`, value, `(was:`, oldValue, `)`);
         }
         this.notify(key, value, oldValue);
     }
@@ -25,14 +25,14 @@ class StateBus {
         }
         this.subscribers.get(key).add(callback);
         if (globalThis.djustDebug) {
-            console.log(`[StateBus] Subscribed to: ${key} (${this.subscribers.get(key).size} subscribers)`);
+            djLog(`[StateBus] Subscribed to: ${key} (${this.subscribers.get(key).size} subscribers)`);
         }
         return () => {
             const subs = this.subscribers.get(key);
             if (subs) {
                 subs.delete(callback);
                 if (globalThis.djustDebug) {
-                    console.log(`[StateBus] Unsubscribed from: ${key} (${subs.size} remaining)`);
+                    djLog(`[StateBus] Unsubscribed from: ${key} (${subs.size} remaining)`);
                 }
             }
         };
@@ -41,7 +41,7 @@ class StateBus {
     notify(key, newValue, oldValue) {
         const callbacks = this.subscribers.get(key) || new Set();
         if (callbacks.size > 0 && globalThis.djustDebug) {
-            console.log(`[StateBus] Notifying ${callbacks.size} subscribers of: ${key}`);
+            djLog(`[StateBus] Notifying ${callbacks.size} subscribers of: ${key}`);
         }
         callbacks.forEach(callback => {
             try {
@@ -56,7 +56,7 @@ class StateBus {
         this.state.clear();
         this.subscribers.clear();
         if (globalThis.djustDebug) {
-            console.log('[StateBus] Cleared all state');
+            djLog('[StateBus] Cleared all state');
         }
     }
 

--- a/python/djust/static/djust/src/06-draft-manager.js
+++ b/python/djust/static/djust/src/06-draft-manager.js
@@ -20,7 +20,7 @@ class DraftManager {
                 localStorage.setItem(`djust_draft_${draftKey}`, JSON.stringify(draftData));
 
                 if (globalThis.djustDebug) {
-                    console.log(`[DraftMode] Saved draft: ${draftKey}`, data);
+                    djLog(`[DraftMode] Saved draft: ${draftKey}`, data);
                 }
             } catch (error) {
                 console.error(`[DraftMode] Failed to save draft ${draftKey}:`, error);
@@ -42,7 +42,7 @@ class DraftManager {
 
             if (globalThis.djustDebug) {
                 const age = Math.round((Date.now() - draftData.timestamp) / 1000);
-                console.log(`[DraftMode] Loaded draft: ${draftKey} (${age}s old)`, draftData.data);
+                djLog(`[DraftMode] Loaded draft: ${draftKey} (${age}s old)`, draftData.data);
             }
 
             return draftData.data;
@@ -62,7 +62,7 @@ class DraftManager {
             localStorage.removeItem(`djust_draft_${draftKey}`);
 
             if (globalThis.djustDebug) {
-                console.log(`[DraftMode] Cleared draft: ${draftKey}`);
+                djLog(`[DraftMode] Cleared draft: ${draftKey}`);
             }
         } catch (error) {
             console.error(`[DraftMode] Failed to clear draft ${draftKey}:`, error);
@@ -89,7 +89,7 @@ class DraftManager {
         keys.forEach(key => this.clearDraft(key));
 
         if (globalThis.djustDebug) {
-            console.log(`[DraftMode] Cleared all ${keys.length} drafts`);
+            djLog(`[DraftMode] Cleared all ${keys.length} drafts`);
         }
     }
 }

--- a/python/djust/static/djust/src/07-form-data.js
+++ b/python/djust/static/djust/src/07-form-data.js
@@ -61,6 +61,6 @@ function _restoreFormData(container, data) {
     });
 
     if (globalThis.djustDebug) {
-        console.log('[DraftMode] Restored form data:', data);
+        djLog('[DraftMode] Restored form data:', data);
     }
 }

--- a/python/djust/static/djust/src/09-event-binding.js
+++ b/python/djust/static/djust/src/09-event-binding.js
@@ -591,7 +591,7 @@ async function _handleDjChange(element, e) {
     }
 
     if (globalThis.djustDebug) {
-        console.log(`[LiveView] dj-change handler: value="${value}", params=`, params);
+        djLog(`[LiveView] dj-change handler: value="${value}", params=`, params);
     }
     await handleEvent(parsedChange.name, params);
 }

--- a/python/djust/static/djust/src/10-loading-states.js
+++ b/python/djust/static/djust/src/10-loading-states.js
@@ -44,7 +44,7 @@ const globalLoadingManager = {
         if (modifiers.length > 0) {
             this.registeredElements.set(element, { eventName, modifiers, originalState });
             if (globalThis.djustDebug) {
-                console.log(`[Loading] Registered element for "${eventName}":`, modifiers);
+                djLog(`[Loading] Registered element for "${eventName}":`, modifiers);
             }
         }
     },
@@ -88,7 +88,7 @@ const globalLoadingManager = {
             }
         });
         if (globalThis.djustDebug) {
-            console.log(`[Loading] Scanned ${this.registeredElements.size} elements with dj-loading attributes`);
+            djLog(`[Loading] Scanned ${this.registeredElements.size} elements with dj-loading attributes`);
         }
     },
 
@@ -102,8 +102,8 @@ const globalLoadingManager = {
             // Check if trigger element has dj-loading.disable
             const hasDisable = triggerElement.hasAttribute('dj-loading.disable');
             if (globalThis.djustDebug) {
-                console.log(`[Loading] triggerElement:`, triggerElement);
-                console.log(`[Loading] hasAttribute('dj-loading.disable'):`, hasDisable);
+                djLog(`[Loading] triggerElement:`, triggerElement);
+                djLog(`[Loading] hasAttribute('dj-loading.disable'):`, hasDisable);
             }
             if (hasDisable) {
                 triggerElement.disabled = true;
@@ -120,7 +120,7 @@ const globalLoadingManager = {
         document.body.classList.add('djust-global-loading');
 
         if (globalThis.djustDebug) {
-            console.log(`[Loading] Started: ${eventName}`);
+            djLog(`[Loading] Started: ${eventName}`);
         }
     },
 
@@ -147,7 +147,7 @@ const globalLoadingManager = {
         document.body.classList.remove('djust-global-loading');
 
         if (globalThis.djustDebug) {
-            console.log(`[Loading] Stopped: ${eventName}`);
+            djLog(`[Loading] Stopped: ${eventName}`);
         }
     },
 

--- a/python/djust/static/djust/src/11-event-handler.js
+++ b/python/djust/static/djust/src/11-event-handler.js
@@ -2,7 +2,7 @@
 // Main Event Handler
 async function handleEvent(eventName, params = {}) {
     if (globalThis.djustDebug) {
-        console.log(`[LiveView] Handling event: ${eventName}`, params);
+        djLog(`[LiveView] Handling event: ${eventName}`, params);
     }
 
     // Extract client-only properties before sending to server.
@@ -64,7 +64,7 @@ async function handleEvent(eventName, params = {}) {
     if (cached) {
         // Cache hit! Apply cached patches without server round-trip
         if (globalThis.djustDebug) {
-            console.log(`[LiveView:cache] Cache hit: ${cacheKey}`);
+            djLog(`[LiveView:cache] Cache hit: ${cacheKey}`);
         }
 
         // Still show brief loading state for UX consistency
@@ -82,7 +82,7 @@ async function handleEvent(eventName, params = {}) {
 
     // Cache miss - need to fetch from server
     if (globalThis.djustDebug && cacheConfig.has(eventName)) {
-        console.log(`[LiveView:cache] Cache miss: ${cacheKey}`);
+        djLog(`[LiveView:cache] Cache miss: ${cacheKey}`);
     }
 
     if (!skipLoading) globalLoadingManager.startLoading(eventName, triggerElement);
@@ -101,7 +101,7 @@ async function handleEvent(eventName, params = {}) {
             if (pendingCacheRequests.has(cacheRequestId)) {
                 pendingCacheRequests.delete(cacheRequestId);
                 if (globalThis.djustDebug) {
-                    console.log(`[LiveView:cache] Cleaned up stale pending request: ${cacheRequestId}`);
+                    djLog(`[LiveView:cache] Cleaned up stale pending request: ${cacheRequestId}`);
                 }
             }
         }, PENDING_CACHE_TIMEOUT);

--- a/python/djust/static/djust/src/12-vdom-patch.js
+++ b/python/djust/static/djust/src/12-vdom-patch.js
@@ -842,7 +842,7 @@ function applyDjUpdateElements(existingRoot, newRoot) {
                         // Clone and append new child
                         existingElement.appendChild(newChild.cloneNode(true));
                         if (globalThis.djustDebug) {
-                            console.log(`[LiveView:dj-update] Appended #${newChild.id} to #${elementId}`);
+                            djLog(`[LiveView:dj-update] Appended #${newChild.id} to #${elementId}`);
                         }
                     }
                 }
@@ -863,7 +863,7 @@ function applyDjUpdateElements(existingRoot, newRoot) {
                         // Clone and prepend new child
                         existingElement.insertBefore(newChild.cloneNode(true), firstExisting);
                         if (globalThis.djustDebug) {
-                            console.log(`[LiveView:dj-update] Prepended #${newChild.id} to #${elementId}`);
+                            djLog(`[LiveView:dj-update] Prepended #${newChild.id} to #${elementId}`);
                         }
                     }
                 }
@@ -873,7 +873,7 @@ function applyDjUpdateElements(existingRoot, newRoot) {
             case 'ignore':
                 // Don't update this element at all
                 if (globalThis.djustDebug) {
-                    console.log(`[LiveView:dj-update] Ignoring #${elementId}`);
+                    djLog(`[LiveView:dj-update] Ignoring #${elementId}`);
                 }
                 break;
 
@@ -1264,7 +1264,7 @@ function applySinglePatch(patch) {
                     insertTarget = node.parentNode;
                     insertRefChild = node.nextSibling;
                     if (globalThis.djustDebug) {
-                        console.log('[LiveView] InsertChild redirected: non-option child into SELECT parent');
+                        djLog('[LiveView] InsertChild redirected: non-option child into SELECT parent');
                     }
                 } else {
                     if (patch.ref_d) {

--- a/python/djust/static/djust/src/13-lazy-hydration.js
+++ b/python/djust/static/djust/src/13-lazy-hydration.js
@@ -110,7 +110,7 @@ const lazyHydrationManager = {
         }
 
         if (globalThis.djustDebug) {
-            console.log(`[LiveView:lazy] Registered element for lazy hydration (mode: ${lazyMode})`, element);
+            djLog(`[LiveView:lazy] Registered element for lazy hydration (mode: ${lazyMode})`, element);
         }
     },
 

--- a/python/djust/static/djust/src/27-exec-listener.js
+++ b/python/djust/static/djust/src/27-exec-listener.js
@@ -35,14 +35,14 @@
             // module ordering puts 26-js-commands.js before this file in the
             // build, but be defensive).
             if (globalThis.djustDebug) {
-                console.log('[djust:exec] js commands module not loaded; skipping exec chain');
+                djLog('[djust:exec] js commands module not loaded; skipping exec chain');
             }
             return;
         }
 
         if (!payload || !Array.isArray(payload.ops)) {
             if (globalThis.djustDebug) {
-                console.log('[djust:exec] malformed payload (expected {ops: [...]}):', payload);
+                djLog('[djust:exec] malformed payload (expected {ops: [...]}):', payload);
             }
             return;
         }
@@ -58,7 +58,7 @@
             // Don't let one bad op break the whole event pipeline. Log in debug
             // mode and swallow — downstream chains keep working.
             if (globalThis.djustDebug) {
-                console.log('[djust:exec] op execution failed:', err);
+                djLog('[djust:exec] op execution failed:', err);
             }
         }
     }

--- a/python/djust/static/djust/src/debug/15-panel-controls.js
+++ b/python/djust/static/djust/src/debug/15-panel-controls.js
@@ -175,7 +175,7 @@
                             this.networkHistory = data.network || [];
                             this.patchHistory = data.patches || [];
                             this.renderTabContent();
-                            console.log('[djust] Debug session imported successfully');
+                            if (globalThis.djustDebug) console.log('[djust] Debug session imported successfully');
                         } catch (err) {
                             console.error('[djust] Failed to import debug session:', err);
                         }
@@ -208,7 +208,7 @@
             this.components = null;
             this.variables = {};
 
-            console.log('[djust] Debug panel destroyed');
+            if (globalThis.djustDebug) console.log('[djust] Debug panel destroyed');
         }
     }
 


### PR DESCRIPTION
Closes #761. Per `djust/CLAUDE.md` rule, no `console.log` without `if (globalThis.djustDebug)` guard.

Added a `djLog` helper in `00-namespace.js` and replaced bare `console.log` → `djLog` across 12 client modules (38 callsites). `console.warn` / `console.error` untouched — those indicate real problems.

Before: 42 unguarded console.log in src/
After: 1 (a comment in the namespace file documenting the helper)

client.js + debug-panel.js rebuilt via `make build-js`.