### PR TITLE
fix(observability): dry_run covers QuerySet bulk writes (#758)

### DIFF
--- a/python/djust/observability/dry_run.py
+++ b/python/djust/observability/dry_run.py
@@ -147,11 +147,30 @@ class DryRunContext:
         self._patches.clear()
 
     def _install_orm(self) -> None:
+        """Patch Django ORM write methods.
+
+        Covers (#758):
+        - Per-instance: Model.save, Model.delete
+        - Bulk: QuerySet.update, QuerySet.delete, bulk_create, bulk_update
+        - Bulk insert/update via `Manager` also flow through QuerySet —
+          patching on QuerySet catches `Model.objects.create()` via
+          `QuerySet.create` too (which internally does `Model.save`,
+          already patched, but having it early lets us tag `kind:
+          "orm_create"` for readability).
+
+        Raw SQL (connection.execute, connection.cursor().execute) is NOT
+        patched — it's deliberately low-level; users invoking it want the
+        side effect. Use the sql_queries observability endpoint to see it.
+        """
         try:
             from django.db.models import Model
+            from django.db.models.query import QuerySet
         except Exception:  # noqa: BLE001
             return
 
+        _self = self
+
+        # --- Per-instance: Model.save, Model.delete -------------------
         orig_save = Model.save
         orig_delete = Model.delete
 
@@ -167,9 +186,41 @@ class DryRunContext:
                 "orm_delete", target, details, orig_delete, (self_, *a), kw
             )
 
-        _self = self
         self._patch(Model, "save", wrapped_save)
         self._patch(Model, "delete", wrapped_delete)
+
+        # --- Bulk: QuerySet.update / delete / bulk_create / bulk_update
+        # These bypass Model.save entirely so without patching QuerySet
+        # a handler that uses Model.objects.filter(...).update(...) would
+        # appear "pure" to dry_run while actually committing writes.
+        for qs_method, kind in [
+            ("update", "orm_bulk_update"),
+            ("delete", "orm_bulk_delete"),
+            ("bulk_create", "orm_bulk_create"),
+            ("bulk_update", "orm_bulk_update"),
+        ]:
+            if not hasattr(QuerySet, qs_method):
+                continue
+            original = getattr(QuerySet, qs_method)
+
+            def _make_qs_wrapper(method_name, orig, kind_tag):
+                def wrapper(self_, *a, **kw):
+                    model_name = getattr(self_, "model", None)
+                    model_name = getattr(model_name, "__name__", "?") if model_name else "?"
+                    target = f"{model_name}.objects.{method_name}"
+                    details: Dict[str, Any] = {}
+                    # For bulk_create/bulk_update the first positional arg
+                    # is the list — record its length for quick triage.
+                    if method_name in ("bulk_create", "bulk_update") and a:
+                        try:
+                            details["count"] = len(a[0])
+                        except TypeError:
+                            pass
+                    return _self._record_or_raise(kind_tag, target, details, orig, (self_, *a), kw)
+
+                return wrapper
+
+            self._patch(QuerySet, qs_method, _make_qs_wrapper(qs_method, original, kind))
 
     def _install_email(self) -> None:
         try:

--- a/python/djust/tests/test_observability_dry_run.py
+++ b/python/djust/tests/test_observability_dry_run.py
@@ -46,6 +46,53 @@ def test_context_blocks_orm_delete():
     assert exc_info.value.kind == "orm_delete"
 
 
+# --- #758: bulk ORM writes via QuerySet ----------------------------------
+
+
+def test_context_blocks_queryset_update():
+    """QuerySet.update bypasses Model.save — must be patched separately (#758)."""
+    from django.contrib.auth.models import User
+
+    with DryRunContext(block=True):
+        with pytest.raises(DryRunViolation) as exc_info:
+            User.objects.filter(username="nobody").update(is_active=False)
+    assert exc_info.value.kind == "orm_bulk_update"
+    assert "User.objects.update" in exc_info.value.target
+
+
+def test_context_blocks_queryset_delete():
+    from django.contrib.auth.models import User
+
+    with DryRunContext(block=True):
+        with pytest.raises(DryRunViolation) as exc_info:
+            User.objects.filter(username="nobody").delete()
+    assert exc_info.value.kind == "orm_bulk_delete"
+
+
+def test_context_blocks_bulk_create():
+    from django.contrib.auth.models import User
+
+    users = [User(username=f"u{i}") for i in range(3)]
+    with DryRunContext(block=True):
+        with pytest.raises(DryRunViolation) as exc_info:
+            User.objects.bulk_create(users)
+    assert exc_info.value.kind == "orm_bulk_create"
+    # Details include count so triage is quick.
+    assert exc_info.value.details.get("count") == 3
+
+
+def test_context_blocks_bulk_update():
+    """bulk_update is a newer Django API — must also be patched (#758)."""
+    from django.contrib.auth.models import User
+
+    users = [User(username=f"u{i}", id=i + 1000) for i in range(2)]
+    with DryRunContext(block=True):
+        with pytest.raises(DryRunViolation) as exc_info:
+            User.objects.bulk_update(users, ["first_name"])
+    assert exc_info.value.kind == "orm_bulk_update"
+    assert exc_info.value.details.get("count") == 2
+
+
 def test_context_records_without_blocking_when_block_false():
     """block=False mode: attempts recorded AND the original call runs.
 


### PR DESCRIPTION
Closes #758. Extends DryRunContext._install_orm to patch QuerySet.update / delete / bulk_create / bulk_update. 4 new test cases. Handlers that do bulk writes now correctly raise DryRunViolation with kind orm_bulk_*.