### PR TITLE
feat: fold djust-admin into djust[admin] extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Package consolidation Phase 1+2: `djust-auth` and `djust-tenants` folded into core** — `djust-auth` (879 LOC) merged into `python/djust/auth/` package. Existing core auth (check_view_auth, LoginRequiredMixin, PermissionRequiredMixin) moved to `auth/core.py`; new modules from djust-auth (views, forms, mixins, social, admin_views) added alongside. `djust-tenants` missing modules (audit, middleware, managers, models, security) merged into existing `python/djust/tenants/`. Both packages are now part of core `pip install djust` — no extras needed since they're small. 27 new tests added (12 auth + 15 tenants). All imports backward-compatible via lazy loading in `__init__.py`.
+- **Package consolidation Phase 3: `djust-admin` folded as `djust[admin]`** — `djust-admin` (3,878 LOC) merged into `python/djust/admin_ext/` as an optional extra (`pip install djust[admin]`). Uses `admin_ext` to avoid collision with `django.contrib.admin`. Includes views, forms, adapters, plugins, decorators, template tags, and 7 HTML templates. 40 new tests. `pip install djust[all]` now includes admin.
 
 ## [0.4.5rc2] - 2026-04-18
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,13 @@ performance = [
     "orjson>=3.11.6; python_version >= '3.10'",  # CVE fix for 3.10+
     "zstandard>=0.22.0",
 ]
+admin = []  # No extra deps beyond djust core
 deploy = [
     "click>=8.0",
     "requests>=2.28",
+]
+all = [
+    "djust[redis,compression,performance,admin,deploy]",
 ]
 dev = [
     "maturin>=1.0,<2.0",

--- a/python/djust/admin_ext/__init__.py
+++ b/python/djust/admin_ext/__init__.py
@@ -1,0 +1,48 @@
+"""
+djust.admin_ext: A modern, reactive Django admin interface powered by djust.
+
+This package provides a drop-in replacement for Django's built-in admin
+with real-time updates, plugin architecture, and a modern UX.
+
+Folded into djust core from the standalone djust-admin package.
+"""
+
+# Import adapters module to register admin_tailwind adapter
+from . import adapters  # noqa: F401
+from .decorators import action, display, register
+from .options import DjustModelAdmin
+from .plugins import AdminPage, AdminPlugin, AdminWidget, NavItem
+from .sites import DjustAdminSite
+
+# Default admin site instance
+site = DjustAdminSite()
+
+
+def autodiscover():
+    """
+    Auto-discover djust_admin.py modules in all installed apps.
+
+    Similar to django.contrib.admin.autodiscover() but looks for
+    djust_admin.py instead of admin.py to avoid conflicts.
+    """
+    from django.utils.module_loading import autodiscover_modules
+
+    autodiscover_modules("djust_admin", register_to=site)
+
+
+default_app_config = "djust.admin_ext.apps.DjustAdminConfig"
+
+
+__all__ = [
+    "DjustAdminSite",
+    "DjustModelAdmin",
+    "AdminPlugin",
+    "AdminPage",
+    "AdminWidget",
+    "NavItem",
+    "register",
+    "action",
+    "display",
+    "site",
+    "autodiscover",
+]

--- a/python/djust/admin_ext/adapters.py
+++ b/python/djust/admin_ext/adapters.py
@@ -1,0 +1,332 @@
+"""
+Admin-specific CSS framework adapters for djust admin_ext.
+
+Extends djust's framework adapters with support for ForeignKey, ManyToMany,
+and date/time fields commonly used in Django admin interfaces.
+"""
+
+from typing import Any, Dict, List
+
+from django import forms
+from django.utils.html import escape
+from djust.frameworks import TailwindAdapter, register_adapter
+
+
+class AdminTailwindAdapter(TailwindAdapter):
+    """
+    Tailwind CSS adapter extended for admin field types.
+
+    Adds support for:
+    - ForeignKey fields (rendered as select dropdowns)
+    - ManyToMany fields (rendered as multi-select)
+    - Date/DateTime/Time fields (proper input types)
+    - Readonly fields
+
+    Usage:
+        # Register at app startup
+        from djust.admin_ext.adapters import register_admin_adapters
+        register_admin_adapters()
+
+        # Use in views
+        self.as_live_field(field_name, framework='admin_tailwind', **field_info)
+    """
+
+    # Tailwind classes for admin fields
+    FIELD_CLASS = (
+        "block w-full rounded-md border-gray-300 shadow-sm "
+        "focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+    )
+    FIELD_CLASS_INVALID = (
+        "block w-full rounded-md border-red-300 shadow-sm "
+        "focus:border-red-500 focus:ring-red-500 sm:text-sm"
+    )
+    SELECT_CLASS = (
+        "block w-full rounded-md border-gray-300 shadow-sm "
+        "focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+    )
+    MULTI_SELECT_CLASS = (
+        "block w-full rounded-md border-gray-300 shadow-sm "
+        "focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+    )
+    LABEL_CLASS = "block text-sm font-medium text-gray-700"
+    ERROR_CLASS = "mt-2 text-sm text-red-600"
+    HELP_TEXT_CLASS = "mt-2 text-sm text-gray-500"
+    WRAPPER_CLASS = "mb-4"
+    CHECKBOX_CLASS = "h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+    CHECKBOX_WRAPPER_CLASS = "flex items-center"
+    CHECKBOX_LABEL_CLASS = "ml-2 block text-sm text-gray-900"
+
+    def render_field(
+        self, field: forms.Field, field_name: str, value: Any, errors: List[str], **kwargs
+    ) -> str:
+        """
+        Render field with admin-specific handling.
+
+        Checks for admin field types (FK, M2M, date) passed in kwargs and
+        routes to appropriate rendering methods.
+
+        Args:
+            field: Django form field instance
+            field_name: Name of the field
+            value: Current field value
+            errors: List of error messages
+            **kwargs: Additional options including:
+                - is_foreign_key: True if FK field
+                - is_many_to_many: True if M2M field
+                - is_date/is_datetime/is_time: True for date fields
+                - options: List of {"value": ..., "label": ...} for FK/M2M
+                - readonly: True if readonly field
+                - input_type: Override input type (date, datetime-local, time)
+
+        Returns:
+            HTML string for the field
+        """
+        # Extract admin-specific options
+        options = kwargs.pop("options", None)
+        is_foreign_key = kwargs.pop("is_foreign_key", False)
+        is_many_to_many = kwargs.pop("is_many_to_many", False)
+        is_date = kwargs.pop("is_date", False)
+        is_datetime = kwargs.pop("is_datetime", False)
+        is_time = kwargs.pop("is_time", False)
+        is_readonly = kwargs.pop("readonly", False)
+        input_type = kwargs.pop("input_type", None)
+
+        has_errors = len(errors) > 0
+
+        # Build wrapper
+        wrapper_class = kwargs.get("wrapper_class", self.WRAPPER_CLASS)
+        html = f'<div class="{wrapper_class}">'
+
+        # Render label
+        if kwargs.get("render_label", True):
+            label_text = kwargs.get("label", field.label or field_name.replace("_", " ").title())
+            required = ' <span class="text-red-500">*</span>' if field.required else ""
+            html += (
+                f'<label for="id_{field_name}" class="{self.LABEL_CLASS}">'
+                f"{escape(label_text)}{required}</label>"
+            )
+
+        html += '<div class="mt-1">'
+
+        # Render based on field type
+        if is_readonly:
+            html += self._render_readonly(field_name, value)
+        elif is_foreign_key and options:
+            html += self._render_fk_select(field, field_name, value, errors, options, **kwargs)
+        elif is_many_to_many and options:
+            html += self._render_m2m_select(field, field_name, value, errors, options, **kwargs)
+        elif is_datetime:
+            html += self._render_datetime_input(
+                field, field_name, value, has_errors, "datetime-local", **kwargs
+            )
+        elif is_date:
+            html += self._render_datetime_input(
+                field, field_name, value, has_errors, "date", **kwargs
+            )
+        elif is_time:
+            html += self._render_datetime_input(
+                field, field_name, value, has_errors, "time", **kwargs
+            )
+        elif input_type:
+            html += self._render_datetime_input(
+                field, field_name, value, has_errors, input_type, **kwargs
+            )
+        else:
+            # Fall back to parent implementation for standard fields
+            html += self._render_standard_field(field, field_name, value, has_errors, **kwargs)
+
+        html += "</div>"
+
+        # Render errors
+        if kwargs.get("render_errors", True) and has_errors:
+            html += self.render_errors(errors)
+
+        # Render help text
+        if kwargs.get("render_help_text", True) and field.help_text:
+            html += f'<p class="{self.HELP_TEXT_CLASS}">{escape(field.help_text)}</p>'
+
+        html += "</div>"
+        return html
+
+    def render_errors(self, errors: List[str], **kwargs) -> str:
+        """Render errors with admin Tailwind styling."""
+        html = ""
+        for error in errors:
+            html += f'<p class="{self.ERROR_CLASS}">{escape(error)}</p>'
+        return html
+
+    def get_field_class(self, field: forms.Field, has_errors: bool = False) -> str:
+        """Get Tailwind CSS field classes for admin."""
+        if isinstance(field, forms.BooleanField):
+            return self.CHECKBOX_CLASS
+        elif has_errors:
+            return self.FIELD_CLASS_INVALID
+        else:
+            return self.FIELD_CLASS
+
+    def _render_readonly(self, field_name: str, value: Any) -> str:
+        """Render a readonly field display."""
+        display_value = value if value else "-"
+        return f'<p class="py-2 text-gray-900">{escape(str(display_value))}</p>'
+
+    def _render_fk_select(
+        self,
+        field: forms.Field,
+        field_name: str,
+        value: Any,
+        errors: List[str],
+        options: List[Dict[str, str]],
+        **kwargs,
+    ) -> str:
+        """Render ForeignKey as select dropdown."""
+        has_errors = len(errors) > 0
+        field_class = self.FIELD_CLASS_INVALID if has_errors else self.SELECT_CLASS
+
+        html = f'<select name="{field_name}" id="id_{field_name}" class="{field_class}" '
+        html += f"dj-change=\"validate_field('{field_name}', value)\">"
+        html += '<option value="">---------</option>'
+
+        for opt in options:
+            selected = "selected" if str(value) == opt["value"] else ""
+            html += (
+                f'<option value="{escape(opt["value"])}" {selected}>{escape(opt["label"])}</option>'
+            )
+
+        html += "</select>"
+        return html
+
+    def _render_m2m_select(
+        self,
+        field: forms.Field,
+        field_name: str,
+        value: Any,
+        errors: List[str],
+        options: List[Dict[str, str]],
+        **kwargs,
+    ) -> str:
+        """Render ManyToMany as multi-select."""
+        has_errors = len(errors) > 0
+        field_class = self.FIELD_CLASS_INVALID if has_errors else self.MULTI_SELECT_CLASS
+
+        # Ensure value is a list of strings (form field.value() may return ints)
+        selected_values = [str(v) for v in value] if isinstance(value, list) else []
+
+        html = f'<select name="{field_name}" id="id_{field_name}" class="{field_class}" '
+        html += 'multiple size="6" '
+        # dj-change handler for M2M - extracts selected option values as array
+        dj_change = (
+            f"validate_field('{field_name}', Array.from(this.selectedOptions).map(o => o.value))"
+        )
+        html += f'dj-change="{dj_change}">'
+
+        for opt in options:
+            selected = "selected" if opt["value"] in selected_values else ""
+            html += (
+                f'<option value="{escape(opt["value"])}" {selected}>{escape(opt["label"])}</option>'
+            )
+
+        html += "</select>"
+        html += '<p class="mt-1 text-xs text-gray-500">Hold Ctrl/Cmd to select multiple</p>'
+        return html
+
+    def _render_datetime_input(
+        self,
+        field: forms.Field,
+        field_name: str,
+        value: Any,
+        has_errors: bool,
+        input_type: str,
+        **kwargs,
+    ) -> str:
+        """Render date/datetime/time input."""
+        field_class = self.FIELD_CLASS_INVALID if has_errors else self.FIELD_CLASS
+
+        # Format value based on type
+        formatted_value = ""
+        if value:
+            if hasattr(value, "strftime"):
+                if input_type == "datetime-local":
+                    formatted_value = value.strftime("%Y-%m-%dT%H:%M")
+                elif input_type == "date":
+                    formatted_value = value.strftime("%Y-%m-%d")
+                elif input_type == "time":
+                    formatted_value = value.strftime("%H:%M")
+            else:
+                formatted_value = str(value)
+
+        html = f'<input type="{input_type}" name="{field_name}" id="id_{field_name}" '
+        html += f'value="{escape(formatted_value)}" class="{field_class}" '
+        html += f"dj-change=\"validate_field('{field_name}', value)\""
+        if field.required:
+            html += " required"
+        html += " />"
+        return html
+
+    def _render_standard_field(
+        self,
+        field: forms.Field,
+        field_name: str,
+        value: Any,
+        has_errors: bool,
+        **kwargs,
+    ) -> str:
+        """Render standard input/textarea/select field."""
+        field_class = self.get_field_class(field, has_errors)
+        field_type = self._get_field_type(field)
+
+        if field_type == "textarea":
+            html = f'<textarea name="{field_name}" id="id_{field_name}" class="{field_class}" '
+            html += f'rows="4" dj-input="validate_field(\'{field_name}\', value)"'
+            if field.required:
+                html += " required"
+            html += f">{escape(str(value) if value else '')}</textarea>"
+            return html
+
+        elif field_type == "checkbox":
+            checked = "checked" if value else ""
+            html = f'<input type="checkbox" name="{field_name}" id="id_{field_name}" '
+            html += f'class="{self.CHECKBOX_CLASS}" {checked} '
+            html += f"dj-change=\"validate_field('{field_name}', this.checked)\""
+            if field.required:
+                html += " required"
+            html += " />"
+            return html
+
+        elif field_type == "select":
+            html = f'<select name="{field_name}" id="id_{field_name}" class="{field_class}" '
+            html += f"dj-change=\"validate_field('{field_name}', value)\">"
+
+            if not field.required:
+                html += '<option value="">---------</option>'
+
+            for choice_value, choice_label in field.choices:
+                selected = "selected" if str(value) == str(choice_value) else ""
+                opt_val = escape(str(choice_value))
+                opt_label = escape(str(choice_label))
+                html += f'<option value="{opt_val}" {selected}>{opt_label}</option>'
+
+            html += "</select>"
+            return html
+
+        else:
+            # Standard input field
+            html = f'<input type="{field_type}" name="{field_name}" id="id_{field_name}" '
+            html += f'value="{escape(str(value) if value else "")}" class="{field_class}" '
+            html += f"dj-input=\"validate_field('{field_name}', value)\""
+            if field.required:
+                html += " required"
+            html += " />"
+            return html
+
+
+def register_admin_adapters():
+    """
+    Register admin-specific framework adapters.
+
+    Call this at app startup (e.g., in AppConfig.ready()).
+    """
+    register_adapter("admin_tailwind", AdminTailwindAdapter())
+
+
+# Auto-register on import
+register_admin_adapters()

--- a/python/djust/admin_ext/apps.py
+++ b/python/djust/admin_ext/apps.py
@@ -1,0 +1,13 @@
+from django.apps import AppConfig
+
+
+class DjustAdminConfig(AppConfig):
+    name = "djust.admin_ext"
+    label = "djust_admin"
+    verbose_name = "Djust Admin"
+    default_auto_field = "django.db.models.BigAutoField"
+
+    def ready(self):
+        from . import autodiscover
+
+        autodiscover()

--- a/python/djust/admin_ext/components/__init__.py
+++ b/python/djust/admin_ext/components/__init__.py
@@ -1,0 +1,8 @@
+"""
+Custom components for djust admin_ext.
+
+These components extend djust's component library with admin-specific
+functionality like filters, bulk action toolbars, and data tables.
+"""
+
+# Components will be added here as development progresses

--- a/python/djust/admin_ext/decorators.py
+++ b/python/djust/admin_ext/decorators.py
@@ -64,13 +64,12 @@ def action(description=None, permissions=None):
     """
 
     def decorator(func):
-        func.short_description = description or func.__name__.replace("_", " ").title()
-        func.allowed_permissions = permissions or []
-
         @wraps(func)
         def wrapper(*args, **kwargs):
             return func(*args, **kwargs)
 
+        wrapper.short_description = description or func.__name__.replace("_", " ").title()
+        wrapper.allowed_permissions = permissions or []
         return wrapper
 
     return decorator
@@ -91,11 +90,6 @@ def display(description=None, ordering=None, boolean=False, empty_value="-"):
     """
 
     def decorator(func):
-        func.short_description = description or func.__name__.replace("_", " ").title()
-        func.admin_order_field = ordering
-        func.boolean = boolean
-        func.empty_value_display = empty_value
-
         @wraps(func)
         def wrapper(*args, **kwargs):
             result = func(*args, **kwargs)
@@ -103,6 +97,10 @@ def display(description=None, ordering=None, boolean=False, empty_value="-"):
                 return empty_value
             return result
 
+        wrapper.short_description = description or func.__name__.replace("_", " ").title()
+        wrapper.admin_order_field = ordering
+        wrapper.boolean = boolean
+        wrapper.empty_value_display = empty_value
         return wrapper
 
     return decorator

--- a/python/djust/admin_ext/decorators.py
+++ b/python/djust/admin_ext/decorators.py
@@ -1,0 +1,108 @@
+"""
+Decorators for djust admin_ext.
+"""
+
+from functools import wraps
+
+
+def register(*models, site=None):
+    """
+    Register a model or models with the admin site.
+
+    Can be used as a decorator:
+
+        from djust.admin_ext import register, DjustModelAdmin
+
+        @register(Article)
+        class ArticleAdmin(DjustModelAdmin):
+            list_display = ['title', 'author']
+
+    Or with multiple models:
+
+        @register(Article, Comment)
+        class ContentAdmin(DjustModelAdmin):
+            pass
+
+    Or with a specific site:
+
+        from djust.admin_ext import DjustAdminSite, register
+
+        my_site = DjustAdminSite(name='my_admin')
+
+        @register(Article, site=my_site)
+        class ArticleAdmin(DjustModelAdmin):
+            pass
+    """
+    from . import site as default_site
+
+    def decorator(admin_class):
+        admin_site = site or default_site
+
+        if not models:
+            raise ValueError("At least one model must be provided to register()")
+
+        for model in models:
+            admin_site.register(model, admin_class)
+
+        return admin_class
+
+    return decorator
+
+
+def action(description=None, permissions=None):
+    """
+    Decorator for admin actions.
+
+    Usage:
+        @action(description="Publish selected articles")
+        def publish_selected(self, request, queryset):
+            queryset.update(status='published')
+
+        @action(description="Archive", permissions=['can_archive'])
+        def archive_selected(self, request, queryset):
+            queryset.update(archived=True)
+    """
+
+    def decorator(func):
+        func.short_description = description or func.__name__.replace("_", " ").title()
+        func.allowed_permissions = permissions or []
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def display(description=None, ordering=None, boolean=False, empty_value="-"):
+    """
+    Decorator for custom display methods in list_display.
+
+    Usage:
+        @display(description="Full Name", ordering="first_name")
+        def full_name(self, obj):
+            return f"{obj.first_name} {obj.last_name}"
+
+        @display(description="Active", boolean=True)
+        def is_active(self, obj):
+            return obj.status == 'active'
+    """
+
+    def decorator(func):
+        func.short_description = description or func.__name__.replace("_", " ").title()
+        func.admin_order_field = ordering
+        func.boolean = boolean
+        func.empty_value_display = empty_value
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            result = func(*args, **kwargs)
+            if result is None:
+                return empty_value
+            return result
+
+        return wrapper
+
+    return decorator

--- a/python/djust/admin_ext/forms.py
+++ b/python/djust/admin_ext/forms.py
@@ -1,0 +1,304 @@
+"""
+Admin-specific form handling for djust admin_ext.
+
+Extends djust's FormMixin with ModelAdmin integration for FK/M2M fields,
+readonly fields, and fieldset-based rendering.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from django import forms
+from django.db.models import ForeignKey, ManyToManyField, OneToOneField
+from django.db.models.fields import DateField, DateTimeField, TimeField
+from djust.forms import FormMixin
+
+
+class AdminFormMixin(FormMixin):
+    """
+    FormMixin extended for ModelAdmin integration.
+
+    Provides:
+    - Form creation via ModelAdmin.get_form()
+    - FK/M2M field option loading
+    - Date/DateTime/Time field detection
+    - Readonly field support
+    - Fieldset-based rendering
+
+    Usage:
+        class ModelDetailView(AdminBaseMixin, AdminFormMixin, LiveView):
+            template_name = "djust_admin/model_detail.html"
+
+            def form_valid(self, form):
+                self.object = form.save()
+                self.save_success = True
+    """
+
+    # Set by subclass or during mount()
+    object: Optional[Any] = None
+
+    def mount(self, request, object_id=None, **kwargs):
+        """Initialize form on view mount with model instance."""
+        self.request = request
+        self.object_id = object_id
+
+        # Load object if editing
+        if object_id and self._model:
+            self.object = self._model.objects.get(pk=object_id)
+        else:
+            self.object = None
+
+        # Initialize form state - don't call parent mount() which expects form_class
+        self.form_data = {}
+        self.form_errors = {}
+        self.field_errors = {}
+        self.is_valid = False
+        self.success_message = ""
+        self.error_message = ""
+
+        # Initialize form data from object
+        if self.object:
+            form = self._create_form()
+            for field in form:
+                self.form_data[field.name] = field.value()
+
+        # Create initial form instance
+        self.form_instance = self._create_form()
+
+    def _create_form(self, data: Optional[Dict[str, Any]] = None) -> forms.Form:
+        """
+        Create a form instance using ModelAdmin.get_form().
+
+        Overrides FormMixin._create_form() to use the ModelAdmin's form class
+        with proper instance binding.
+
+        Args:
+            data: Form data dictionary
+
+        Returns:
+            Django Form instance
+        """
+        form_class = self._model_admin.get_form(self.request, self.object)
+
+        if data:
+            return form_class(data=data, instance=self.object)
+        return form_class(instance=self.object)
+
+    def get_field_options(self, field_name: str) -> List[Dict[str, str]]:
+        """
+        Get FK/M2M options for a field.
+
+        Returns a list of {"value": pk, "label": str(obj)} for related objects.
+
+        Args:
+            field_name: Name of the field
+
+        Returns:
+            List of option dicts for select rendering
+        """
+        try:
+            django_field = self._model._meta.get_field(field_name)
+            if isinstance(django_field, (ForeignKey, OneToOneField, ManyToManyField)):
+                related_model = django_field.remote_field.model
+                return [
+                    {"value": str(obj.pk), "label": str(obj)}
+                    for obj in related_model.objects.all()[:100]
+                ]
+        except Exception:
+            pass
+        return []
+
+    def get_field_info(self, field_name: str) -> Dict[str, Any]:
+        """
+        Get field metadata for rendering.
+
+        Returns info about field type (FK, M2M, date, etc.) and options.
+
+        Args:
+            field_name: Name of the field
+
+        Returns:
+            Dict with field type info and options
+        """
+        info = {
+            "is_foreign_key": False,
+            "is_many_to_many": False,
+            "is_date": False,
+            "is_datetime": False,
+            "is_time": False,
+            "options": [],
+            "input_type": None,  # None = let adapter auto-detect field type
+        }
+
+        try:
+            django_field = self._model._meta.get_field(field_name)
+
+            if isinstance(django_field, (ForeignKey, OneToOneField)):
+                info["is_foreign_key"] = True
+                info["options"] = self.get_field_options(field_name)
+            elif isinstance(django_field, ManyToManyField):
+                info["is_many_to_many"] = True
+                info["options"] = self.get_field_options(field_name)
+            elif isinstance(django_field, DateTimeField):
+                info["is_datetime"] = True
+                info["input_type"] = "datetime-local"
+            elif isinstance(django_field, DateField):
+                info["is_date"] = True
+                info["input_type"] = "date"
+            elif isinstance(django_field, TimeField):
+                info["is_time"] = True
+                info["input_type"] = "time"
+        except Exception:
+            pass
+
+        return info
+
+    def get_field_value(self, field_name: str, default: Any = "") -> Any:
+        """
+        Get current value for a field with FK/M2M and date handling.
+
+        Overrides FormMixin.get_field_value() to properly format FK IDs,
+        M2M lists, and date/time values.
+
+        Args:
+            field_name: Name of the field
+            default: Default value if not found
+
+        Returns:
+            Field value, properly formatted
+        """
+        # Check form_data first
+        if field_name in self.form_data:
+            return self.form_data.get(field_name, default)
+
+        # Get from object if available
+        if not self.object:
+            return default
+
+        try:
+            django_field = self._model._meta.get_field(field_name)
+
+            # ForeignKey - return the ID
+            if isinstance(django_field, (ForeignKey, OneToOneField)):
+                fk_value = getattr(self.object, f"{field_name}_id", None)
+                return str(fk_value) if fk_value is not None else default
+
+            # ManyToMany - return list of IDs
+            elif isinstance(django_field, ManyToManyField):
+                if self.object.pk:
+                    selected_ids = list(
+                        getattr(self.object, field_name).values_list("pk", flat=True)
+                    )
+                    return [str(pk) for pk in selected_ids]
+                return []
+
+            # Date/DateTime/Time - format properly
+            elif isinstance(django_field, DateTimeField):
+                obj_value = getattr(self.object, field_name, None)
+                if obj_value:
+                    return obj_value.strftime("%Y-%m-%dT%H:%M")
+                return default
+
+            elif isinstance(django_field, DateField):
+                obj_value = getattr(self.object, field_name, None)
+                if obj_value:
+                    return obj_value.strftime("%Y-%m-%d")
+                return default
+
+            elif isinstance(django_field, TimeField):
+                obj_value = getattr(self.object, field_name, None)
+                if obj_value:
+                    return obj_value.strftime("%H:%M")
+                return default
+
+            # Regular field
+            else:
+                return getattr(self.object, field_name, default)
+
+        except Exception:
+            return default
+
+    def validate_field(self, field_name: str = "", value: Any = None, **kwargs):
+        """
+        Validate a single field in real-time.
+
+        Extends FormMixin.validate_field() to work with ModelAdmin forms.
+
+        Args:
+            field_name: Name of the field to validate
+            value: Current field value
+        """
+        if not field_name:
+            return
+
+        # Ensure form state is initialized
+        if not hasattr(self, "form_data"):
+            self.form_data = {}
+        if not hasattr(self, "field_errors"):
+            self.field_errors = {}
+
+        # Update form data
+        self.form_data[field_name] = value
+
+        # Create form with current data
+        form = self._create_form(self.form_data)
+
+        # Clear previous error for this field
+        if field_name in self.field_errors:
+            del self.field_errors[field_name]
+
+        # Validate the specific field
+        if field_name in form.fields:
+            field = form.fields[field_name]
+            try:
+                cleaned_value = field.clean(value)
+                field.run_validators(cleaned_value)
+
+                # Run form's clean method for this field if it exists
+                if not hasattr(form, "cleaned_data"):
+                    form.cleaned_data = {}
+                form.cleaned_data[field_name] = cleaned_value
+
+                clean_method = getattr(form, f"clean_{field_name}", None)
+                if clean_method:
+                    clean_method()
+
+            except forms.ValidationError as e:
+                self.field_errors[field_name] = e.messages
+
+        # Update form instance
+        self.form_instance = form
+
+    def submit_form(self, **kwargs):
+        """
+        Handle form submission.
+
+        Extends FormMixin.submit_form() to work with ModelAdmin forms.
+        """
+        # Merge kwargs into form_data
+        self.form_data.update(kwargs)
+
+        # Create form with all data
+        form = self._create_form(self.form_data)
+
+        # Validate entire form
+        if form.is_valid():
+            self.is_valid = True
+            self.field_errors = {}
+            self.form_errors = {}
+            self.form_instance = form
+
+            # Call form_valid hook
+            if hasattr(self, "form_valid"):
+                self.form_valid(form)
+        else:
+            self.is_valid = False
+            self.field_errors = {field: errors for field, errors in form.errors.items()}
+
+            if form.non_field_errors():
+                self.form_errors = form.non_field_errors()
+
+            self.form_instance = form
+
+            # Call form_invalid hook
+            if hasattr(self, "form_invalid"):
+                self.form_invalid(form)

--- a/python/djust/admin_ext/options.py
+++ b/python/djust/admin_ext/options.py
@@ -1,0 +1,234 @@
+"""
+DjustModelAdmin - Configuration class for model admin interfaces.
+
+Similar to Django's ModelAdmin but designed for reactive LiveView rendering.
+"""
+
+from django.db import models
+from django.forms import modelform_factory
+
+
+class DjustModelAdmin:
+    """
+    Configuration for how a model is displayed in djust admin.
+
+    Usage:
+        from djust.admin_ext import DjustModelAdmin, site
+
+        @site.register(Article)
+        class ArticleAdmin(DjustModelAdmin):
+            list_display = ['title', 'author', 'published_date', 'status']
+            list_filter = ['status', 'author']
+            search_fields = ['title', 'content']
+            ordering = ['-published_date']
+    """
+
+    # List view configuration
+    list_display = ["__str__"]
+    list_display_links = None
+    list_filter = []
+    list_select_related = False
+    list_per_page = 25
+    list_max_show_all = 200
+    search_fields = []
+    ordering = None
+
+    # Detail view configuration
+    fields = None
+    exclude = None
+    readonly_fields = []
+    fieldsets = None
+
+    # Form configuration
+    form = None
+    formfield_overrides = {}
+
+    # Actions
+    actions = ["delete_selected"]
+
+    # Permissions
+    def has_add_permission(self, request):
+        return True
+
+    def has_change_permission(self, request, obj=None):
+        return True
+
+    def has_delete_permission(self, request, obj=None):
+        return True
+
+    def has_view_permission(self, request, obj=None):
+        return True
+
+    def __init__(self, model, admin_site):
+        self.model = model
+        self.admin_site = admin_site
+        self.opts = model._meta
+
+    def get_queryset(self, request):
+        """Return the queryset for the list view."""
+        qs = self.model._default_manager.get_queryset()
+
+        # Apply select_related if configured
+        if self.list_select_related:
+            if isinstance(self.list_select_related, (list, tuple)):
+                qs = qs.select_related(*self.list_select_related)
+            else:
+                qs = qs.select_related()
+        else:
+            # Auto-optimize: select_related for FK/O2O fields in list_display
+            fk_fields = []
+            for field_name in self.list_display:
+                try:
+                    field = self.opts.get_field(field_name)
+                    if isinstance(field, (models.ForeignKey, models.OneToOneField)):
+                        fk_fields.append(field_name)
+                except Exception:
+                    pass
+            if fk_fields:
+                qs = qs.select_related(*fk_fields)
+
+        # Apply default ordering
+        ordering = self.get_ordering(request)
+        if ordering:
+            qs = qs.order_by(*ordering)
+
+        return qs
+
+    def get_ordering(self, request):
+        """Return the ordering for the list view."""
+        return self.ordering or ()
+
+    def get_list_display(self, request):
+        """Return the list of fields to display in the list view."""
+        return self.list_display
+
+    def get_list_filter(self, request):
+        """Return the list of filters for the list view."""
+        return self.list_filter
+
+    def get_search_fields(self, request):
+        """Return the list of fields to search."""
+        return self.search_fields
+
+    def get_fields(self, request, obj=None):
+        """Return the fields to display in the detail form."""
+        if self.fields:
+            return self.fields
+
+        # Auto-generate from model
+        return [f.name for f in self.opts.get_fields() if f.editable and not f.auto_created]
+
+    def get_readonly_fields(self, request, obj=None):
+        """Return the list of readonly fields."""
+        return self.readonly_fields
+
+    def get_exclude(self, request, obj=None):
+        """Return the list of excluded fields."""
+        return self.exclude or ()
+
+    def get_form(self, request, obj=None, **kwargs):
+        """Return the form class for the detail view."""
+        if self.form:
+            return self.form
+
+        # Generate form from model
+        fields = self.get_fields(request, obj)
+        exclude = self.get_exclude(request, obj)
+
+        return modelform_factory(
+            self.model,
+            fields=fields,
+            exclude=exclude,
+        )
+
+    def get_fieldsets(self, request, obj=None):
+        """Return fieldsets for the detail form."""
+        if self.fieldsets:
+            return self.fieldsets
+
+        # Default: single fieldset with all fields
+        return [(None, {"fields": self.get_fields(request, obj)})]
+
+    def get_actions(self, request):
+        """Return the list of available actions."""
+        actions = {}
+
+        for action_name in self.actions:
+            if callable(action_name):
+                func = action_name
+                name = action_name.__name__
+            else:
+                func = getattr(self, action_name, None)
+                name = action_name
+
+            if func:
+                actions[name] = {
+                    "func": func,
+                    "description": getattr(
+                        func, "short_description", name.replace("_", " ").title()
+                    ),
+                }
+
+        return actions
+
+    def delete_selected(self, request, queryset):
+        """Default action: delete selected objects."""
+        count = queryset.count()
+        queryset.delete()
+        return f"Successfully deleted {count} items."
+
+    delete_selected.short_description = "Delete selected items"
+
+    # Field value rendering
+    def get_field_value(self, obj, field_name):
+        """Get the display value for a field."""
+        if field_name == "__str__":
+            return str(obj)
+
+        # Check for custom method
+        if hasattr(self, field_name):
+            method = getattr(self, field_name)
+            if callable(method):
+                return method(obj)
+
+        # Check for model attribute
+        if hasattr(obj, field_name):
+            value = getattr(obj, field_name)
+
+            # Handle callables (methods)
+            if callable(value):
+                value = value()
+
+            # Handle foreign keys
+            if isinstance(value, models.Model):
+                return str(value)
+
+            # Handle booleans
+            if isinstance(value, bool):
+                return "Yes" if value else "No"
+
+            # Handle None
+            if value is None:
+                return "-"
+
+            return value
+
+        return "-"
+
+    def get_field_display_name(self, field_name):
+        """Get the display name for a field column."""
+        if field_name == "__str__":
+            return self.opts.verbose_name.title()
+
+        # Check for custom method with short_description
+        if hasattr(self, field_name):
+            method = getattr(self, field_name)
+            if hasattr(method, "short_description"):
+                return method.short_description
+
+        # Try to get from model field
+        try:
+            field = self.opts.get_field(field_name)
+            return field.verbose_name.title()
+        except Exception:
+            return field_name.replace("_", " ").title()

--- a/python/djust/admin_ext/plugins.py
+++ b/python/djust/admin_ext/plugins.py
@@ -1,0 +1,185 @@
+"""
+Plugin system for djust admin_ext.
+
+Provides extension points for packages to hook into the admin interface:
+- AdminPlugin: Groups pages, widgets, and nav items for a package
+- AdminPage: Custom LiveView page inside admin chrome
+- AdminWidget: Dashboard card on admin index
+- NavItem: Sidebar navigation entry
+
+Example usage (in your_package/djust_admin.py):
+
+    from djust.admin_ext import site
+    from djust.admin_ext.plugins import AdminPlugin, AdminPage, AdminWidget
+
+    class MyWidget(AdminWidget):
+        widget_id = "my_stats"
+        label = "My Stats"
+        template_name = "my_package/admin/widgets/stats.html"
+
+        def get_context(self, request):
+            return {"count": 42}
+
+    class MyPlugin(AdminPlugin):
+        name = "my_package"
+        verbose_name = "My Package"
+
+        def get_widgets(self):
+            return [MyWidget()]
+
+    site.register_plugin(MyPlugin)
+"""
+
+
+class NavItem:
+    """Sidebar navigation entry."""
+
+    def __init__(
+        self,
+        label,
+        url_name,
+        icon=None,
+        order=0,
+        section=None,
+        permission=None,
+    ):
+        self.label = label
+        self.url_name = url_name
+        self.icon = icon
+        self.order = order
+        self.section = section
+        self.permission = permission
+
+    def has_permission(self, request):
+        """Check if the user has permission to see this nav item."""
+        if self.permission is None:
+            return True
+        return request.user.has_perm(self.permission)
+
+    def __repr__(self):
+        return f"NavItem(label={self.label!r}, url_name={self.url_name!r})"
+
+
+class AdminPage:
+    """
+    Custom LiveView page within admin chrome.
+
+    Auto-generates a NavItem unless show_in_nav=False.
+    """
+
+    def __init__(
+        self,
+        url_path,
+        url_name,
+        view_class,
+        label=None,
+        icon=None,
+        nav_section=None,
+        nav_order=0,
+        permission=None,
+        show_in_nav=True,
+    ):
+        self.url_path = url_path.strip("/")
+        self.url_name = url_name
+        self.view_class = view_class
+        self.label = label or url_name.replace("_", " ").title()
+        self.icon = icon
+        self.nav_section = nav_section
+        self.nav_order = nav_order
+        self.permission = permission
+        self.show_in_nav = show_in_nav
+
+    def get_nav_item(self):
+        """Generate a NavItem for this page."""
+        if not self.show_in_nav:
+            return None
+        return NavItem(
+            label=self.label,
+            url_name=self.url_name,
+            icon=self.icon,
+            order=self.nav_order,
+            section=self.nav_section,
+            permission=self.permission,
+        )
+
+    def __repr__(self):
+        return f"AdminPage(url_path={self.url_path!r}, url_name={self.url_name!r})"
+
+
+class AdminWidget:
+    """
+    Dashboard widget on admin index.
+
+    Subclass and override get_context() to provide data for your template.
+    """
+
+    widget_id = None
+    label = ""
+    template_name = None
+    order = 0
+    size = "md"  # "sm", "md", or "lg"
+    permission = None
+
+    def get_context(self, request):
+        """Return context dict for the widget template. Override in subclasses."""
+        return {}
+
+    def has_permission(self, request):
+        """Check if the user has permission to see this widget."""
+        if self.permission is None:
+            return True
+        return request.user.has_perm(self.permission)
+
+    def render(self, request):
+        """Render the widget to HTML using Django's template engine."""
+        from django.template.loader import render_to_string
+
+        if not self.template_name:
+            return ""
+        context = self.get_context(request)
+        context["widget"] = self
+        return render_to_string(self.template_name, context, request=request)
+
+    def __repr__(self):
+        return f"AdminWidget(widget_id={self.widget_id!r}, label={self.label!r})"
+
+
+class AdminPlugin:
+    """
+    Base class for admin extensions. One per package.
+
+    Subclass and implement get_pages(), get_widgets() to hook into admin.
+    Register via site.register_plugin(MyPlugin).
+    """
+
+    name = None  # Unique identifier (required)
+    verbose_name = None  # Human-readable name
+
+    def get_pages(self):
+        """Return list of AdminPage instances. Override in subclasses."""
+        return []
+
+    def get_widgets(self):
+        """Return list of AdminWidget instances. Override in subclasses."""
+        return []
+
+    def get_nav_items(self):
+        """
+        Return list of NavItem instances for the sidebar.
+
+        By default, auto-generates NavItems from pages that have show_in_nav=True.
+        Override for custom nav items.
+        """
+        items = []
+        for page in self.get_pages():
+            nav_item = page.get_nav_item()
+            if nav_item is not None:
+                items.append(nav_item)
+        return items
+
+    def ready(self):
+        """Called when the plugin is registered. Override for setup logic."""
+        pass
+
+    def __repr__(self):
+        return f"AdminPlugin(name={self.name!r})"

--- a/python/djust/admin_ext/sites.py
+++ b/python/djust/admin_ext/sites.py
@@ -1,0 +1,325 @@
+"""
+DjustAdminSite - The main admin site class.
+
+Manages both model registrations (CRUD) and plugin registrations (extensions).
+Similar to Django's AdminSite but renders using djust LiveViews
+for reactive, real-time admin interfaces.
+"""
+
+from django.apps import apps
+from django.urls import path, reverse
+
+
+class DjustAdminSite:
+    """
+    A reactive admin site powered by djust.
+
+    Supports two registration systems:
+    - Model registration: register(Model, ModelAdmin) for CRUD
+    - Plugin registration: register_plugin(PluginClass) for extensions
+
+    Usage:
+        from djust.admin_ext import DjustAdminSite, DjustModelAdmin
+
+        admin_site = DjustAdminSite(name='djust_admin')
+
+        @admin_site.register(MyModel)
+        class MyModelAdmin(DjustModelAdmin):
+            list_display = ['name', 'created_at']
+    """
+
+    site_header = "djust administration"
+    site_title = "djust admin"
+    index_title = "Dashboard"
+
+    def __init__(self, name="djust_admin"):
+        self.name = name
+        self._registry = {}  # model -> DjustModelAdmin
+        self._plugins = {}  # name -> AdminPlugin instance
+
+    # ---- Model registration (ported API) ----
+
+    def register(self, model_or_iterable, admin_class=None, **options):
+        """
+        Register a model with the admin site.
+
+        Can be used as a decorator:
+            @admin_site.register(MyModel)
+            class MyModelAdmin(DjustModelAdmin):
+                pass
+
+        Or called directly:
+            admin_site.register(MyModel, MyModelAdmin)
+        """
+
+        def _model_admin_wrapper(admin_cls):
+            if isinstance(model_or_iterable, (list, tuple)):
+                models = model_or_iterable
+            else:
+                models = [model_or_iterable]
+
+            for model in models:
+                if model in self._registry:
+                    raise ValueError(f"Model {model.__name__} is already registered")
+                self._registry[model] = admin_cls(model, self)
+            return admin_cls
+
+        if admin_class is not None:
+            return _model_admin_wrapper(admin_class)
+
+        return _model_admin_wrapper
+
+    def unregister(self, model_or_iterable):
+        """Unregister a model from the admin site."""
+        if isinstance(model_or_iterable, type):
+            model_or_iterable = [model_or_iterable]
+
+        for model in model_or_iterable:
+            if model not in self._registry:
+                raise ValueError(f"Model {model.__name__} is not registered")
+            del self._registry[model]
+
+    def is_registered(self, model):
+        """Check if a model is registered with this site."""
+        return model in self._registry
+
+    # ---- Plugin registration (NEW) ----
+
+    def register_plugin(self, plugin_class_or_instance):
+        """
+        Register a plugin with the admin site.
+
+        Accepts a class (instantiated automatically) or an instance.
+
+            site.register_plugin(AuthAdminPlugin)
+            # or
+            site.register_plugin(AuthAdminPlugin())
+        """
+        if isinstance(plugin_class_or_instance, type):
+            plugin = plugin_class_or_instance()
+        else:
+            plugin = plugin_class_or_instance
+
+        if not plugin.name:
+            raise ValueError(f"Plugin {plugin.__class__.__name__} must have a 'name' attribute")
+
+        if plugin.name in self._plugins:
+            raise ValueError(f"Plugin '{plugin.name}' is already registered")
+
+        self._plugins[plugin.name] = plugin
+        plugin.ready()
+
+    def unregister_plugin(self, name):
+        """Unregister a plugin by name."""
+        if name not in self._plugins:
+            raise ValueError(f"Plugin '{name}' is not registered")
+        del self._plugins[name]
+
+    def get_plugin(self, name):
+        """Get a registered plugin by name."""
+        return self._plugins.get(name)
+
+    # ---- URL generation ----
+
+    def get_urls(self):
+        """Return URL patterns for the admin site (models + plugins)."""
+        from .views import (
+            AdminIndexView,
+            LoginView,
+            LogoutView,
+            ModelCreateView,
+            ModelDeleteView,
+            ModelDetailView,
+            ModelListView,
+            register_admin_view,
+        )
+
+        # Register login/logout views
+        login_id = f"{self.name}_login"
+        logout_id = f"{self.name}_logout"
+        register_admin_view(login_id, admin_site=self)
+        register_admin_view(logout_id, admin_site=self)
+
+        # Register index view
+        index_id = f"{self.name}_index"
+        register_admin_view(index_id, admin_site=self)
+        urlpatterns = [
+            path("login/", LoginView.as_view(_view_registry_id=login_id), name="login"),
+            path("logout/", LogoutView.as_view(_view_registry_id=logout_id), name="logout"),
+            path("", AdminIndexView.as_view(_view_registry_id=index_id), name="index"),
+        ]
+
+        # Add URLs for each registered model
+        for model, model_admin in self._registry.items():
+            info = (model._meta.app_label, model._meta.model_name)
+            base_id = f"{self.name}_{model._meta.app_label}_{model._meta.model_name}"
+
+            list_id = f"{base_id}_list"
+            add_id = f"{base_id}_add"
+            change_id = f"{base_id}_change"
+            delete_id = f"{base_id}_delete"
+
+            register_admin_view(list_id, admin_site=self, model=model, model_admin=model_admin)
+            register_admin_view(add_id, admin_site=self, model=model, model_admin=model_admin)
+            register_admin_view(change_id, admin_site=self, model=model, model_admin=model_admin)
+            register_admin_view(delete_id, admin_site=self, model=model, model_admin=model_admin)
+
+            urlpatterns += [
+                path(
+                    f"{model._meta.app_label}/{model._meta.model_name}/",
+                    ModelListView.as_view(_view_registry_id=list_id),
+                    name="%s_%s_changelist" % info,
+                ),
+                path(
+                    f"{model._meta.app_label}/{model._meta.model_name}/add/",
+                    ModelCreateView.as_view(_view_registry_id=add_id),
+                    name="%s_%s_add" % info,
+                ),
+                path(
+                    f"{model._meta.app_label}/{model._meta.model_name}/<path:object_id>/change/",
+                    ModelDetailView.as_view(_view_registry_id=change_id),
+                    name="%s_%s_change" % info,
+                ),
+                path(
+                    f"{model._meta.app_label}/{model._meta.model_name}/<path:object_id>/delete/",
+                    ModelDeleteView.as_view(_view_registry_id=delete_id),
+                    name="%s_%s_delete" % info,
+                ),
+            ]
+
+        # Add URLs for plugin pages
+        for plugin_name, plugin in self._plugins.items():
+            for page in plugin.get_pages():
+                page_view_id = f"{self.name}_plugin_{page.url_name}"
+                register_admin_view(page_view_id, admin_site=self)
+
+                # Wrap the plugin page view with admin chrome
+                view_class = page.view_class
+                urlpatterns.append(
+                    path(
+                        f"{page.url_path}/",
+                        view_class.as_view(_view_registry_id=page_view_id),
+                        name=page.url_name,
+                    ),
+                )
+
+        return urlpatterns
+
+    @property
+    def urls(self):
+        """Return (urlpatterns, app_name, namespace) tuple."""
+        return self.get_urls(), "djust_admin", self.name
+
+    # ---- Navigation data ----
+
+    def get_app_list(self, request):
+        """Return a sorted list of all installed apps with their models."""
+        app_dict = {}
+
+        for model, model_admin in self._registry.items():
+            app_label = model._meta.app_label
+
+            if app_label not in app_dict:
+                app_config = apps.get_app_config(app_label)
+                app_dict[app_label] = {
+                    "name": app_config.verbose_name,
+                    "app_label": app_label,
+                    "models": [],
+                }
+
+            info = (app_label, model._meta.model_name)
+            app_dict[app_label]["models"].append(
+                {
+                    "name": model._meta.verbose_name_plural,
+                    "object_name": model._meta.object_name,
+                    "model": model,
+                    "admin_url": reverse(
+                        f"{self.name}:%s_%s_changelist" % info,
+                        current_app=self.name,
+                    ),
+                    "add_url": reverse(
+                        f"{self.name}:%s_%s_add" % info,
+                        current_app=self.name,
+                    ),
+                }
+            )
+
+        app_list = sorted(app_dict.values(), key=lambda x: x["name"])
+        for app in app_list:
+            app["models"].sort(key=lambda x: x["name"])
+
+        return app_list
+
+    def get_plugin_nav(self, request):
+        """
+        Return plugin nav items grouped by section.
+
+        Returns a list of dicts:
+        [
+            {"section": "Authentication", "items": [{"label": ..., "url": ...}, ...]},
+            ...
+        ]
+        """
+        sections = {}
+
+        for plugin_name, plugin in self._plugins.items():
+            for nav_item in plugin.get_nav_items():
+                if not nav_item.has_permission(request):
+                    continue
+
+                section_name = str(nav_item.section or plugin.verbose_name or plugin.name)
+                if section_name not in sections:
+                    sections[section_name] = []
+
+                try:
+                    url = reverse(
+                        f"{self.name}:{nav_item.url_name}",
+                        current_app=self.name,
+                    )
+                except Exception:
+                    url = "#"
+
+                sections[section_name].append(
+                    {
+                        "label": str(nav_item.label),
+                        "url": str(url),
+                        "icon": str(nav_item.icon),
+                        "order": nav_item.order,
+                    }
+                )
+
+        # Sort items within each section and build result
+        result = []
+        for section_name in sorted(sections.keys()):
+            items = sorted(sections[section_name], key=lambda x: x["order"])
+            result.append({"section": section_name, "items": items})
+
+        return result
+
+    def get_widgets(self, request):
+        """
+        Collect and render all widgets from registered plugins.
+
+        Returns a list of dicts with pre-rendered HTML:
+        [{"widget_id": ..., "label": ..., "html": ..., "size": ..., "order": ...}, ...]
+        """
+        widgets = []
+
+        for plugin_name, plugin in self._plugins.items():
+            for widget in plugin.get_widgets():
+                if not widget.has_permission(request):
+                    continue
+
+                html = widget.render(request)
+                widgets.append(
+                    {
+                        "widget_id": widget.widget_id,
+                        "label": widget.label,
+                        "html": html,
+                        "size": widget.size,
+                        "order": widget.order,
+                    }
+                )
+
+        widgets.sort(key=lambda w: w["order"])
+        return widgets

--- a/python/djust/admin_ext/templates/djust_admin/base.html
+++ b/python/djust/admin_ext/templates/djust_admin/base.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ title }} | {{ site_title }}{% endblock %}</title>
+
+    <!-- Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+
+    <style>
+        [x-cloak] { display: none !important; }
+    </style>
+
+    {% block extra_head %}{% endblock %}
+</head>
+<body class="bg-gray-100 min-h-screen" data-djust-root>
+    <!-- Sidebar -->
+    <aside class="fixed inset-y-0 left-0 w-64 bg-gray-900 text-white overflow-y-auto">
+        <!-- Header -->
+        <div class="h-16 flex items-center px-6 border-b border-gray-800">
+            <h1 class="text-lg font-semibold">{{ site_header }}</h1>
+        </div>
+
+        <!-- Navigation -->
+        <nav class="mt-6 px-4">
+            <!-- Model navigation (grouped by app) -->
+            {% for app in app_list %}
+            <div class="mb-6">
+                <h3 class="px-2 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                    {{ app.name }}
+                </h3>
+                <ul class="mt-2 space-y-1">
+                    {% for model in app.models %}
+                    <li>
+                        <a href="{{ model.admin_url }}"
+                           class="flex items-center px-2 py-2 text-sm font-medium rounded-md
+                                  {% if request.path == model.admin_url %}
+                                  bg-gray-800 text-white
+                                  {% else %}
+                                  text-gray-300 hover:bg-gray-800 hover:text-white
+                                  {% endif %}">
+                            {{ model.name }}
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endfor %}
+
+            <!-- Plugin navigation (grouped by section) -->
+            {% for section in plugin_nav %}
+            <div class="mb-6">
+                <h3 class="px-2 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                    {{ section.section }}
+                </h3>
+                <ul class="mt-2 space-y-1">
+                    {% for item in section.items %}
+                    <li>
+                        <a href="{{ item.url }}"
+                           class="flex items-center px-2 py-2 text-sm font-medium rounded-md text-gray-300 hover:bg-gray-800 hover:text-white">
+                            {% if item.icon %}
+                            <span class="mr-2">{{ item.icon|safe }}</span>
+                            {% endif %}
+                            {{ item.label }}
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endfor %}
+        </nav>
+    </aside>
+
+    <!-- Main content -->
+    <div class="pl-64">
+        <!-- Top bar -->
+        <header class="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-6">
+            <div class="flex items-center space-x-4">
+                {% block breadcrumbs %}
+                <nav class="text-sm">
+                    <a href="{% url admin_site_name|add:':index' %}" class="text-gray-500 hover:text-gray-700">Home</a>
+                    {% block breadcrumb_items %}{% endblock %}
+                </nav>
+                {% endblock %}
+            </div>
+            <div class="flex items-center space-x-4">
+                {% if is_authenticated %}
+                <span class="text-sm text-gray-600">{{ username }}</span>
+                <a href="{% url admin_site_name|add:':logout' %}"
+                   class="text-sm text-gray-500 hover:text-gray-700">
+                    Log out
+                </a>
+                {% endif %}
+            </div>
+        </header>
+
+        <!-- Page content -->
+        <main class="p-6">
+            {% block content %}{% endblock %}
+        </main>
+    </div>
+
+    {% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/python/djust/admin_ext/templates/djust_admin/base.html
+++ b/python/djust/admin_ext/templates/djust_admin/base.html
@@ -79,7 +79,7 @@
             <div class="flex items-center space-x-4">
                 {% block breadcrumbs %}
                 <nav class="text-sm">
-                    <a href="{% url admin_site_name|add:':index' %}" class="text-gray-500 hover:text-gray-700">Home</a>
+                    <a href="{% url admin_site_name|concat:':index' %}" class="text-gray-500 hover:text-gray-700">Home</a>
                     {% block breadcrumb_items %}{% endblock %}
                 </nav>
                 {% endblock %}
@@ -87,7 +87,7 @@
             <div class="flex items-center space-x-4">
                 {% if is_authenticated %}
                 <span class="text-sm text-gray-600">{{ username }}</span>
-                <a href="{% url admin_site_name|add:':logout' %}"
+                <a href="{% url admin_site_name|concat:':logout' %}"
                    class="text-sm text-gray-500 hover:text-gray-700">
                     Log out
                 </a>

--- a/python/djust/admin_ext/templates/djust_admin/index.html
+++ b/python/djust/admin_ext/templates/djust_admin/index.html
@@ -1,0 +1,58 @@
+{% extends "djust_admin/base.html" %}
+
+{% block content %}
+<div class="max-w-7xl mx-auto">
+    <h1 class="text-2xl font-bold text-gray-900 mb-8">{{ title }}</h1>
+
+    <!-- Widget grid (from plugins) -->
+    {% if has_widgets %}
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+        {% for widget in widgets %}
+        <div class="bg-white rounded-lg shadow overflow-hidden
+                    {% if widget.size == 'lg' %}md:col-span-2 lg:col-span-2
+                    {% elif widget.size == 'sm' %}
+                    {% endif %}">
+            {% if widget.label %}
+            <div class="px-4 py-3 border-b border-gray-200">
+                <h3 class="text-sm font-medium text-gray-900">{{ widget.label }}</h3>
+            </div>
+            {% endif %}
+            <div class="p-4">
+                {{ widget.html|safe }}
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    <!-- Model listing (grouped by app) -->
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {% for app in app_list %}
+        <div class="bg-white rounded-lg shadow overflow-hidden">
+            <div class="bg-gray-800 px-4 py-3">
+                <h2 class="text-lg font-medium text-white">{{ app.name }}</h2>
+            </div>
+            <ul class="divide-y divide-gray-200">
+                {% for model in app.models %}
+                <li class="px-4 py-3 hover:bg-gray-50">
+                    <div class="flex items-center justify-between">
+                        <a href="{{ model.admin_url }}" class="text-sm font-medium text-indigo-600 hover:text-indigo-500">
+                            {{ model.name }}
+                        </a>
+                        <a href="{{ model.add_url }}"
+                           class="inline-flex items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded text-indigo-700 bg-indigo-100 hover:bg-indigo-200">
+                            + Add
+                        </a>
+                    </div>
+                </li>
+                {% endfor %}
+            </ul>
+        </div>
+        {% empty %}
+        <div class="col-span-full text-center py-12">
+            <p class="text-gray-500">No models registered yet.</p>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}

--- a/python/djust/admin_ext/templates/djust_admin/login.html
+++ b/python/djust/admin_ext/templates/djust_admin/login.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Log in | {{ site_title }}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+    window.addEventListener('djust:push_event', function(e) {
+        if (e.detail && e.detail.event === 'redirect') {
+            window.location.href = e.detail.payload.url;
+        }
+    });
+    </script>
+</head>
+<body class="min-h-screen bg-gray-100 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+<div data-djust-root>
+
+    <div class="max-w-md w-full space-y-8">
+        <div>
+            <h2 class="mt-6 text-center text-3xl font-extrabold text-gray-900">
+                {{ site_header }}
+            </h2>
+            <p class="mt-2 text-center text-sm text-gray-600">
+                Sign in to your account
+            </p>
+        </div>
+
+        <div class="bg-white py-8 px-4 shadow rounded-lg sm:px-10">
+            <!-- Error message -->
+            {% if error %}
+            <div class="mb-4 rounded-md bg-red-50 p-4">
+                <div class="flex">
+                    <div class="flex-shrink-0">
+                        <svg class="h-5 w-5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
+                            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+                        </svg>
+                    </div>
+                    <div class="ml-3">
+                        <p class="text-sm font-medium text-red-800">{{ error }}</p>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
+
+            <div class="space-y-6">
+                <div>
+                    <label for="username" class="block text-sm font-medium text-gray-700">
+                        Username
+                    </label>
+                    <div class="mt-1">
+                        <input id="username"
+                               name="username"
+                               type="text"
+                               autocomplete="username"
+                               required
+                               value="{{ username }}"
+                               dj-input="update_username"
+                               dj-keydown.enter="do_login"
+                               class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+                    </div>
+                </div>
+
+                <div>
+                    <label for="password" class="block text-sm font-medium text-gray-700">
+                        Password
+                    </label>
+                    <div class="mt-1">
+                        <input id="password"
+                               name="password"
+                               type="password"
+                               autocomplete="current-password"
+                               required
+                               dj-input="update_password"
+                               dj-keydown.enter="do_login"
+                               class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+                    </div>
+                </div>
+
+                <div>
+                    <button type="button"
+                            dj-click="do_login"
+                            class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                        Sign in
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/python/djust/admin_ext/templates/djust_admin/logout.html
+++ b/python/djust/admin_ext/templates/djust_admin/logout.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Logged out | {{ site_title }}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-gray-100 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+
+    <div class="max-w-md w-full space-y-8">
+        <div>
+            <h2 class="mt-6 text-center text-3xl font-extrabold text-gray-900">
+                {{ site_header }}
+            </h2>
+        </div>
+
+        <div class="bg-white py-8 px-4 shadow rounded-lg sm:px-10 text-center">
+            <div class="mb-4">
+                <svg class="mx-auto h-12 w-12 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+            </div>
+            <h3 class="text-lg font-medium text-gray-900 mb-2">
+                Logged out successfully
+            </h3>
+            <p class="text-sm text-gray-600 mb-6">
+                You have been logged out of the admin site.
+            </p>
+            <a href="{{ login_url }}"
+               class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                Log in again
+            </a>
+        </div>
+    </div>
+</body>
+</html>

--- a/python/djust/admin_ext/templates/djust_admin/model_delete.html
+++ b/python/djust/admin_ext/templates/djust_admin/model_delete.html
@@ -1,0 +1,67 @@
+{% extends "djust_admin/base.html" %}
+{% load djust_admin_tags %}
+
+{% block breadcrumb_items %}
+<span class="mx-2 text-gray-400">/</span>
+<a href="{% url admin_site_name|add:':'|add:opts.app_label|add:'_'|add:opts.model_name|add:'_changelist' %}"
+   class="text-gray-500 hover:text-gray-700">{{ opts.verbose_name_plural|title }}</a>
+<span class="mx-2 text-gray-400">/</span>
+<span class="text-gray-700">Delete</span>
+{% endblock %}
+
+{% block content %}
+<!-- Redirect after deletion -->
+{% if redirect_url %}
+<script>window.location.href = "{{ redirect_url }}";</script>
+{% endif %}
+
+<div class="max-w-2xl mx-auto">
+    <div class="bg-white shadow rounded-lg overflow-hidden">
+        <div class="px-4 py-5 sm:p-6">
+            <div class="flex items-center">
+                <div class="flex-shrink-0">
+                    <svg class="h-12 w-12 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+                    </svg>
+                </div>
+                <div class="ml-4">
+                    <h3 class="text-lg leading-6 font-medium text-gray-900">
+                        Delete {{ opts.verbose_name }}
+                    </h3>
+                    <p class="mt-1 text-sm text-gray-500">
+                        Are you sure you want to delete "{{ object_str }}"?
+                    </p>
+                </div>
+            </div>
+
+            <div class="mt-6">
+                <p class="text-sm text-gray-500">
+                    This action cannot be undone. This will permanently delete the {{ opts.verbose_name }}
+                    and all related data.
+                </p>
+            </div>
+        </div>
+
+        <div class="px-4 py-3 bg-gray-50 border-t border-gray-200 flex items-center justify-end space-x-3">
+            <a href="{{ list_url }}"
+               class="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                Cancel
+            </a>
+            <button type="button"
+                    dj-click="confirm_delete()"
+                    class="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+                    {% if is_deleting %}disabled{% endif %}>
+                {% if is_deleting %}
+                <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+                Deleting...
+                {% else %}
+                Yes, delete
+                {% endif %}
+            </button>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/python/djust/admin_ext/templates/djust_admin/model_delete.html
+++ b/python/djust/admin_ext/templates/djust_admin/model_delete.html
@@ -3,7 +3,7 @@
 
 {% block breadcrumb_items %}
 <span class="mx-2 text-gray-400">/</span>
-<a href="{% url admin_site_name|add:':'|add:opts.app_label|add:'_'|add:opts.model_name|add:'_changelist' %}"
+<a href="{% url admin_site_name|concat:':'|concat:opts.app_label|concat:'_'|concat:opts.model_name|concat:'_changelist' %}"
    class="text-gray-500 hover:text-gray-700">{{ opts.verbose_name_plural|title }}</a>
 <span class="mx-2 text-gray-400">/</span>
 <span class="text-gray-700">Delete</span>

--- a/python/djust/admin_ext/templates/djust_admin/model_detail.html
+++ b/python/djust/admin_ext/templates/djust_admin/model_detail.html
@@ -1,0 +1,101 @@
+{% extends "djust_admin/base.html" %}
+
+{% block breadcrumb_items %}
+<span class="mx-2 text-gray-400">/</span>
+<a href="{% url admin_site_name|add:':'|add:opts.app_label|add:'_'|add:opts.model_name|add:'_changelist' %}"
+   class="text-gray-500 hover:text-gray-700">{{ opts.verbose_name_plural|title }}</a>
+<span class="mx-2 text-gray-400">/</span>
+<span class="text-gray-700">{% if object %}{{ object }}{% else %}Add{% endif %}</span>
+{% endblock %}
+
+{% block content %}
+<!-- Redirect on save -->
+{% if redirect_url %}
+<script>window.location.href = "{{ redirect_url }}";</script>
+{% endif %}
+
+<div class="max-w-4xl mx-auto">
+    <!-- Header -->
+    <div class="mb-6">
+        <h1 class="text-2xl font-bold text-gray-900">{{ title }}</h1>
+    </div>
+
+    <!-- Success message -->
+    {% if save_success %}
+    <div class="mb-4 rounded-md bg-green-50 p-4">
+        <div class="flex">
+            <div class="flex-shrink-0">
+                <svg class="h-5 w-5 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+                </svg>
+            </div>
+            <div class="ml-3">
+                <p class="text-sm font-medium text-green-800">
+                    Changes saved successfully.
+                </p>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Form -->
+    <div class="bg-white shadow rounded-lg">
+        {% for fieldset in fieldsets %}
+        <div class="{% if not forloop.first %}border-t border-gray-200{% endif %}">
+            {% if fieldset.name %}
+            <div class="px-4 py-3 bg-gray-50 border-b border-gray-200">
+                <h3 class="text-lg font-medium text-gray-900">{{ fieldset.name }}</h3>
+            </div>
+            {% endif %}
+
+            <div class="px-4 py-5 space-y-6 sm:p-6">
+                {% for field in fieldset.fields %}
+                <!-- Pre-rendered field HTML from as_live_field() -->
+                {{ field.html|safe }}
+                {% endfor %}
+            </div>
+        </div>
+        {% endfor %}
+
+        <!-- Action buttons -->
+        <div class="px-4 py-3 bg-gray-50 border-t border-gray-200 flex items-center justify-between rounded-b-lg">
+            <div>
+                {% if object_pk and has_delete_permission %}
+                <a href="{{ delete_url }}"
+                   class="text-red-600 hover:text-red-800 text-sm font-medium">
+                    Delete
+                </a>
+                {% endif %}
+            </div>
+            <div class="flex items-center space-x-3">
+                <button type="button"
+                        dj-click="save_and_add_another()"
+                        class="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                        {% if is_saving %}disabled{% endif %}>
+                    Save and add another
+                </button>
+                <button type="button"
+                        dj-click="save_and_continue()"
+                        class="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                        {% if is_saving %}disabled{% endif %}>
+                    Save and continue editing
+                </button>
+                <button type="button"
+                        dj-click="save()"
+                        class="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                        {% if is_saving %}disabled{% endif %}>
+                    {% if is_saving %}
+                    <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    Saving...
+                    {% else %}
+                    Save
+                    {% endif %}
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/python/djust/admin_ext/templates/djust_admin/model_detail.html
+++ b/python/djust/admin_ext/templates/djust_admin/model_detail.html
@@ -2,7 +2,7 @@
 
 {% block breadcrumb_items %}
 <span class="mx-2 text-gray-400">/</span>
-<a href="{% url admin_site_name|add:':'|add:opts.app_label|add:'_'|add:opts.model_name|add:'_changelist' %}"
+<a href="{% url admin_site_name|concat:':'|concat:opts.app_label|concat:'_'|concat:opts.model_name|concat:'_changelist' %}"
    class="text-gray-500 hover:text-gray-700">{{ opts.verbose_name_plural|title }}</a>
 <span class="mx-2 text-gray-400">/</span>
 <span class="text-gray-700">{% if object %}{{ object }}{% else %}Add{% endif %}</span>

--- a/python/djust/admin_ext/templates/djust_admin/model_list.html
+++ b/python/djust/admin_ext/templates/djust_admin/model_list.html
@@ -1,0 +1,220 @@
+{% extends "djust_admin/base.html" %}
+
+{% block breadcrumb_items %}
+<span class="mx-2 text-gray-400">/</span>
+<span class="text-gray-700">{{ opts.verbose_name_plural|title }}</span>
+{% endblock %}
+
+{% block content %}
+<div class="max-w-7xl mx-auto">
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+        <h1 class="text-2xl font-bold text-gray-900">{{ opts.verbose_name_plural|title }}</h1>
+        {% if has_add_permission %}
+        <a href="{{ add_url }}"
+           class="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700">
+            <svg class="-ml-1 mr-2 h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+            </svg>
+            Add {{ opts.verbose_name }}
+        </a>
+        {% endif %}
+    </div>
+
+    <div class="flex gap-6">
+        <!-- Main content area -->
+        <div class="{% if has_filters %}flex-1{% else %}w-full{% endif %}">
+            <!-- Toolbar -->
+            <div class="bg-white rounded-lg shadow mb-4">
+                <div class="px-4 py-3 border-b border-gray-200">
+                    <div class="flex items-center justify-between">
+                        <!-- Search -->
+                        <div class="flex-1 max-w-md">
+                            <div class="relative">
+                                <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                                    <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+                                    </svg>
+                                </div>
+                                <input type="text"
+                                       placeholder="Search..."
+                                       value="{{ search_query }}"
+                                       dj-input="search(value)"
+                                       class="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md leading-5 bg-white placeholder-gray-500 focus:outline-none focus:placeholder-gray-400 focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+                            </div>
+                        </div>
+
+                        <!-- Actions dropdown -->
+                        {% if selected_ids %}
+                        <div class="ml-4 flex items-center space-x-2">
+                            <span class="text-sm text-gray-600">{{ selected_ids|length }} selected</span>
+                            <select dj-change="run_action(value)"
+                                    class="block pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                <option value="">-- Select action --</option>
+                                {% for action in actions %}
+                                <option value="{{ action.name }}">{{ action.label }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        {% endif %}
+                    </div>
+                </div>
+
+                <!-- Table -->
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <!-- Select all checkbox -->
+                                <th scope="col" class="px-6 py-3 w-10">
+                                    <input type="checkbox"
+                                           {% if select_all %}checked{% endif %}
+                                           dj-click="toggle_select_all()"
+                                           class="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded">
+                                </th>
+                                {% for column in columns %}
+                                <th scope="col"
+                                    class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider
+                                           {% if column.sortable %}cursor-pointer hover:bg-gray-100{% endif %}"
+                                    {% if column.sortable %}dj-click="sort_by('{{ column.name }}')"{% endif %}>
+                                    <div class="flex items-center space-x-1">
+                                        <span>{{ column.label }}</span>
+                                        {% if column.sortable %}
+                                        <span class="text-gray-400">
+                                            {% if ordering == column.name %}
+                                            <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+                                                <path fill-rule="evenodd" d="M14.707 10.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L10 13.586l3.293-3.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+                                            </svg>
+                                            {% elif ordering == '-'|add:column.name %}
+                                            <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+                                                <path fill-rule="evenodd" d="M5.293 9.707a1 1 0 010-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 01-1.414 1.414L10 6.414l-3.293 3.293a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+                                            </svg>
+                                            {% else %}
+                                            <svg class="h-4 w-4 opacity-0 group-hover:opacity-100" fill="currentColor" viewBox="0 0 20 20">
+                                                <path d="M5 10a1 1 0 011-1h8a1 1 0 110 2H6a1 1 0 01-1-1z"/>
+                                            </svg>
+                                            {% endif %}
+                                        </span>
+                                        {% endif %}
+                                    </div>
+                                </th>
+                                {% endfor %}
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            {% for row in rows %}
+                            <tr class="hover:bg-gray-50 {% if row.selected %}bg-indigo-50{% endif %}">
+                                <td class="px-6 py-4 whitespace-nowrap">
+                                    <input type="checkbox"
+                                           {% if row.selected %}checked{% endif %}
+                                           dj-click="toggle_select({{ row.pk }})"
+                                           class="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded">
+                                </td>
+                                {% for value in row.values %}
+                                <td class="px-6 py-4 whitespace-nowrap text-sm {% if forloop.first %}font-medium text-gray-900{% else %}text-gray-500{% endif %}">
+                                    {% if forloop.first %}
+                                    <a href="{{ row.edit_url }}" class="text-indigo-600 hover:text-indigo-900">
+                                        {{ value }}
+                                    </a>
+                                    {% else %}
+                                    {{ value }}
+                                    {% endif %}
+                                </td>
+                                {% endfor %}
+                            </tr>
+                            {% empty %}
+                            <tr>
+                                <td colspan="{{ columns|length|add:1 }}" class="px-6 py-12 text-center text-gray-500">
+                                    {% if search_query %}
+                                    No results found for "{{ search_query }}"
+                                    {% else %}
+                                    No {{ opts.verbose_name_plural }} found.
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+
+                <!-- Pagination -->
+                {% if pagination.num_pages > 1 %}
+                <div class="bg-white px-4 py-3 border-t border-gray-200 sm:px-6">
+                    <div class="flex items-center justify-between">
+                        <div class="text-sm text-gray-700">
+                            Showing page
+                            <span class="font-medium">{{ pagination.number }}</span>
+                            of
+                            <span class="font-medium">{{ pagination.num_pages }}</span>
+                            ({{ pagination.count }} results)
+                        </div>
+                        <div class="flex space-x-2">
+                            {% if pagination.has_previous %}
+                            <button dj-click="go_to_page(1)"
+                                    class="px-3 py-1 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50">
+                                First
+                            </button>
+                            <button dj-click="go_to_page({{ pagination.previous_page_number }})"
+                                    class="px-3 py-1 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50">
+                                Previous
+                            </button>
+                            {% endif %}
+
+                            <span class="px-3 py-1 text-sm text-gray-700">
+                                Page {{ pagination.number }} of {{ pagination.num_pages }}
+                            </span>
+
+                            {% if pagination.has_next %}
+                            <button dj-click="go_to_page({{ pagination.next_page_number }})"
+                                    class="px-3 py-1 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50">
+                                Next
+                            </button>
+                            <button dj-click="go_to_page({{ pagination.num_pages }})"
+                                    class="px-3 py-1 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50">
+                                Last
+                            </button>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+                {% endif %}
+            </div>
+        </div>
+
+        <!-- Filter sidebar -->
+        {% if has_filters %}
+        <div class="w-64 flex-shrink-0">
+            <div class="bg-white rounded-lg shadow">
+                <div class="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+                    <h3 class="text-sm font-medium text-gray-900">Filters</h3>
+                    {% if active_filters %}
+                    <button dj-click="clear_filters()"
+                            class="text-xs text-indigo-600 hover:text-indigo-800">
+                        Clear all
+                    </button>
+                    {% endif %}
+                </div>
+                <div class="px-4 py-3 space-y-4">
+                    {% for filter in filters %}
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">
+                            {{ filter.label }}
+                        </label>
+                        <select dj-change="apply_filter('{{ filter.name }}', value)"
+                                class="block w-full pl-3 pr-10 py-2 text-sm border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 rounded-md">
+                            <option value="">All</option>
+                            {% for choice in filter.choices %}
+                            <option value="{{ choice.value }}" {% if filter.current_value == choice.value %}selected{% endif %}>
+                                {{ choice.label }}
+                            </option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/python/djust/admin_ext/templates/djust_admin/model_list.html
+++ b/python/djust/admin_ext/templates/djust_admin/model_list.html
@@ -85,7 +85,7 @@
                                             <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
                                                 <path fill-rule="evenodd" d="M14.707 10.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L10 13.586l3.293-3.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
                                             </svg>
-                                            {% elif ordering == '-'|add:column.name %}
+                                            {% elif ordering == '-'|concat:column.name %}
                                             <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
                                                 <path fill-rule="evenodd" d="M5.293 9.707a1 1 0 010-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 01-1.414 1.414L10 6.414l-3.293 3.293a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
                                             </svg>

--- a/python/djust/admin_ext/templatetags/djust_admin_tags.py
+++ b/python/djust/admin_ext/templatetags/djust_admin_tags.py
@@ -22,8 +22,8 @@ def get_field(form, field_name):
 
 
 @register.filter
-def add(value, arg):
-    """Concatenate strings."""
+def concat(value, arg):
+    """Concatenate two values as strings."""
     return str(value) + str(arg)
 
 

--- a/python/djust/admin_ext/templatetags/djust_admin_tags.py
+++ b/python/djust/admin_ext/templatetags/djust_admin_tags.py
@@ -1,0 +1,35 @@
+"""Template tags and filters for djust admin_ext."""
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def get_item(dictionary, key):
+    """Get an item from a dictionary by key."""
+    if dictionary is None:
+        return None
+    return dictionary.get(key)
+
+
+@register.filter
+def get_field(form, field_name):
+    """Get a field from a form by name."""
+    if form is None:
+        return None
+    return form[field_name] if field_name in form.fields else None
+
+
+@register.filter
+def add(value, arg):
+    """Concatenate strings."""
+    return str(value) + str(arg)
+
+
+@register.simple_tag
+def admin_url(admin_site_name, view_name, *args, **kwargs):
+    """Generate admin URL."""
+    from django.urls import reverse
+
+    return reverse(f"{admin_site_name}:{view_name}", args=args, kwargs=kwargs)

--- a/python/djust/admin_ext/views.py
+++ b/python/djust/admin_ext/views.py
@@ -1,0 +1,683 @@
+"""
+LiveView-based admin views for djust admin_ext.
+
+These views use djust's LiveView to provide reactive, real-time admin interfaces.
+Includes plugin-aware context (plugin_nav, widgets) for the admin shell.
+"""
+
+from functools import wraps
+
+from django.contrib.auth import authenticate, logout
+from django.core.paginator import Paginator
+from django.db.models import ForeignKey, OneToOneField, Q
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from djust import LiveView
+from djust.decorators import debounce, event_handler, state
+
+from .forms import AdminFormMixin
+
+# Global registry for admin view configurations
+# This avoids storing non-serializable objects on view instances
+_VIEW_REGISTRY = {}
+
+
+def register_admin_view(view_id, admin_site, model=None, model_admin=None):
+    """Register admin config for a view."""
+    _VIEW_REGISTRY[view_id] = {
+        "admin_site": admin_site,
+        "model": model,
+        "model_admin": model_admin,
+    }
+
+
+def get_admin_config(view_id):
+    """Get admin config for a view."""
+    return _VIEW_REGISTRY.get(view_id, {})
+
+
+def admin_login_required(view_func):
+    """
+    Decorator that checks if the user is authenticated and is staff.
+    Redirects to admin login if not.
+    """
+
+    @wraps(view_func)
+    def wrapped_view(request, *args, **kwargs):
+        if not request.user.is_authenticated or not request.user.is_staff:
+            admin_site_name = kwargs.get("admin_site_name", "djust_admin")
+            login_url = reverse(f"{admin_site_name}:login")
+            return HttpResponseRedirect(f"{login_url}?next={request.path}")
+        return view_func(request, *args, **kwargs)
+
+    return wrapped_view
+
+
+class AdminBaseMixin:
+    """Base mixin for all admin views. Provides admin chrome context."""
+
+    # View ID for registry lookup - set via as_view()
+    # Prefixed with underscore so LiveView's get_context_data() skips it
+    _view_registry_id = None
+
+    @classmethod
+    def as_view(cls, **initkwargs):
+        """Wrap the view with login required check."""
+        view = super().as_view(**initkwargs)
+        return admin_login_required(view)
+
+    @property
+    def _admin_site(self):
+        """Admin site from registry."""
+        config = get_admin_config(self._view_registry_id)
+        return config.get("admin_site")
+
+    @property
+    def _model(self):
+        """Model class from registry."""
+        config = get_admin_config(self._view_registry_id)
+        return config.get("model")
+
+    @property
+    def _model_admin(self):
+        """ModelAdmin from registry."""
+        config = get_admin_config(self._view_registry_id)
+        return config.get("model_admin")
+
+    def get_admin_context(self):
+        """Add common admin context (JSON serializable).
+
+        All string values are forced through str() to resolve Django's
+        lazy translation proxies (__proxy__), which are not JSON
+        serializable.
+        """
+        # Build a serializable app list
+        app_list = []
+        for app in self._admin_site.get_app_list(self.request):
+            app_data = {"name": str(app["name"]), "app_label": str(app["app_label"]), "models": []}
+            for model in app["models"]:
+                app_data["models"].append(
+                    {
+                        "name": str(model["name"]),
+                        "object_name": str(model["object_name"]),
+                        "admin_url": str(model["admin_url"]),
+                        "add_url": str(model["add_url"]),
+                    }
+                )
+            app_list.append(app_data)
+
+        # Build serializable opts
+        opts = None
+        if self._model:
+            opts = {
+                "verbose_name": str(self._model._meta.verbose_name),
+                "verbose_name_plural": str(self._model._meta.verbose_name_plural),
+                "app_label": str(self._model._meta.app_label),
+                "model_name": str(self._model._meta.model_name),
+            }
+
+        # Plugin navigation
+        plugin_nav = self._admin_site.get_plugin_nav(self.request)
+
+        return {
+            "site_header": str(self._admin_site.site_header),
+            "site_title": str(self._admin_site.site_title),
+            "app_list": app_list,
+            "plugin_nav": plugin_nav,
+            "opts": opts,
+            "admin_site_name": str(self._admin_site.name),
+            "username": self.request.user.username if self.request.user.is_authenticated else None,
+            "is_authenticated": self.request.user.is_authenticated,
+        }
+
+
+class AdminIndexView(AdminBaseMixin, LiveView):
+    """
+    Admin dashboard / index view.
+
+    Shows widgets from plugins + all registered apps and models.
+    """
+
+    template_name = "djust_admin/index.html"
+
+    def mount(self, request, **kwargs):
+        self.request = request
+
+    def get_context_data(self, **kwargs):
+        # Collect widgets from all plugins (pre-rendered HTML)
+        widgets = self._admin_site.get_widgets(self.request)
+
+        return {
+            **self.get_admin_context(),
+            "title": self._admin_site.index_title if self._admin_site else "Dashboard",
+            "widgets": widgets,
+            "has_widgets": len(widgets) > 0,
+        }
+
+
+class ModelListView(AdminBaseMixin, LiveView):
+    """
+    Model list view with real-time search, filtering, and bulk actions.
+    """
+
+    template_name = "djust_admin/model_list.html"
+
+    # Reactive state
+    search_query = state(default="")
+    current_page = state(default=1)
+    ordering = state(default=None)
+    selected_ids = state(default=[])
+    select_all = state(default=False)
+    active_filters = state(default={})
+
+    def mount(self, request, **kwargs):
+        self.request = request
+        self.selected_ids = []
+        self.select_all = False
+        self.active_filters = {}
+
+    def get_queryset(self):
+        """Get filtered and sorted queryset."""
+        qs = self._model_admin.get_queryset(self.request)
+
+        # Apply search
+        if self.search_query:
+            search_fields = self._model_admin.get_search_fields(self.request)
+            if search_fields:
+                q_objects = Q()
+                for field in search_fields:
+                    q_objects |= Q(**{f"{field}__icontains": self.search_query})
+                qs = qs.filter(q_objects)
+
+        # Apply active filters
+        for field_name, value in self.active_filters.items():
+            if value is not None and value != "":
+                if value == "true":
+                    qs = qs.filter(**{field_name: True})
+                elif value == "false":
+                    qs = qs.filter(**{field_name: False})
+                else:
+                    qs = qs.filter(**{field_name: value})
+
+        # Apply ordering
+        if self.ordering:
+            qs = qs.order_by(self.ordering)
+
+        return qs
+
+    def get_page(self):
+        """Get the current page of results."""
+        qs = self.get_queryset()
+        paginator = Paginator(qs, self._model_admin.list_per_page)
+        return paginator.get_page(self.current_page)
+
+    def get_context_data(self, **kwargs):
+        page = self.get_page()
+        list_display = self._model_admin.get_list_display(self.request)
+
+        # Build column headers
+        columns = []
+        for field_name in list_display:
+            columns.append(
+                {
+                    "name": field_name,
+                    "label": self._model_admin.get_field_display_name(field_name),
+                    "sortable": field_name != "__str__",
+                }
+            )
+
+        # Build rows
+        rows = []
+        for obj in page:
+            row = {
+                "pk": obj.pk,
+                "selected": obj.pk in self.selected_ids,
+                "edit_url": reverse(
+                    f"{self._admin_site.name}:{self._model._meta.app_label}_{self._model._meta.model_name}_change",
+                    args=[obj.pk],
+                ),
+                "values": [],
+            }
+            for field_name in list_display:
+                row["values"].append(self._model_admin.get_field_value(obj, field_name))
+            rows.append(row)
+
+        # Serialize pagination data
+        pagination = {
+            "number": page.number,
+            "has_previous": page.has_previous(),
+            "has_next": page.has_next(),
+            "previous_page_number": page.previous_page_number() if page.has_previous() else None,
+            "next_page_number": page.next_page_number() if page.has_next() else None,
+            "num_pages": page.paginator.num_pages,
+            "count": page.paginator.count,
+            "page_range": list(page.paginator.page_range),
+        }
+
+        # Serialize actions
+        actions_raw = self._model_admin.get_actions(self.request)
+        actions = [
+            {"name": name, "label": info.get("label", name)} for name, info in actions_raw.items()
+        ]
+
+        # Build filter options
+        filters = []
+        list_filter = getattr(self._model_admin, "list_filter", [])
+        for filter_field in list_filter:
+            try:
+                field = self._model._meta.get_field(filter_field)
+                filter_data = {
+                    "name": filter_field,
+                    "label": field.verbose_name.title()
+                    if hasattr(field, "verbose_name")
+                    else filter_field.replace("_", " ").title(),
+                    "choices": [],
+                    "current_value": self.active_filters.get(filter_field, ""),
+                }
+
+                if (
+                    hasattr(field, "get_internal_type")
+                    and field.get_internal_type() == "BooleanField"
+                ):
+                    filter_data["choices"] = [
+                        {"value": "true", "label": "Yes"},
+                        {"value": "false", "label": "No"},
+                    ]
+                elif hasattr(field, "choices") and field.choices:
+                    filter_data["choices"] = [
+                        {"value": str(c[0]), "label": str(c[1])} for c in field.choices
+                    ]
+                elif isinstance(field, (ForeignKey, OneToOneField)):
+                    related_model = field.remote_field.model
+                    related_qs = related_model.objects.all()[:50]
+                    filter_data["choices"] = [
+                        {"value": str(obj.pk), "label": str(obj)} for obj in related_qs
+                    ]
+                else:
+                    distinct_values = (
+                        self.get_queryset().values_list(filter_field, flat=True).distinct()[:20]
+                    )
+                    filter_data["choices"] = [
+                        {"value": str(v), "label": str(v)} for v in distinct_values if v is not None
+                    ]
+
+                filters.append(filter_data)
+            except Exception:
+                pass
+
+        return {
+            **self.get_admin_context(),
+            "title": f"Select {self._model._meta.verbose_name} to change",
+            "columns": columns,
+            "rows": rows,
+            "pagination": pagination,
+            "search_query": self.search_query,
+            "ordering": self.ordering,
+            "selected_ids": self.selected_ids,
+            "select_all": self.select_all,
+            "active_filters": self.active_filters,
+            "filters": filters,
+            "has_filters": len(filters) > 0,
+            "actions": actions,
+            "add_url": reverse(
+                f"{self._admin_site.name}:{self._model._meta.app_label}_{self._model._meta.model_name}_add",
+            ),
+            "has_add_permission": self._model_admin.has_add_permission(self.request),
+        }
+
+    @event_handler
+    @debounce(300)
+    def search(self, query: str):
+        """Handle search input with debounce."""
+        self.search_query = query
+        self.current_page = 1
+        self.selected_ids = []
+        self.select_all = False
+
+    @event_handler
+    def sort_by(self, field: str):
+        """Handle column sorting."""
+        if self.ordering == field:
+            self.ordering = f"-{field}"
+        elif self.ordering == f"-{field}":
+            self.ordering = None
+        else:
+            self.ordering = field
+        self.current_page = 1
+
+    @event_handler
+    def go_to_page(self, page: int):
+        """Handle pagination."""
+        self.current_page = page
+        self.selected_ids = []
+        self.select_all = False
+
+    @event_handler
+    def toggle_select(self, pk: int):
+        """Toggle selection of a single row."""
+        if pk in self.selected_ids:
+            self.selected_ids = [x for x in self.selected_ids if x != pk]
+        else:
+            self.selected_ids = self.selected_ids + [pk]
+        self.select_all = False
+
+    @event_handler
+    def toggle_select_all(self):
+        """Toggle selection of all visible rows."""
+        if self.select_all:
+            self.selected_ids = []
+            self.select_all = False
+        else:
+            page = self.get_page()
+            self.selected_ids = [obj.pk for obj in page]
+            self.select_all = True
+
+    @event_handler
+    def run_action(self, action_name: str):
+        """Execute a bulk action on selected items."""
+        if not self.selected_ids:
+            return
+
+        actions = self._model_admin.get_actions(self.request)
+        if action_name not in actions:
+            return
+
+        queryset = self._model.objects.filter(pk__in=self.selected_ids)
+        action_func = actions[action_name]["func"]
+        result = action_func(self.request, queryset)
+
+        self.selected_ids = []
+        self.select_all = False
+        return result
+
+    @event_handler
+    def apply_filter(self, field: str, value: str):
+        """Apply a filter to the list."""
+        if value:
+            self.active_filters = {**self.active_filters, field: value}
+        else:
+            filters = dict(self.active_filters)
+            if field in filters:
+                del filters[field]
+            self.active_filters = filters
+
+        self.current_page = 1
+        self.selected_ids = []
+        self.select_all = False
+
+    @event_handler
+    def clear_filters(self):
+        """Clear all active filters."""
+        self.active_filters = {}
+        self.current_page = 1
+        self.selected_ids = []
+        self.select_all = False
+
+
+class ModelDetailView(AdminBaseMixin, AdminFormMixin, LiveView):
+    """
+    Model detail/edit view with real-time form validation.
+    """
+
+    template_name = "djust_admin/model_detail.html"
+
+    is_saving = state(default=False)
+    save_success = state(default=False)
+    redirect_url = state(default=None)
+
+    def mount(self, request, object_id=None, **kwargs):
+        super().mount(request, object_id=object_id, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        readonly_fields = self._model_admin.get_readonly_fields(self.request, self.object)
+
+        fieldsets_data = []
+        for fieldset_name, fieldset_options in self._model_admin.get_fieldsets(
+            self.request, self.object
+        ):
+            fields_data = []
+            for field_name in fieldset_options.get("fields", []):
+                if self.form_instance and field_name in self.form_instance.fields:
+                    field_info = self.get_field_info(field_name)
+                    is_readonly = field_name in readonly_fields
+
+                    field_html = self.as_live_field(
+                        field_name,
+                        framework="admin_tailwind",
+                        options=field_info.get("options", []),
+                        is_foreign_key=field_info.get("is_foreign_key", False),
+                        is_many_to_many=field_info.get("is_many_to_many", False),
+                        is_date=field_info.get("is_date", False),
+                        is_datetime=field_info.get("is_datetime", False),
+                        is_time=field_info.get("is_time", False),
+                        input_type=field_info.get("input_type"),
+                        readonly=is_readonly,
+                        render_label=True,
+                        render_errors=True,
+                        render_help_text=True,
+                    )
+
+                    fields_data.append(
+                        {
+                            "name": field_name,
+                            "html": field_html,
+                        }
+                    )
+
+            fieldsets_data.append(
+                {
+                    "name": fieldset_name,
+                    "fields": fields_data,
+                }
+            )
+
+        return {
+            **self.get_admin_context(),
+            "title": f"Change {self.object}"
+            if self.object
+            else f"Add {self._model._meta.verbose_name}",
+            "object": str(self.object) if self.object else None,
+            "object_pk": self.object.pk if self.object else None,
+            "is_saving": self.is_saving,
+            "save_success": self.save_success,
+            "fieldsets": fieldsets_data,
+            "has_delete_permission": self._model_admin.has_delete_permission(
+                self.request, self.object
+            ),
+            "delete_url": reverse(
+                f"{self._admin_site.name}:{self._model._meta.app_label}_{self._model._meta.model_name}_delete",
+                args=[self.object.pk],
+            )
+            if self.object
+            else None,
+        }
+
+    @event_handler
+    def update_field(self, field: str, value):
+        """Handle field value change."""
+        self.save_success = False
+        self.validate_field(field_name=field, value=value)
+
+    def form_valid(self, form):
+        self.object = form.save()
+        self.save_success = True
+
+    def form_invalid(self, form):
+        self.save_success = False
+
+    @event_handler
+    def save(self, redirect=True):
+        """Save the form."""
+        self.is_saving = True
+        self.save_success = False
+        self.redirect_url = None
+
+        self.submit_form()
+
+        if self.save_success and redirect:
+            self.redirect_url = reverse(
+                f"{self._admin_site.name}:{self._model._meta.app_label}_{self._model._meta.model_name}_changelist"
+            )
+
+        self.is_saving = False
+
+    @event_handler
+    def save_and_continue(self):
+        """Save and stay on the same page."""
+        self.save(redirect=False)
+
+    @event_handler
+    def save_and_add_another(self):
+        """Save and redirect to add another."""
+        self.save(redirect=False)
+        if self.save_success:
+            self.redirect_url = reverse(
+                f"{self._admin_site.name}:{self._model._meta.app_label}_{self._model._meta.model_name}_add"
+            )
+
+
+class ModelCreateView(ModelDetailView):
+    """Model create view - reuses detail view with no object."""
+
+    def mount(self, request, **kwargs):
+        super().mount(request, object_id=None, **kwargs)
+
+
+class ModelDeleteView(AdminBaseMixin, LiveView):
+    """Model delete confirmation view."""
+
+    template_name = "djust_admin/model_delete.html"
+
+    confirmed = state(default=False)
+    is_deleting = state(default=False)
+    redirect_url = state(default=None)
+
+    def mount(self, request, object_id=None, **kwargs):
+        self.request = request
+        self.object_id = object_id
+        self.object = self._model.objects.get(pk=object_id)
+        self.object_str = str(self.object)
+
+    def get_context_data(self, **kwargs):
+        return {
+            **self.get_admin_context(),
+            "title": f"Delete {self.object_str}",
+            "object_str": self.object_str,
+            "is_deleting": self.is_deleting,
+            "redirect_url": self.redirect_url,
+            "list_url": reverse(
+                f"{self._admin_site.name}:{self._model._meta.app_label}_{self._model._meta.model_name}_changelist",
+            ),
+        }
+
+    @event_handler
+    def confirm_delete(self):
+        """Confirm and execute deletion."""
+        self.is_deleting = True
+        self.object.delete()
+        self.redirect_url = reverse(
+            f"{self._admin_site.name}:{self._model._meta.app_label}_{self._model._meta.model_name}_changelist"
+        )
+        self.is_deleting = False
+
+
+class LoginView(LiveView):
+    """Admin login view."""
+
+    template_name = "djust_admin/login.html"
+
+    _view_registry_id = None
+
+    username = state(default="")
+    password = state(default="")
+    error = state(default="")
+
+    def mount(self, request, **kwargs):
+        self.request = request
+        self.next_url = request.GET.get("next", "")
+
+    @property
+    def _admin_site(self):
+        config = get_admin_config(self._view_registry_id)
+        return config.get("admin_site")
+
+    def get_context_data(self, **kwargs):
+        return {
+            "site_header": self._admin_site.site_header
+            if self._admin_site
+            else "djust administration",
+            "site_title": self._admin_site.site_title if self._admin_site else "djust admin",
+            "username": self.username,
+            "error": self.error,
+        }
+
+    @event_handler
+    def update_username(self, value: str, field: str = None):
+        self.username = value
+        self.error = ""
+
+    @event_handler
+    def update_password(self, value: str, field: str = None):
+        self.password = value
+        self.error = ""
+
+    @event_handler
+    def do_login(self, **kwargs):
+        """Attempt to log in the user."""
+        from django.contrib.auth import BACKEND_SESSION_KEY, HASH_SESSION_KEY, SESSION_KEY
+
+        if not self.username or not self.password:
+            self.error = "Please enter both username and password."
+            return
+
+        user = authenticate(self.request, username=self.username, password=self.password)
+
+        if user is not None:
+            if user.is_active and user.is_staff:
+                # Manual session login for WebSocket context
+                session = self.request.session
+                session[SESSION_KEY] = str(user.pk)
+                session[BACKEND_SESSION_KEY] = user.backend
+                session[HASH_SESSION_KEY] = user.get_session_auth_hash()
+                session.save()
+
+                if self.next_url:
+                    redirect_url = self.next_url
+                else:
+                    admin_name = self._admin_site.name if self._admin_site else "djust_admin"
+                    redirect_url = reverse(f"{admin_name}:index")
+                self.push_event("redirect", {"url": redirect_url})
+            else:
+                self.error = "Your account is not authorized to access the admin."
+        else:
+            self.error = "Invalid username or password."
+
+        self.password = ""
+
+
+class LogoutView(LiveView):
+    """Admin logout view."""
+
+    template_name = "djust_admin/logout.html"
+
+    _view_registry_id = None
+
+    def mount(self, request, **kwargs):
+        self.request = request
+        logout(request)
+
+    @property
+    def _admin_site(self):
+        config = get_admin_config(self._view_registry_id)
+        return config.get("admin_site")
+
+    def get_context_data(self, **kwargs):
+        return {
+            "site_header": self._admin_site.site_header
+            if self._admin_site
+            else "djust administration",
+            "site_title": self._admin_site.site_title if self._admin_site else "djust admin",
+            "login_url": reverse(f"{self._admin_site.name}:login")
+            if self._admin_site
+            else "/djust-admin/login/",
+        }

--- a/python/djust/tests/test_admin_basic.py
+++ b/python/djust/tests/test_admin_basic.py
@@ -1,0 +1,80 @@
+"""Basic tests for djust.admin_ext."""
+
+import pytest
+from django.test import TestCase
+
+from djust.admin_ext import (
+    AdminPage,
+    AdminPlugin,
+    AdminWidget,
+    DjustAdminSite,
+    DjustModelAdmin,
+    NavItem,
+    site,
+)
+
+pytestmark = pytest.mark.admin
+
+
+class TestDjustAdminSite(TestCase):
+    """Tests for DjustAdminSite."""
+
+    def test_default_site_exists(self):
+        """Default admin site should be available."""
+        assert site is not None
+        assert isinstance(site, DjustAdminSite)
+
+    def test_site_name(self):
+        """Site should have default name."""
+        assert site.name == "djust_admin"
+
+    def test_custom_site(self):
+        """Can create custom admin site."""
+        custom_site = DjustAdminSite(name="custom")
+        assert custom_site.name == "custom"
+
+    def test_site_headers(self):
+        """Site should have configurable headers."""
+        custom_site = DjustAdminSite()
+        custom_site.site_header = "Custom Header"
+        custom_site.site_title = "Custom Title"
+        assert custom_site.site_header == "Custom Header"
+        assert custom_site.site_title == "Custom Title"
+
+    def test_site_has_plugins_registry(self):
+        """Site should have a plugins registry."""
+        custom_site = DjustAdminSite()
+        assert hasattr(custom_site, "_plugins")
+        assert custom_site._plugins == {}
+
+
+class TestDjustModelAdmin(TestCase):
+    """Tests for DjustModelAdmin."""
+
+    def test_default_list_display(self):
+        """Default list_display should be __str__."""
+        assert DjustModelAdmin.list_display == ["__str__"]
+
+    def test_default_list_per_page(self):
+        """Default list_per_page should be 25."""
+        assert DjustModelAdmin.list_per_page == 25
+
+    def test_default_actions(self):
+        """Default actions should include delete_selected."""
+        assert "delete_selected" in DjustModelAdmin.actions
+
+
+class TestPluginExports(TestCase):
+    """Tests that plugin classes are properly exported."""
+
+    def test_admin_plugin_importable(self):
+        assert AdminPlugin is not None
+
+    def test_admin_page_importable(self):
+        assert AdminPage is not None
+
+    def test_admin_widget_importable(self):
+        assert AdminWidget is not None
+
+    def test_nav_item_importable(self):
+        assert NavItem is not None

--- a/python/djust/tests/test_admin_plugins.py
+++ b/python/djust/tests/test_admin_plugins.py
@@ -1,0 +1,419 @@
+"""Tests for the djust.admin_ext plugin system."""
+
+import pytest
+from django.test import RequestFactory, TestCase
+
+from djust.admin_ext import AdminPage, AdminPlugin, AdminWidget, NavItem
+from djust.admin_ext.sites import DjustAdminSite
+
+pytestmark = pytest.mark.admin
+
+
+class TestNavItem(TestCase):
+    """Tests for NavItem."""
+
+    def test_basic_nav_item(self):
+        item = NavItem(label="Users", url_name="users_list")
+        assert item.label == "Users"
+        assert item.url_name == "users_list"
+        assert item.order == 0
+        assert item.section is None
+        assert item.permission is None
+
+    def test_nav_item_with_options(self):
+        item = NavItem(
+            label="Settings",
+            url_name="settings_page",
+            icon="<svg>...</svg>",
+            order=10,
+            section="Config",
+            permission="myapp.view_settings",
+        )
+        assert item.label == "Settings"
+        assert item.order == 10
+        assert item.section == "Config"
+        assert item.permission == "myapp.view_settings"
+
+    def test_has_permission_no_perm_required(self):
+        item = NavItem(label="Test", url_name="test")
+        factory = RequestFactory()
+        request = factory.get("/")
+        request.user = type("User", (), {"has_perm": lambda self, p: False})()
+        assert item.has_permission(request) is True
+
+    def test_has_permission_with_perm(self):
+        item = NavItem(label="Test", url_name="test", permission="myapp.can_view")
+        factory = RequestFactory()
+        request = factory.get("/")
+        # User without permission
+        request.user = type("User", (), {"has_perm": lambda self, p: False})()
+        assert item.has_permission(request) is False
+        # User with permission
+        request.user = type("User", (), {"has_perm": lambda self, p: True})()
+        assert item.has_permission(request) is True
+
+    def test_repr(self):
+        item = NavItem(label="Users", url_name="users_list")
+        assert "Users" in repr(item)
+        assert "users_list" in repr(item)
+
+
+class TestAdminPage(TestCase):
+    """Tests for AdminPage."""
+
+    def test_basic_page(self):
+        page = AdminPage(
+            url_path="auth/providers/",
+            url_name="auth_providers",
+            view_class=object,  # placeholder
+            label="OAuth Providers",
+        )
+        assert page.url_path == "auth/providers"  # strips slashes
+        assert page.url_name == "auth_providers"
+        assert page.label == "OAuth Providers"
+        assert page.show_in_nav is True
+
+    def test_auto_label(self):
+        page = AdminPage(
+            url_path="my_page",
+            url_name="my_page",
+            view_class=object,
+        )
+        assert page.label == "My Page"
+
+    def test_get_nav_item(self):
+        page = AdminPage(
+            url_path="providers/",
+            url_name="providers",
+            view_class=object,
+            label="Providers",
+            nav_section="Auth",
+            nav_order=5,
+            permission="auth.view_provider",
+        )
+        nav_item = page.get_nav_item()
+        assert nav_item is not None
+        assert nav_item.label == "Providers"
+        assert nav_item.url_name == "providers"
+        assert nav_item.section == "Auth"
+        assert nav_item.order == 5
+        assert nav_item.permission == "auth.view_provider"
+
+    def test_hidden_page_no_nav(self):
+        page = AdminPage(
+            url_path="hidden/",
+            url_name="hidden",
+            view_class=object,
+            show_in_nav=False,
+        )
+        assert page.get_nav_item() is None
+
+
+class TestAdminWidget(TestCase):
+    """Tests for AdminWidget."""
+
+    def test_default_widget(self):
+        widget = AdminWidget()
+        assert widget.widget_id is None
+        assert widget.label == ""
+        assert widget.template_name is None
+        assert widget.order == 0
+        assert widget.size == "md"
+        assert widget.permission is None
+
+    def test_get_context_default(self):
+        widget = AdminWidget()
+        factory = RequestFactory()
+        request = factory.get("/")
+        assert widget.get_context(request) == {}
+
+    def test_custom_widget(self):
+        class StatsWidget(AdminWidget):
+            widget_id = "stats"
+            label = "Statistics"
+            template_name = "test/stats.html"
+            order = 10
+            size = "lg"
+
+            def get_context(self, request):
+                return {"count": 42}
+
+        widget = StatsWidget()
+        assert widget.widget_id == "stats"
+        assert widget.label == "Statistics"
+        assert widget.order == 10
+        assert widget.size == "lg"
+
+        factory = RequestFactory()
+        request = factory.get("/")
+        ctx = widget.get_context(request)
+        assert ctx == {"count": 42}
+
+    def test_has_permission_no_perm(self):
+        widget = AdminWidget()
+        factory = RequestFactory()
+        request = factory.get("/")
+        request.user = type("User", (), {"has_perm": lambda self, p: False})()
+        assert widget.has_permission(request) is True
+
+    def test_render_no_template(self):
+        widget = AdminWidget()
+        factory = RequestFactory()
+        request = factory.get("/")
+        assert widget.render(request) == ""
+
+
+class TestAdminPlugin(TestCase):
+    """Tests for AdminPlugin."""
+
+    def test_basic_plugin(self):
+        class MyPlugin(AdminPlugin):
+            name = "my_plugin"
+            verbose_name = "My Plugin"
+
+        plugin = MyPlugin()
+        assert plugin.name == "my_plugin"
+        assert plugin.verbose_name == "My Plugin"
+        assert plugin.get_pages() == []
+        assert plugin.get_widgets() == []
+        assert plugin.get_nav_items() == []
+
+    def test_plugin_with_pages(self):
+        class MyPlugin(AdminPlugin):
+            name = "test"
+            verbose_name = "Test"
+
+            def get_pages(self):
+                return [
+                    AdminPage("page1/", "page1", object, label="Page 1", nav_section="Test"),
+                    AdminPage("page2/", "page2", object, label="Page 2", nav_section="Test"),
+                ]
+
+        plugin = MyPlugin()
+        pages = plugin.get_pages()
+        assert len(pages) == 2
+
+        # Auto-generated nav items
+        nav_items = plugin.get_nav_items()
+        assert len(nav_items) == 2
+        assert nav_items[0].label == "Page 1"
+        assert nav_items[1].label == "Page 2"
+
+    def test_plugin_with_hidden_page(self):
+        class MyPlugin(AdminPlugin):
+            name = "test"
+
+            def get_pages(self):
+                return [
+                    AdminPage("visible/", "visible", object, label="Visible"),
+                    AdminPage("hidden/", "hidden", object, show_in_nav=False),
+                ]
+
+        plugin = MyPlugin()
+        nav_items = plugin.get_nav_items()
+        assert len(nav_items) == 1
+        assert nav_items[0].label == "Visible"
+
+    def test_ready_called(self):
+        ready_called = []
+
+        class MyPlugin(AdminPlugin):
+            name = "test"
+
+            def ready(self):
+                ready_called.append(True)
+
+        plugin = MyPlugin()
+        plugin.ready()
+        assert len(ready_called) == 1
+
+
+class TestSitePluginRegistration(TestCase):
+    """Tests for plugin registration on DjustAdminSite."""
+
+    def test_register_plugin_class(self):
+        site = DjustAdminSite(name="test")
+
+        class MyPlugin(AdminPlugin):
+            name = "my_plugin"
+            verbose_name = "My Plugin"
+
+        site.register_plugin(MyPlugin)
+        assert site.get_plugin("my_plugin") is not None
+        assert site.get_plugin("my_plugin").verbose_name == "My Plugin"
+
+    def test_register_plugin_instance(self):
+        site = DjustAdminSite(name="test")
+
+        class MyPlugin(AdminPlugin):
+            name = "my_plugin"
+
+        plugin = MyPlugin()
+        site.register_plugin(plugin)
+        assert site.get_plugin("my_plugin") is plugin
+
+    def test_register_plugin_no_name(self):
+        site = DjustAdminSite(name="test")
+
+        class BadPlugin(AdminPlugin):
+            pass  # name is None
+
+        with pytest.raises(ValueError, match="must have a 'name'"):
+            site.register_plugin(BadPlugin)
+
+    def test_register_duplicate_plugin(self):
+        site = DjustAdminSite(name="test")
+
+        class MyPlugin(AdminPlugin):
+            name = "my_plugin"
+
+        site.register_plugin(MyPlugin)
+        with pytest.raises(ValueError, match="already registered"):
+            site.register_plugin(MyPlugin)
+
+    def test_unregister_plugin(self):
+        site = DjustAdminSite(name="test")
+
+        class MyPlugin(AdminPlugin):
+            name = "my_plugin"
+
+        site.register_plugin(MyPlugin)
+        assert site.get_plugin("my_plugin") is not None
+
+        site.unregister_plugin("my_plugin")
+        assert site.get_plugin("my_plugin") is None
+
+    def test_unregister_nonexistent_plugin(self):
+        site = DjustAdminSite(name="test")
+        with pytest.raises(ValueError, match="not registered"):
+            site.unregister_plugin("nonexistent")
+
+    def test_ready_called_on_registration(self):
+        site = DjustAdminSite(name="test")
+        ready_calls = []
+
+        class MyPlugin(AdminPlugin):
+            name = "test_ready"
+
+            def ready(self):
+                ready_calls.append(True)
+
+        site.register_plugin(MyPlugin)
+        assert len(ready_calls) == 1
+
+    def test_get_plugin_nav(self):
+        site = DjustAdminSite(name="test")
+
+        class MyPlugin(AdminPlugin):
+            name = "auth"
+            verbose_name = "Authentication"
+
+            def get_pages(self):
+                return [
+                    AdminPage(
+                        "auth/providers/",
+                        "auth_providers",
+                        object,
+                        label="OAuth Providers",
+                        nav_section="Authentication",
+                    ),
+                    AdminPage(
+                        "auth/users/",
+                        "auth_users",
+                        object,
+                        label="Users",
+                        nav_section="Authentication",
+                        nav_order=10,
+                    ),
+                ]
+
+        site.register_plugin(MyPlugin)
+
+        factory = RequestFactory()
+        request = factory.get("/")
+        request.user = type(
+            "User",
+            (),
+            {
+                "is_authenticated": True,
+                "is_staff": True,
+                "has_perm": lambda self, p: True,
+            },
+        )()
+
+        nav = site.get_plugin_nav(request)
+        assert len(nav) == 1
+        assert nav[0]["section"] == "Authentication"
+        assert len(nav[0]["items"]) == 2
+        # Items should be sorted by order
+        assert nav[0]["items"][0]["label"] == "OAuth Providers"
+        assert nav[0]["items"][1]["label"] == "Users"
+
+    def test_get_widgets(self):
+        site = DjustAdminSite(name="test")
+
+        class TestWidget(AdminWidget):
+            widget_id = "test_stats"
+            label = "Test Stats"
+            order = 5
+
+        class MyPlugin(AdminPlugin):
+            name = "test"
+
+            def get_widgets(self):
+                return [TestWidget()]
+
+        site.register_plugin(MyPlugin)
+
+        factory = RequestFactory()
+        request = factory.get("/")
+        request.user = type(
+            "User",
+            (),
+            {
+                "is_authenticated": True,
+                "has_perm": lambda self, p: True,
+            },
+        )()
+
+        widgets = site.get_widgets(request)
+        assert len(widgets) == 1
+        assert widgets[0]["widget_id"] == "test_stats"
+        assert widgets[0]["label"] == "Test Stats"
+        assert widgets[0]["order"] == 5
+
+    def test_get_widgets_permission_filtering(self):
+        site = DjustAdminSite(name="test")
+
+        class PublicWidget(AdminWidget):
+            widget_id = "public"
+            label = "Public"
+
+        class PrivateWidget(AdminWidget):
+            widget_id = "private"
+            label = "Private"
+            permission = "myapp.view_private"
+
+        class MyPlugin(AdminPlugin):
+            name = "test"
+
+            def get_widgets(self):
+                return [PublicWidget(), PrivateWidget()]
+
+        site.register_plugin(MyPlugin)
+
+        factory = RequestFactory()
+        request = factory.get("/")
+        # User without the permission
+        request.user = type(
+            "User",
+            (),
+            {
+                "is_authenticated": True,
+                "has_perm": lambda self, p: False,
+            },
+        )()
+
+        widgets = site.get_widgets(request)
+        assert len(widgets) == 1
+        assert widgets[0]["widget_id"] == "public"


### PR DESCRIPTION
## Summary

- **Phase 3 of v0.5.0 package consolidation** — fold `djust-admin` (3,878 LOC) into `python/djust/admin_ext/`
- Uses `admin_ext/` to avoid collision with `django.contrib.admin`
- All imports updated: `from djust_admin` → `from djust.admin_ext`
- Added `[project.optional-dependencies] admin = []` and `all` extras
- 40 new tests, 3356 total tests pass

## Test plan

- [x] `pytest -m admin` — 40 tests pass (sites, plugins, registration, decorators)
- [x] Full suite: 3356 passed (42 more than baseline)
- [x] Import verification: all public API accessible via `from djust.admin_ext import ...`
- [x] Pre-commit + pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)