### PR TITLE
fix(admin_ext): add DEBUG logging + escapejs for redirect URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 dependencies = [
  "ahash",
  "criterion",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 dependencies = [
  "ahash",
  "criterion",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 dependencies = [
  "bincode",
  "criterion",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 dependencies = [
  "ahash",
  "chrono",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 dependencies = [
  "ahash",
  "criterion",

--- a/python/djust/admin_ext/forms.py
+++ b/python/djust/admin_ext/forms.py
@@ -5,12 +5,15 @@ Extends djust's FormMixin with ModelAdmin integration for FK/M2M fields,
 readonly fields, and fieldset-based rendering.
 """
 
+import logging
 from typing import Any, Dict, List, Optional
 
 from django import forms
 from django.db.models import ForeignKey, ManyToManyField, OneToOneField
 from django.db.models.fields import DateField, DateTimeField, TimeField
 from djust.forms import FormMixin
+
+logger = logging.getLogger(__name__)
 
 
 class AdminFormMixin(FormMixin):
@@ -104,7 +107,7 @@ class AdminFormMixin(FormMixin):
                     for obj in related_model.objects.all()[:100]
                 ]
         except Exception:
-            pass
+            logger.debug("Failed to get field options for %s", field_name, exc_info=True)
         return []
 
     def get_field_info(self, field_name: str) -> Dict[str, Any]:
@@ -148,7 +151,7 @@ class AdminFormMixin(FormMixin):
                 info["is_time"] = True
                 info["input_type"] = "time"
         except Exception:
-            pass
+            logger.debug("Failed to get field info for %s", field_name, exc_info=True)
 
         return info
 
@@ -215,6 +218,7 @@ class AdminFormMixin(FormMixin):
                 return getattr(self.object, field_name, default)
 
         except Exception:
+            logger.debug("Failed to get field value for %s", field_name, exc_info=True)
             return default
 
     def validate_field(self, field_name: str = "", value: Any = None, **kwargs):

--- a/python/djust/admin_ext/options.py
+++ b/python/djust/admin_ext/options.py
@@ -4,8 +4,11 @@ DjustModelAdmin - Configuration class for model admin interfaces.
 Similar to Django's ModelAdmin but designed for reactive LiveView rendering.
 """
 
+import logging
 from django.db import models
 from django.forms import modelform_factory
+
+logger = logging.getLogger(__name__)
 
 
 class DjustModelAdmin:
@@ -83,7 +86,7 @@ class DjustModelAdmin:
                     if isinstance(field, (models.ForeignKey, models.OneToOneField)):
                         fk_fields.append(field_name)
                 except Exception:
-                    pass
+                    logger.debug("Failed to resolve FK for %s", field_name, exc_info=True)
             if fk_fields:
                 qs = qs.select_related(*fk_fields)
 
@@ -231,4 +234,5 @@ class DjustModelAdmin:
             field = self.opts.get_field(field_name)
             return field.verbose_name.title()
         except Exception:
+            logger.debug("Failed to get verbose name for %s", field_name, exc_info=True)
             return field_name.replace("_", " ").title()

--- a/python/djust/admin_ext/sites.py
+++ b/python/djust/admin_ext/sites.py
@@ -6,8 +6,11 @@ Similar to Django's AdminSite but renders using djust LiveViews
 for reactive, real-time admin interfaces.
 """
 
+import logging
 from django.apps import apps
 from django.urls import path, reverse
+
+logger = logging.getLogger(__name__)
 
 
 class DjustAdminSite:
@@ -277,6 +280,7 @@ class DjustAdminSite:
                         current_app=self.name,
                     )
                 except Exception:
+                    logger.debug("Failed to reverse URL for %s", nav_item.url_name, exc_info=True)
                     url = "#"
 
                 sections[section_name].append(

--- a/python/djust/admin_ext/templates/djust_admin/model_delete.html
+++ b/python/djust/admin_ext/templates/djust_admin/model_delete.html
@@ -12,7 +12,7 @@
 {% block content %}
 <!-- Redirect after deletion -->
 {% if redirect_url %}
-<script>window.location.href = "{{ redirect_url }}";</script>
+<script>window.location.href = "{{ redirect_url|escapejs }}";</script>
 {% endif %}
 
 <div class="max-w-2xl mx-auto">

--- a/python/djust/admin_ext/templates/djust_admin/model_detail.html
+++ b/python/djust/admin_ext/templates/djust_admin/model_detail.html
@@ -11,7 +11,7 @@
 {% block content %}
 <!-- Redirect on save -->
 {% if redirect_url %}
-<script>window.location.href = "{{ redirect_url }}";</script>
+<script>window.location.href = "{{ redirect_url|escapejs }}";</script>
 {% endif %}
 
 <div class="max-w-4xl mx-auto">

--- a/python/djust/admin_ext/views.py
+++ b/python/djust/admin_ext/views.py
@@ -5,6 +5,7 @@ These views use djust's LiveView to provide reactive, real-time admin interfaces
 Includes plugin-aware context (plugin_nav, widgets) for the admin shell.
 """
 
+import logging
 from functools import wraps
 
 from django.contrib.auth import authenticate, logout
@@ -16,6 +17,8 @@ from djust import LiveView
 from djust.decorators import debounce, event_handler, state
 
 from .forms import AdminFormMixin
+
+logger = logging.getLogger(__name__)
 
 # Global registry for admin view configurations
 # This avoids storing non-serializable objects on view instances
@@ -303,7 +306,7 @@ class ModelListView(AdminBaseMixin, LiveView):
 
                 filters.append(filter_data)
             except Exception:
-                pass
+                logger.debug("Failed to build filter for %s", filter_field, exc_info=True)
 
         return {
             **self.get_admin_context(),


### PR DESCRIPTION
## Summary

- **#775**: Replace 7 silent `except Exception: pass` blocks with `logger.debug(..., exc_info=True)` for traceability during development
- **#776**: Use `|escapejs` filter for `redirect_url` in JS context (model_detail.html, model_delete.html) per CLAUDE.md rule #2

## Test plan

- [x] Core test suite: 3360 passed
- [x] `ruff check python/djust/admin_ext/` passes
- [x] Pre-commit hooks pass

Closes #775
Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)