### PR TITLE
fix: add theming/admin_ext to demo INSTALLED_APPS for test discovery (#777)

### DIFF
--- a/examples/demo_project/demo_project/settings.py
+++ b/examples/demo_project/demo_project/settings.py
@@ -43,6 +43,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'channels',
     'djust',
+    'djust.theming',     # Optional extra — needed for theming tests
+    'djust.admin_ext',   # Optional extra — needed for admin tests
     # New organized apps
     'djust_shared',      # Shared components and base classes
     'djust_homepage',    # Landing page and navigation


### PR DESCRIPTION
## Summary

Adds `djust.theming` and `djust.admin_ext` to the demo project's INSTALLED_APPS. These are the pytest test settings — the theming and admin tests need their apps registered for template tag loading and template discovery.

**Before**: 3360 tests pass, ~1000 theming tests fail (templates not found)
**After**: 5061 tests pass (+1700 theming tests now work)

The remaining ~60 theming test failures are editor view URL resolution tests that need the theming URL patterns included in the demo project's urls.py — a separate issue.

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)