### PR TITLE
feat(theming): extract reusable scaffold CSS from project base.css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Scaffold CSS — reusable layout/utility pack in `djust.theming`** — `djust_theming/static/djust_theming/css/scaffold.css` gains ~729 lines of framework-generic scaffold covering typography, responsive grid utilities (`.grid-2/3/4`), hero section, flash messages (Django + LiveView), accessibility utilities (`.sr-only`), extended layout helpers (`.flex-center`, `.content-narrow/-wide`), stat-display variants, auth layout, live indicator dot, card-accent variants, code blocks, noise texture overlay, shared nav links, dashboard/centered grids, and the full `data-layout` switching system (sidebar, topbar, dashboard, centered, sidebar-topbar). All new rules use CSS-variable fallbacks so the scaffold works without a loaded theme; no hardcoded hex colors; `.container` max-width now reads `var(--container-width, 1200px)`. Pure-CSS addition — no Python/JS/test behavior changes. (PR #836)
+
 ## [0.5.1rc1] - 2026-04-21
 
 ### Added

--- a/python/djust/theming/static/djust_theming/css/scaffold.css
+++ b/python/djust/theming/static/djust_theming/css/scaffold.css
@@ -264,9 +264,9 @@ a:hover {
 /* Container */
 .container {
   width: 100%;
-  max-width: 1200px;
+  max-width: var(--container-width, 1200px);
   margin: 0 auto;
-  padding-inline: var(--space-4);
+  padding-inline: var(--space-4, 1rem);
 }
 
 
@@ -1293,7 +1293,732 @@ html {
 
 
 /* ============================================
-   8. Responsive Breakpoints
+   8. Typography (headings, paragraphs, links)
+   ============================================ */
+
+h1, h2, h3, h4, h5, h6 {
+  color: hsl(var(--foreground));
+  font-family: var(--font-heading, var(--font-sans, system-ui, sans-serif));
+  margin-bottom: 0.75rem;
+  font-weight: var(--font-bold, 700);
+  line-height: var(--leading-tight, 1.25);
+  letter-spacing: -0.025em;
+}
+
+h1 { font-size: var(--text-4xl, 2.25rem); }
+h2 { font-size: var(--text-3xl, 1.875rem); }
+h3 { font-size: var(--text-2xl, 1.5rem); }
+h4 { font-size: var(--text-xl, 1.25rem); }
+h5 { font-size: var(--text-lg, 1.125rem); }
+h6 { font-size: var(--text-base, 1rem); }
+
+p { margin-bottom: 0.75rem; }
+
+
+/* ============================================
+   9. Grid Utilities
+   ============================================ */
+
+.grid-2 { grid-template-columns: repeat(2, 1fr); }
+.grid-3 { grid-template-columns: repeat(3, 1fr); }
+.grid-4 { grid-template-columns: repeat(4, 1fr); }
+
+.grid-2,
+.grid-3,
+.grid-4 {
+  display: grid;
+  gap: var(--grid-gap, 1.5rem);
+}
+
+@media (max-width: 768px) {
+  .grid-2,
+  .grid-3,
+  .grid-4 {
+    grid-template-columns: 1fr;
+  }
+}
+
+
+/* ============================================
+   10. Hero Section
+   ============================================ */
+
+.hero {
+  text-align: center;
+  padding: var(--hero-padding-top, 6rem) var(--space-8, 2rem) var(--hero-padding-bottom, 4rem);
+  position: relative;
+  border-bottom: var(--border-width, 1px) solid hsl(var(--border));
+  background:
+    radial-gradient(
+      ellipse at 50% 0%,
+      var(--gradient-from, hsl(var(--brand, var(--primary)) / 0.06)) 0%,
+      var(--gradient-to, transparent) 70%
+    );
+}
+
+.hero h1 {
+  font-size: var(--hero-font-size, 3.75rem);
+  font-weight: var(--font-bold, 900);
+  line-height: var(--hero-line-height, 1.05);
+  letter-spacing: var(--letter-spacing, -0.03em);
+  margin-bottom: 1.5rem;
+  color: hsl(var(--foreground));
+  max-width: var(--hero-max-width, 56rem);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.hero h1 .hero-accent {
+  color: hsl(var(--brand, var(--primary)));
+}
+
+.hero-subtitle {
+  font-size: var(--text-lg, 1.2rem);
+  line-height: var(--leading-relaxed, 1.6);
+  color: hsl(var(--muted-foreground));
+  max-width: var(--prose-max-width, 540px);
+  margin: 0 auto 2.5rem;
+}
+
+.hero-actions {
+  display: flex;
+  gap: var(--space-4, 1rem);
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 768px) {
+  .hero {
+    padding: var(--space-8, 3rem) var(--space-4, 1rem) var(--space-8, 2rem);
+  }
+  .hero h1 {
+    font-size: var(--text-4xl, 2.25rem);
+  }
+}
+
+
+/* ============================================
+   11. Flash Messages (Django messages framework)
+   ============================================ */
+
+.flash-messages,
+.messages {
+  margin-bottom: var(--space-6, 1.5rem);
+}
+
+.flash-item,
+.message {
+  padding: var(--space-3, 0.875rem) var(--space-4, 1rem);
+  border-radius: var(--radius, 0.5rem);
+  margin-bottom: var(--space-3, 0.75rem);
+  border: 1px solid;
+  font-size: var(--text-sm, 0.875rem);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2, 0.5rem);
+}
+
+.flash-icon {
+  flex-shrink: 0;
+  font-size: var(--text-lg, 1.125rem);
+}
+
+.flash-item-success,
+.message-success {
+  background: hsl(var(--success) / 0.1);
+  border-color: hsl(var(--success) / 0.3);
+  color: hsl(var(--success));
+}
+
+.flash-item-error,
+.message-error {
+  background: hsl(var(--destructive) / 0.1);
+  border-color: hsl(var(--destructive) / 0.3);
+  color: hsl(var(--destructive));
+}
+
+.flash-item-warning,
+.message-warning {
+  background: hsl(var(--warning) / 0.1);
+  border-color: hsl(var(--warning) / 0.3);
+  color: hsl(var(--warning));
+}
+
+.flash-item-info,
+.message-info {
+  background: hsl(var(--info, var(--primary)) / 0.1);
+  border-color: hsl(var(--info, var(--primary)) / 0.3);
+  color: hsl(var(--info, var(--primary)));
+}
+
+/* djust LiveView flash banner (fixed top) */
+.dj-flash-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 99997;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.dj-flash {
+  padding: var(--space-2, 10px) var(--space-5, 20px);
+  font-family: var(--font-sans, system-ui, sans-serif);
+  font-size: var(--text-xs, 13px);
+  font-weight: var(--font-semibold, 600);
+  text-align: center;
+  animation: dj-flash-slide-in var(--duration-slow, 0.3s) ease-out;
+}
+
+.dj-flash-info {
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+}
+
+.dj-flash-success {
+  background: hsl(var(--success, 142 71% 45%));
+  color: hsl(var(--success-foreground, 0 0% 100%));
+}
+
+.dj-flash-warning {
+  background: hsl(var(--warning, 38 92% 50%));
+  color: hsl(var(--warning-foreground, 24 10% 10%));
+}
+
+.dj-flash-error {
+  background: hsl(var(--destructive));
+  color: hsl(var(--destructive-foreground));
+}
+
+.dj-flash-removing {
+  animation: dj-flash-slide-out var(--duration-slow, 0.3s) ease-in forwards;
+}
+
+@keyframes dj-flash-slide-in {
+  from { transform: translateY(-100%); opacity: 0; }
+  to   { transform: translateY(0);     opacity: 1; }
+}
+
+@keyframes dj-flash-slide-out {
+  from { transform: translateY(0);     opacity: 1; }
+  to   { transform: translateY(-100%); opacity: 0; }
+}
+
+
+/* ============================================
+   12. Accessibility
+   ============================================ */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.sr-only-focusable:focus,
+.sr-only-focusable:active {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: inherit;
+  margin: inherit;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+}
+
+
+/* ============================================
+   13. Extended Utilities
+   ============================================ */
+
+/* Text */
+.text-small { font-size: var(--text-sm, 0.875rem); }
+.text-right { text-align: right; }
+.text-primary { color: hsl(var(--primary)); }
+
+/* Flex helpers */
+.flex-center {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}
+
+.flex-between {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
+/* Spacing */
+.section-gap { margin-top: var(--section-spacing, 2rem); }
+.list-spaced { padding-left: 1.25rem; line-height: 2; }
+
+/* Layout */
+.w-full { width: 100%; }
+.mx-auto { margin-left: auto; margin-right: auto; }
+
+/* Content width constraints */
+.content-narrow {
+  max-width: var(--prose-max-width, 40rem);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.content-wide {
+  max-width: var(--content-wide-width, 80rem);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+
+/* ============================================
+   14. Stat Display Variants
+   ============================================ */
+
+.stat-value-primary { color: hsl(var(--primary)); }
+.stat-value-success { color: hsl(var(--success)); }
+.stat-value-lg { font-size: var(--text-3xl, 2rem); }
+.stat-value-xl { font-size: var(--text-4xl, 3.5rem); }
+
+.stat-display {
+  text-align: center;
+  padding: var(--space-4, 1rem);
+}
+
+.stat-display .stat-value {
+  margin-bottom: var(--space-1, 0.25rem);
+}
+
+.stat-display .stat-label {
+  font-size: var(--text-sm, 0.875rem);
+  color: hsl(var(--muted-foreground));
+}
+
+
+/* ============================================
+   15. Auth Layout
+   ============================================ */
+
+.auth-wrapper,
+.auth-layout {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - 8rem);
+  padding: var(--space-8, 2rem) var(--space-4, 1rem);
+}
+
+.auth-card {
+  width: 100%;
+  max-width: var(--auth-card-width, 400px);
+  background: hsl(var(--card));
+  color: hsl(var(--card-foreground, var(--foreground)));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius, 0.5rem);
+  padding: var(--space-8, 2.5rem) var(--space-6, 2rem);
+  box-shadow: var(--shadow-lg);
+}
+
+.auth-brand {
+  text-align: center;
+  margin-bottom: var(--space-6, 2rem);
+  padding-bottom: var(--space-5, 1.5rem);
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+
+/* ============================================
+   16. Pulsing Live Indicator
+   ============================================ */
+
+.live-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full, 50%);
+  background: hsl(var(--success));
+  display: inline-block;
+  animation: live-pulse calc(var(--duration-slow, 0.3s) * 6) infinite;
+}
+
+@keyframes live-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(0.8); }
+}
+
+
+/* ============================================
+   17. Feature Icon Block
+   ============================================ */
+
+.feature-icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: var(--radius, 0.5rem);
+  background: hsl(var(--primary) / 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-xl, 1.25rem);
+  margin-bottom: var(--space-3, 0.75rem);
+}
+
+
+/* ============================================
+   18. Card Accent Variants
+   ============================================ */
+
+.card-accent {
+  border-left: var(--border-width, 3px) solid hsl(var(--primary));
+}
+
+.card-accent-success {
+  border-left: var(--border-width, 3px) solid hsl(var(--success));
+}
+
+.card-accent-warning {
+  border-left: var(--border-width, 3px) solid hsl(var(--warning));
+}
+
+
+/* ============================================
+   19. Code Blocks
+   ============================================ */
+
+.code,
+code {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  background: hsl(var(--code, var(--muted)));
+  color: hsl(var(--code-foreground, var(--foreground)));
+  padding: 0.125rem 0.375rem;
+  border-radius: var(--radius-sm, 0.25rem);
+  font-size: 0.875em;
+}
+
+pre {
+  background: hsl(var(--code, var(--muted)));
+  color: hsl(var(--code-foreground, var(--foreground)));
+  padding: var(--space-4, 1rem);
+  border-radius: var(--radius, 0.5rem);
+  overflow-x: auto;
+  margin-bottom: var(--space-4, 1rem);
+  font-size: var(--text-sm, 0.875rem);
+}
+
+pre code,
+pre .code {
+  background: none;
+  padding: 0;
+  color: inherit;
+}
+
+
+/* ============================================
+   20. Noise Texture Overlay
+   ============================================ */
+
+/* Uses foreground color so it works on both light and dark backgrounds.
+   Controlled by --noise-opacity (default 0 = invisible). */
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: var(--noise-opacity, 0);
+  background-image:
+    repeating-conic-gradient(hsl(var(--foreground)) 0% 25%, transparent 0% 50%),
+    repeating-conic-gradient(hsl(var(--foreground)) 0% 25%, transparent 0% 50%);
+  background-size: 3px 3px, 7px 7px;
+  background-position: 0 0, 2px 3px;
+}
+
+
+/* ============================================
+   21. Layout System (data-layout attribute switching)
+   ============================================ */
+
+.layout-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.layout-sidebar-nav {
+  display: none;
+}
+
+.layout-main {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 100vh;
+}
+
+.main-content {
+  flex: 1;
+  padding-bottom: var(--section-spacing, 2.5rem);
+}
+
+.main-padded {
+  padding-top: var(--section-spacing, 2.5rem);
+}
+
+/* --- Sidebar layout --- */
+.layout-shell[data-layout="sidebar"],
+.layout-shell[data-layout="sidebar-topbar"] {
+  flex-direction: row;
+}
+
+.layout-shell[data-layout="sidebar"] .layout-sidebar-nav,
+.layout-shell[data-layout="sidebar-topbar"] .layout-sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  width: var(--sidebar-width, 240px);
+  background: hsl(var(--surface-2, var(--card)));
+  border-right: var(--border-width, 1px) solid hsl(var(--border));
+  padding: var(--space-4, 1rem) 0;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+.layout-shell[data-layout="sidebar"] .navbar,
+.layout-shell[data-layout="sidebar-topbar"] .layout-sidebar-nav ~ .layout-main .navbar .navbar-brand {
+  display: none;
+}
+
+.sidebar-brand {
+  padding: 0 var(--space-5, 1.25rem);
+  margin-bottom: var(--space-6, 1.5rem);
+}
+
+.sidebar-brand .navbar-logo {
+  font-size: 1rem;
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1, 0.25rem);
+  padding: 0 var(--space-3, 0.75rem);
+  flex: 1;
+}
+
+.sidebar-footer {
+  padding: var(--space-3, 0.75rem);
+  border-top: var(--border-width, 1px) solid hsl(var(--border));
+  margin-top: auto;
+  position: relative;
+}
+
+/* Theme panel pops UP from sidebar footer */
+.sidebar-footer .theme-panel-menu {
+  bottom: 100%;
+  top: auto;
+  left: 0;
+  right: auto;
+  width: var(--sidebar-width, 240px);
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+
+/* ============================================
+   22. Shared Nav Links (navbar + sidebar contexts)
+   ============================================ */
+
+/* In navbar context: horizontal, inherit navbar styling */
+.navbar-menu .nav-link {
+  color: hsl(var(--muted-foreground));
+  text-decoration: none;
+  font-size: var(--text-sm, 0.9rem);
+  font-weight: var(--font-medium, 500);
+  transition: color var(--duration-normal, 0.2s);
+}
+
+.navbar-menu .nav-link:hover {
+  color: hsl(var(--foreground));
+  text-decoration: none;
+}
+
+.navbar-menu .nav-link.active {
+  color: hsl(var(--foreground));
+}
+
+/* In sidebar context: vertical blocks with active background */
+.sidebar-nav .nav-link {
+  display: block;
+  padding: var(--space-2, 0.5rem) var(--space-3, 0.75rem);
+  border-radius: var(--radius-md, 6px);
+  color: hsl(var(--muted-foreground));
+  text-decoration: none;
+  font-size: var(--text-sm, 0.875rem);
+  font-weight: var(--font-medium, 500);
+  transition: all var(--duration-fast, 0.15s) var(--ease-out, ease-out);
+}
+
+.sidebar-nav .nav-link:hover {
+  background: hsl(var(--accent));
+  color: hsl(var(--foreground));
+  text-decoration: none;
+}
+
+.sidebar-nav .nav-link.active {
+  background: hsl(var(--brand, var(--primary)) / 0.1);
+  color: hsl(var(--brand, var(--primary)));
+  font-weight: var(--font-semibold, 600);
+}
+
+
+/* ============================================
+   23. Dashboard Layout
+   ============================================ */
+
+.layout-shell[data-layout="dashboard"] .main-content .container {
+  max-width: 100%;
+  padding: 0 var(--space-4, 1rem);
+}
+
+.layout-shell[data-layout="dashboard"] .hero {
+  padding-top: var(--space-6, 1.5rem);
+  padding-bottom: var(--space-4, 1rem);
+  border-bottom: none;
+}
+
+.layout-shell[data-layout="dashboard"] .hero h1 {
+  font-size: var(--text-3xl, 2rem);
+}
+
+.layout-shell[data-layout="dashboard"] .hero-subtitle {
+  display: none;
+}
+
+.layout-shell[data-layout="dashboard"] .hero-actions {
+  display: none;
+}
+
+.layout-shell[data-layout="dashboard"] .grid-3 {
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-3, 0.75rem);
+}
+
+.layout-shell[data-layout="dashboard"] .grid-4 {
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-3, 0.75rem);
+}
+
+/* Standalone dashboard grid utility */
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--dashboard-card-min, 280px), 1fr));
+  gap: var(--space-4, 1rem);
+  width: 100%;
+}
+
+
+/* ============================================
+   24. Centered Layout
+   ============================================ */
+
+.layout-shell[data-layout="centered"] .main-content .container {
+  max-width: var(--prose-max-width, 40rem);
+}
+
+.layout-shell[data-layout="centered"] .hero {
+  padding-top: var(--space-8, 2rem);
+  padding-bottom: var(--space-6, 1.5rem);
+}
+
+.layout-shell[data-layout="centered"] .hero h1 {
+  font-size: var(--text-3xl, 2.5rem);
+}
+
+.layout-shell[data-layout="centered"] .grid-3,
+.layout-shell[data-layout="centered"] .grid-4 {
+  grid-template-columns: 1fr;
+}
+
+/* Standalone centered-content utility */
+.centered-content {
+  max-width: var(--prose-max-width, 40rem);
+  margin-left: auto;
+  margin-right: auto;
+  padding-inline: var(--space-4, 1rem);
+}
+
+
+/* ============================================
+   25. Topbar Layout
+   ============================================ */
+
+.layout-shell[data-layout="topbar"] .navbar {
+  border-bottom: var(--border-width, 2px) solid hsl(var(--brand, var(--primary)));
+}
+
+.layout-shell[data-layout="topbar"] .hero {
+  display: none;
+}
+
+.layout-shell[data-layout="topbar"] .main-content {
+  padding-top: var(--section-spacing, 2rem);
+}
+
+
+/* ============================================
+   26. Sidebar + Topbar Layout
+   ============================================ */
+
+.layout-shell[data-layout="sidebar-topbar"] .navbar {
+  padding: var(--space-2, 0.5rem) 0;
+  border-bottom: var(--border-width, 1px) solid hsl(var(--border));
+}
+
+.layout-shell[data-layout="sidebar-topbar"] .navbar .navbar-brand {
+  display: none;
+}
+
+.layout-shell[data-layout="sidebar-topbar"] .hero {
+  padding-top: var(--space-8, 2rem);
+  padding-bottom: var(--space-6, 1.5rem);
+}
+
+/* Responsive: collapse sidebar on mobile */
+@media (max-width: 768px) {
+  .layout-shell[data-layout="sidebar"],
+  .layout-shell[data-layout="sidebar-topbar"] {
+    flex-direction: column;
+  }
+
+  .layout-shell[data-layout="sidebar"] .layout-sidebar-nav,
+  .layout-shell[data-layout="sidebar-topbar"] .layout-sidebar-nav {
+    width: 100%;
+    height: auto;
+    position: relative;
+    border-right: none;
+    border-bottom: var(--border-width, 1px) solid hsl(var(--border));
+  }
+
+  .layout-shell[data-layout="sidebar"] .navbar {
+    display: flex;
+  }
+}
+
+
+/* ============================================
+   27. Responsive Breakpoints
    ============================================ */
 
 @media (min-width: 576px) {
@@ -1319,7 +2044,7 @@ html {
 
 
 /* ============================================
-   9. RTL Overrides
+   28. RTL Overrides
    ============================================ */
 
 /* Sidebar active indicator flips to inline-end in RTL */


### PR DESCRIPTION
## Summary

- Moves ~729 lines of reusable scaffold CSS into `djust_theming/css/scaffold.css`
- Patterns extracted from a downstream djust application and generalized for any djust project
- All rules use CSS variable fallbacks so they work without a custom theme

## Sections added

| Section | Classes | Purpose |
|---------|---------|---------|
| Typography | `h1`-`h6`, `p` | Heading/body font families via `--font-heading`/`--font-body` |
| Grid Utilities | `.grid-2`, `.grid-3`, `.grid-4` | Responsive CSS grid layouts |
| Hero Section | `.hero`, `.hero-accent`, `.hero-subtitle` | Landing page hero pattern |
| Flash Messages | `.flash-messages`, `.flash-item`, `.dj-flash-*` | Django + djust LiveView flash |
| Accessibility | `.sr-only`, `.sr-only-focusable` | Screen reader utilities |
| Extended Utilities | `.text-small`, `.flex-center`, `.content-narrow` | Layout + text helpers |
| Stat Display | `.stat-display`, `.stat-value-*` | Large number + label pattern |
| Auth Layout | `.auth-wrapper`, `.auth-card` | Centered login page layout |
| Live Indicator | `.live-dot` | Pulsing green dot animation |
| Card Accents | `.card-accent`, `.card-accent-success` | Colored left-border card variants |
| Code Blocks | `.code`, `pre`, `code` | Syntax display styling |
| Layout System | `[data-layout]`, sidebar, topbar, centered, dashboard | Full layout switching via data attributes |

## What stays in the source project's own base.css

Project-specific branding (top bars, footers, customer-branded navbar elements, domain-specific card variants).

## Test plan

- [ ] Existing djust-theming tests pass
- [ ] Full project test suite passes locally (same pre-existing theming/mcp failures as main — no regressions introduced)
- [ ] Manual smoke: scaffold classes render correctly against the default theme tokens