### PR TITLE
fix(ci): resolve playwright-tests E001 + security-tests coverage threshold

### DIFF
--- a/examples/demo_project/demo_project/settings.py
+++ b/examples/demo_project/demo_project/settings.py
@@ -6,147 +6,147 @@ from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-SECRET_KEY = 'django-insecure-demo-key-change-in-production'
+SECRET_KEY = "django-insecure-demo-key-change-in-production"
 
 DEBUG = True
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
 # CSRF trusted origins for production
 CSRF_TRUSTED_ORIGINS = [
-    'https://djust.k8.trylinux.org',
-    'http://localhost:8002',
-    'http://127.0.0.1:8002',
-    'https://djust.org',
-    'https://www.djust.org',
+    "https://djust.k8.trylinux.org",
+    "http://localhost:8002",
+    "http://127.0.0.1:8002",
+    "https://djust.org",
+    "https://www.djust.org",
 ]
 
 # CSRF cookie settings for production HTTPS
 CSRF_COOKIE_SECURE = False  # Set to True only when DEBUG=False
-CSRF_COOKIE_SAMESITE = 'Lax'
+CSRF_COOKIE_SAMESITE = "Lax"
 CSRF_COOKIE_HTTPONLY = False  # Allow JavaScript to read the cookie
 CSRF_USE_SESSIONS = False  # Keep CSRF token in cookie, not session
 
 # Session cookie settings
 SESSION_COOKIE_SECURE = False  # Set to True only when DEBUG=False
-SESSION_COOKIE_SAMESITE = 'Lax'
+SESSION_COOKIE_SAMESITE = "Lax"
 
 # Allow iframes from same origin (for embedded demos on homepage)
-X_FRAME_OPTIONS = 'SAMEORIGIN'
+X_FRAME_OPTIONS = "SAMEORIGIN"
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'channels',
-    'djust',
-    'djust.theming',     # Optional extra — needed for theming tests
-    'djust.admin_ext',   # Optional extra — needed for admin tests
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "channels",
+    "djust",
+    "djust.theming",  # Optional extra — needed for theming tests
+    "djust.admin_ext",  # Optional extra — needed for admin tests
     # New organized apps
-    'djust_shared',      # Shared components and base classes
-    'djust_homepage',    # Landing page and navigation
-    'djust_demos',       # Feature demonstrations
-    'djust_forms',       # Forms demonstrations
-    'djust_tests',       # Test views
-    'djust_docs',        # Documentation views
-    'djust_rentals',     # Rental property management app
+    "djust_shared",  # Shared components and base classes
+    "djust_homepage",  # Landing page and navigation
+    "djust_demos",  # Feature demonstrations
+    "djust_forms",  # Forms demonstrations
+    "djust_tests",  # Test views
+    "djust_docs",  # Documentation views
+    "djust_rentals",  # Rental property management app
     # Old app (will be phased out)
-    'demo_app',
+    "demo_app",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
+    "django.middleware.security.SecurityMiddleware",
     # Observability localhost-gate — must come early so it rejects LAN
     # requests before any downstream middleware can do work.
-    'djust.observability.middleware.LocalhostOnlyObservabilityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "djust.observability.middleware.LocalhostOnlyObservabilityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-ROOT_URLCONF = 'demo_project.urls'
+ROOT_URLCONF = "demo_project.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [BASE_DIR / 'templates'],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-                'demo_app.context_processors.navbar',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+                "demo_app.context_processors.navbar",
+                # Required when INSTALLED_APPS includes ``djust.theming``
+                # (djust_theming.E001 check). Exposes theme_head, theme_switcher,
+                # and related template variables.
+                "djust.theming.context_processors.theme_context",
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = 'demo_project.wsgi.application'
-ASGI_APPLICATION = 'demo_project.asgi.application'
+WSGI_APPLICATION = "demo_project.wsgi.application"
+ASGI_APPLICATION = "demo_project.asgi.application"
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
     }
 }
 
 AUTH_PASSWORD_VALIDATORS = [
-    {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'},
-    {'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator'},
-    {'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator'},
-    {'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator'},
+    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
 
-LANGUAGE_CODE = 'en-us'
-TIME_ZONE = 'UTC'
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
 USE_I18N = True
 USE_TZ = True
 
-STATIC_URL = 'static/'
+STATIC_URL = "static/"
 STATICFILES_DIRS = [
-    BASE_DIR / 'static',
-    BASE_DIR / 'demo_app' / 'static',
+    BASE_DIR / "static",
+    BASE_DIR / "demo_app" / "static",
 ]
-STATIC_ROOT = BASE_DIR / 'staticfiles'
+STATIC_ROOT = BASE_DIR / "staticfiles"
 
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Unique cookie names to avoid collisions with other Django projects on localhost
 SESSION_COOKIE_NAME = "djust_demo_sessionid"
 CSRF_COOKIE_NAME = "djust_demo_csrftoken"
 
 # Channels configuration
-CHANNEL_LAYERS = {
-    'default': {
-        'BACKEND': 'channels.layers.InMemoryChannelLayer'
-    }
-}
+CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
 
 # LiveView WebSocket Security
 # List of module prefixes allowed for WebSocket view mounting
 # LiveView Configuration
 LIVEVIEW_CONFIG = {
-    'use_websocket': True,  # Use HTTP-only mode (disable WebSocket)
-    'debug_vdom': False,  # Enable detailed VDOM patch logging
+    "use_websocket": True,  # Use HTTP-only mode (disable WebSocket)
+    "debug_vdom": False,  # Enable detailed VDOM patch logging
 }
 
 # Security: Whitelist allowed modules for LiveView
 # Only views from these modules can be mounted via WebSocket
 LIVEVIEW_ALLOWED_MODULES = [
-    'demo_app.views',
-    'djust_demos.views',
-    'djust_shared.views',
-    'djust_rentals.views',
-    'djust_tests.views',
+    "demo_app.views",
+    "djust_demos.views",
+    "djust_shared.views",
+    "djust_rentals.views",
+    "djust_tests.views",
 ]
 
 # djust State Backend Configuration
@@ -155,25 +155,22 @@ DJUST_CONFIG = {
     # State backend: 'memory' (dev) or 'redis' (production)
     # - 'memory': Fast, simple, but no horizontal scaling (single server only)
     # - 'redis': Production-ready with horizontal scaling across multiple servers
-    'STATE_BACKEND': 'memory',  # Change to 'redis' for production
-
+    "STATE_BACKEND": "memory",  # Change to 'redis' for production
     # Redis connection URL (only used if STATE_BACKEND='redis')
     # Format: redis://[:password@]host[:port][/database]
     # Examples:
     #   'redis://localhost:6379/0'           # Local Redis
     #   'redis://:password@redis-host:6379/0' # With password
     #   'redis://redis.example.com:6379/1'   # Remote Redis, DB 1
-    'REDIS_URL': 'redis://localhost:6379/0',
-
+    "REDIS_URL": "redis://localhost:6379/0",
     # Session TTL (Time-To-Live) in seconds
     # How long inactive sessions are kept before cleanup
     # Default: 3600 seconds (1 hour)
-    'SESSION_TTL': 3600,
-
+    "SESSION_TTL": 3600,
     # Tenant configuration (for multi-tenant demo)
-    'TENANT_RESOLVER': 'header',  # Demo uses query param override in view
-    'TENANT_REQUIRED': False,     # Don't 404 without tenant
-    'TENANT_DEFAULT': 'acme',     # Default tenant for demo
+    "TENANT_RESOLVER": "header",  # Demo uses query param override in view
+    "TENANT_REQUIRED": False,  # Don't 404 without tenant
+    "TENANT_DEFAULT": "acme",  # Default tenant for demo
 }
 
 # Production Redis Configuration Example:

--- a/tests/unit/test_security_validation_hints.py
+++ b/tests/unit/test_security_validation_hints.py
@@ -1,0 +1,246 @@
+"""Coverage for ``djust.validation`` hint generators.
+
+The hint generators produce actionable error messages when parameter
+coercion fails. They're exercised indirectly by
+``validate_handler_params`` but the exact wording is worth locking in —
+these messages are what app developers see when a template attribute
+comes through in the wrong type.
+"""
+
+from __future__ import annotations
+
+
+from djust.validation import (
+    _coerce_single_value,
+    _coerce_value,
+    coerce_parameter_types,
+    format_type_error_hint,
+    get_handler_signature_info,
+    validate_handler_params,
+    validate_parameter_types,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# format_type_error_hint routes to the right sub-generator
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_hint_generic_for_unknown_pair():
+    hint = format_type_error_hint("x", expected="SomeCustomType", actual="dict", value={})
+    assert "SomeCustomType" in hint
+
+
+def test_hint_routes_str_to_int():
+    hint = format_type_error_hint("count", expected="int", actual="str", value="abc")
+    assert "could not be converted to int" in hint
+    assert "data-count:int" in hint
+
+
+def test_hint_routes_str_to_int_no_coercion_attempted():
+    hint = format_type_error_hint(
+        "count", expected="int", actual="str", value="abc", coercion_attempted=False
+    )
+    # The "could not be converted" phrase is gated on coercion_attempted=True.
+    assert "could not be converted" not in hint
+    assert "data-count:int" in hint
+
+
+def test_hint_routes_str_to_float():
+    hint = format_type_error_hint("price", expected="float", actual="str", value="oops")
+    assert "data-price:float" in hint
+    assert "could not be converted to float" in hint
+
+
+def test_hint_routes_str_to_float_no_coercion_attempted():
+    hint = format_type_error_hint(
+        "price", expected="float", actual="str", value="oops", coercion_attempted=False
+    )
+    assert "could not be converted" not in hint
+    assert "data-price:float" in hint
+
+
+def test_hint_routes_str_to_bool():
+    hint = format_type_error_hint("enabled", expected="bool", actual="str", value="maybe")
+    assert "data-enabled:bool" in hint
+    assert "treated as False" in hint
+
+
+def test_hint_routes_str_to_bool_no_coercion_attempted():
+    hint = format_type_error_hint(
+        "enabled", expected="bool", actual="str", value="maybe", coercion_attempted=False
+    )
+    assert "treated as False" not in hint
+    assert "data-enabled:bool" in hint
+
+
+def test_hint_routes_str_to_list():
+    hint = format_type_error_hint("tags", expected="list", actual="str", value="a,b,c")
+    assert "data-tags:json" in hint
+    assert "data-tags:list" in hint
+
+
+def test_hint_routes_str_to_decimal():
+    hint = format_type_error_hint("amount", expected="Decimal", actual="str", value="not-a-number")
+    assert "could not be converted to Decimal" in hint
+
+
+def test_hint_routes_str_to_decimal_no_coercion_attempted():
+    hint = format_type_error_hint(
+        "amount",
+        expected="Decimal",
+        actual="str",
+        value="not-a-number",
+        coercion_attempted=False,
+    )
+    assert "could not be converted" not in hint
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# validate_parameter_types surfaces type errors with hints
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_validate_parameter_types_returns_type_errors():
+    def handler(self, n: int = 0, **kwargs):
+        return n
+
+    errors = validate_parameter_types(handler, {"n": "not-a-number"})
+    assert errors  # non-empty → at least one type error surfaced
+
+
+def test_validate_parameter_types_ok_for_correct_types():
+    def handler(self, n: int = 0, **kwargs):
+        return n
+
+    errors = validate_parameter_types(handler, {"n": 42})
+    assert not errors  # None or [] both mean "no errors"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# coerce_parameter_types / _coerce_value edge cases
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_coerce_returns_original_on_failure_for_non_str_source():
+    def handler(self, n: int = 0, **kwargs):
+        return n
+
+    # Pass a dict — coercion should not try to turn dict into int.
+    result = coerce_parameter_types(handler, {"n": {"x": 1}})
+    # Left as-is; caller should see the dict and generate a type error.
+    assert result["n"] == {"x": 1}
+
+
+def test_coerce_value_with_no_origin_returns_direct_coercion():
+    # origin=None means not a generic (e.g., list[int]). Should behave like a
+    # plain ``int()`` coercion.
+    assert _coerce_value("42", int, None) == 42
+
+
+def test_coerce_value_list_with_comma_separated_and_element_coercion():
+    # list[int] from comma-separated string.
+    result = _coerce_value("1,2,3", list, list)
+    assert result == ["1", "2", "3"]  # elements stay str when no element type info
+
+
+def test_coerce_single_value_noop_when_types_match():
+    # Only str inputs are touched by the coercer; already-typed values pass through.
+    assert _coerce_single_value("42", int) == 42
+    assert _coerce_single_value("3.14", float) == 3.14
+
+
+def test_coerce_single_value_empty_string_to_int_zero():
+    assert _coerce_single_value("", int) == 0
+
+
+def test_coerce_single_value_bool_truthy_strings():
+    for truthy in ("true", "TRUE", "1", "yes", "on"):
+        assert _coerce_single_value(truthy, bool) is True
+
+
+def test_coerce_single_value_bool_falsy_strings():
+    for falsy in ("false", "FALSE", "0", "no", "off", ""):
+        assert _coerce_single_value(falsy, bool) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# get_handler_signature_info coverage
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_signature_info_captures_required_and_optional():
+    def handler(self, req: int, opt: str = "", **kwargs):
+        """Do a thing."""
+        return None
+
+    info = get_handler_signature_info(handler)
+    by_name = {p["name"]: p for p in info["params"]}
+    assert by_name["req"]["required"] is True
+    assert by_name["opt"]["required"] is False
+    assert info["accepts_kwargs"] is True
+
+
+def test_signature_info_no_kwargs():
+    def handler(self, x: int):
+        return x
+
+    info = get_handler_signature_info(handler)
+    assert info["accepts_kwargs"] is False
+
+
+def test_signature_info_no_docstring():
+    def handler(self, x: int = 0, **kwargs):
+        return x
+
+    info = get_handler_signature_info(handler)
+    assert info["description"] == ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# validate_handler_params: coverage for edge branches
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_validate_handler_params_reports_missing_required():
+    def handler(self, required: int, **kwargs):
+        return required
+
+    result = validate_handler_params(handler, {}, "my_event")
+    assert result["valid"] is False
+    assert "required" in result["expected"]
+
+
+def test_validate_handler_params_reports_unexpected_without_kwargs():
+    def handler(self, x: int = 0):
+        return x
+
+    result = validate_handler_params(handler, {"unknown": 1}, "my_event")
+    assert result["valid"] is False
+
+
+def test_validate_handler_params_accepts_unexpected_with_kwargs():
+    def handler(self, x: int = 0, **kwargs):
+        return x
+
+    result = validate_handler_params(handler, {"x": 1, "extra": "ok"}, "my_event")
+    assert result["valid"] is True
+
+
+def test_validate_handler_params_reports_type_error_in_details():
+    def handler(self, n: int = 0, **kwargs):
+        return n
+
+    result = validate_handler_params(handler, {"n": "abc"}, "my_event", coerce=False)
+    assert result["valid"] is False
+    assert result["type_errors"]
+
+
+def test_validate_handler_params_positional_args_bind_to_named_params():
+    def handler(self, a: int, b: int = 0, **kwargs):
+        return a + b
+
+    result = validate_handler_params(handler, {}, "my_event", positional_args=[1, 2])
+    assert result["valid"] is True
+    assert result["coerced_params"]["a"] == 1
+    assert result["coerced_params"]["b"] == 2


### PR DESCRIPTION
## Summary

Two pre-existing CI failures that have required `--admin` merge on PRs #835 and #837. Both are addressed here so subsequent PRs can merge normally.

## 1. playwright-tests — `djust_theming.E001`

Demo project had `djust.theming` in `INSTALLED_APPS` but its `TEMPLATES[0]['OPTIONS']['context_processors']` didn't include `djust.theming.context_processors.theme_context`, tripping the `djust_theming.E001` system check. This in turn blocked `manage.py migrate --noinput` in the Playwright workflow, causing the whole job to fail.

**Fix**: Added the context processor to demo_project settings. (`examples/demo_project/demo_project/settings.py`)

Verification (local):
- `python manage.py check` — 0 ERRORS (previously 1: E001)
- `python manage.py migrate --noinput` — runs clean

## 2. security-tests — coverage threshold

Workflow runs `pytest --cov-fail-under=75` over `djust.security`, `djust.uploads`, and `djust.validation`. Coverage has drifted to 69%.

**Fix**: Rather than lower the threshold, added `tests/unit/test_security_validation_hints.py` — 27 targeted tests covering `djust.validation`'s hint generators (`_get_string_to_int_hint`, `_get_string_to_float_hint`, `_get_string_to_bool_hint`, `_get_string_to_list_hint`, `_get_string_to_decimal_hint`), the `format_type_error_hint` router, `validate_parameter_types`, coercion edge cases in `_coerce_value` / `_coerce_single_value`, and `get_handler_signature_info` shape.

Coverage before → after:

| Module | Before | After |
|--------|--------|-------|
| `djust/validation.py` | 65% | **90%** |
| `djust/uploads.py` | 66% | 66% |
| `djust/security/*` | 74-100% | 74-100% |
| **Total** | **69%** | **76%** ✅ |

Security test suite: 233 → 260 tests passing.

## Why this matters

- Removes the need for `--admin` on future PR merges (the canonical path through Stage 13 Merge PR)
- Fixes a latent footgun: any app installing `djust.theming` without the context processor would have seen the same E001 error
- Locks in the validation hint-message wording — these are messages app developers see when template attribute types misalign

## Test plan

- [x] `manage.py check` passes with 0 ERRORS on demo_project
- [x] `manage.py migrate --noinput` succeeds on demo_project
- [x] `pytest tests/unit/test_security_*.py python/tests/test_security*.py --cov-fail-under=75` passes locally
- [x] All 260 security-test cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)