### PR TITLE
feat: LiveView testing utilities (v0.5.1 P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.1rc2] - 2026-04-21
+### Added
+
+- **LiveView testing utilities (v0.5.1 P2)** — Seven new methods on `LiveViewTestClient` for Phoenix LiveViewTest parity: `assert_push_event(event_name, params=None)` verifies a handler queued a client-bound push event (payload match is subset-based so tests stay resilient to later payload additions); `assert_patch(path=None, params=None)` / `assert_redirect(path=None, params=None)` assert `live_patch` / `live_redirect` calls; `render_async()` drains pending `start_async` / `assign_async` tasks synchronously so subsequent assertions see their results; `follow_redirect()` resolves the queued redirect via Django's URL router and returns a new test client mounted on the destination view; `assert_stream_insert(stream_name, item=None)` verifies stream operations (item subset-match for dicts); `trigger_info(message)` synthetically delivers a `handle_info` message so pubsub / pg_notify handlers can be tested without real backend wiring. Full user-facing guide at `docs/website/guides/testing.md`. 21 new test cases. (`python/djust/testing.py`)
+
+
 
 ### Added
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ This roadmap outlines what has been built, what is actively being worked on, and
 | **P1** | Function Components (stateless) | Cheap render-only components without WS overhead — Phoenix.Component parity | v0.5.0 |
 | **P1** | `assign_async` / AsyncResult | Foundation for responsive dashboards — independent loading boundaries | v0.5.0 |
 | **P1** | Template fragments (static subtree) | Biggest wire-size optimization; how Phoenix achieves sub-ms updates | v0.5.0 |
-| **P1** | LiveView testing utilities | `assert_push_event()`, `assert_patch()`, `render_async()` — test DX is adoption-critical | v0.5.0 |
+| ~~**P1**~~ | ~~LiveView testing utilities~~ ✅ Shipped in v0.5.1 (7 methods + 21 tests) | ~~`assert_push_event()`, `assert_patch()`, `render_async()` — test DX is adoption-critical~~ | ~~v0.5.0~~ |
 | **P1** | Keyed for-loop change tracking | O(changed) not O(total) for list re-renders — foundation for large-list performance | v0.5.0 |
 | **P1** | Temporary assigns | Phoenix's #1 memory optimization — without it, large lists (chat, feeds) leak memory unboundedly | v0.5.0 |
 | **P1** | ✅ `manage.py djust_gen_live` scaffolding | Phoenix's generators are the #1 onboarding DX feature; scaffold views/templates/tests from a model | v0.4.0 |
@@ -704,7 +704,7 @@ class OrderDashboardView(LiveView):
 
 ~~**Package consolidation: fold `djust-theming` into core** ([ADR-007](docs/adr/007-package-taxonomy-and-consolidation.md))~~ ✅ **Shipped in v0.5.0 (PR #772)** — Phase 2 of the three-phase consolidation landed as part of the v0.5.0 "Full Package Consolidation" milestone rather than slipping to v0.5.1. `djust_theming/` (~37.6K LOC) was moved to `python/djust/theming/` with `djust-theming 0.5.0` shipping as a compat shim. Retained in the ROADMAP for historical context; sunset tracked under v0.6.0 Phase 4.
 
-**LiveView testing utilities** — (Moved from v0.5.0) The existing `LiveViewTestClient` covers basic mount/event/render. Production apps need: `assert_push_event(event_name, params)` to verify server→client push events, `assert_patch(path)` / `assert_redirect(path)` for navigation testing, `render_async()` that waits for `start_async` callbacks to complete before asserting, `follow_redirect()` for chaining navigation, `assert_stream_insert(stream, item)` for testing streaming operations, and `trigger_info(message)` for testing `handle_info` handlers. Phoenix's `LiveViewTest` is considered best-in-class testing DX — we need parity. ~300 lines Python.
+~~**LiveView testing utilities**~~ ✅ **Shipped in v0.5.1** (7 methods + 21 tests in `LiveViewTestClient`). `assert_push_event`, `assert_patch`, `assert_redirect`, `render_async`, `follow_redirect`, `assert_stream_insert`, `trigger_info` all match the v0.5.1 roadmap spec. Full user guide at `docs/website/guides/testing.md`. See also the priority matrix row above.
 
 ```python
 # Target API
@@ -1039,7 +1039,7 @@ High-impact areas for contributions:
 32. **`assign_async`/`AsyncResult`** — High-level async data loading, ~200 lines Python
 33. **`handle_async` callback** — Typed async completion handler (Phoenix 1.0 parity), ~80 lines Python
 34. **Declarative component assigns** — Type-checked attrs with defaults/validation, ~120 lines Python
-35. **LiveView testing utilities** — `assert_push_event`, `assert_patch`, `render_async`, ~300 lines Python
+35. ~~**LiveView testing utilities**~~ ✅ **Shipped in v0.5.1** — 7 methods + 21 tests; see guide at `docs/website/guides/testing.md`.
 36. **Error overlay (dev mode)** — In-browser Python stack traces, ~100 lines Python + ~80 lines JS
 37. **Template fragments** — Rust-side static subtree fingerprinting for wire-size optimization
 38. **Connection multiplexing** — Share one WS across multiple LiveViews, ~200 lines JS + Python

--- a/docs/website/_config.yaml
+++ b/docs/website/_config.yaml
@@ -228,6 +228,11 @@ navigation:
         file: testing/index.md
         order: 1
         level: intermediate
+      - title: Testing LiveViews (v0.5.1 API)
+        slug: testing-liveviews
+        file: guides/testing.md
+        order: 2
+        level: intermediate
 
   - title: Advanced
     slug: advanced

--- a/docs/website/guides/testing.md
+++ b/docs/website/guides/testing.md
@@ -1,0 +1,183 @@
+---
+title: Testing LiveViews
+layout: doc
+---
+
+# Testing LiveViews
+
+djust ships `LiveViewTestClient` — a synchronous test client that lets you
+exercise LiveView behavior end-to-end without standing up a real WebSocket
+consumer. Inspired by Phoenix's `LiveViewTest`.
+
+```python
+from djust.testing import LiveViewTestClient
+
+def test_counter_increments():
+    client = LiveViewTestClient(CounterView).mount()
+    client.send_event("increment")
+    client.assert_state(count=1)
+```
+
+The client instantiates the view, calls `mount()`, and invokes handlers
+directly — the same code path the WebSocket consumer runs, minus the
+transport layer.
+
+## Core methods
+
+- `mount(**params)` — instantiate the view and run `mount()`. Returns `self`.
+- `send_event(name, **params)` — call a handler by name. Returns a dict with
+  `state_before`, `state_after`, `duration_ms`, `success`, `error`.
+- `assert_state(**expected)` — exact-match assertions on public view attrs.
+- `assert_state_contains(**expected)` — substring match (strings) or subset
+  match (dicts/lists).
+- `get_state()` — return a snapshot of public attrs.
+- `render(engine="rust")` — render the view template and return the HTML.
+
+## Phoenix-parity assertions (v0.5.1)
+
+Seven additional methods cover the rest of the production test surface.
+
+### `assert_push_event(event_name, params=None)`
+
+Verify the last `send_event` queued a client-bound push event.
+
+```python
+class SaveView(LiveView):
+    @event_handler
+    def save(self, **kwargs):
+        self.push_event("flash", {"type": "success", "message": "saved"})
+
+client = LiveViewTestClient(SaveView).mount()
+client.send_event("save")
+client.assert_push_event("flash", {"type": "success"})
+# Payload match is SUBSET — extra keys in the stored payload are OK.
+```
+
+### `assert_patch(path=None, params=None)` / `assert_redirect(path=None, params=None)`
+
+Verify the handler queued a navigation.
+
+```python
+class FilterView(LiveView):
+    @event_handler
+    def filter(self, **kwargs):
+        self.live_patch(params={"page": 2, "category": "books"}, path="/items/")
+
+client = LiveViewTestClient(FilterView).mount()
+client.send_event("filter")
+client.assert_patch("/items/", {"page": 2})  # subset match on params
+```
+
+`assert_redirect` has the same signature and matches `live_redirect` calls.
+
+### `render_async()`
+
+Drain pending `start_async` / `assign_async` tasks synchronously so tests
+can assert on their results.
+
+```python
+class ReportView(LiveView):
+    @event_handler
+    def generate(self, **kwargs):
+        self.generating = True
+        self.start_async(self._build_report)
+
+    def _build_report(self):
+        self.report = build(...)
+        self.generating = False
+
+client = LiveViewTestClient(ReportView).mount()
+client.send_event("generate")
+client.assert_state(generating=True)      # pre-drain
+client.render_async()
+client.assert_state(generating=False)     # post-drain
+assert client.view_instance.report is not None
+```
+
+`render_async()` runs exactly one batch of pending tasks; callbacks that
+queue more work require a second call. Matches production consumer semantics.
+
+### `follow_redirect()`
+
+After a `live_redirect`, mount the destination view and return a new client
+rooted on it.
+
+```python
+class LoginView(LiveView):
+    @event_handler
+    def submit(self, email="", password="", **kwargs):
+        if authenticate(email, password):
+            self.live_redirect("/dashboard/")
+
+login_client = LiveViewTestClient(LoginView).mount()
+login_client.send_event("submit", email="a@b.com", password="x")
+dashboard_client = login_client.follow_redirect()
+dashboard_client.assert_state(user_email="a@b.com")
+```
+
+### `assert_stream_insert(stream_name, item=None)`
+
+Verify a stream operation was queued.
+
+```python
+class ChatView(LiveView):
+    def mount(self, request, **kwargs):
+        self.stream("messages", [])
+
+    @event_handler
+    def post(self, text="", **kwargs):
+        self.stream_insert("messages", {"id": next_id(), "text": text})
+
+client = LiveViewTestClient(ChatView).mount()
+client.send_event("post", text="hello")
+client.assert_stream_insert("messages", {"text": "hello"})
+```
+
+Dict items are matched by subset; other types by equality.
+
+### `trigger_info(message)`
+
+Synthetically deliver a `handle_info` message (the hook `pg_notify` uses).
+Tests pubsub / database-notification handlers without real backend wiring.
+
+```python
+class OrdersView(LiveView):
+    def mount(self, request, **kwargs):
+        self.listen("orders")
+        self.count = 0
+
+    def handle_info(self, message):
+        if message.get("type") == "db_notify":
+            self.count += 1
+
+client = LiveViewTestClient(OrdersView).mount()
+client.trigger_info({"type": "db_notify", "channel": "orders", "payload": {"event": "save"}})
+client.assert_state(count=1)
+```
+
+## Putting it together
+
+A typical integration test combines several of these:
+
+```python
+def test_create_item_flow():
+    client = LiveViewTestClient(InventoryView).mount()
+    client.send_event("create", name="widget")
+    client.assert_stream_insert("items", {"name": "widget"})
+    client.assert_push_event("flash", {"type": "success"})
+    client.assert_patch("/items/", {"highlight": "widget"})
+```
+
+## When to reach for each tool
+
+- **Unit test a handler** → `send_event` + `assert_state`
+- **Test a push-event / flash** → `assert_push_event`
+- **Test navigation** → `assert_patch` / `assert_redirect` / `follow_redirect`
+- **Test async workflow** → `render_async`
+- **Test streaming/append** → `assert_stream_insert`
+- **Test pubsub / db_notify reaction** → `trigger_info`
+- **Test rendered HTML** → `render()` and assert on the returned string
+- **Snapshot test rendered HTML** → inherit `SnapshotTestMixin` (separate)
+
+For end-to-end browser tests, use Playwright against `examples/demo_project`
+(or your own Django app running djust).

--- a/docs/website/guides/testing.md
+++ b/docs/website/guides/testing.md
@@ -83,8 +83,14 @@ class ReportView(LiveView):
         self.start_async(self._build_report)
 
     def _build_report(self):
-        self.report = build(...)
-        self.generating = False
+        try:
+            self.report = build(...)
+        except Exception as exc:
+            # Always guard async callbacks — a crash that leaves `generating`
+            # True will leave the client stuck in a loading state.
+            self.error = str(exc)
+        finally:
+            self.generating = False
 
 client = LiveViewTestClient(ReportView).mount()
 client.send_event("generate")
@@ -126,7 +132,8 @@ class ChatView(LiveView):
 
     @event_handler
     def post(self, text="", **kwargs):
-        self.stream_insert("messages", {"id": next_id(), "text": text})
+        from uuid import uuid4
+        self.stream_insert("messages", {"id": uuid4().hex, "text": text})
 
 client = LiveViewTestClient(ChatView).mount()
 client.send_event("post", text="hello")

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -116,6 +116,7 @@ Test LiveViews without a browser.
 |                                       |                                                                                     |
 | ------------------------------------- | ----------------------------------------------------------------------------------- |
 | **[Testing Guide](testing/index.md)** | `LiveViewTestClient`, `SnapshotTestMixin`, `LiveViewSmokeTest`, `@performance_test` |
+| **[Testing LiveViews (v0.5.1 API)](guides/testing.md)** | Phoenix-parity assertions: `assert_push_event`, `assert_patch`, `render_async`, `follow_redirect`, `assert_stream_insert`, `trigger_info` |
 
 ---
 

--- a/python/djust/testing.py
+++ b/python/djust/testing.py
@@ -506,8 +506,6 @@ class LiveViewTestClient:
         tasks = getattr(self.view_instance, "_async_tasks", None)
         if not tasks:
             return
-        import inspect
-
         from asgiref.sync import async_to_sync
 
         # Drain so tasks re-queued by their callbacks are visible to the next
@@ -531,8 +529,8 @@ class LiveViewTestClient:
             A new ``LiveViewTestClient`` pointed at the destination view.
 
         Raises:
-            AssertionError: No redirect was queued.
-            RuntimeError: URL resolves to a non-LiveView view.
+            AssertionError: No redirect was queued, or the URL resolves to a
+                non-LiveView view.
         """
         self._require_mounted()
         nav = getattr(self.view_instance, "_pending_navigation", [])
@@ -546,6 +544,16 @@ class LiveViewTestClient:
 
         match = resolve(target["path"])
         view_cls = getattr(match.func, "view_class", None) or match.func
+        # Guard: the destination must actually be a LiveView. Without this,
+        # ``client.mount()`` would explode with a confusing traceback.
+        from djust.live_view import LiveView
+
+        if not (isinstance(view_cls, type) and issubclass(view_cls, LiveView)):
+            raise AssertionError(
+                f"follow_redirect: {target['path']!r} resolves to {view_cls!r} which "
+                f"is not a LiveView subclass. The test client can only follow "
+                f"redirects to LiveView destinations."
+            )
         client = LiveViewTestClient(view_cls, user=self.user)
         mount_params = dict(target.get("params") or {})
         mount_params.update(match.kwargs)
@@ -593,8 +601,7 @@ class LiveViewTestClient:
             elif stored == item:
                 return
         raise AssertionError(
-            f"Expected stream_insert({stream_name!r}, {item!r}) but stream contains: "
-            f"{stream_items}"
+            f"Expected stream_insert({stream_name!r}, {item!r}) but stream contains: {stream_items}"
         )
 
     def trigger_info(self, message: Any) -> Dict[str, Any]:

--- a/python/djust/testing.py
+++ b/python/djust/testing.py
@@ -390,7 +390,7 @@ class LiveViewTestClient:
         event_name: str,
         params: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Verify the most recent event queued a ``push_event`` with this name.
+        """Verify that at least one queued ``push_event`` matches this name.
 
         Searches ``view_instance._pending_push_events`` (populated by
         :meth:`PushEventMixin.push_event`). If ``params`` is given, the stored

--- a/python/djust/testing.py
+++ b/python/djust/testing.py
@@ -381,6 +381,283 @@ class LiveViewTestClient:
         """
         return self.events.copy()
 
+    # ========================================================================
+    # v0.5.1 — Phoenix LiveViewTest parity assertions
+    # ========================================================================
+
+    def assert_push_event(
+        self,
+        event_name: str,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Verify the most recent event queued a ``push_event`` with this name.
+
+        Searches ``view_instance._pending_push_events`` (populated by
+        :meth:`PushEventMixin.push_event`). If ``params`` is given, the stored
+        payload must be a superset of it (extra keys are allowed — matches
+        are subset-based so tests are resilient to later payload additions).
+
+        Args:
+            event_name: Name passed to ``self.push_event(...)`` in the handler.
+            params: Optional payload subset to match. ``None`` skips payload check.
+
+        Raises:
+            AssertionError: No matching push event queued.
+            RuntimeError: View not mounted.
+
+        Example::
+
+            client.send_event("save")
+            client.assert_push_event("flash", {"type": "success"})
+        """
+        self._require_mounted()
+        pending = getattr(self.view_instance, "_pending_push_events", [])
+        for name, payload in pending:
+            if name != event_name:
+                continue
+            if params is None:
+                return
+            if all(payload.get(k) == v for k, v in params.items()):
+                return
+        available = ", ".join(n for n, _ in pending) or "(none)"
+        raise AssertionError(
+            f"Expected push_event({event_name!r}{', ' + repr(params) if params else ''}) "
+            f"but handler queued: {available}"
+        )
+
+    def assert_patch(
+        self,
+        path: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Verify the handler queued a :meth:`live_patch` navigation.
+
+        Args:
+            path: Optional URL path to match. ``None`` matches any patch.
+            params: Optional query-param subset to match against ``nav["params"]``.
+
+        Raises:
+            AssertionError: No matching live_patch queued.
+        """
+        self._require_mounted()
+        nav = getattr(self.view_instance, "_pending_navigation", [])
+        patches = [n for n in nav if n.get("type") == "live_patch"]
+        if not patches:
+            raise AssertionError(
+                f"Expected a live_patch, but the handler queued: "
+                f"{[n.get('type') for n in nav] or '(no navigation)'}"
+            )
+        for p in patches:
+            if path is not None and p.get("path") != path:
+                continue
+            if params is not None:
+                p_params = p.get("params") or {}
+                if not all(p_params.get(k) == v for k, v in params.items()):
+                    continue
+            return
+        raise AssertionError(
+            f"Expected live_patch(path={path!r}, params={params!r}) but got: {patches}"
+        )
+
+    def assert_redirect(
+        self,
+        path: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Verify the handler queued a :meth:`live_redirect` navigation.
+
+        See :meth:`assert_patch` for args/behavior — identical shape, different
+        navigation type.
+        """
+        self._require_mounted()
+        nav = getattr(self.view_instance, "_pending_navigation", [])
+        redirects = [n for n in nav if n.get("type") == "live_redirect"]
+        if not redirects:
+            raise AssertionError(
+                f"Expected a live_redirect, but the handler queued: "
+                f"{[n.get('type') for n in nav] or '(no navigation)'}"
+            )
+        for r in redirects:
+            if path is not None and r.get("path") != path:
+                continue
+            if params is not None:
+                r_params = r.get("params") or {}
+                if not all(r_params.get(k) == v for k, v in params.items()):
+                    continue
+            return
+        raise AssertionError(
+            f"Expected live_redirect(path={path!r}, params={params!r}) but got: {redirects}"
+        )
+
+    def render_async(self) -> None:
+        """Synchronously run any pending ``start_async`` / ``assign_async`` tasks.
+
+        The production WS consumer runs these tasks after the handler returns;
+        in unit tests we drain them inline so subsequent assertions see their
+        results. Each task's ``(callback, args, kwargs)`` tuple is called in
+        declaration order; exceptions propagate so test authors see real
+        failures instead of silent skips. Async callbacks are driven via
+        ``asgiref.sync.async_to_sync``.
+
+        Raises:
+            RuntimeError: View not mounted.
+        """
+        self._require_mounted()
+        tasks = getattr(self.view_instance, "_async_tasks", None)
+        if not tasks:
+            return
+        import inspect
+
+        from asgiref.sync import async_to_sync
+
+        # Drain so tasks re-queued by their callbacks are visible to the next
+        # render_async() call (matches the production consumer semantics).
+        pending = list(tasks.items())
+        self.view_instance._async_tasks = {}
+        for _name, (callback, args, kwargs) in pending:
+            result = callback(*args, **kwargs)
+            if inspect.iscoroutine(result):
+                async_to_sync(_await_coro)(result)
+
+    def follow_redirect(self) -> "LiveViewTestClient":
+        """After a handler queued a ``live_redirect``, mount the destination.
+
+        Resolves the queued redirect path against Django's URL resolver, finds
+        the target ``LiveView`` class, and returns a fresh
+        :class:`LiveViewTestClient` mounted on it. Query params from the
+        redirect become mount kwargs.
+
+        Returns:
+            A new ``LiveViewTestClient`` pointed at the destination view.
+
+        Raises:
+            AssertionError: No redirect was queued.
+            RuntimeError: URL resolves to a non-LiveView view.
+        """
+        self._require_mounted()
+        nav = getattr(self.view_instance, "_pending_navigation", [])
+        redirects = [n for n in nav if n.get("type") == "live_redirect"]
+        if not redirects:
+            raise AssertionError(
+                "Expected a live_redirect to follow, but the handler queued no redirect."
+            )
+        target = redirects[-1]
+        from django.urls import resolve
+
+        match = resolve(target["path"])
+        view_cls = getattr(match.func, "view_class", None) or match.func
+        client = LiveViewTestClient(view_cls, user=self.user)
+        mount_params = dict(target.get("params") or {})
+        mount_params.update(match.kwargs)
+        client.mount(**mount_params)
+        return client
+
+    def assert_stream_insert(
+        self,
+        stream_name: str,
+        item: Optional[Any] = None,
+    ) -> None:
+        """Verify the handler queued a ``stream_insert`` for ``stream_name``.
+
+        Args:
+            stream_name: The stream name passed to :meth:`stream_insert`.
+            item: Optional item to match (subset-match on dict keys if item
+                is a dict; equality otherwise).
+
+        Raises:
+            AssertionError: No matching stream op queued.
+        """
+        self._require_mounted()
+        ops = getattr(self.view_instance, "_stream_operations", [])
+        inserts = [
+            o for o in ops if o.get("type") == "stream_insert" and o.get("stream") == stream_name
+        ]
+        if not inserts:
+            available = sorted({o.get("stream") for o in ops if o.get("type") == "stream_insert"})
+            raise AssertionError(
+                f"Expected stream_insert on {stream_name!r}, "
+                f"but inserts were queued on: {available or '(none)'}"
+            )
+        if item is None:
+            return
+        # The op dict only stores metadata (dom_id, position); the actual item
+        # lives in ``view_instance._streams[stream_name]``. Walk the stream's
+        # items to match.
+        streams = getattr(self.view_instance, "_streams", {})
+        stream_obj = streams.get(stream_name)
+        stream_items = list(getattr(stream_obj, "items", ())) if stream_obj else []
+        for stored in stream_items:
+            if isinstance(item, dict) and isinstance(stored, dict):
+                if all(stored.get(k) == v for k, v in item.items()):
+                    return
+            elif stored == item:
+                return
+        raise AssertionError(
+            f"Expected stream_insert({stream_name!r}, {item!r}) but stream contains: "
+            f"{stream_items}"
+        )
+
+    def trigger_info(self, message: Any) -> Dict[str, Any]:
+        """Synthetically deliver a ``handle_info`` message to the view.
+
+        Lets tests exercise ``pg_notify`` / pubsub handlers without standing
+        up real backend infrastructure. Every LiveView inherits a no-op
+        ``handle_info`` default from :class:`NotificationMixin`, so calling
+        this on a view that hasn't overridden it returns success with no
+        state change — the assertion job belongs to the test author.
+
+        Args:
+            message: The payload to pass. Typically a dict of the shape
+                ``{"type": "db_notify", "channel": "...", "payload": {...}}``.
+
+        Returns:
+            Dict with ``state_before`` / ``state_after`` / ``duration_ms`` /
+            ``error`` — same shape as :meth:`send_event`.
+
+        Raises:
+            RuntimeError: View not mounted.
+        """
+        self._require_mounted()
+        handler = getattr(self.view_instance, "handle_info", None)
+        if not callable(handler):  # defensive — NotificationMixin always provides it
+            raise AttributeError(
+                f"{type(self.view_instance).__name__} does not define handle_info()."
+            )
+        state_before = self.get_state()
+        start_time = time.perf_counter()
+        error = None
+        try:
+            handler(message)
+        except Exception as exc:
+            error = str(exc)
+        duration_ms = (time.perf_counter() - start_time) * 1000
+        state_after = self.get_state()
+        self.events.append(
+            {
+                "type": "handle_info",
+                "message": message,
+                "timestamp": time.time(),
+                "duration_ms": duration_ms,
+                "error": error,
+            }
+        )
+        return {
+            "success": error is None,
+            "error": error,
+            "state_before": state_before,
+            "state_after": state_after,
+            "duration_ms": duration_ms,
+        }
+
+    def _require_mounted(self) -> None:
+        if not self._mounted or not self.view_instance:
+            raise RuntimeError("View not mounted. Call client.mount() first.")
+
+
+async def _await_coro(coro):
+    """Helper for ``render_async`` — awaits a coroutine under async_to_sync."""
+    return await coro
+
 
 class SnapshotTestMixin:
     """

--- a/python/djust/tests/test_testing_utilities.py
+++ b/python/djust/tests/test_testing_utilities.py
@@ -326,6 +326,7 @@ def test_assertions_require_mount():
         ("assert_patch", ("/x/",)),
         ("assert_redirect", ("/y/",)),
         ("render_async", ()),
+        ("follow_redirect", ()),
         ("assert_stream_insert", ("s",)),
         ("trigger_info", ({"type": "x"},)),
     ]:

--- a/python/djust/tests/test_testing_utilities.py
+++ b/python/djust/tests/test_testing_utilities.py
@@ -1,0 +1,356 @@
+"""Tests for v0.5.1 LiveViewTestClient Phoenix-parity assertions.
+
+Covers assert_push_event, assert_patch, assert_redirect, render_async,
+follow_redirect, assert_stream_insert, and trigger_info.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from djust.decorators import event_handler
+from djust.live_view import LiveView
+from djust.testing import LiveViewTestClient
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# assert_push_event
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_assert_push_event_matches_by_name():
+    class V(LiveView):
+        @event_handler
+        def save(self, **kwargs):
+            self.push_event("flash", {"type": "success", "message": "saved"})
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("save")
+    c.assert_push_event("flash")
+
+
+def test_assert_push_event_matches_payload_subset():
+    class V(LiveView):
+        @event_handler
+        def save(self, **kwargs):
+            self.push_event("flash", {"type": "success", "message": "saved"})
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("save")
+    # Only asserting one key — subset match tolerates the other.
+    c.assert_push_event("flash", {"type": "success"})
+
+
+def test_assert_push_event_fails_on_wrong_name():
+    class V(LiveView):
+        @event_handler
+        def save(self, **kwargs):
+            self.push_event("flash", {"type": "success"})
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("save")
+    with pytest.raises(AssertionError, match="Expected push_event"):
+        c.assert_push_event("toast")
+
+
+def test_assert_push_event_fails_on_payload_mismatch():
+    class V(LiveView):
+        @event_handler
+        def save(self, **kwargs):
+            self.push_event("flash", {"type": "error"})
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("save")
+    with pytest.raises(AssertionError):
+        c.assert_push_event("flash", {"type": "success"})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# assert_patch
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_assert_patch_matches_path():
+    class V(LiveView):
+        @event_handler
+        def filter(self, **kwargs):
+            self.live_patch(params={"page": 2}, path="/items/")
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("filter")
+    c.assert_patch("/items/")
+
+
+def test_assert_patch_matches_params_subset():
+    class V(LiveView):
+        @event_handler
+        def filter(self, **kwargs):
+            self.live_patch(params={"page": 2, "category": "books"}, path="/items/")
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("filter")
+    c.assert_patch("/items/", {"page": 2})
+
+
+def test_assert_patch_fails_when_redirect_queued_instead():
+    class V(LiveView):
+        @event_handler
+        def go(self, **kwargs):
+            self.live_redirect("/detail/")
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("go")
+    with pytest.raises(AssertionError, match="Expected a live_patch"):
+        c.assert_patch("/detail/")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# assert_redirect
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_assert_redirect_matches_path():
+    class V(LiveView):
+        @event_handler
+        def save_and_exit(self, **kwargs):
+            self.live_redirect("/dashboard/")
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("save_and_exit")
+    c.assert_redirect("/dashboard/")
+
+
+def test_assert_redirect_fails_on_wrong_path():
+    class V(LiveView):
+        @event_handler
+        def go(self, **kwargs):
+            self.live_redirect("/home/")
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("go")
+    with pytest.raises(AssertionError):
+        c.assert_redirect("/dashboard/")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# render_async
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_render_async_no_pending_tasks_is_noop():
+    class V(LiveView):
+        @event_handler
+        def nop(self, **kwargs):
+            return None
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("nop")
+    c.render_async()  # must not raise
+
+
+def test_render_async_runs_pending_sync_callback():
+    class V(LiveView):
+        value = 0
+
+        def mount(self, request=None, **kwargs):
+            self.value = 0
+
+        def _heavy_work(self):
+            self.value = 42
+
+        @event_handler
+        def kick_off(self, **kwargs):
+            self.start_async(self._heavy_work, name="work")
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("kick_off")
+    # Task is queued but hasn't run yet — the test client doesn't drive the WS
+    # consumer's async loop.
+    assert c.view_instance.value == 0
+    c.render_async()
+    assert c.view_instance.value == 42
+
+
+def test_render_async_drains_so_recursive_tasks_are_not_auto_rerun():
+    """One call to render_async runs the current batch; tasks scheduled by
+    those callbacks require a second call. Matches production semantics."""
+    tracker = {"runs": 0}
+
+    class V(LiveView):
+        def mount(self, request=None, **kwargs):
+            pass
+
+        def _first(self):
+            tracker["runs"] += 1
+            self.start_async(self._second, name="second")
+
+        def _second(self):
+            tracker["runs"] += 1
+
+        @event_handler
+        def kick_off(self, **kwargs):
+            self.start_async(self._first, name="first")
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("kick_off")
+    c.render_async()
+    assert tracker["runs"] == 1  # _first ran; _second requeued but not run
+    c.render_async()
+    assert tracker["runs"] == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# assert_stream_insert
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_assert_stream_insert_matches_by_name():
+    class V(LiveView):
+        def mount(self, request=None, **kwargs):
+            self.stream("msgs", [])
+
+        @event_handler
+        def add(self, **kwargs):
+            self.stream_insert("msgs", {"id": 1, "text": "hi"})
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("add")
+    c.assert_stream_insert("msgs")
+
+
+def test_assert_stream_insert_matches_dict_subset():
+    class V(LiveView):
+        def mount(self, request=None, **kwargs):
+            self.stream("msgs", [])
+
+        @event_handler
+        def add(self, **kwargs):
+            self.stream_insert("msgs", {"id": 1, "text": "hi", "ts": 123})
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("add")
+    c.assert_stream_insert("msgs", {"id": 1})
+
+
+def test_assert_stream_insert_fails_on_wrong_stream():
+    class V(LiveView):
+        def mount(self, request=None, **kwargs):
+            self.stream("msgs", [])
+
+        @event_handler
+        def add(self, **kwargs):
+            self.stream_insert("msgs", {"id": 1})
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("add")
+    with pytest.raises(AssertionError):
+        c.assert_stream_insert("notifications")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# trigger_info
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_trigger_info_invokes_handle_info():
+    class V(LiveView):
+        notifications = 0
+
+        def mount(self, request=None, **kwargs):
+            self.notifications = 0
+
+        def handle_info(self, message):
+            if message.get("type") == "db_notify":
+                self.notifications += 1
+
+    c = LiveViewTestClient(V).mount()
+    c.trigger_info({"type": "db_notify", "channel": "orders"})
+    assert c.view_instance.notifications == 1
+
+
+def test_trigger_info_records_event_with_duration():
+    class V(LiveView):
+        def mount(self, request=None, **kwargs):
+            pass
+
+        def handle_info(self, message):
+            pass
+
+    c = LiveViewTestClient(V).mount()
+    result = c.trigger_info({"type": "x"})
+    assert result["success"] is True
+    assert "duration_ms" in result
+    history = c.get_event_history()
+    assert any(e.get("type") == "handle_info" for e in history)
+
+
+def test_trigger_info_noop_default_is_callable():
+    """Every LiveView inherits a no-op handle_info from NotificationMixin;
+    trigger_info on a view that hasn't overridden it just returns success."""
+
+    class V(LiveView):
+        def mount(self, request=None, **kwargs):
+            pass
+
+    c = LiveViewTestClient(V).mount()
+    result = c.trigger_info({"type": "x"})
+    assert result["success"] is True
+
+
+def test_trigger_info_captures_handler_exception():
+    class V(LiveView):
+        def mount(self, request=None, **kwargs):
+            pass
+
+        def handle_info(self, message):
+            raise RuntimeError("boom")
+
+    c = LiveViewTestClient(V).mount()
+    result = c.trigger_info({"type": "x"})
+    assert result["success"] is False
+    assert "boom" in result["error"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _require_mounted guards
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_assertions_require_mount():
+    class V(LiveView):
+        pass
+
+    c = LiveViewTestClient(V)  # not mounted
+    for method, args in [
+        ("assert_push_event", ("evt",)),
+        ("assert_patch", ("/x/",)),
+        ("assert_redirect", ("/y/",)),
+        ("render_async", ()),
+        ("assert_stream_insert", ("s",)),
+        ("trigger_info", ({"type": "x"},)),
+    ]:
+        with pytest.raises(RuntimeError, match="not mounted"):
+            getattr(c, method)(*args)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Integration — chain assertions
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_combined_push_event_patch_and_stream():
+    class V(LiveView):
+        def mount(self, request=None, **kwargs):
+            self.stream("items", [])
+
+        @event_handler
+        def create(self, **kwargs):
+            self.stream_insert("items", {"id": 7, "name": "new"})
+            self.push_event("flash", {"message": "created"})
+            self.live_patch(params={"highlight": "7"}, path="/items/")
+
+    c = LiveViewTestClient(V).mount()
+    c.send_event("create")
+    c.assert_stream_insert("items", {"id": 7})
+    c.assert_push_event("flash", {"message": "created"})
+    c.assert_patch("/items/", {"highlight": "7"})


### PR DESCRIPTION
## Summary

Ships the v0.5.1 P2 "LiveView testing utilities" roadmap item. Seven new methods on `LiveViewTestClient` for Phoenix LiveViewTest parity.

## Methods

| Method | Reads from | Purpose |
|---|---|---|
| `assert_push_event(event_name, params=None)` | `view_instance._pending_push_events` | Verify a handler queued a push event (payload subset-match) |
| `assert_patch(path, params=None)` | `view_instance._pending_navigation` | Verify `live_patch` was queued |
| `assert_redirect(path, params=None)` | Same | Verify `live_redirect` was queued |
| `render_async()` | `view_instance._async_tasks` | Drain pending `start_async` / `assign_async` tasks synchronously |
| `follow_redirect()` | Last redirect in `_pending_navigation` | Mount the destination view and return a new `LiveViewTestClient` |
| `assert_stream_insert(stream_name, item=None)` | `_stream_operations` + `_streams` | Verify a stream insert landed |
| `trigger_info(message)` | Calls `view_instance.handle_info(message)` | Synthetic pubsub delivery for testing |

## Tests

**21 new test cases** in `python/djust/tests/test_testing_utilities.py`:
- 4 × `assert_push_event` (name match, payload subset, wrong name, payload mismatch)
- 3 × `assert_patch` (path, params subset, wrong-type-queued)
- 2 × `assert_redirect` (path match, wrong path)
- 3 × `render_async` (no-op, pending callback, drain-not-recursive)
- 3 × `assert_stream_insert` (by name, dict subset, wrong stream)
- 4 × `trigger_info` (invokes handler, records duration, no-op default, exception capture)
- 1 × `_require_mounted` parametrized over all 7 methods
- 1 × integration combining push_event + patch + stream_insert

## User-facing guide

`docs/website/guides/testing.md` covers every method with copy-pasteable examples. Linked from both `_config.yaml` and `index.md`.

## Stage 7 review fixes applied

The Stage 7 subagent review caught several blocking misses from my initial implementation — all addressed before this PR opens:

- CHANGELOG.md Unreleased entry added
- `docs/website/_config.yaml` + `index.md` nav entries added
- ROADMAP.md strikethroughs at priority matrix (line 22), milestone detail (line 707), feature list (line 1042)
- `follow_redirect` now validates the resolved class IS a `LiveView` subclass (docstring previously promised this; implementation didn't)
- Removed duplicate `import inspect` in `render_async`
- `test_assertions_require_mount` parametrize now includes `follow_redirect`
- `ReportView._build_report` doc example now shows try/except/finally async guard matching `CLAUDE.md` async-work guidance
- `ChatView` doc example uses `uuid4().hex` instead of undefined `next_id()`

Also caught (and cleanly reported): **zero customer-name leaks** per the new djust-local DOWNSTREAM-APP LEAK SCAN; **zero wiring gaps** per WIRING_CHECK (expected for test-only API).

## Test plan

- [x] 21 new tests pass locally (`make test` → 2240 passed, 2 skipped)
- [x] Zero regressions (baseline matches post-#841 green state)
- [x] Ruff + format + bandit + detect-secrets pre-commit hooks pass
- [x] Guide linked from nav
- [ ] CI should merge on first run — no `--admin` needed (post-#838/#841 CI is fully clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)