### PR TITLE
feat(js): dj-dialog — native &lt;dialog&gt; modal integration (v0.5.1 P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **LiveView testing utilities (v0.5.1 P2)** — Seven new methods on `LiveViewTestClient` for Phoenix LiveViewTest parity: `assert_push_event(event_name, params=None)` verifies a handler queued a client-bound push event (payload match is subset-based so tests stay resilient to later payload additions); `assert_patch(path=None, params=None)` / `assert_redirect(path=None, params=None)` assert `live_patch` / `live_redirect` calls; `render_async()` drains pending `start_async` / `assign_async` tasks synchronously so subsequent assertions see their results; `follow_redirect()` resolves the queued redirect via Django's URL router and returns a new test client mounted on the destination view; `assert_stream_insert(stream_name, item=None)` verifies stream operations (item subset-match for dicts); `trigger_info(message)` synthetically delivers a `handle_info` message so pubsub / pg_notify handlers can be tested without real backend wiring. Full user-facing guide at `docs/website/guides/testing.md`. 21 new test cases. (`python/djust/testing.py`)
+- **`dj-dialog` — native `<dialog>` modal integration (v0.5.1 P2)** — Declarative opt-in for the HTML `<dialog>` element's built-in modal behavior. Mark a `<dialog>` with `dj-dialog="open"` to call `showModal()` (backdrop, focus-trap, and Escape handling all browser-native); set `dj-dialog="close"` to call `close()`. A document-level `MutationObserver` watches for attribute changes and DOM insertions so VDOM morphs that swap `dj-dialog` work automatically without per-element re-registration. Idempotent — re-asserting `"open"` on an already-open dialog is a no-op; gracefully ignores non-`<dialog>` elements carrying the attribute. ~80 LOC JS in `python/djust/static/djust/src/35-dj-dialog.js`. 8 JSDOM tests in `tests/js/dj_dialog.test.js`.
 
-
+## [0.5.1rc2] - 2026-04-21
 
 ### Added
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,7 +43,7 @@ This roadmap outlines what has been built, what is actively being worked on, and
 | **P3** | View Transitions API | Cheapest way to make navigation feel native | v0.5.0 |
 | **P3** | Islands of interactivity | Content-heavy sites with small interactive zones | v0.7.0 |
 | **P3** | Offline mutation queue | Mobile/spotty-connection differentiator | v0.6.0 |
-| **P3** | Native `<dialog>` integration | Browser-native modals with better a11y than custom implementations | v0.5.0 |
+| ~~**P3**~~ | ~~Native `<dialog>` integration~~ ✅ Shipped in v0.5.1 (`dj-dialog="open|close"`, 8 tests) | ~~Browser-native modals with better a11y than custom implementations~~ | ~~v0.5.0~~ |
 | ~~**P0**~~ | ~~`push_commands` + `djust:exec` auto-executor~~ ✅ ([ADR-002](docs/adr/002-backend-driven-ui-automation.md) Phase 1a) | ~~Foundation primitive for every backend-driven UI feature in ADRs 002-006~~ | v0.4.2 |
 | ~~**P0**~~ | ~~`wait_for_event` async primitive~~ ✅ ([ADR-002](docs/adr/002-backend-driven-ui-automation.md) Phase 1b) | ~~Lets background handlers pause until real user actions — required for TutorialMixin~~ | v0.4.2 |
 | ~~**P0**~~ | ~~`TutorialMixin` + `{% tutorial_bubble %}`~~ ✅ ([ADR-002](docs/adr/002-backend-driven-ui-automation.md) Phase 1c) | ~~Declarative guided tours with zero custom JS — v0.4.2 headline feature~~ | v0.4.2 |
@@ -745,7 +745,7 @@ class ProductView(LiveView):
 
 **Stable component IDs (React 19 `useId` equivalent)** — (Moved from v0.5.0) `self.unique_id(suffix)` returning deterministic IDs stable across renders. ~30 lines Python.
 
-**Native `<dialog>` element integration** — (Moved from v0.5.0) Browser-native modals with `dj-dialog="open|close"`. Built-in focus trapping, backdrop, Escape handling. ~20 lines JS.
+~~**Native `<dialog>` element integration**~~ ✅ **Shipped in v0.5.1** — `dj-dialog="open|close"` attribute, MutationObserver-driven sync, 8 JSDOM tests. See `python/djust/static/djust/src/35-dj-dialog.js`.
 
 **Automatic dirty tracking** — Track which view attributes have changed since mount or the last event, exposing `self.changed_fields` and `self.is_dirty`. Template: `{% if is_dirty %}<button dj-click="save">Save changes</button>{% endif %}`. Use cases: "unsaved changes" warnings (`beforeunload`), conditional save buttons, optimized `handle_event` that skips work when nothing changed. Combined with selective re-rendering, dirty tracking is the foundation for efficient large views. ~60 lines Python.
 
@@ -1007,7 +1007,7 @@ High-impact areas for contributions:
 8. ~~**`dj-click-away`**~~ ✅
 9. ~~**`dj-lock`**~~ ✅
 10. ~~**`dj-page-loading`**~~ ✅
-11. **Native `<dialog>` integration** — `dj-dialog="open|close"`, ~20 lines JS
+11. ~~**Native `<dialog>` integration**~~ ✅ **Shipped in v0.5.1** — `dj-dialog="open|close"` with MutationObserver sync.
 12. **`dj-no-submit`** — Prevent enter-key form submission, ~10 lines JS
 13. **`page_loading` on `dj.push`** — Trigger loading bar during heavy events, ~15 lines JS
 14. ~~**`dj-scroll-into-view`**~~ ✅

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -10021,3 +10021,89 @@ globalThis.djust.formPolish = {
     _isEnterKey,
     _isEligibleEnterTarget,
 };
+
+// dj-dialog — native <dialog> modal integration (v0.5.1 P2)
+//
+// Usage:
+//   <dialog id="settings" dj-dialog="open">...</dialog>
+//
+// When the attribute value changes from close → open, showModal() is called
+// (which adds backdrop, focus-trap, and Escape handling — all browser-native).
+// When it changes from open → close, close() is called.
+//
+// Leverages the HTML <dialog> element's own modal behavior so djust doesn't
+// re-implement focus management. A MutationObserver watches every <dialog>
+// on the page; VDOM morphs that swap the dj-dialog value fire the right
+// showModal/close call automatically.
+
+function _syncDialogState(el) {
+    if (!(el instanceof HTMLDialogElement)) return;
+    const state = (el.getAttribute('dj-dialog') || '').trim().toLowerCase();
+    if (state === 'open') {
+        if (!el.open) {
+            try { el.showModal(); }
+            catch (_e) {
+                // Some browsers throw if the element is already modal or
+                // in an inconsistent DOM state — fall back to the boolean
+                // open attribute so the dialog is at least visible.
+                el.setAttribute('open', '');
+            }
+        }
+    } else if (state === 'close' || state === 'closed') {
+        if (el.open) el.close();
+    }
+}
+
+function _syncAllDialogs(root) {
+    const scope = root || document;
+    const dialogs = scope.querySelectorAll('dialog[dj-dialog]');
+    dialogs.forEach(_syncDialogState);
+}
+
+function _installDjDialogObserver() {
+    // Initial pass — handle dialogs rendered at page load.
+    _syncAllDialogs();
+
+    // Watch for attribute changes on any <dialog> in the tree. Single
+    // document-level observer rather than per-element listeners so VDOM
+    // morphs that swap dj-dialog pick it up without re-registration.
+    const observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (m) {
+            if (m.type === 'attributes' && m.attributeName === 'dj-dialog') {
+                if (m.target instanceof HTMLDialogElement) {
+                    _syncDialogState(m.target);
+                }
+            } else if (m.type === 'childList') {
+                m.addedNodes.forEach(function (node) {
+                    if (node.nodeType === 1) {
+                        if (node instanceof HTMLDialogElement && node.hasAttribute('dj-dialog')) {
+                            _syncDialogState(node);
+                        } else if (node.querySelectorAll) {
+                            _syncAllDialogs(node);
+                        }
+                    }
+                });
+            }
+        });
+    });
+    observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['dj-dialog'],
+        subtree: true,
+        childList: true,
+    });
+}
+
+if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', _installDjDialogObserver);
+    } else {
+        _installDjDialogObserver();
+    }
+}
+
+globalThis.djust = globalThis.djust || {};
+globalThis.djust.djDialog = {
+    _syncDialogState,
+    _syncAllDialogs,
+};

--- a/python/djust/static/djust/src/35-dj-dialog.js
+++ b/python/djust/static/djust/src/35-dj-dialog.js
@@ -1,0 +1,86 @@
+
+// dj-dialog — native <dialog> modal integration (v0.5.1 P2)
+//
+// Usage:
+//   <dialog id="settings" dj-dialog="open">...</dialog>
+//
+// When the attribute value changes from close → open, showModal() is called
+// (which adds backdrop, focus-trap, and Escape handling — all browser-native).
+// When it changes from open → close, close() is called.
+//
+// Leverages the HTML <dialog> element's own modal behavior so djust doesn't
+// re-implement focus management. A MutationObserver watches every <dialog>
+// on the page; VDOM morphs that swap the dj-dialog value fire the right
+// showModal/close call automatically.
+
+function _syncDialogState(el) {
+    if (!(el instanceof HTMLDialogElement)) return;
+    const state = (el.getAttribute('dj-dialog') || '').trim().toLowerCase();
+    if (state === 'open') {
+        if (!el.open) {
+            try { el.showModal(); }
+            catch (_e) {
+                // Some browsers throw if the element is already modal or
+                // in an inconsistent DOM state — fall back to the boolean
+                // open attribute so the dialog is at least visible.
+                el.setAttribute('open', '');
+            }
+        }
+    } else if (state === 'close' || state === 'closed') {
+        if (el.open) el.close();
+    }
+}
+
+function _syncAllDialogs(root) {
+    const scope = root || document;
+    const dialogs = scope.querySelectorAll('dialog[dj-dialog]');
+    dialogs.forEach(_syncDialogState);
+}
+
+function _installDjDialogObserver() {
+    // Initial pass — handle dialogs rendered at page load.
+    _syncAllDialogs();
+
+    // Watch for attribute changes on any <dialog> in the tree. Single
+    // document-level observer rather than per-element listeners so VDOM
+    // morphs that swap dj-dialog pick it up without re-registration.
+    const observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (m) {
+            if (m.type === 'attributes' && m.attributeName === 'dj-dialog') {
+                if (m.target instanceof HTMLDialogElement) {
+                    _syncDialogState(m.target);
+                }
+            } else if (m.type === 'childList') {
+                m.addedNodes.forEach(function (node) {
+                    if (node.nodeType === 1) {
+                        if (node instanceof HTMLDialogElement && node.hasAttribute('dj-dialog')) {
+                            _syncDialogState(node);
+                        } else if (node.querySelectorAll) {
+                            _syncAllDialogs(node);
+                        }
+                    }
+                });
+            }
+        });
+    });
+    observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['dj-dialog'],
+        subtree: true,
+        childList: true,
+    });
+}
+
+if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', _installDjDialogObserver);
+    } else {
+        _installDjDialogObserver();
+    }
+}
+
+globalThis.djust = globalThis.djust || {};
+globalThis.djust.djDialog = {
+    _syncDialogState,
+    _syncAllDialogs,
+};

--- a/tests/js/dj_dialog.test.js
+++ b/tests/js/dj_dialog.test.js
@@ -1,0 +1,137 @@
+/**
+ * Tests for dj-dialog — v0.5.1 native <dialog> modal integration.
+ *
+ * Uses jsdom for DOM + MutationObserver. jsdom's HTMLDialogElement
+ * stubs showModal/close — we replace them with spies where needed to
+ * verify the right call was issued.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import fs from 'fs';
+
+const clientCode = fs.readFileSync('./python/djust/static/djust/client.js', 'utf-8');
+
+function createDom(bodyHtml = '') {
+    const dom = new JSDOM(`<!DOCTYPE html>
+<html><head></head>
+<body>
+  <div dj-view="test.views.TestView" dj-root>
+    ${bodyHtml}
+  </div>
+</body>
+</html>`, { runScripts: 'dangerously', url: 'http://localhost/' });
+
+    class MockWebSocket {
+        static CONNECTING = 0;
+        static OPEN = 1;
+        static CLOSING = 2;
+        static CLOSED = 3;
+        constructor() {
+            this.readyState = MockWebSocket.OPEN;
+            this.onopen = null; this.onclose = null; this.onmessage = null;
+        }
+        send() {}
+        close() {}
+    }
+    dom.window.WebSocket = MockWebSocket;
+    dom.window.DJUST_USE_WEBSOCKET = false;
+
+    // jsdom's HTMLDialogElement doesn't implement showModal/close with the
+    // real "open" attribute side-effect — stub it so the observer can drive
+    // a realistic state machine.
+    const ProtoDialog = dom.window.HTMLDialogElement.prototype;
+    ProtoDialog.showModal = function () {
+        this.setAttribute('open', '');
+        this._wasShownAsModal = true;
+    };
+    ProtoDialog.close = function () {
+        this.removeAttribute('open');
+    };
+    Object.defineProperty(ProtoDialog, 'open', {
+        configurable: true,
+        get() { return this.hasAttribute('open'); },
+        set(v) { v ? this.setAttribute('open', '') : this.removeAttribute('open'); },
+    });
+
+    dom.window.eval(clientCode);
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+    return dom;
+}
+
+function waitForMutation(dom) {
+    // MutationObserver fires asynchronously on the microtask queue. Flush
+    // with a Promise.resolve() chain so the observer callback runs.
+    return new Promise((resolve) => dom.window.setTimeout(resolve, 0));
+}
+
+describe('dj-dialog', () => {
+    let dom;
+
+    it('opens a dialog via showModal when dj-dialog="open" is present on load', async () => {
+        dom = createDom('<dialog id="d" dj-dialog="open">hi</dialog>');
+        const el = dom.window.document.getElementById('d');
+        expect(el.open).toBe(true);
+        expect(el._wasShownAsModal).toBe(true);
+    });
+
+    it('keeps a dialog closed when dj-dialog="close"', async () => {
+        dom = createDom('<dialog id="d" dj-dialog="close">hi</dialog>');
+        const el = dom.window.document.getElementById('d');
+        expect(el.open).toBe(false);
+    });
+
+    it('opens when the attribute flips from close → open', async () => {
+        dom = createDom('<dialog id="d" dj-dialog="close">hi</dialog>');
+        const el = dom.window.document.getElementById('d');
+        expect(el.open).toBe(false);
+        el.setAttribute('dj-dialog', 'open');
+        await waitForMutation(dom);
+        expect(el.open).toBe(true);
+    });
+
+    it('closes when the attribute flips from open → close', async () => {
+        dom = createDom('<dialog id="d" dj-dialog="open">hi</dialog>');
+        const el = dom.window.document.getElementById('d');
+        expect(el.open).toBe(true);
+        el.setAttribute('dj-dialog', 'close');
+        await waitForMutation(dom);
+        expect(el.open).toBe(false);
+    });
+
+    it('syncs a dialog injected later (VDOM morph simulation)', async () => {
+        dom = createDom('<div id="host"></div>');
+        const host = dom.window.document.getElementById('host');
+        host.innerHTML = '<dialog id="d" dj-dialog="open">late</dialog>';
+        await waitForMutation(dom);
+        const el = dom.window.document.getElementById('d');
+        expect(el.open).toBe(true);
+    });
+
+    it('ignores non-dialog elements with dj-dialog attribute', async () => {
+        dom = createDom('<div id="d" dj-dialog="open">not a dialog</div>');
+        const el = dom.window.document.getElementById('d');
+        // Div doesn't have an open property mapped; and showModal shouldn't
+        // have been called (it doesn't exist on div). The key test is that
+        // no exception was thrown during the initial sync pass.
+        expect(el.hasAttribute('open')).toBe(false);
+    });
+
+    it('is idempotent — repeated "open" values don\'t fire showModal twice', async () => {
+        dom = createDom('<dialog id="d" dj-dialog="open">hi</dialog>');
+        const el = dom.window.document.getElementById('d');
+        let showCount = 0;
+        const original = el.showModal.bind(el);
+        el.showModal = function () { showCount += 1; return original(); };
+        // Force mutation with the same value — observer fires, but the
+        // sync function early-returns because el.open is already true.
+        el.setAttribute('dj-dialog', 'open');
+        await waitForMutation(dom);
+        expect(showCount).toBe(0); // no re-open
+    });
+
+    it('exposes _syncDialogState on window.djust.djDialog', () => {
+        dom = createDom('');
+        expect(typeof dom.window.djust.djDialog._syncDialogState).toBe('function');
+    });
+});


### PR DESCRIPTION
## Summary

Ships `dj-dialog` — declarative opt-in for the HTML `<dialog>` element's built-in modal behavior. v0.5.1 P2 item.

### Usage

```html
<dialog id="settings" dj-dialog="open">
  <h2>Settings</h2>
  <button dj-click="close_settings">Close</button>
</dialog>
```

- `dj-dialog="open"` → `showModal()` (backdrop, focus-trap, Escape — all browser-native)
- `dj-dialog="close"` → `close()`

### Implementation

- Document-level `MutationObserver` watches for `dj-dialog` attribute changes AND `childList` mutations (VDOM morph inserting a new dialog works automatically).
- Single observer, not per-element listeners — re-registration-free.
- Idempotent: re-asserting the current state is a no-op.
- Gracefully ignores non-`<dialog>` elements carrying the attribute.
- Falls back to `setAttribute('open', '')` if `showModal()` throws (some browsers' inconsistent modal state).

### Tests

**8 JSDOM cases** in `tests/js/dj_dialog.test.js`:
- Opens on load with `dj-dialog="open"`
- Stays closed with `dj-dialog="close"`
- Flips open when attribute changes close → open
- Flips close when attribute changes open → close
- Syncs dialogs injected after initial load (VDOM morph)
- Ignores `<div dj-dialog="open">` (non-dialog element)
- Idempotent: re-asserting "open" doesn't re-call `showModal`
- Exposes `_syncDialogState` on `window.djust.djDialog` for test harnesses

### Metrics

- `client.js`: 36 → 37 source modules (+~80 LOC)
- No new Python-side code — browser handles focus trap / backdrop / Escape natively

### Test plan

- [x] 8 new JSDOM tests pass
- [x] Pre-commit hooks all pass
- [ ] CI should go green first try (post-#841 + #842 clean baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)