### PR TITLE
Bump version to 0.5.1rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1rc3] - 2026-04-21
+
 ### Added
 
 - **LiveView testing utilities (v0.5.1 P2)** — Seven new methods on `LiveViewTestClient` for Phoenix LiveViewTest parity: `assert_push_event(event_name, params=None)` verifies a handler queued a client-bound push event (payload match is subset-based so tests stay resilient to later payload additions); `assert_patch(path=None, params=None)` / `assert_redirect(path=None, params=None)` assert `live_patch` / `live_redirect` calls; `render_async()` drains pending `start_async` / `assign_async` tasks synchronously so subsequent assertions see their results; `follow_redirect()` resolves the queued redirect via Django's URL router and returns a new test client mounted on the destination view; `assert_stream_insert(stream_name, item=None)` verifies stream operations (item subset-match for dicts); `trigger_info(message)` synthetically delivers a `handle_info` message so pubsub / pg_notify handlers can be tested without real backend wiring. Full user-facing guide at `docs/website/guides/testing.md`. 21 new test cases. (`python/djust/testing.py`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1-rc.2"
+version = "0.5.1-rc.3"
 edition = "2021"
 authors = ["djust contributors"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "djust"
-version = "0.5.1rc2"
+version = "0.5.1rc3"
 description = "Phoenix LiveView-style reactive components for Django with Rust-powered performance. Real-time UI updates over WebSocket, no JavaScript build step required."
 authors = [{name = "djust contributors"}]
 readme = "README.md"

--- a/python/djust/__init__.py
+++ b/python/djust/__init__.py
@@ -66,7 +66,7 @@ except ImportError:
     # Rust components not yet built - this is optional
     rust_components = None  # noqa: F841 — accessed as djust.rust_components by user code
 
-__version__ = "0.5.1rc2"
+__version__ = "0.5.1rc3"
 
 
 def enable_hot_reload():

--- a/python/djust/components/__init__.py
+++ b/python/djust/components/__init__.py
@@ -33,7 +33,7 @@ descriptors, mixins, rust handlers, gallery).
     python manage.py component_gallery
 """
 
-__version__ = "0.5.1rc2"
+__version__ = "0.5.1rc3"
 
 default_app_config = "djust.components.apps.DjustComponentsConfig"
 


### PR DESCRIPTION
Mechanical release bump — v0.5.1 feature-complete.

## Items shipped in 0.5.1rc3 (all v0.5.1 P2)
- LiveView testing utilities (#842)
- dj-dialog native <dialog> integration (#845)
- inputs_for nested formsets (335cce26 + #847 docs)
- Dev-mode error overlay (#848)
- Type-safe template validation (#849)

## Test plan
- [x] make test: 3312 pass, 1 flaky perf test (passes on re-run)
- [x] make version-check: consistent
- [x] make release-dry-run: validates

After merge: tag v0.5.1rc3, GitHub Actions builds wheels + PyPI publish.