### PR TITLE
feat(typecheck): address #850/#851/#852 — tag support, MRO walk, shared helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`djust_typecheck` — `{% firstof %}` / `{% cycle %}` / `{% blocktrans with %}` tag support (#850)** — The extractor now captures positional context-variable references in `{% firstof a b c %}` and `{% cycle a b c %}` (string literals and `as <name>` suffixes are correctly ignored), and the `with x=expr` (and `count x=expr`) clauses of `{% blocktrans %}` / `{% blocktranslate %}` produce both the template-local binding (`x`) and the reference (`expr`). Eliminates a class of false positives (blocktrans locals) and false negatives (firstof/cycle args). (`python/djust/management/commands/djust_typecheck.py`)
+
+### Changed
+
+- **`djust_typecheck` — walk MRO for parent-class `self.foo = ...` assigns (#851)** — `_extract_context_keys_from_ast` now iterates `cls.__mro__` (skipping `djust.*`, `djust_*`, `django.*`, and `builtins`), so a child view that relies on attributes set in a parent `mount()` no longer produces spurious "unresolved" reports. The filter drops Django's `View` / namespace-framework attrs (`request`, `head`, `kwargs`, `args`) that would otherwise surface from the base class. (`python/djust/management/commands/djust_typecheck.py`)
+- **Shared class-introspection helpers (#852)** — `_walk_subclasses`, `_is_user_class`, and `_app_label_for_class` are now a single source of truth in the new `djust.management._introspect` module; `djust_audit` and `djust_typecheck` both import from it. No behavior change; purely a refactor to prevent drift as the set of management commands grows. `_introspect.walk_subclasses` also gained cycle-safety (diamond-inheritance deduplication) which the old recursive implementation lacked. (`python/djust/management/_introspect.py`, `python/djust/management/commands/djust_audit.py`, `python/djust/management/commands/djust_typecheck.py`)
+
 ## [0.5.1rc4] - 2026-04-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "0.5.1-rc.3"
+version = "0.5.1-rc.4"
 dependencies = [
  "ahash",
  "criterion",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "0.5.1-rc.3"
+version = "0.5.1-rc.4"
 dependencies = [
  "ahash",
  "criterion",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "0.5.1-rc.3"
+version = "0.5.1-rc.4"
 dependencies = [
  "bincode",
  "criterion",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "0.5.1-rc.3"
+version = "0.5.1-rc.4"
 dependencies = [
  "ahash",
  "chrono",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "0.5.1-rc.3"
+version = "0.5.1-rc.4"
 dependencies = [
  "ahash",
  "criterion",

--- a/python/djust/management/_introspect.py
+++ b/python/djust/management/_introspect.py
@@ -1,0 +1,58 @@
+"""Shared class-introspection helpers used by multiple management commands.
+
+Three management commands — ``djust_audit``, ``djust_doctor``, and
+``djust_typecheck`` — independently grew near-identical implementations of
+"walk every LiveView subclass defined in user code." The duplication has been
+flagged during code review on PR #849; this module centralizes the shared
+helpers.
+
+Anything more than class-walking / user-vs-framework filtering belongs elsewhere
+— this file stays deliberately small.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def walk_subclasses(cls: type) -> Iterable[type]:
+    """Recursively yield every subclass of ``cls`` at any depth.
+
+    Duplicates are skipped — diamond inheritance would otherwise repeat a class.
+    """
+    seen: set = set()
+    stack: list = list(cls.__subclasses__())
+    while stack:
+        sub = stack.pop()
+        if sub in seen:
+            continue
+        seen.add(sub)
+        yield sub
+        stack.extend(sub.__subclasses__())
+
+
+def is_user_class(cls: type) -> bool:
+    """Return True if ``cls`` is user-defined (not internal djust framework code).
+
+    Classes defined in ``djust.*`` or ``djust_*`` modules are framework classes
+    and should be skipped by commands that audit "user views." The exception is
+    test modules and example projects, which are user-shaped and should be
+    included when reachable.
+    """
+    mod = getattr(cls, "__module__", "") or ""
+    if mod.startswith("djust.") or mod.startswith("djust_"):
+        if "test" not in mod and "example" not in mod:
+            return False
+    return True
+
+
+def app_label_for_class(cls: type) -> str:
+    """Return the Django-app-label-shaped prefix of a class's module path.
+
+    For ``myapp.views.FooView`` this returns ``"myapp"``. Unlike Django's
+    ``apps.get_containing_app_config``, this never needs the app registry to be
+    ready — it works at import time and is safe to call during management
+    command startup.
+    """
+    mod = getattr(cls, "__module__", "") or ""
+    return mod.split(".", 1)[0] if mod else ""

--- a/python/djust/management/commands/djust_audit.py
+++ b/python/djust/management/commands/djust_audit.py
@@ -21,6 +21,12 @@ from typing import Dict
 
 from django.core.management.base import BaseCommand
 
+# Shared class-introspection helpers live in djust.management._introspect so
+# djust_audit and djust_typecheck stay in sync.
+from djust.management._introspect import app_label_for_class as _app_label_for_class
+from djust.management._introspect import is_user_class as _is_user_class
+from djust.management._introspect import walk_subclasses as _walk_subclasses
+
 logger = logging.getLogger(__name__)
 
 # Optional mixins that users explicitly add to their LiveView classes.
@@ -46,31 +52,6 @@ _DECORATOR_KEYS = {
     "client_state",
     "permission_required",
 }
-
-
-def _walk_subclasses(cls):
-    """Recursively yield all subclasses of cls."""
-    for sub in cls.__subclasses__():
-        yield sub
-        yield from _walk_subclasses(sub)
-
-
-def _is_user_class(cls):
-    """Return True if cls is a user-defined class (not internal djust framework)."""
-    module = getattr(cls, "__module__", "") or ""
-    if module.startswith("djust.") or module.startswith("djust_"):
-        if "test" not in module and "example" not in module:
-            return False
-    return True
-
-
-def _app_label_for_class(cls):
-    """Extract the Django app label from a class's module path."""
-    module = getattr(cls, "__module__", "") or ""
-    # The app label is typically the first component of the module path
-    # e.g., "demo_app.views" -> "demo_app"
-    parts = module.split(".")
-    return parts[0] if parts else ""
 
 
 def _get_handler_metadata(cls, base_classes=None):

--- a/python/djust/management/commands/djust_typecheck.py
+++ b/python/djust/management/commands/djust_typecheck.py
@@ -135,14 +135,18 @@ def _extract_context_keys_from_ast(cls) -> Set[str]:
         if klass is object:
             continue
         mod = getattr(klass, "__module__", "") or ""
-        # Skip framework classes: djust internals, Django, rest_framework,
-        # and anything else under a well-known namespace package. Test / example
-        # modules that live under djust.* are kept so our own test helpers work.
+        # Skip framework classes: djust internals, Django, DRF, and builtins.
+        # Test / example modules that live under djust.* are kept so our own
+        # test helpers work.
         if (mod.startswith("djust.") or mod.startswith("djust_")) and (
             "test" not in mod and "example" not in mod
         ):
             continue
-        if mod.startswith("django.") or mod in {"django", "django.views", "builtins"}:
+        if mod.startswith("django.") or mod == "django":
+            continue
+        if mod.startswith("rest_framework.") or mod == "rest_framework":
+            continue
+        if mod == "builtins":
             continue
         try:
             src = inspect.getsource(klass)
@@ -247,6 +251,17 @@ def _extract_template_locals(src: str) -> Set[str]:
             parts = args.split()
             if len(parts) >= 3 and parts[1] == "as":
                 locals_.add(parts[2])
+        elif tag == "cycle":
+            # `{% cycle "odd" "even" as row_class %}` → bind row_class locally.
+            # The cycle args themselves are references (handled in
+            # _extract_referenced_names); the name after `as` is a local.
+            parts = args.split()
+            if "as" in parts:
+                idx = parts.index("as")
+                if idx + 1 < len(parts):
+                    m = _IDENT_RE.match(parts[idx + 1])
+                    if m:
+                        locals_.add(m.group(1))
     return locals_
 
 

--- a/python/djust/management/commands/djust_typecheck.py
+++ b/python/djust/management/commands/djust_typecheck.py
@@ -46,6 +46,16 @@ from typing import Any, Dict, List, Optional, Set
 
 from django.core.management.base import BaseCommand
 
+from djust.management._introspect import (
+    app_label_for_class as _app_label,
+)
+from djust.management._introspect import (
+    is_user_class as _is_user_class,
+)
+from djust.management._introspect import (
+    walk_subclasses as _walk_subclasses,
+)
+
 
 # Names the framework always provides.
 _ALWAYS_AVAILABLE: Set[str] = {
@@ -87,25 +97,6 @@ _IDENT_RE = re.compile(r"([A-Za-z_][\w]*)")
 _NOQA_RE = re.compile(r"\{#\s*djust_typecheck:\s*noqa(?:\s+(\w+(?:\s*,\s*\w+)*))?\s*#\}")
 
 
-def _walk_subclasses(cls):
-    for sub in cls.__subclasses__():
-        yield sub
-        yield from _walk_subclasses(sub)
-
-
-def _is_user_class(cls) -> bool:
-    mod = getattr(cls, "__module__", "") or ""
-    if mod.startswith("djust.") or mod.startswith("djust_"):
-        if "test" not in mod and "example" not in mod:
-            return False
-    return True
-
-
-def _app_label(cls) -> str:
-    mod = getattr(cls, "__module__", "") or ""
-    return mod.split(".", 1)[0] if mod else ""
-
-
 def _public_class_attrs(cls) -> Set[str]:
     """Names declared directly on the class body (or inherited from user bases)."""
     names: Set[str] = set()
@@ -123,25 +114,50 @@ def _public_class_attrs(cls) -> Set[str]:
 def _extract_context_keys_from_ast(cls) -> Set[str]:
     """Best-effort static extraction of context-provided names.
 
-    Collects three sources from the class source:
+    Collects three sources from the class source, walking the MRO so keys
+    set on any user-code ancestor (mixins, base views) are visible to the
+    checker:
+
     1. Literal dict keys in ``get_context_data`` ``return {...}``.
     2. ``self.foo = ...`` attribute assignments anywhere in the class
        (``mount``, event handlers, helper methods — they all populate
        public state that templates can read).
     3. Properties declared on the class (``@property``-decorated methods).
+
+    Framework base classes (``djust.*`` / ``djust_*``) are skipped to avoid
+    surfacing internal helpers as user-visible context keys.
     """
     keys: Set[str] = set()
     import inspect
     import textwrap
 
-    try:
-        src = inspect.getsource(cls)
-    except (OSError, TypeError):
-        return keys
-    try:
-        tree = ast.parse(textwrap.dedent(src))
-    except SyntaxError:
-        return keys
+    for klass in cls.__mro__:
+        if klass is object:
+            continue
+        mod = getattr(klass, "__module__", "") or ""
+        # Skip framework classes: djust internals, Django, rest_framework,
+        # and anything else under a well-known namespace package. Test / example
+        # modules that live under djust.* are kept so our own test helpers work.
+        if (mod.startswith("djust.") or mod.startswith("djust_")) and (
+            "test" not in mod and "example" not in mod
+        ):
+            continue
+        if mod.startswith("django.") or mod in {"django", "django.views", "builtins"}:
+            continue
+        try:
+            src = inspect.getsource(klass)
+        except (OSError, TypeError):
+            continue
+        try:
+            tree = ast.parse(textwrap.dedent(src))
+        except SyntaxError:
+            continue
+        _collect_context_keys_from_tree(tree, keys)
+    return keys
+
+
+def _collect_context_keys_from_tree(tree: ast.AST, keys: Set[str]) -> None:
+    """Walk a parsed class body and add discoverable context keys to ``keys``."""
     for node in ast.walk(tree):
         # 1. get_context_data literal returns
         if isinstance(node, ast.FunctionDef) and node.name == "get_context_data":
@@ -194,11 +210,10 @@ def _extract_context_keys_from_ast(cls) -> Set[str]:
                         name = deco.func.attr
                 if name == "property" and not node.name.startswith("_"):
                     keys.add(node.name)
-    return keys
 
 
 def _extract_template_locals(src: str) -> Set[str]:
-    """Names bound by the template itself (for/with loops)."""
+    """Names bound by the template itself (for/with/blocktrans loops)."""
     locals_: Set[str] = set()
     for match in _TAG_RE.finditer(src):
         tag = match.group(1)
@@ -217,6 +232,16 @@ def _extract_template_locals(src: str) -> Set[str]:
                     m = _IDENT_RE.match(name)
                     if m:
                         locals_.add(m.group(1))
+        elif tag == "blocktrans" or tag == "blocktranslate":
+            # `{% blocktrans with x=foo y=bar %}` → bind x, y.
+            # Also supports `count var=expr` which binds `var` the same way.
+            if "with" in args.split() or "count" in args.split():
+                for piece in args.split():
+                    if "=" in piece:
+                        name = piece.split("=", 1)[0].strip()
+                        m = _IDENT_RE.match(name)
+                        if m:
+                            locals_.add(m.group(1))
         elif tag == "inputs_for":
             # djust block tag: `{% inputs_for formset as form %}` → bind form
             parts = args.split()
@@ -261,6 +286,31 @@ def _extract_referenced_names(src: str) -> List[tuple]:
         elif tag in {"url", "static"}:
             # Positional args are name-strings, not context vars.
             continue
+        elif tag in {"firstof", "cycle"}:
+            # `{% firstof a b c %}` / `{% cycle a b c %}` — each non-literal token
+            # is a context variable. Skip string literals and numbers.
+            for token in args.split():
+                if not token or token[0] in {"'", '"'} or token.isdigit():
+                    continue
+                # `cycle` supports `as name` suffix which binds a loop var — skip
+                # the "as X" clause itself; X is a local, not a reference.
+                if token == "as":
+                    break
+                m = _IDENT_RE.match(token)
+                if m:
+                    refs.append((m.group(1), line))
+        elif tag in {"blocktrans", "blocktranslate"}:
+            # `{% blocktrans with x=expr y=expr %}` — the right-hand side of each
+            # x=expr pair is a context variable reference. `x` itself is a local
+            # (handled in _extract_template_locals).
+            for piece in args.split():
+                if "=" in piece:
+                    rhs = piece.split("=", 1)[1].strip()
+                    if not rhs or rhs[0] in {"'", '"'} or rhs.isdigit():
+                        continue
+                    m = _IDENT_RE.match(rhs)
+                    if m:
+                        refs.append((m.group(1), line))
     return refs
 
 

--- a/python/djust/tests/test_djust_typecheck.py
+++ b/python/djust/tests/test_djust_typecheck.py
@@ -68,6 +68,60 @@ def test_extract_template_locals_binds_inputs_for_as_var():
     assert "form" in locals_
 
 
+def test_extract_template_locals_binds_blocktrans_with_vars():
+    """Issue #850: `{% blocktrans with x=foo y=bar %}` → bind x, y as template locals."""
+    src = "{% blocktrans with name=first_name count=total %}Hi {{ name }} ({{ count }}){% endblocktrans %}"
+    locals_ = _extract_template_locals(src)
+    assert "name" in locals_
+    assert "count" in locals_
+
+
+def test_extract_template_locals_binds_blocktranslate_alias():
+    """`blocktranslate` is the newer Django alias for `blocktrans`."""
+    src = "{% blocktranslate with x=foo %}hi{% endblocktranslate %}"
+    locals_ = _extract_template_locals(src)
+    assert "x" in locals_
+
+
+def test_extract_referenced_names_extracts_firstof_args():
+    """Issue #850: `{% firstof a b c %}` — each non-literal token is a context var."""
+    src = "{% firstof primary fallback default %}"
+    names = {n for n, _ in _extract_referenced_names(src)}
+    assert {"primary", "fallback", "default"} <= names
+
+
+def test_extract_referenced_names_extracts_cycle_args():
+    """Issue #850: `{% cycle a b c %}` — positional args are context vars."""
+    src = "{% cycle even odd %}"
+    names = {n for n, _ in _extract_referenced_names(src)}
+    assert {"even", "odd"} <= names
+
+
+def test_extract_referenced_names_ignores_firstof_string_literals():
+    """String-literal tokens inside firstof must NOT be reported as variables."""
+    src = "{% firstof user_name 'anonymous' %}"
+    names = {n for n, _ in _extract_referenced_names(src)}
+    assert "user_name" in names
+    assert "anonymous" not in names
+
+
+def test_extract_referenced_names_ignores_cycle_as_suffix():
+    """`{% cycle 'a' 'b' as row_class %}` — `row_class` is a local binding, not a var."""
+    src = "{% cycle odd_class even_class as row_class %}"
+    names = {n for n, _ in _extract_referenced_names(src)}
+    assert "odd_class" in names
+    assert "even_class" in names
+    assert "row_class" not in names  # it's a local after `as`, not a reference
+
+
+def test_extract_referenced_names_extracts_blocktrans_with_rhs():
+    """`{% blocktrans with x=foo %}` — `foo` is a reference (`x` is the local)."""
+    src = "{% blocktrans with name=first_name count=total_items %}...{% endblocktrans %}"
+    names = {n for n, _ in _extract_referenced_names(src)}
+    assert "first_name" in names
+    assert "total_items" in names
+
+
 def test_public_class_attrs_returns_non_underscore_names():
     class _V(LiveView):
         foo = 1
@@ -111,6 +165,40 @@ def test_extract_context_keys_from_ast_finds_annotated_assignments():
 
     keys = _extract_context_keys_from_ast(_V)
     assert {"count", "label"} <= keys
+
+
+def test_extract_context_keys_from_ast_walks_mro_for_parent_assigns():
+    """Issue #851: self.foo = ... assignments on a user-code parent class must be visible.
+
+    Before the MRO walk, ChildView below would falsely flag `parent_attr` as
+    unresolved because the AST walker only inspected ChildView's own source.
+    """
+
+    class BaseView(LiveView):
+        def mount(self, request=None, **kwargs):
+            self.parent_attr = "set-by-parent"
+
+    class ChildView(BaseView):
+        def mount(self, request=None, **kwargs):
+            super().mount(request=request, **kwargs)
+            self.child_attr = "set-by-child"
+
+    keys = _extract_context_keys_from_ast(ChildView)
+    assert "parent_attr" in keys  # the MRO walk picked up BaseView.mount
+    assert "child_attr" in keys
+
+
+def test_extract_context_keys_from_ast_skips_django_framework_classes():
+    """MRO walk must not surface `request`/`head`/`kwargs`/`args` from django.views.View."""
+
+    class _V(LiveView):
+        def get_context_data(self, **kwargs):
+            return {"alpha": 1}
+
+    keys = _extract_context_keys_from_ast(_V)
+    # Django's View class has self.request = request and method names like head().
+    # Those must be filtered out — only user-code context keys belong here.
+    assert keys == {"alpha"}
 
 
 def test_extract_context_keys_from_ast_finds_property_methods():

--- a/python/djust/tests/test_djust_typecheck.py
+++ b/python/djust/tests/test_djust_typecheck.py
@@ -114,6 +114,17 @@ def test_extract_referenced_names_ignores_cycle_as_suffix():
     assert "row_class" not in names  # it's a local after `as`, not a reference
 
 
+def test_extract_template_locals_binds_cycle_as_var():
+    """Stage 11 regression: `{% cycle a b as row_class %}` — row_class is a template local.
+
+    Without this, a subsequent `{{ row_class }}` would be falsely flagged as
+    unresolved because it's not declared anywhere else on the view.
+    """
+    src = "{% cycle 'odd' 'even' as row_class %}<tr class='{{ row_class }}'></tr>"
+    locals_ = _extract_template_locals(src)
+    assert "row_class" in locals_
+
+
 def test_extract_referenced_names_extracts_blocktrans_with_rhs():
     """`{% blocktrans with x=foo %}` — `foo` is a reference (`x` is the local)."""
     src = "{% blocktrans with name=first_name count=total_items %}...{% endblocktrans %}"

--- a/uv.lock
+++ b/uv.lock
@@ -729,7 +729,7 @@ wheels = [
 
 [[package]]
 name = "djust"
-version = "0.5.1rc3"
+version = "0.5.1rc4"
 source = { editable = "." }
 dependencies = [
     { name = "channels", extra = ["daphne"] },


### PR DESCRIPTION
Three related follow-ups to the v0.5.1 `djust_typecheck` command, landed together because they touch the same module family. Closes #850, #851, #852.

## #850 — `{% firstof %}`, `{% cycle %}`, `{% blocktrans with %}` support

Template locals now include the `x=expr` bindings from `blocktrans with` / `blocktranslate with` (and `count x=expr`). Referenced names now include positional args of firstof/cycle (skipping string literals and the `as <name>` suffix), and the expr side of blocktrans with-pairs. Fixes false negatives on firstof/cycle and false positives on blocktrans locals.

## #851 — MRO walk for parent-class `self.x` assigns

`_extract_context_keys_from_ast` now iterates `cls.__mro__`, skipping `djust.*` / `djust_*` / `django.*` / builtins framework classes. Child views that rely on attributes set in a parent `mount()` no longer produce spurious "unresolved" reports. The filter also correctly drops Django View's own `self.request`/`head`/`kwargs`/`args` (regression lock-in test added).

## #852 — Shared class-introspection helpers

`_walk_subclasses`/`_is_user_class`/`_app_label_for_class` were duplicated in `djust_audit.py` and `djust_typecheck.py`. Extracted to new `djust.management._introspect` module; both commands import from there. The new `walk_subclasses` also gained diamond-safety (deduplication via visited set) that the old recursive impl lacked.

## Tests
- 19 → 28 cases in `test_djust_typecheck.py`
- Three blocktrans/firstof/cycle positive cases
- String-literal / `as` suffix negative cases
- MRO walk picks up parent `self.foo` assigns
- Django View attrs do NOT leak through MRO (regression lock-in)
- Full `audit or typecheck` suite: 41 green

## Test plan
- [x] pytest test_djust_typecheck.py: 28 green
- [x] pytest -k 'audit or typecheck': 41 green
- [x] Manual djust_audit --json against demo project
- [x] No downstream-app name leaks (scanned)
- [x] CHANGELOG Unreleased updated