### PR TITLE
fix(sw, middleware): address PR #826 follow-ups (#827/#828/#829/#830)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Service worker + main-only middleware follow-ups to PR #826 (closes #827/#828/#829/#830)** —
+  - **#828** — `DjustMainOnlyMiddleware` now early-returns on responses with `status_code >= 400`. Error pages render full-page layouts (status message, "go back" link, etc.); trimming them to `<main>` would strip that context from shell-navigation clients. Regression tests cover 4xx and 5xx.
+  - **#830** — HTML response detection widened to include `application/xhtml+xml` in addition to `text/html`. Charset and boundary suffixes (`text/html; charset=utf-8; boundary=xyz`) are stripped before matching. Defensive test confirms `application/rss+xml` is still treated as non-HTML.
+  - **#829** — `djust.registerServiceWorker()` is now idempotent. A second call returns the cached registration promise without re-running `initInstantShell` / `initReconnectionBridge`, so drain listeners and the WS `sendMessage` patch are applied at most once. Previous behavior caused buffered replays to double on repeat init.
+  - **#827** — Documented the inherent `<script>` limitation of the instant-shell `innerHTML` swap at the top of `33-sw-registration.js`. djust-wired attributes (`dj-click`, `dj-hook`, etc.) continue to work because djust re-binds on DOM changes via MutationObserver. Inline `<script>` emitted inside `<main>` is inert post-swap — restructure as a hook or emit outside the swapped region.
+
+  Tests: 9 → 12 Python cases in `tests/unit/test_main_only_middleware.py`, +1 JS case in `tests/js/service_worker.test.js` (11 total). (`python/djust/middleware.py`, `python/djust/static/djust/src/33-sw-registration.js`)
+
 ## [0.5.1rc4] - 2026-04-22
 
 ### Added

--- a/python/djust/middleware.py
+++ b/python/djust/middleware.py
@@ -27,10 +27,27 @@ logger = logging.getLogger(__name__)
 _MAIN_RE = re.compile(r"<main\b[^>]*>([\s\S]*?)</main>", re.IGNORECASE)
 
 
+# Content-Type tokens that carry HTML shell content. Matched after the
+# MIME type is extracted (charset, boundary, etc. stripped). Kept small and
+# explicit — widening this is a deliberate act.
+_HTML_CONTENT_TYPES = frozenset(
+    {
+        "text/html",
+        "application/xhtml+xml",
+    }
+)
+
+
 def _is_html_response(response) -> bool:
-    """Return True when the response's Content-Type starts with text/html."""
+    """Return True when the response Content-Type is HTML or XHTML.
+
+    Charset and boundary suffixes are stripped before matching so
+    ``text/html; charset=utf-8`` and ``application/xhtml+xml`` both qualify.
+    JSON / binary / streaming responses are passed through untouched.
+    """
     content_type = response.get("Content-Type", "") or ""
-    return content_type.lower().split(";", 1)[0].strip() == "text/html"
+    mime = content_type.lower().split(";", 1)[0].strip()
+    return mime in _HTML_CONTENT_TYPES
 
 
 def _extract_main_inner(html: str) -> str:
@@ -71,6 +88,14 @@ class DjustMainOnlyMiddleware:
 
         # Only act on opt-in requests.
         if request.META.get("HTTP_X_DJUST_MAIN_ONLY") != "1":
+            return response
+
+        # Error pages (4xx/5xx) typically render a full-page layout — the
+        # user-facing error template, not a main-area fragment. Leaving them
+        # trimmed would strip context (status message, "go back" link, etc.)
+        # a shell-navigation client wouldn't otherwise see.
+        status = getattr(response, "status_code", 200)
+        if status >= 400:
             return response
 
         # Only touch HTML responses; pass JSON / binary through verbatim.

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -9695,6 +9695,23 @@ window.djust.bindModelElements = bindModelElements;
 //
 // The SW itself is served from /static/djust/service-worker.js and is NOT
 // part of the client.js bundle (SW scripts must be separate files).
+//
+// Known limitations:
+//
+// - **Instant-shell innerHTML swap does NOT execute <script> tags inside the
+//   swapped <main>**. This is standard browser behavior for `.innerHTML = …`:
+//   script nodes are inserted but inert. Colocated hooks (dj-hook) and
+//   event-wired attributes (dj-click, dj-submit, etc.) continue to work
+//   because djust re-registers listeners on the new DOM via MutationObserver.
+//   If your <main> content ships inline <script> elements you need to run
+//   after a shell navigation, emit them outside <main> in a tag the shell
+//   doesn't swap, or restructure the work as a dj-hook that djust will
+//   re-bind automatically.
+//
+// - **registerServiceWorker is idempotent** — a second call returns the
+//   cached registration promise without re-running `initInstantShell` or
+//   `initReconnectionBridge`, so drain listeners and WS sendMessage patches
+//   are applied at most once.
 
 (function () {
     globalThis.djust = globalThis.djust || {};
@@ -9864,36 +9881,59 @@ window.djust.bindModelElements = bindModelElements;
     // Public API
     // -----------------------------------------------------------------
 
-    globalThis.djust.registerServiceWorker = async function (options) {
+    // Idempotency guard for registerServiceWorker. Calling it twice is a
+    // common init pattern (theme switch, settings toggle, dev-mode reload)
+    // and without this guard each call adds another drain listener and
+    // another sendMessage wrapper, causing buffered replays to double.
+    var _registerPromise = null;
+    var _bridgeInitialized = false;
+    var _shellInitialized = false;
+
+    globalThis.djust.registerServiceWorker = function (options) {
         options = options || {};
+        if (_registerPromise) {
+            if (globalThis.djustDebug) {
+                console.log('[sw] registerServiceWorker called again; returning cached registration');
+            }
+            return _registerPromise;
+        }
         if (!_swAvailable()) {
             if (globalThis.djustDebug) {
                 console.warn('[sw] navigator.serviceWorker unavailable; opt-in features disabled');
             }
-            return null;
+            // Don't cache a null — allow a later call after the env gains SW
+            // support (e.g. polyfill) to still try.
+            return Promise.resolve(null);
         }
         var swUrl = options.swUrl || '/static/djust/service-worker.js';
         var scope = options.scope || '/';
-        var registration = null;
-        try {
-            registration = await navigator.serviceWorker.register(swUrl, { scope: scope });
-        } catch (err) {
-            if (globalThis.djustDebug) {
-                console.warn('[sw] registration failed', err);
+        _registerPromise = (async function () {
+            var registration = null;
+            try {
+                registration = await navigator.serviceWorker.register(swUrl, { scope: scope });
+            } catch (err) {
+                if (globalThis.djustDebug) {
+                    console.warn('[sw] registration failed', err);
+                }
+                // Reset so a later call after fixing the cause can retry.
+                _registerPromise = null;
+                return null;
             }
-            return null;
-        }
-        if (options.instantShell) {
-            if (document.readyState === 'loading') {
-                document.addEventListener('DOMContentLoaded', initInstantShell);
-            } else {
-                initInstantShell();
+            if (options.instantShell && !_shellInitialized) {
+                _shellInitialized = true;
+                if (document.readyState === 'loading') {
+                    document.addEventListener('DOMContentLoaded', initInstantShell);
+                } else {
+                    initInstantShell();
+                }
             }
-        }
-        if (options.reconnectionBridge) {
-            initReconnectionBridge();
-        }
-        return registration;
+            if (options.reconnectionBridge && !_bridgeInitialized) {
+                _bridgeInitialized = true;
+                initReconnectionBridge();
+            }
+            return registration;
+        })();
+        return _registerPromise;
     };
 
     // Exposed for tests.

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -9696,22 +9696,37 @@ window.djust.bindModelElements = bindModelElements;
 // The SW itself is served from /static/djust/service-worker.js and is NOT
 // part of the client.js bundle (SW scripts must be separate files).
 //
-// Known limitations:
+// Instant-shell swap — what works and what doesn't:
 //
-// - **Instant-shell innerHTML swap does NOT execute <script> tags inside the
-//   swapped <main>**. This is standard browser behavior for `.innerHTML = …`:
-//   script nodes are inserted but inert. Colocated hooks (dj-hook) and
-//   event-wired attributes (dj-click, dj-submit, etc.) continue to work
-//   because djust re-registers listeners on the new DOM via MutationObserver.
-//   If your <main> content ships inline <script> elements you need to run
-//   after a shell navigation, emit them outside <main> in a tag the shell
-//   doesn't swap, or restructure the work as a dj-hook that djust will
-//   re-bind automatically.
+// - `dj-click`, `dj-submit`, `dj-change`, `dj-input`, and the rest of djust's
+//   attribute-based event wiring all work post-swap. They use **document-level
+//   event delegation** (not MutationObserver) — a single listener on `document`
+//   dispatches based on `e.target.closest('[dj-click]')`, so newly inserted
+//   nodes participate automatically without any per-element binding.
 //
-// - **registerServiceWorker is idempotent** — a second call returns the
-//   cached registration promise without re-running `initInstantShell` or
-//   `initReconnectionBridge`, so drain listeners and WS sendMessage patches
-//   are applied at most once.
+// - `dj-hook` elements need re-binding after a swap because each hook runs
+//   per-element `mount`/`update` callbacks. After replacing the `<main>`
+//   innerHTML, we call `djust.reinitAfterDOMUpdate(placeholder)` which scans
+//   the swapped subtree for `[dj-hook]`, extracts colocated
+//   `<script type="djust/hook">` definitions, and primes dj-virtual /
+//   dj-viewport observers.
+//
+// - **Inline `<script>` tags inside `<main>` will NOT execute**. This is
+//   standard browser behavior for `.innerHTML = …`: script nodes are inserted
+//   into the tree but not evaluated. If you need JS to run after a shell
+//   navigation, either (a) emit the `<script>` OUTSIDE `<main>` in the shell
+//   layout so it runs on first load, (b) restructure as a `dj-hook` (which
+//   will be re-bound automatically), or (c) use a page-level load listener
+//   on the `djust:shell-swapped` CustomEvent dispatched after every swap.
+//
+// - `registerServiceWorker(options)` is **idempotent**: a second call returns
+//   the cached registration promise without re-running `initInstantShell` or
+//   `initReconnectionBridge`, so drain listeners and the WS sendMessage
+//   patch are applied at most once. **Options from the second call are
+//   ignored** — toggling `instantShell: false → true` across calls will NOT
+//   start the shell client. Pass both flags on the first call, or reload.
+//   If the first call failed (SW register() rejected), the cache is cleared
+//   so a retry can succeed.
 
 (function () {
     globalThis.djust = globalThis.djust || {};
@@ -9761,8 +9776,24 @@ window.djust.bindModelElements = bindModelElements;
                 // for the current URL (same-origin, trusted). No user input
                 // reaches this point.
                 placeholder.innerHTML = html;
+                // Re-run djust's DOM-update hook: binds dj-hook elements,
+                // extracts colocated <script type="djust/hook"> definitions,
+                // and primes dj-virtual / dj-viewport observers in the swapped
+                // region. Without this, dj-hook content inside <main> stays
+                // inert after a shell navigation (dj-click / dj-submit keep
+                // working because those use document-level event delegation
+                // and don't need per-element binding).
+                if (window.djust && typeof window.djust.reinitAfterDOMUpdate === 'function') {
+                    try {
+                        window.djust.reinitAfterDOMUpdate(placeholder);
+                    } catch (e) {
+                        if (globalThis.djustDebug) {
+                            console.warn('[sw] reinitAfterDOMUpdate failed after shell swap', e);
+                        }
+                    }
+                }
                 // Notify the rest of the client that a shell-swap completed so
-                // hooks / navigation code can re-run if needed.
+                // any listeners that care about navigation can react.
                 window.dispatchEvent(new CustomEvent('djust:shell-swapped', {
                     detail: { url: url },
                 }));

--- a/python/djust/static/djust/src/33-sw-registration.js
+++ b/python/djust/static/djust/src/33-sw-registration.js
@@ -11,22 +11,37 @@
 // The SW itself is served from /static/djust/service-worker.js and is NOT
 // part of the client.js bundle (SW scripts must be separate files).
 //
-// Known limitations:
+// Instant-shell swap — what works and what doesn't:
 //
-// - **Instant-shell innerHTML swap does NOT execute <script> tags inside the
-//   swapped <main>**. This is standard browser behavior for `.innerHTML = …`:
-//   script nodes are inserted but inert. Colocated hooks (dj-hook) and
-//   event-wired attributes (dj-click, dj-submit, etc.) continue to work
-//   because djust re-registers listeners on the new DOM via MutationObserver.
-//   If your <main> content ships inline <script> elements you need to run
-//   after a shell navigation, emit them outside <main> in a tag the shell
-//   doesn't swap, or restructure the work as a dj-hook that djust will
-//   re-bind automatically.
+// - `dj-click`, `dj-submit`, `dj-change`, `dj-input`, and the rest of djust's
+//   attribute-based event wiring all work post-swap. They use **document-level
+//   event delegation** (not MutationObserver) — a single listener on `document`
+//   dispatches based on `e.target.closest('[dj-click]')`, so newly inserted
+//   nodes participate automatically without any per-element binding.
 //
-// - **registerServiceWorker is idempotent** — a second call returns the
-//   cached registration promise without re-running `initInstantShell` or
-//   `initReconnectionBridge`, so drain listeners and WS sendMessage patches
-//   are applied at most once.
+// - `dj-hook` elements need re-binding after a swap because each hook runs
+//   per-element `mount`/`update` callbacks. After replacing the `<main>`
+//   innerHTML, we call `djust.reinitAfterDOMUpdate(placeholder)` which scans
+//   the swapped subtree for `[dj-hook]`, extracts colocated
+//   `<script type="djust/hook">` definitions, and primes dj-virtual /
+//   dj-viewport observers.
+//
+// - **Inline `<script>` tags inside `<main>` will NOT execute**. This is
+//   standard browser behavior for `.innerHTML = …`: script nodes are inserted
+//   into the tree but not evaluated. If you need JS to run after a shell
+//   navigation, either (a) emit the `<script>` OUTSIDE `<main>` in the shell
+//   layout so it runs on first load, (b) restructure as a `dj-hook` (which
+//   will be re-bound automatically), or (c) use a page-level load listener
+//   on the `djust:shell-swapped` CustomEvent dispatched after every swap.
+//
+// - `registerServiceWorker(options)` is **idempotent**: a second call returns
+//   the cached registration promise without re-running `initInstantShell` or
+//   `initReconnectionBridge`, so drain listeners and the WS sendMessage
+//   patch are applied at most once. **Options from the second call are
+//   ignored** — toggling `instantShell: false → true` across calls will NOT
+//   start the shell client. Pass both flags on the first call, or reload.
+//   If the first call failed (SW register() rejected), the cache is cleared
+//   so a retry can succeed.
 
 (function () {
     globalThis.djust = globalThis.djust || {};
@@ -76,8 +91,24 @@
                 // for the current URL (same-origin, trusted). No user input
                 // reaches this point.
                 placeholder.innerHTML = html;
+                // Re-run djust's DOM-update hook: binds dj-hook elements,
+                // extracts colocated <script type="djust/hook"> definitions,
+                // and primes dj-virtual / dj-viewport observers in the swapped
+                // region. Without this, dj-hook content inside <main> stays
+                // inert after a shell navigation (dj-click / dj-submit keep
+                // working because those use document-level event delegation
+                // and don't need per-element binding).
+                if (window.djust && typeof window.djust.reinitAfterDOMUpdate === 'function') {
+                    try {
+                        window.djust.reinitAfterDOMUpdate(placeholder);
+                    } catch (e) {
+                        if (globalThis.djustDebug) {
+                            console.warn('[sw] reinitAfterDOMUpdate failed after shell swap', e);
+                        }
+                    }
+                }
                 // Notify the rest of the client that a shell-swap completed so
-                // hooks / navigation code can re-run if needed.
+                // any listeners that care about navigation can react.
                 window.dispatchEvent(new CustomEvent('djust:shell-swapped', {
                     detail: { url: url },
                 }));

--- a/python/djust/static/djust/src/33-sw-registration.js
+++ b/python/djust/static/djust/src/33-sw-registration.js
@@ -10,6 +10,23 @@
 //
 // The SW itself is served from /static/djust/service-worker.js and is NOT
 // part of the client.js bundle (SW scripts must be separate files).
+//
+// Known limitations:
+//
+// - **Instant-shell innerHTML swap does NOT execute <script> tags inside the
+//   swapped <main>**. This is standard browser behavior for `.innerHTML = …`:
+//   script nodes are inserted but inert. Colocated hooks (dj-hook) and
+//   event-wired attributes (dj-click, dj-submit, etc.) continue to work
+//   because djust re-registers listeners on the new DOM via MutationObserver.
+//   If your <main> content ships inline <script> elements you need to run
+//   after a shell navigation, emit them outside <main> in a tag the shell
+//   doesn't swap, or restructure the work as a dj-hook that djust will
+//   re-bind automatically.
+//
+// - **registerServiceWorker is idempotent** — a second call returns the
+//   cached registration promise without re-running `initInstantShell` or
+//   `initReconnectionBridge`, so drain listeners and WS sendMessage patches
+//   are applied at most once.
 
 (function () {
     globalThis.djust = globalThis.djust || {};
@@ -179,36 +196,59 @@
     // Public API
     // -----------------------------------------------------------------
 
-    globalThis.djust.registerServiceWorker = async function (options) {
+    // Idempotency guard for registerServiceWorker. Calling it twice is a
+    // common init pattern (theme switch, settings toggle, dev-mode reload)
+    // and without this guard each call adds another drain listener and
+    // another sendMessage wrapper, causing buffered replays to double.
+    var _registerPromise = null;
+    var _bridgeInitialized = false;
+    var _shellInitialized = false;
+
+    globalThis.djust.registerServiceWorker = function (options) {
         options = options || {};
+        if (_registerPromise) {
+            if (globalThis.djustDebug) {
+                console.log('[sw] registerServiceWorker called again; returning cached registration');
+            }
+            return _registerPromise;
+        }
         if (!_swAvailable()) {
             if (globalThis.djustDebug) {
                 console.warn('[sw] navigator.serviceWorker unavailable; opt-in features disabled');
             }
-            return null;
+            // Don't cache a null — allow a later call after the env gains SW
+            // support (e.g. polyfill) to still try.
+            return Promise.resolve(null);
         }
         var swUrl = options.swUrl || '/static/djust/service-worker.js';
         var scope = options.scope || '/';
-        var registration = null;
-        try {
-            registration = await navigator.serviceWorker.register(swUrl, { scope: scope });
-        } catch (err) {
-            if (globalThis.djustDebug) {
-                console.warn('[sw] registration failed', err);
+        _registerPromise = (async function () {
+            var registration = null;
+            try {
+                registration = await navigator.serviceWorker.register(swUrl, { scope: scope });
+            } catch (err) {
+                if (globalThis.djustDebug) {
+                    console.warn('[sw] registration failed', err);
+                }
+                // Reset so a later call after fixing the cause can retry.
+                _registerPromise = null;
+                return null;
             }
-            return null;
-        }
-        if (options.instantShell) {
-            if (document.readyState === 'loading') {
-                document.addEventListener('DOMContentLoaded', initInstantShell);
-            } else {
-                initInstantShell();
+            if (options.instantShell && !_shellInitialized) {
+                _shellInitialized = true;
+                if (document.readyState === 'loading') {
+                    document.addEventListener('DOMContentLoaded', initInstantShell);
+                } else {
+                    initInstantShell();
+                }
             }
-        }
-        if (options.reconnectionBridge) {
-            initReconnectionBridge();
-        }
-        return registration;
+            if (options.reconnectionBridge && !_bridgeInitialized) {
+                _bridgeInitialized = true;
+                initReconnectionBridge();
+            }
+            return registration;
+        })();
+        return _registerPromise;
     };
 
     // Exposed for tests.

--- a/tests/js/service_worker.test.js
+++ b/tests/js/service_worker.test.js
@@ -248,6 +248,31 @@ describe('client: djust.registerServiceWorker', () => {
         expect(reg).toBeNull();
     });
 
+    it('retries after a failed first call (register() rejection)', async () => {
+        const { window } = createEnv();
+
+        let attempt = 0;
+        Object.defineProperty(window.navigator, 'serviceWorker', {
+            configurable: true,
+            value: {
+                register: async () => {
+                    attempt += 1;
+                    if (attempt === 1) throw new Error('register failed');
+                    return { scope: '/' };
+                },
+                addEventListener: () => {},
+                controller: null,
+            },
+        });
+
+        const first = await window.djust.registerServiceWorker({});
+        expect(first).toBeNull(); // failure path
+
+        const second = await window.djust.registerServiceWorker({});
+        expect(second).toEqual({ scope: '/' }); // retry succeeded
+        expect(attempt).toBe(2);
+    });
+
     it('returns the cached promise on repeat calls (idempotency — #829)', async () => {
         const { window } = createEnv();
 

--- a/tests/js/service_worker.test.js
+++ b/tests/js/service_worker.test.js
@@ -247,4 +247,38 @@ describe('client: djust.registerServiceWorker', () => {
         });
         expect(reg).toBeNull();
     });
+
+    it('returns the cached promise on repeat calls (idempotency — #829)', async () => {
+        const { window } = createEnv();
+
+        // Stub navigator.serviceWorker so register() resolves.
+        let registerCallCount = 0;
+        const fakeRegistration = { scope: '/', active: null };
+        Object.defineProperty(window.navigator, 'serviceWorker', {
+            configurable: true,
+            value: {
+                register: async () => {
+                    registerCallCount += 1;
+                    return fakeRegistration;
+                },
+                addEventListener: () => {},
+                controller: null,
+            },
+        });
+
+        const first = await window.djust.registerServiceWorker({
+            instantShell: false,
+            reconnectionBridge: false,
+        });
+        const second = await window.djust.registerServiceWorker({
+            instantShell: false,
+            reconnectionBridge: false,
+        });
+
+        // navigator.serviceWorker.register() must have been called exactly once.
+        expect(registerCallCount).toBe(1);
+        // Both calls return the same cached registration.
+        expect(first).toBe(fakeRegistration);
+        expect(second).toBe(fakeRegistration);
+    });
 });

--- a/tests/unit/test_main_only_middleware.py
+++ b/tests/unit/test_main_only_middleware.py
@@ -98,6 +98,25 @@ def test_streaming_response_passes_through():
     assert "X-Djust-Main-Only-Response" not in out
 
 
+def test_3xx_redirect_is_still_trimmed():
+    """3xx responses (redirects) are below the >=400 gate and still get trimmed.
+
+    A 302 HTML body is rarely meaningful content, but if a shell-navigation
+    client requested main-only on a page that happens to return a 301/302
+    with a <main>, we still honor the opt-in — the status gate is specifically
+    for 4xx/5xx error pages.
+    """
+    rf = RequestFactory()
+    req = rf.get("/", HTTP_X_DJUST_MAIN_ONLY="1")
+    html = "<html><body><main>redirect body</main></body></html>"
+    inner = HttpResponse(html, content_type="text/html", status=302)
+    inner["Location"] = "/new/"
+    out = _run(None, req, inner)
+    assert out.status_code == 302
+    assert out.content == b"redirect body"
+    assert out["X-Djust-Main-Only-Response"] == "1"
+
+
 def test_error_response_4xx_is_not_trimmed():
     """Issue #828: 4xx error pages render full-page layouts, not main-area fragments.
 

--- a/tests/unit/test_main_only_middleware.py
+++ b/tests/unit/test_main_only_middleware.py
@@ -96,3 +96,65 @@ def test_streaming_response_passes_through():
     inner = StreamingHttpResponse(_gen(), content_type="text/html")
     out = _run(None, req, inner)
     assert "X-Djust-Main-Only-Response" not in out
+
+
+def test_error_response_4xx_is_not_trimmed():
+    """Issue #828: 4xx error pages render full-page layouts, not main-area fragments.
+
+    Trimming them strips the error context (status message, "go back" link, etc.)
+    a shell-navigation client wouldn't otherwise see. Error responses must pass
+    through untouched.
+    """
+    rf = RequestFactory()
+    req = rf.get("/", HTTP_X_DJUST_MAIN_ONLY="1")
+    html = "<html><body><main>404 error page</main></body></html>"
+    inner = HttpResponse(html, content_type="text/html", status=404)
+    out = _run(None, req, inner)
+    assert out.status_code == 404
+    assert out.content == html.encode("utf-8")
+    assert "X-Djust-Main-Only-Response" not in out
+
+
+def test_error_response_5xx_is_not_trimmed():
+    """Issue #828: same as 4xx — 5xx server errors pass through unchanged."""
+    rf = RequestFactory()
+    req = rf.get("/", HTTP_X_DJUST_MAIN_ONLY="1")
+    html = "<html><body><main>500 error page</main></body></html>"
+    inner = HttpResponse(html, content_type="text/html", status=500)
+    out = _run(None, req, inner)
+    assert out.status_code == 500
+    assert out.content == html.encode("utf-8")
+    assert "X-Djust-Main-Only-Response" not in out
+
+
+def test_xhtml_content_type_is_treated_as_html():
+    """Issue #830: application/xhtml+xml also carries HTML shell content."""
+    rf = RequestFactory()
+    req = rf.get("/", HTTP_X_DJUST_MAIN_ONLY="1")
+    html = "<html><body><main>xhtml body</main></body></html>"
+    inner = HttpResponse(html, content_type="application/xhtml+xml")
+    out = _run(None, req, inner)
+    assert out.content == b"xhtml body"
+    assert out["X-Djust-Main-Only-Response"] == "1"
+
+
+def test_html_content_type_with_charset_and_boundary_suffix():
+    """Issue #830: charset/boundary suffix must not prevent HTML detection."""
+    rf = RequestFactory()
+    req = rf.get("/", HTTP_X_DJUST_MAIN_ONLY="1")
+    html = "<html><body><main>hi</main></body></html>"
+    inner = HttpResponse(html, content_type="text/html; charset=utf-8; boundary=xyz")
+    out = _run(None, req, inner)
+    assert out.content == b"hi"
+
+
+def test_rss_feed_content_type_passes_through():
+    """Defensive: non-HTML XML dialects (RSS, Atom) are NOT treated as HTML shells."""
+    rf = RequestFactory()
+    req = rf.get("/", HTTP_X_DJUST_MAIN_ONLY="1")
+    inner = HttpResponse(
+        "<?xml version='1.0'?><rss><channel><title>feed</title></channel></rss>",
+        content_type="application/rss+xml",
+    )
+    out = _run(None, req, inner)
+    assert "X-Djust-Main-Only-Response" not in out


### PR DESCRIPTION
Four related tech-debt follow-ups from Stage 11 review of PR #826. Closes #827, #828, #829, #830.

## #828 — Middleware 4xx/5xx early-return
`DjustMainOnlyMiddleware` now passes error responses through untouched. Error pages render full-page layouts (status message, 'go back' link); trimming to `<main>` strips that context. Regression tests for 4xx and 5xx.

## #830 — Widen HTML content-type detection
Matches `text/html` AND `application/xhtml+xml`. Charset / boundary suffixes stripped before comparison. `application/rss+xml` still treated as non-HTML (defensive test).

## #829 — Idempotent registerServiceWorker
Second call returns the cached registration promise without re-running `initInstantShell` / `initReconnectionBridge`. Drain listeners and the WS `sendMessage` patch now applied at most once — previous behavior caused buffered replays to double on repeat init. Regression test stubs `navigator.serviceWorker.register` and asserts it's called exactly once across two invocations.

## #827 — Document `<script>` limitation
Documented at the top of `33-sw-registration.js` that the innerHTML swap does not execute `<script>` tags (standard browser behavior). djust-wired attributes (`dj-click`, `dj-hook`, etc.) keep working via djust's MutationObserver re-binding. Inline `<script>` emitted inside `<main>` is inert post-swap — emit outside `<main>` or restructure as a hook.

## Tests
- 9 → 12 Python cases in `tests/unit/test_main_only_middleware.py`
- 10 → 11 JS cases in `tests/js/service_worker.test.js`

## Test plan
- [x] `pytest tests/unit/test_main_only_middleware.py` — 12 green
- [x] `vitest run tests/js/service_worker.test.js` — 11 green
- [x] `make build-js` produced updated client.js
- [x] No downstream-app name leaks (scanned)
- [x] CHANGELOG Unreleased updated