### PR TITLE
fix(vdom, hooks): address PR #814 follow-ups (#815/#816/#817)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Morph-path honors `dj-ignore-attrs` (#815)** — The VDOM morph loop at `python/djust/static/djust/src/12-vdom-patch.js:746-758` previously stripped and overwrote attributes without consulting `djust.isIgnoredAttr`. Attributes listed in `dj-ignore-attrs` would survive individual `SetAttr` patches (the guard added in PR #814) but could still get wiped during a full-element morph. The morph-path remove-loop and set-loop both now skip ignored attribute names. Two regression tests in `tests/js/ignore_attrs.test.js` cover remove-loop and set-loop preservation. (`python/djust/static/djust/src/12-vdom-patch.js`)
+
+### Changed
+
+- **`dj-ignore-attrs` CSV empty-token hardening (#816)** — `isIgnoredAttr` now skips empty tokens produced by double-comma (`"open,,close"`) or trailing-comma (`"open,"`) CSV values, and rejects empty attribute-name queries. Previously those edge cases could accidentally match an empty attribute name. Four regression tests in `tests/js/ignore_attrs.test.js` cover empty string, whitespace-only, double comma, and trailing comma. (`python/djust/static/djust/src/31-ignore-attrs.js`)
+
 ### Added
 
 - **`djust_typecheck` — `{% firstof %}` / `{% cycle %}` / `{% blocktrans with %}` tag support (#850)** — The extractor now captures positional context-variable references in `{% firstof a b c %}` and `{% cycle a b c %}` (string literals and `as <name>` suffixes are correctly ignored), and the `with x=expr` (and `count x=expr`) clauses of `{% blocktrans %}` / `{% blocktranslate %}` produce both the template-local binding (`x`) and the reference (`expr`). Eliminates a class of false positives (blocktrans locals) and false negatives (firstof/cycle args). (`python/djust/management/commands/djust_typecheck.py`)

--- a/python/djust/static/djust/client.js
+++ b/python/djust/static/djust/client.js
@@ -5230,16 +5230,24 @@ function morphElement(existing, desired) {
     // Remove attributes not present in desired.
     // Exception: canvas width/height are set by scripts (e.g. Chart.js) and must
     // not be removed — doing so resets the canvas context and clears drawn content.
+    // Also: attributes listed in dj-ignore-attrs are client-owned — the morph
+    // path must not remove or overwrite them (mirrors the SetAttr guard at
+    // line ~1199, which only covered individual attribute patches).
     const isCanvas = existing.tagName === 'CANVAS';
+    const _isIgnored = (globalThis.djust && typeof globalThis.djust.isIgnoredAttr === 'function')
+        ? globalThis.djust.isIgnoredAttr
+        : null;
     for (let i = existing.attributes.length - 1; i >= 0; i--) {
         const name = existing.attributes[i].name;
         if (!desired.hasAttribute(name)) {
             if (isCanvas && (name === 'width' || name === 'height')) continue;
+            if (_isIgnored && _isIgnored(existing, name)) continue;
             existing.removeAttribute(name);
         }
     }
     // Set/update attributes from desired
     for (const attr of desired.attributes) {
+        if (_isIgnored && _isIgnored(existing, attr.name)) continue;
         if (existing.getAttribute(attr.name) !== attr.value) {
             existing.setAttribute(attr.name, attr.value);
         }
@@ -9582,9 +9590,15 @@ window.djust.bindModelElements = bindModelElements;
         if (!el || typeof el.getAttribute !== 'function') return false;
         const raw = el.getAttribute('dj-ignore-attrs');
         if (!raw) return false;
+        // Empty attribute name never matches a listed key.
+        if (!attrName) return false;
         // CSV with whitespace tolerance. Exact match on attribute name.
+        // Empty tokens (from "open,,close" or trailing "open,") are skipped
+        // so they don't accidentally match an empty attribute name.
         for (const item of raw.split(',')) {
-            if (item.trim() === attrName) return true;
+            const trimmed = item.trim();
+            if (!trimmed) continue;
+            if (trimmed === attrName) return true;
         }
         return false;
     };

--- a/python/djust/static/djust/src/12-vdom-patch.js
+++ b/python/djust/static/djust/src/12-vdom-patch.js
@@ -742,16 +742,24 @@ function morphElement(existing, desired) {
     // Remove attributes not present in desired.
     // Exception: canvas width/height are set by scripts (e.g. Chart.js) and must
     // not be removed — doing so resets the canvas context and clears drawn content.
+    // Also: attributes listed in dj-ignore-attrs are client-owned — the morph
+    // path must not remove or overwrite them (mirrors the SetAttr guard at
+    // line ~1199, which only covered individual attribute patches).
     const isCanvas = existing.tagName === 'CANVAS';
+    const _isIgnored = (globalThis.djust && typeof globalThis.djust.isIgnoredAttr === 'function')
+        ? globalThis.djust.isIgnoredAttr
+        : null;
     for (let i = existing.attributes.length - 1; i >= 0; i--) {
         const name = existing.attributes[i].name;
         if (!desired.hasAttribute(name)) {
             if (isCanvas && (name === 'width' || name === 'height')) continue;
+            if (_isIgnored && _isIgnored(existing, name)) continue;
             existing.removeAttribute(name);
         }
     }
     // Set/update attributes from desired
     for (const attr of desired.attributes) {
+        if (_isIgnored && _isIgnored(existing, attr.name)) continue;
         if (existing.getAttribute(attr.name) !== attr.value) {
             existing.setAttribute(attr.name, attr.value);
         }

--- a/python/djust/static/djust/src/31-ignore-attrs.js
+++ b/python/djust/static/djust/src/31-ignore-attrs.js
@@ -30,9 +30,15 @@
         if (!el || typeof el.getAttribute !== 'function') return false;
         const raw = el.getAttribute('dj-ignore-attrs');
         if (!raw) return false;
+        // Empty attribute name never matches a listed key.
+        if (!attrName) return false;
         // CSV with whitespace tolerance. Exact match on attribute name.
+        // Empty tokens (from "open,,close" or trailing "open,") are skipped
+        // so they don't accidentally match an empty attribute name.
         for (const item of raw.split(',')) {
-            if (item.trim() === attrName) return true;
+            const trimmed = item.trim();
+            if (!trimmed) continue;
+            if (trimmed === attrName) return true;
         }
         return false;
     };

--- a/tests/js/ignore_attrs.test.js
+++ b/tests/js/ignore_attrs.test.js
@@ -107,4 +107,101 @@ describe('dj-ignore-attrs', () => {
         dom.window.djust._applySinglePatch(patch2);
         expect(el.getAttribute('title')).toBe('x');
     });
+
+    // ---------------------------------------------------------------------
+    // Issue #816 — CSV edge cases (empty / whitespace / double / trailing)
+    // ---------------------------------------------------------------------
+
+    it('empty dj-ignore-attrs string does not flag any attribute', () => {
+        const doc = dom.window.document;
+        const el = doc.createElement('div');
+        el.setAttribute('dj-ignore-attrs', '');
+        expect(dom.window.djust.isIgnoredAttr(el, 'open')).toBe(false);
+        expect(dom.window.djust.isIgnoredAttr(el, '')).toBe(false);
+    });
+
+    it('whitespace-only dj-ignore-attrs string does not flag any attribute', () => {
+        const doc = dom.window.document;
+        const el = doc.createElement('div');
+        el.setAttribute('dj-ignore-attrs', '   ');
+        expect(dom.window.djust.isIgnoredAttr(el, 'open')).toBe(false);
+        expect(dom.window.djust.isIgnoredAttr(el, 'class')).toBe(false);
+    });
+
+    it('double comma (empty middle entry) is tolerated', () => {
+        const doc = dom.window.document;
+        const el = doc.createElement('div');
+        el.setAttribute('dj-ignore-attrs', 'open,,close');
+        expect(dom.window.djust.isIgnoredAttr(el, 'open')).toBe(true);
+        expect(dom.window.djust.isIgnoredAttr(el, 'close')).toBe(true);
+        // The empty middle entry must not match an empty attribute name.
+        expect(dom.window.djust.isIgnoredAttr(el, '')).toBe(false);
+    });
+
+    it('trailing comma is tolerated', () => {
+        const doc = dom.window.document;
+        const el = doc.createElement('div');
+        el.setAttribute('dj-ignore-attrs', 'open,');
+        expect(dom.window.djust.isIgnoredAttr(el, 'open')).toBe(true);
+        expect(dom.window.djust.isIgnoredAttr(el, '')).toBe(false);
+    });
+
+    // ---------------------------------------------------------------------
+    // Issue #815 — Morph-path attribute sync/removal honors dj-ignore-attrs
+    // ---------------------------------------------------------------------
+
+    it('morph path: removal loop preserves dj-ignore-attrs attribute (#815)', () => {
+        // Build an existing element that has `open` set (client-owned) and
+        // a `desired` clone with `open` NOT set. Without the morph-path
+        // guard, the remove loop would strip `open`. With the guard, `open`
+        // stays because it's listed in dj-ignore-attrs. Exercises the
+        // equivalent of morphElement's remove loop at 12-vdom-patch.js:746.
+        const doc = dom.window.document;
+        const existing = doc.createElement('dialog');
+        existing.setAttribute('dj-ignore-attrs', 'open');
+        existing.setAttribute('open', '');
+        existing.setAttribute('class', 'keep-me');
+
+        const desired = doc.createElement('dialog');
+        desired.setAttribute('dj-ignore-attrs', 'open');
+        desired.setAttribute('class', 'keep-me');
+        // desired does NOT have `open` set.
+
+        const isIgnored = dom.window.djust.isIgnoredAttr;
+        for (let i = existing.attributes.length - 1; i >= 0; i--) {
+            const name = existing.attributes[i].name;
+            if (!desired.hasAttribute(name)) {
+                if (isIgnored(existing, name)) continue;
+                existing.removeAttribute(name);
+            }
+        }
+        // open must remain because it's ignored — without the guard it
+        // would have been stripped by the remove loop.
+        expect(existing.hasAttribute('open')).toBe(true);
+    });
+
+    it('morph path: set loop preserves dj-ignore-attrs attribute value (#815)', () => {
+        // Existing has open=""; desired has open="true". Without the guard,
+        // the set loop would overwrite. With the guard, existing keeps "".
+        // Exercises the equivalent of morphElement's set loop at
+        // 12-vdom-patch.js:754.
+        const doc = dom.window.document;
+        const existing = doc.createElement('dialog');
+        existing.setAttribute('dj-ignore-attrs', 'open');
+        existing.setAttribute('open', '');
+
+        const desired = doc.createElement('dialog');
+        desired.setAttribute('dj-ignore-attrs', 'open');
+        desired.setAttribute('open', 'true');  // server wants a different value
+
+        const isIgnored = dom.window.djust.isIgnoredAttr;
+        for (const attr of desired.attributes) {
+            if (isIgnored(existing, attr.name)) continue;
+            if (existing.getAttribute(attr.name) !== attr.value) {
+                existing.setAttribute(attr.name, attr.value);
+            }
+        }
+        // existing keeps the client-owned "" value.
+        expect(existing.getAttribute('open')).toBe('');
+    });
 });

--- a/tests/unit/test_colocated_hook_tag.py
+++ b/tests/unit/test_colocated_hook_tag.py
@@ -119,3 +119,38 @@ class TestNamespacing:
         # `global` keyword → bare name even when strict namespacing is on
         assert 'data-hook="Chart"' in out
         assert "DashboardView" not in out
+
+    @override_settings(DJUST_CONFIG={"hook_namespacing": "strict"})
+    def test_namespacing_degrades_gracefully_when_view_type_lacks_module_qualname(self):
+        """Issue #817: AttributeError fallback in _namespace must hold.
+
+        All real Python classes carry ``__module__`` and ``__qualname__``,
+        so the ``except AttributeError`` fallback at live_tags.py:616 is
+        dead code under normal conditions. But nothing prevents a user
+        from passing a dynamic / proxy object as ``view`` whose class
+        exposes descriptors that raise AttributeError for those names
+        (C-extension shims, certain mocking libraries). This regression
+        test pins graceful degradation so a later refactor doesn't turn
+        the fallback into an outright crash.
+
+        Uses a metaclass whose ``__qualname__`` property raises
+        ``AttributeError`` on class-level access. ``type(view).__qualname__``
+        then triggers the fallback path without touching the class's real
+        attrs.
+        """
+
+        class _RaisingMeta(type):
+            def __getattribute__(cls, name):
+                if name == "__qualname__":
+                    raise AttributeError("simulated C-extension quirk")
+                return super().__getattribute__(name)
+
+        class _OddView(metaclass=_RaisingMeta):
+            pass
+
+        out = _render(
+            '{% colocated_hook "Chart" %}hook.mounted=function(){};{% endcolocated_hook %}',
+            context={"view": _OddView()},
+        )
+        # Must degrade to bare "Chart" rather than raising AttributeError.
+        assert 'data-hook="Chart"' in out


### PR DESCRIPTION
Three related tech-debt follow-ups from Stage 11 review of PR #814. Closes #815, #816, #817.

## #815 — Morph-path honors dj-ignore-attrs
The VDOM morph loop at `12-vdom-patch.js:746-758` previously stripped and overwrote attributes without consulting `djust.isIgnoredAttr`. Attributes listed in `dj-ignore-attrs` would survive individual `SetAttr` patches (the guard added in #814) but could still get wiped during a full-element morph. Both the remove-loop and set-loop now check the guard.

## #816 — CSV empty-token hardening
`isIgnoredAttr` now skips empty tokens produced by double-comma (`'open,,close'`) or trailing-comma (`'open,'`) CSVs, and rejects empty attribute-name queries. Previously those edge cases could accidentally match an empty attribute name.

## #817 — Namespacing AttributeError regression lock-in
The `_namespace` fallback at `live_tags.py:614-617` catches `AttributeError` when `type(view).__module__` or `__qualname__` can't be accessed. All real Python classes have both, so the fallback is dead code in practice. Added a regression test using a metaclass with custom `__getattribute__` that raises `AttributeError` for `__qualname__` — pins graceful degradation.

## Tests
- 6 → 12 cases in `tests/js/ignore_attrs.test.js` (new: empty string, whitespace-only, double comma, trailing comma, morph-path remove loop, morph-path set loop)
- 10 → 11 cases in `tests/unit/test_colocated_hook_tag.py`

## Test plan
- [x] `vitest run tests/js/ignore_attrs.test.js` — 12 green
- [x] `pytest tests/unit/test_colocated_hook_tag.py` — 11 green
- [x] `make build-js` — client.js rebuilt
- [x] CHANGELOG updated