### PR TITLE
fix(components): render_slot works end-to-end via Rust engine (#861)

### DIFF
--- a/python/djust/components/function_component.py
+++ b/python/djust/components/function_component.py
@@ -383,6 +383,13 @@ class SlotTagHandler:
         return _emit_slot_sentinel({"name": name, "attrs": attrs, "content": content})
 
 
+# Matches a bare identifier or a dotted chain of identifiers: `slot`,
+# `slot.0`, `slots.col.0.content`. Used by RenderSlotTagHandler to decide
+# whether a pre-resolved arg is still an unresolved path (resolution
+# failed upstream) vs. a resolved scalar value. See #861.
+_LOOKS_LIKE_PATH = re.compile(r"^[A-Za-z_][\w]*(?:\.[A-Za-z_0-9][\w]*)*$")
+
+
 class RenderSlotTagHandler:
     """Inline tag: ``{% render_slot REF %}``.
 
@@ -390,15 +397,66 @@ class RenderSlotTagHandler:
     like ``slots.col.0``). If the resolved value is a dict it is assumed to
     be a single slot entry; if a list, the first entry is emitted. The
     content is returned verbatim (already-escaped HTML from the parent).
+
+    **Dual-caller contract (#861)**: this handler is called from two paths
+    with different arg shapes:
+
+    1. **Rust template engine** — the engine pre-resolves variable args
+       before calling handlers. For `{% render_slot slots.col.0 %}`,
+       ``args[0]`` arrives already as the resolved slot dict, JSON-encoded
+       (because ``value_to_arg_string`` JSON-serializes ``List``/``Object``
+       values for transport across the FFI boundary). The handler's
+       ``_resolve_context_path`` call on a JSON string would then fail,
+       producing silent empty output — the exact #861 symptom.
+
+    2. **Direct Python call** — ``RenderSlotTagHandler().render(["slots.col.0"], ctx)``
+       passes the literal dotted-path string; the handler resolves against
+       ``context`` itself.
+
+    Resolution: try a JSON parse first (shape 1 — Rust-engine output).
+    If that yields a structured value, extract from it. Otherwise fall
+    back to the path-resolution semantics (shape 2 — direct callers).
+    This keeps end-to-end Rust rendering of named slots working and
+    preserves the existing direct-caller contract.
     """
 
     def render(self, args: list[str], context: dict[str, Any]) -> str:
         if not args:
             return ""
-        target = str(args[0])
-        value = _resolve_context_path(target, context)
-        if value is None:
-            return ""
+        raw = str(args[0])
+
+        # Shape 1: Rust-engine pre-resolved structured value (JSON string).
+        # Only treat as JSON if it parses AS a list or dict — bare strings,
+        # numbers, and bools pass through below.
+        try:
+            import json
+
+            parsed = json.loads(raw)
+            if isinstance(parsed, (list, dict)):
+                return self._render_value(parsed)
+        except (ValueError, TypeError):
+            pass
+
+        # Shape 2: the arg still LOOKS like a dotted path (no dots → simple
+        # identifier; with dots → multi-segment identifier). Under the Rust
+        # engine, an arg that still looks like an unresolved path means
+        # resolution failed upstream — preserve the old direct-caller
+        # contract and return empty on miss. This also handles the direct-
+        # Python-caller case where args[0] is a literal path.
+        if _LOOKS_LIKE_PATH.match(raw):
+            value = _resolve_context_path(raw, context)
+            if value is None:
+                return ""
+            return self._render_value(value)
+
+        # Shape 3: a pre-resolved scalar (Rust engine stringified a number,
+        # bool, or string). Emit as-is — this is the value the user asked
+        # for. Covers `{% render_slot slot.content %}` where the content is
+        # a string that doesn't itself look like a dotted identifier.
+        return raw
+
+    @staticmethod
+    def _render_value(value: Any) -> str:
         if isinstance(value, list):
             if not value:
                 return ""

--- a/tests/unit/test_named_slots.py
+++ b/tests/unit/test_named_slots.py
@@ -196,6 +196,33 @@ class TestEndToEnd:
         out = render('{% call "card" %}{% slot header %}H{% endslot %}B{% endcall %}')
         assert out == "<div>H|B</div>"
 
+    def test_render_slot_end_to_end_via_rust_engine(self, ensure_rust_handlers):
+        """Issue #861 regression: `{% render_slot %}` via the Rust template
+        engine used to return empty string for every input because the Rust
+        engine pre-resolves args (so the handler saw a JSON-encoded dict
+        rather than the literal path it expected). Handler now dual-dispatches
+        based on arg shape.
+        """
+        from djust._rust import render_template
+
+        ctx = {
+            "slots": {
+                "col": [
+                    {"name": "col", "attrs": {}, "content": "first-col-content"},
+                    {"name": "col", "attrs": {}, "content": "second-col-content"},
+                ],
+            },
+        }
+        # slots.col.0 → first entry's content (Rust resolves to dict, JSON-encoded)
+        assert render_template("{% render_slot slots.col.0 %}", ctx) == "first-col-content"
+        # slots.col.1 → second entry's content
+        assert render_template("{% render_slot slots.col.1 %}", ctx) == "second-col-content"
+        # slots.col.0.content → the string directly (Rust resolves to string scalar)
+        assert render_template("{% render_slot slots.col.0.content %}", ctx) == "first-col-content"
+        # Missing path → empty (Rust passes the unresolved path through; handler resolves against
+        # context, finds nothing, returns empty).
+        assert render_template("{% render_slot slots.missing.0 %}", ctx) == ""
+
     def test_render_slot_dotted_path_resolves_slot_entry(self):
         """Issue #790: `RenderSlotTagHandler` resolves `slots.col.0` to the first col slot.
 


### PR DESCRIPTION
Closes #861.

`{% render_slot slots.col.0 %}` through the Rust template engine used to return empty string for every input. The Rust engine pre-resolves variable args before calling handlers — for structured values that means `args[0]` arrives JSON-encoded. The handler was treating it as a dotted path, finding nothing, and returning empty.

## Fix

Dual-dispatch in `RenderSlotTagHandler.render`:

1. **JSON parse first** — if the arg parses as list/dict, it's a Rust-resolved structured value; extract content.
2. **Path-shape check** — if the arg still looks like a dotted identifier, it's an unresolved path (Rust failed resolution OR direct Python caller); try `_resolve_context_path`; empty on miss.
3. **Otherwise** — pre-resolved scalar (Rust resolved a string/number/bool to literal form); emit as-is.

Preserves the direct-Python-caller contract AND makes the Rust-engine path work.

## Tests

13 → 14 cases in `test_named_slots.py`, including a new end-to-end test through `render_template` covering:
- `slots.col.0` (Rust → JSON dict)
- `slots.col.1` (second entry)
- `slots.col.0.content` (Rust → string scalar)
- `slots.missing.0` (Rust passes path through; handler returns empty)

## User impact

Named slots now actually work as documented. Users previously had to extract slot content in Python as a workaround — that workaround remains supported but is no longer mandatory.