### PR TITLE
fix: handle PEP 604 union types in get_handler_signature_info (#899)

### DIFF
--- a/python/djust/validation.py
+++ b/python/djust/validation.py
@@ -11,6 +11,7 @@ Provides runtime validation of event handler signatures including:
 
 import inspect
 import logging
+import types
 from decimal import Decimal, InvalidOperation
 from typing import Any, Callable, Dict, List, Optional, Union, get_type_hints, get_origin, get_args
 from uuid import UUID
@@ -392,6 +393,30 @@ def validate_parameter_types(
     return errors if errors else None
 
 
+def _type_display_name(hint: Any) -> str:
+    """Human-readable name for a type hint, including PEP 604 unions.
+
+    >>> _type_display_name(str)
+    'str'
+    >>> _type_display_name(str | None)
+    'str | None'
+    >>> _type_display_name(Optional[int])
+    'int | None'
+    """
+    if isinstance(hint, types.UnionType):
+        return " | ".join(_single_type_name(arg) for arg in hint.__args__)
+    origin = get_origin(hint)
+    if origin is Union:
+        return " | ".join(_single_type_name(arg) for arg in get_args(hint))
+    return _single_type_name(hint)
+
+
+def _single_type_name(t: Any) -> str:
+    if t is type(None):
+        return "None"
+    return getattr(t, "__name__", str(t))
+
+
 def get_handler_signature_info(handler: Callable) -> Dict[str, Any]:
     """
     Extract comprehensive signature information from handler.
@@ -442,7 +467,7 @@ def get_handler_signature_info(handler: Callable) -> Dict[str, Any]:
 
         param_info = {
             "name": name,
-            "type": type_hints.get(name, Any).__name__ if name in type_hints else "Any",
+            "type": _type_display_name(type_hints.get(name, Any)) if name in type_hints else "Any",
             "required": param.default == inspect.Parameter.empty,
             "default": str(param.default) if param.default != inspect.Parameter.empty else None,
         }

--- a/python/djust/validation.py
+++ b/python/djust/validation.py
@@ -375,7 +375,8 @@ def validate_parameter_types(
 
         expected_type = type_hints[param_name]
 
-        # Skip complex types (Union, Optional, etc.) and Any
+        # Skip complex types (Union, Optional, UnionType, etc.) and Any.
+        # This guard means .__name__ below is safe — only simple types pass.
         if not isinstance(expected_type, type) or expected_type is Any:
             continue
 
@@ -412,6 +413,7 @@ def _type_display_name(hint: Any) -> str:
 
 
 def _single_type_name(t: Any) -> str:
+    """Display name for a single type, mapping NoneType → 'None'."""
     if t is type(None):
         return "None"
     return getattr(t, "__name__", str(t))

--- a/python/tests/test_validation.py
+++ b/python/tests/test_validation.py
@@ -271,8 +271,30 @@ class TestGetHandlerSignatureInfo:
         info = get_handler_signature_info(handler_with_optional)
         param = info["params"][0]
         assert param["name"] == "value"
-        assert "int" in param["type"]
-        assert "None" in param["type"]
+        assert param["type"] == "int | None"
+
+    def test_signature_info_multi_union_type(self):
+        """Test signature info for handler with multi-type PEP 604 union."""
+
+        def handler_with_multi_union(self, value: str | int | None = None, **kwargs):
+            pass
+
+        info = get_handler_signature_info(handler_with_multi_union)
+        param = info["params"][0]
+        assert param["name"] == "value"
+        assert param["type"] == "str | int | None"
+
+    def test_signature_info_any_type(self):
+        """Test signature info for handler with typing.Any."""
+        from typing import Any
+
+        def handler_with_any(self, value: Any = None, **kwargs):
+            pass
+
+        info = get_handler_signature_info(handler_with_any)
+        param = info["params"][0]
+        assert param["name"] == "value"
+        assert param["type"] == "Any"
 
 
 class TestValidationIntegration:

--- a/python/tests/test_validation.py
+++ b/python/tests/test_validation.py
@@ -246,6 +246,34 @@ class TestGetHandlerSignatureInfo:
         assert info["accepts_kwargs"] is False
         assert info["description"] == "Handler with no parameters"
 
+    def test_signature_info_union_type(self):
+        """Test signature info for handler with PEP 604 union type (str | None).
+
+        Regression test for #899: UnionType has no __name__.
+        """
+
+        def handler_with_union(self, value: str | None = None, **kwargs):
+            pass
+
+        info = get_handler_signature_info(handler_with_union)
+        param = info["params"][0]
+        assert param["name"] == "value"
+        assert param["type"] == "str | None"
+        assert param["required"] is False
+
+    def test_signature_info_optional_type(self):
+        """Test signature info for handler with typing.Optional (same as X | None)."""
+        from typing import Optional
+
+        def handler_with_optional(self, value: Optional[int] = None, **kwargs):
+            pass
+
+        info = get_handler_signature_info(handler_with_optional)
+        param = info["params"][0]
+        assert param["name"] == "value"
+        assert "int" in param["type"]
+        assert "None" in param["type"]
+
 
 class TestValidationIntegration:
     """Integration tests combining validation functions"""


### PR DESCRIPTION
## Problem

`@event_handler()` crashes at class definition time when a handler parameter uses PEP 604 union syntax (`str | None`):

```
AttributeError: 'types.UnionType' object has no attribute '__name__'
```

Blocks Django from starting — all views in the module fail to import.

## Fix

Add `_type_display_name()` and `_single_type_name()` helpers in `validation.py`:
- `types.UnionType` (PEP 604): `str | None` → `"str | None"`
- `typing.Optional`: `Optional[int]` → `"int | None"`  
- `NoneType` → `"None"` (not `"NoneType"`)
- Simple types: `str` → `"str"`

## Tests

2 new test cases in `test_validation.py` for union and Optional params.

Closes #899