### PR TITLE
fix: 3 real bugs surfaced during CodeQL cleanup audits (closes #930, #932, #933)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **3 latent bugs caught by prior CodeQL-cleanup audits — closes #930, #932, #933** —
+  **#930 FormArrayNode inner content**: `{% form_array %}...{% endform_array %}` parsed the block
+  body into a nodelist via `parser.parse(("endform_array",))` but `FormArrayNode.render` never
+  rendered that nodelist — users' inner template markup silently disappeared. Fixed by rendering
+  the nodelist once per row with `row`, `row_index`, and `forloop` (dict shape:
+  `{counter, counter0, first, last}`) pushed onto the template context; empty or whitespace-only
+  blocks keep the original single-input-per-row default output, so existing users see no change.
+  **#932 tag_input missing `name=` attribute**: `TagInput._render_custom` rendered a visible
+  "type to add" `<input class="tag-input-field" placeholder="...">` with no `name=`, so form
+  submissions silently dropped the tag list from POST data. Fixed by emitting a
+  `<input type="hidden" name="<self.name>" value="<csv of tags>">` alongside the visible input
+  whenever `self.name` is non-empty; hidden value is `html.escape`'d.
+  **#933 gallery/registry.py dead discover_\*  path**: `discover_template_tags()` and
+  `discover_component_classes()` were public helpers exported from
+  `djust.components.gallery.__init__` but `get_gallery_data()` never called them — a developer
+  adding a new `@register.tag` or `Component` subclass without updating the curated
+  `EXAMPLES` / `CLASS_EXAMPLES` dicts had that new thing silently missing from the rendered
+  gallery. Fixed by wiring both helpers into `get_gallery_data()` as a cross-check: any
+  registered tag / component class missing an example entry emits a `logger.debug` warning
+  naming the missing entries, and discovery failures are caught so the gallery never breaks
+  at runtime. 12 regression tests across `python/djust/tests/test_form_array_930.py`,
+  `python/djust/tests/test_tag_input_932.py`, `python/djust/tests/test_gallery_registry_933.py`
+  (7 of which fail on main pre-fix). No behavior change for non-broken inputs.
+  (`python/djust/components/templatetags/djust_components.py`,
+  `python/djust/components/components/tag_input.py`,
+  `python/djust/components/gallery/registry.py`)
+
 - **dj-remove follow-ups — closes #900, #901** — Extracted shared `_teardownState(el, state)` helper in `42-dj-remove.js` so `_finalizeRemoval` and `_cancelRemoval` no longer duplicate the clearTimeout + removeEventListener + observer.disconnect + _pendingRemovals.delete block (Stage 11 nit from PR #898). Added a debug warning (gated on `globalThis.djustDebug`) when `_parseRemoveSpec` encounters a 2-token value like `dj-remove="fade-out 300"` — previously silent fall-through. 2 new JSDOM regression cases in `tests/js/dj_remove.test.js` (12/12 passing).
 
 ## [0.5.6rc1] - 2026-04-23

--- a/python/djust/components/components/tag_input.py
+++ b/python/djust/components/components/tag_input.py
@@ -47,6 +47,7 @@ class TagInput(Component):
         cls = "tag-input"
         if self.custom_class:
             cls += f" {html.escape(self.custom_class)}"
+        e_name = html.escape(self.name)
         e_label = html.escape(self.label)
         e_placeholder = html.escape(self.placeholder)
         dj_event = html.escape(self.event or self.name)
@@ -60,8 +61,16 @@ class TagInput(Component):
                 f'dj-click="{dj_event}" data-value="remove:{e_tag}">&times;</button>'
                 f"</span>"
             )
+        # Hidden input carries the serialized tag list under the field name
+        # so that form submissions POST the current tags, even though the
+        # visible `.tag-input-field` is a transient "type to add" input.
+        hidden_value = html.escape(",".join(str(t) for t in tags))
+        hidden_html = (
+            f'<input type="hidden" name="{e_name}" value="{hidden_value}">' if self.name else ""
+        )
         return (
             f'<div class="{cls}">{label_html}'
+            f"{hidden_html}"
             f'<div class="tag-input-tags">{"".join(tag_parts)}</div>'
             f'<input type="text" class="tag-input-field" placeholder="{e_placeholder}">'
             f"</div>"

--- a/python/djust/components/gallery/registry.py
+++ b/python/djust/components/gallery/registry.py
@@ -1,5 +1,9 @@
 """Auto-discovery of template tags and component classes for the gallery."""
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 def discover_template_tags():
     """Discover all registered template tags from the djust_components library.
@@ -30,8 +34,47 @@ def get_gallery_data():
 
     Returns:
         dict with 'categories' key mapping to {category_name: [component_info, ...]}
+
+    The gallery's curated EXAMPLES / CLASS_EXAMPLES dicts in ``examples.py`` are
+    the source of truth for what gets rendered — each entry carries human-authored
+    variant data that auto-discovery can't reproduce. We still call
+    ``discover_template_tags()`` and ``discover_component_classes()`` here to
+    cross-check the two sources: any tag or component class that is registered
+    in the codebase but missing an entry in the curated EXAMPLES emits a
+    ``logger.debug`` warning. This catches the common drift where a developer
+    adds a new ``@register.tag`` or ``Component`` subclass but forgets to add
+    a gallery example — without this check the new thing silently disappears
+    from the gallery instead of the author noticing at dev time.
     """
     from .examples import EXAMPLES, CLASS_EXAMPLES, CATEGORIES
+
+    # Cross-check discovered registrations against the curated example lists.
+    # Missing entries are debug-logged (not raised) so this never breaks the
+    # gallery at runtime — it just surfaces the gap for anyone running with
+    # ``logging.getLogger("djust.components.gallery.registry").setLevel(DEBUG)``.
+    try:
+        registered_tags = discover_template_tags()
+        missing_tags = sorted(set(registered_tags) - set(EXAMPLES))
+        if missing_tags:
+            logger.debug(
+                "gallery: %d registered template tag(s) missing EXAMPLES entries: %s",
+                len(missing_tags),
+                ", ".join(missing_tags),
+            )
+    except Exception as exc:  # pragma: no cover - defensive: never break the gallery
+        logger.debug("gallery: discover_template_tags() failed: %s", exc)
+
+    try:
+        registered_classes = discover_component_classes()
+        missing_classes = sorted(set(registered_classes) - set(CLASS_EXAMPLES))
+        if missing_classes:
+            logger.debug(
+                "gallery: %d registered component class(es) missing CLASS_EXAMPLES entries: %s",
+                len(missing_classes),
+                ", ".join(missing_classes),
+            )
+    except Exception as exc:  # pragma: no cover - defensive: never break the gallery
+        logger.debug("gallery: discover_component_classes() failed: %s", exc)
 
     # Group template tag examples by category
     categories = {}

--- a/python/djust/components/templatetags/djust_components.py
+++ b/python/djust/components/templatetags/djust_components.py
@@ -8091,10 +8091,25 @@ class FormArrayNode(template.Node):
         can_add = row_count < max_rows
         can_remove = row_count > min_rows
 
-        # Render template content for each row, or default inputs
+        # Render template content for each row, or default inputs.
+        #
+        # If the `{% form_array %}...{% endform_array %}` block contains inner
+        # template markup, that nodelist is rendered once per row with the
+        # loop variables ``row``, ``forloop`` and ``row_index`` pushed onto the
+        # context stack. This lets callers customize per-row layout, e.g.::
+        #
+        #     {% form_array name="items" rows=rows %}
+        #       <input name="items[{{ row_index }}][label]" value="{{ row.label }}">
+        #       <input name="items[{{ row_index }}][value]" value="{{ row.value }}">
+        #     {% endform_array %}
+        #
+        # If the nodelist is empty (self-closing-style usage), fall back to the
+        # single-input-per-row default rendering.
+        has_inner = bool(self.nodelist) and any(
+            not (isinstance(n, template.base.TextNode) and not n.s.strip()) for n in self.nodelist
+        )
         rows_html = []
         for i, row in enumerate(rows):
-            val = conditional_escape(str(row.get("value", "") if isinstance(row, dict) else row))
             remove_html = ""
             if can_remove:
                 remove_html = (
@@ -8102,12 +8117,35 @@ class FormArrayNode(template.Node):
                     f'dj-click="{e_remove_event}" data-value="{i}" '
                     f'aria-label="Remove row {i + 1}">&times;</button>'
                 )
-            rows_html.append(
-                f'<div class="dj-form-array__row" data-index="{i}">'
-                f'<input type="text" name="{e_name}[{i}]" value="{val}" '
-                f'class="dj-form-array__input">'
-                f"{remove_html}</div>"
-            )
+
+            if has_inner:
+                # Render the inner block with per-row context
+                row_ctx = {
+                    "row": row,
+                    "row_index": i,
+                    "forloop": {
+                        "counter": i + 1,
+                        "counter0": i,
+                        "first": i == 0,
+                        "last": i == len(rows) - 1,
+                    },
+                }
+                with context.push(**row_ctx):
+                    inner_html = self.nodelist.render(context)
+                rows_html.append(
+                    f'<div class="dj-form-array__row" data-index="{i}">'
+                    f"{inner_html}{remove_html}</div>"
+                )
+            else:
+                val = conditional_escape(
+                    str(row.get("value", "") if isinstance(row, dict) else row)
+                )
+                rows_html.append(
+                    f'<div class="dj-form-array__row" data-index="{i}">'
+                    f'<input type="text" name="{e_name}[{i}]" value="{val}" '
+                    f'class="dj-form-array__input">'
+                    f"{remove_html}</div>"
+                )
 
         add_disabled = "" if can_add else " disabled"
         add_html = (

--- a/python/djust/tests/test_form_array_930.py
+++ b/python/djust/tests/test_form_array_930.py
@@ -1,0 +1,142 @@
+"""Regression test for bug #930 — FormArrayNode dropped inner template content.
+
+Before the fix: `{% form_array %}...{% endform_array %}` parsed the block body
+into a nodelist via ``parser.parse(("endform_array",))`` but ``FormArrayNode.render``
+never rendered that nodelist — users' inner template markup silently disappeared.
+
+After the fix: when the block body is non-empty, FormArrayNode renders the
+nodelist once per row with ``row``, ``row_index``, and ``forloop`` pushed onto
+the template context; when the block body is empty/whitespace-only, the node
+falls back to its original single-input-per-row default output.
+
+These tests exercise ``FormArrayNode`` directly (bypassing the template
+library-loader), since ``djust.components`` is not registered in the test
+settings' ``INSTALLED_APPS``. They rely on the node's kwargs dict accepting
+bare Python values (strings, variables) — the same shape ``_parse_kv_args``
+produces at parse time.
+"""
+
+import tests.conftest  # noqa: F401  -- configure Django settings
+
+from django import template as dj_template
+from django.template import Context
+from django.template.base import NodeList, TextNode, VariableNode, FilterExpression, Parser
+
+
+def _make_parser() -> Parser:
+    return Parser([])
+
+
+def _fexpr(raw: str) -> FilterExpression:
+    return FilterExpression(raw, _make_parser())
+
+
+def _FormArrayNode():
+    from djust.components.templatetags.djust_components import FormArrayNode
+
+    return FormArrayNode
+
+
+def test_form_array_renders_inner_content_per_row():
+    """Bug #930: inner block markup must be rendered once per row."""
+    FormArrayNode = _FormArrayNode()
+
+    nodelist = NodeList(
+        [
+            TextNode("<span class='label'>"),
+            VariableNode(_fexpr("row.label")),
+            TextNode("</span><input name='items["),
+            VariableNode(_fexpr("row_index")),
+            TextNode("][value]' value='"),
+            VariableNode(_fexpr("row.value")),
+            TextNode("'>"),
+        ]
+    )
+
+    # kwargs can be bare python values — _resolve() passes them through.
+    node = FormArrayNode(
+        nodelist,
+        {"name": "items", "rows": dj_template.Variable("rows")},
+    )
+
+    rows = [
+        {"label": "First", "value": "one"},
+        {"label": "Second", "value": "two"},
+    ]
+    html = node.render(Context({"rows": rows}))
+
+    assert "First" in html
+    assert "Second" in html
+    assert "items[0][value]" in html
+    assert "items[1][value]" in html
+    assert "value='one'" in html
+    assert "value='two'" in html
+
+
+def test_form_array_empty_block_falls_back_to_default_inputs():
+    """Empty-nodelist form_array keeps the default row inputs."""
+    FormArrayNode = _FormArrayNode()
+
+    node = FormArrayNode(
+        NodeList([]),
+        {"name": "items", "rows": dj_template.Variable("rows")},
+    )
+    rows = [{"value": "alpha"}, {"value": "beta"}]
+    html = node.render(Context({"rows": rows}))
+
+    assert 'name="items[0]"' in html
+    assert 'name="items[1]"' in html
+    assert 'value="alpha"' in html
+    assert 'value="beta"' in html
+    assert "dj-form-array" in html
+
+
+def test_form_array_whitespace_only_block_falls_back_to_default_inputs():
+    """Whitespace-only inner content should also hit the default-render branch."""
+    FormArrayNode = _FormArrayNode()
+
+    node = FormArrayNode(
+        NodeList([TextNode("   \n  ")]),
+        {"name": "items", "rows": dj_template.Variable("rows")},
+    )
+    rows = [{"value": "x"}]
+    html = node.render(Context({"rows": rows}))
+
+    assert 'name="items[0]"' in html
+    assert 'value="x"' in html
+
+
+def test_form_array_forloop_counter_in_inner_block():
+    """`forloop.counter`, `forloop.first`, `forloop.last` work inside the block.
+
+    ``forloop`` is pushed onto the context as a dict, which Django's variable
+    resolver handles via dict-lookup (``{{ forloop.counter }}`` -> ``forloop["counter"]``).
+    """
+    FormArrayNode = _FormArrayNode()
+
+    nodelist = NodeList(
+        [
+            TextNode("[c="),
+            VariableNode(_fexpr("forloop.counter")),
+            TextNode(" first="),
+            VariableNode(_fexpr("forloop.first")),
+            TextNode(" last="),
+            VariableNode(_fexpr("forloop.last")),
+            TextNode(" idx="),
+            VariableNode(_fexpr("row_index")),
+            TextNode(" v="),
+            VariableNode(_fexpr("row.v")),
+            TextNode("]"),
+        ]
+    )
+    node = FormArrayNode(
+        nodelist,
+        {"name": "items", "rows": dj_template.Variable("rows")},
+    )
+
+    rows = [{"v": "a"}, {"v": "b"}, {"v": "c"}]
+    html = node.render(Context({"rows": rows}))
+
+    assert "[c=1 first=True last=False idx=0 v=a]" in html
+    assert "[c=2 first=False last=False idx=1 v=b]" in html
+    assert "[c=3 first=False last=True idx=2 v=c]" in html

--- a/python/djust/tests/test_gallery_registry_933.py
+++ b/python/djust/tests/test_gallery_registry_933.py
@@ -1,0 +1,105 @@
+"""Regression test for bug #933 — gallery registry discover_* helpers were unused.
+
+Before the fix: ``discover_template_tags()`` and ``discover_component_classes()``
+were public helpers exported from ``djust.components.gallery.__init__`` but
+``get_gallery_data()`` never called them. A developer adding a new
+``@register.tag`` or ``Component`` subclass without updating the curated
+``EXAMPLES`` / ``CLASS_EXAMPLES`` dicts would have that new thing silently
+missing from the rendered gallery.
+
+After the fix: ``get_gallery_data()`` calls both discover helpers and emits a
+``logger.debug`` warning listing every registered tag / component class that
+is missing an EXAMPLES / CLASS_EXAMPLES entry. The gallery still renders the
+curated data as its source of truth (discover output can't reproduce
+human-authored variant examples), but the drift is now observable.
+"""
+
+import logging
+
+import tests.conftest  # noqa: F401  -- configure Django settings
+
+
+def test_get_gallery_data_invokes_discover_helpers(monkeypatch):
+    """Bug #933: ``get_gallery_data()`` must exercise both discover helpers."""
+    from djust.components.gallery import registry
+
+    called = {"tags": 0, "classes": 0}
+
+    real_discover_tags = registry.discover_template_tags
+    real_discover_classes = registry.discover_component_classes
+
+    def tracking_discover_tags():
+        called["tags"] += 1
+        return real_discover_tags()
+
+    def tracking_discover_classes():
+        called["classes"] += 1
+        return real_discover_classes()
+
+    monkeypatch.setattr(registry, "discover_template_tags", tracking_discover_tags)
+    monkeypatch.setattr(registry, "discover_component_classes", tracking_discover_classes)
+
+    data = registry.get_gallery_data()
+
+    assert called["tags"] == 1, "discover_template_tags must be called exactly once"
+    assert called["classes"] == 1, "discover_component_classes must be called exactly once"
+    # The curated data is still the source of truth for the gallery output
+    assert "categories" in data
+    assert isinstance(data["categories"], dict)
+
+
+def test_get_gallery_data_logs_missing_tag_examples(monkeypatch, caplog):
+    """A registered tag missing from EXAMPLES should be logged at DEBUG."""
+    from djust.components.gallery import registry
+
+    # Simulate a tag registered in the codebase but absent from EXAMPLES
+    monkeypatch.setattr(
+        registry,
+        "discover_template_tags",
+        lambda: {"brand_new_tag": object(), "another_new_tag": object()},
+    )
+    # Keep class discovery identical so we isolate the tag warning
+    monkeypatch.setattr(registry, "discover_component_classes", lambda: {})
+
+    with caplog.at_level(logging.DEBUG, logger="djust.components.gallery.registry"):
+        registry.get_gallery_data()
+
+    messages = " ".join(r.getMessage() for r in caplog.records)
+    assert "missing EXAMPLES entries" in messages
+    assert "brand_new_tag" in messages
+    assert "another_new_tag" in messages
+
+
+def test_get_gallery_data_logs_missing_class_examples(monkeypatch, caplog):
+    """A registered component class missing from CLASS_EXAMPLES should be logged at DEBUG."""
+    from djust.components.gallery import registry
+
+    monkeypatch.setattr(registry, "discover_template_tags", lambda: {})
+    monkeypatch.setattr(
+        registry,
+        "discover_component_classes",
+        lambda: {"NewlyAddedComponent": object()},
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="djust.components.gallery.registry"):
+        registry.get_gallery_data()
+
+    messages = " ".join(r.getMessage() for r in caplog.records)
+    assert "missing CLASS_EXAMPLES entries" in messages
+    assert "NewlyAddedComponent" in messages
+
+
+def test_get_gallery_data_discover_failure_does_not_break_gallery(monkeypatch):
+    """If discover_* raises, the gallery must still render (degrades gracefully)."""
+    from djust.components.gallery import registry
+
+    def boom():
+        raise RuntimeError("discovery exploded")
+
+    monkeypatch.setattr(registry, "discover_template_tags", boom)
+    monkeypatch.setattr(registry, "discover_component_classes", boom)
+
+    # Must not propagate
+    data = registry.get_gallery_data()
+    assert "categories" in data
+    assert isinstance(data["categories"], dict)

--- a/python/djust/tests/test_tag_input_932.py
+++ b/python/djust/tests/test_tag_input_932.py
@@ -1,0 +1,56 @@
+"""Regression test for bug #932 — TagInput rendered no `name=` attribute.
+
+Before the fix: ``TagInput._render_custom`` produced an ``<input
+type='text' class='tag-input-field' placeholder='...'>`` but omitted
+``name=``. When the enclosing ``<form>`` submitted, the field's value was
+silently dropped from the POST data — the server received no ``name`` key
+for the tag list.
+
+After the fix: a hidden ``<input type="hidden" name="<self.name>"
+value="<csv of tags>">`` is emitted alongside the transient "type to add"
+text input, so form submissions POST the current tag list under the
+component's ``name``.
+"""
+
+import tests.conftest  # noqa: F401  -- configure Django settings
+
+from djust.components.components.tag_input import TagInput
+
+
+def test_tag_input_renders_name_attribute():
+    """Bug #932: TagInput output must include ``name="<self.name>"``."""
+    comp = TagInput(name="skills", tags=["python", "rust"])
+    html = comp._render_custom()
+
+    assert (
+        'name="skills"' in html
+    ), "TagInput output must carry a `name=` attribute so form POSTs include the field value"
+
+
+def test_tag_input_hidden_input_carries_csv_of_tags():
+    """The hidden input's value must be a csv of the current tag list."""
+    comp = TagInput(name="topics", tags=["a", "b", "c"])
+    html = comp._render_custom()
+
+    assert 'type="hidden"' in html
+    assert 'name="topics"' in html
+    # The serialized value carries all three tags
+    assert 'value="a,b,c"' in html
+
+
+def test_tag_input_no_name_emits_no_hidden_input():
+    """With an empty name we omit the hidden input entirely."""
+    comp = TagInput(name="", tags=["x"])
+    html = comp._render_custom()
+
+    # No stray hidden input when the component has no name
+    assert 'type="hidden"' not in html
+
+
+def test_tag_input_hidden_input_value_is_html_escaped():
+    """Tag values containing HTML-special chars must be escaped inside the hidden input."""
+    comp = TagInput(name="tags", tags=['<script>alert("x")</script>'])
+    html = comp._render_custom()
+
+    assert "<script>" not in html.split('type="hidden"', 1)[-1].split(">", 1)[0] + ">"
+    assert "&lt;script&gt;" in html


### PR DESCRIPTION
## Summary

Fixes three latent bugs caught during earlier CodeQL-cleanup audits. All three were real user-facing defects where the framework silently dropped data or output on specific (common) inputs.

### #930 — `FormArrayNode` dropped inner template content

`{% form_array %}<p>inner</p>{% endform_array %}` parsed the inner block into `self.nodelist` via `parser.parse(("endform_array",))`, but `FormArrayNode.render(context)` never rendered it. Users writing custom per-row markup silently lost it. The inline comment on line 8094 (`# Render template content for each row, or default inputs`) documented intent that was never wired in.

**Fix**: render `self.nodelist` once per row with `row`, `row_index`, and `forloop` (dict shape `{counter, counter0, first, last}`) pushed onto the context. Empty or whitespace-only blocks keep the original single-input-per-row default output, so existing users see zero change.

### #932 — `tag_input` component missing `name=` attribute

`TagInput._render_custom` produced a visible "type to add" `<input class="tag-input-field" placeholder="...">` with no `name=`. When the enclosing `<form>` submitted, the field's tag list was silently dropped from POST data. Users who built forms around `TagInput` would have seen `request.POST["my_tags"]` return `None`.

**Fix**: emit a hidden `<input type="hidden" name="<self.name>" value="<csv of tags>">` alongside the visible input whenever `self.name` is non-empty. Hidden value is `html.escape`'d.

### #933 — `gallery/registry.py` discover_* helpers were dead exports

`discover_template_tags()` and `discover_component_classes()` are public helpers exported from `djust.components.gallery.__init__`, but `get_gallery_data()` never called them. A developer adding a new `@register.tag` or `Component` subclass without updating the curated `EXAMPLES` / `CLASS_EXAMPLES` dicts had that new thing silently missing from the rendered gallery — no warning, no error, just quiet drift.

**Fix**: wire both discover helpers into `get_gallery_data()` as a cross-check. Any registered tag or component class that is missing an entry in `EXAMPLES` / `CLASS_EXAMPLES` emits a `logger.debug` warning naming the drift. Discovery failures are caught so the gallery never breaks at runtime. The curated data remains the source of truth for rendering (discover output can't reproduce human-authored variant examples).

## Test plan

- [x] 12 regression tests in 3 new files:
  - `python/djust/tests/test_form_array_930.py` (4 cases)
  - `python/djust/tests/test_tag_input_932.py` (4 cases)
  - `python/djust/tests/test_gallery_registry_933.py` (4 cases)
- [x] Verified 7 of 12 fail on `origin/main` pre-fix (direct bug coverage); the other 5 cover default/fallback behavior that already worked and is preserved.
- [x] `make test-python`: 3428 passed, 15 skipped (matches pre-existing baseline).
- [x] `.venv/bin/pytest` (full testpaths): 5732 passed, 17 skipped. 3 pre-existing failures on `test_api_response`, `test_observability_eval_handler`, `test_observability_reset_view` that expect exception messages in response bodies (they were fixed to log-only in an earlier PR and the tests are stale — same failures exist on untouched `origin/main`).
- [x] Pre-commit hooks (ruff, ruff-format, bandit, detect-secrets) and pre-push pytest pass.

No behavior change for non-broken inputs.

Closes #930, #932, #933.