### PR TITLE
cleanup: sanitize_for_log simplification + ruff-format drifted files (closes #914, #915)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Mechanical cleanup — closes #914, #915** —
+  **#914**: dropped redundant `ch == " "` clause in `_log_utils.sanitize_for_log` —
+  ASCII space is already printable so the explicit check was dead.
+  **#915**: bulk-applied `ruff format` (pinned pre-commit version 0.8.4) to 4 pre-drifted
+  files (3 theming test files + `uploads.py`) to bring them to canonical form.
+  No behavior change in either fix.
+
 - **3 latent bugs caught by prior CodeQL-cleanup audits — closes #930, #932, #933** —
   **#930 FormArrayNode inner content**: `{% form_array %}...{% endform_array %}` parsed the block
   body into a nodelist via `parser.parse(("endform_array",))` but `FormArrayNode.render` never

--- a/python/djust/_log_utils.py
+++ b/python/djust/_log_utils.py
@@ -32,7 +32,7 @@ def sanitize_for_log(value: Any) -> str:
     # Replace control chars (C0 range, excluding space) with a visible marker.
     cleaned_chars = []
     for ch in value:
-        if ch == " " or ch.isprintable():
+        if ch.isprintable():
             cleaned_chars.append(ch)
         else:
             cleaned_chars.append("?")

--- a/python/djust/tests/test_theming_check_compat.py
+++ b/python/djust/tests/test_theming_check_compat.py
@@ -68,7 +68,7 @@ class TestCheckThemeCompat:
     def test_missing_required_attr(self, theme_dir):
         """alert.html with <div> but no role='alert' produces an error."""
         alert = theme_dir / "components" / "alert.html"
-        alert.write_text('<div class="alert">\n' "  {{ message }}\n" "</div>\n")
+        alert.write_text('<div class="alert">\n  {{ message }}\n</div>\n')
         issues = check_theme_compat(theme_dir)
         errors = [i for i in issues if i.severity == "error"]
         assert len(errors) >= 1
@@ -106,11 +106,7 @@ class TestCheckThemeCompat:
         dropdown = theme_dir / "components" / "dropdown.html"
         # Has <div> and <button> but no aria-haspopup="true"
         dropdown.write_text(
-            '<div class="dropdown">\n'
-            "  {{ id }}\n"
-            "  {{ label }}\n"
-            "  <button>Toggle</button>\n"
-            "</div>\n"
+            '<div class="dropdown">\n  {{ id }}\n  {{ label }}\n  <button>Toggle</button>\n</div>\n'
         )
         issues = check_theme_compat(theme_dir)
         errors = [i for i in issues if i.severity == "error"]
@@ -126,7 +122,7 @@ class TestCheckThemeCompat:
     def test_context_var_detected_in_if_tag(self, theme_dir):
         """Required context var used in {% if var %} is not flagged."""
         button = theme_dir / "components" / "button.html"
-        button.write_text("<button>\n" "  {% if text %}{{ text }}{% endif %}\n" "</button>\n")
+        button.write_text("<button>\n  {% if text %}{{ text }}{% endif %}\n</button>\n")
         issues = check_theme_compat(theme_dir)
         errors = [i for i in issues if i.severity == "error" and "text" in i.message]
         assert errors == []

--- a/python/djust/tests/test_theming_installable_packages.py
+++ b/python/djust/tests/test_theming_installable_packages.py
@@ -59,7 +59,7 @@ pytestmark = pytest.mark.theming
 
 def get_theme_manifest():
     return ThemeManifest(
-        name="{pkg_name.replace('_', '-')}",
+        name="{pkg_name.replace("_", "-")}",
         version="1.0.0",
         description="Test theme package",
         design_system="material",

--- a/python/djust/tests/test_theming_palette.py
+++ b/python/djust/tests/test_theming_palette.py
@@ -185,18 +185,16 @@ class TestWCAGContrast:
     def test_all_fg_bg_pairs_pass_aa_light(self, preset):
         for name, fg, bg in _all_fg_bg_pairs(preset.light):
             ratio = self.validator.calculate_contrast_ratio(fg, bg)
-            assert ratio >= 4.5, (
-                f"Light {name}: contrast {ratio:.2f} < 4.5:1 "
-                f"(fg={fg.to_hsl()}, bg={bg.to_hsl()})"
-            )
+            assert (
+                ratio >= 4.5
+            ), f"Light {name}: contrast {ratio:.2f} < 4.5:1 (fg={fg.to_hsl()}, bg={bg.to_hsl()})"
 
     def test_all_fg_bg_pairs_pass_aa_dark(self, preset):
         for name, fg, bg in _all_fg_bg_pairs(preset.dark):
             ratio = self.validator.calculate_contrast_ratio(fg, bg)
-            assert ratio >= 4.5, (
-                f"Dark {name}: contrast {ratio:.2f} < 4.5:1 "
-                f"(fg={fg.to_hsl()}, bg={bg.to_hsl()})"
-            )
+            assert (
+                ratio >= 4.5
+            ), f"Dark {name}: contrast {ratio:.2f} < 4.5:1 (fg={fg.to_hsl()}, bg={bg.to_hsl()})"
 
     def test_border_contrast_minimum_light(self, preset):
         ratio = self.validator.calculate_contrast_ratio(

--- a/python/djust/uploads.py
+++ b/python/djust/uploads.py
@@ -707,8 +707,7 @@ class UploadManager:
                 "not a client handle."
             )
             logger.error(
-                "UploadWriter.close() return not JSON-serializable for upload %s "
-                "(writer=%s): %s",
+                "UploadWriter.close() return not JSON-serializable for upload %s (writer=%s): %s",
                 entry.ref,
                 type(writer).__name__,
                 exc,


### PR DESCRIPTION
## Summary

Pure mechanical cleanup, no behavior changes.

- **#914**: `python/djust/_log_utils.py` — dropped the redundant `ch == " " or` clause in `sanitize_for_log`. ASCII space (0x20) is already in `str.isprintable()`'s positive set (`chr(0x20).isprintable() is True`), so the explicit check was dead.
- **#915**: bulk-applied `ruff format` (via pinned pre-commit ruff 0.8.4) to 4 pre-drifted files (3 theming test files + `uploads.py`) to bring them to canonical form. Zero source-code-semantics changes.

Note: the original issue's list of 10 files was based on a newer ruff version. Running the repo's pinned pre-commit ruff 0.8.4 showed only 4 actually drifted — those are the ones in this PR.

## Test plan

- [x] `chr(0x20).isprintable() is True` verified
- [x] `test_preserves_ascii` already locks in `"hello world"` → `"hello world"` (space preserved)
- [x] Full Python suite passes (3428 passed, 15 skipped) — pre-push hook ran it
- [x] `pre-commit run --all-files` clean on the branch files