### PR TITLE
feat(mixins): ADR-009 + UploadMixin schema-change replay + NotificationMixin cross-loop restore (closes #892, #896, #897)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ADR-009: Mixin side-effect replay on WebSocket state restoration —
+  closes #897** — formalizes the `_restore_<concept>()` pattern first
+  shipped ad-hoc in PRs #891 (UploadMixin, #889) and #895 (PresenceMixin
+  + NotificationMixin, #893 / #894). Codifies the serialization contract
+  (JSON-only saved attrs), error handling (WARNING-level wrap, never
+  kill the WS), convergence/idempotency requirement, naming convention
+  (`_restore_<concept>`), and call ordering in `LiveViewConsumer`.
+  Documents the rejected alternatives: don't-skip-mount (perf cost),
+  snapshot-entire-managers (serialization complexity), pickle-to-session
+  (security + format stability). New file:
+  `docs/adr/009-mixin-side-effect-replay.md`.
+
 ### Fixed
+
+- **UploadMixin defensive replay for schema-changed configs — closes #892** —
+  `_restore_upload_configs` now wraps each per-slot `allow_upload(**cfg)`
+  in try/except `TypeError`. On signature mismatch (kwarg added / renamed
+  / removed between djust versions), logs a WARNING identifying the slot
+  + the mismatched kwarg, then falls back to `allow_upload(slot_name)`
+  — bare-minimum replay — so uploads for that slot still work with
+  default config. One broken saved dict no longer kills replay for every
+  other slot on the page. Each saved dict is now tagged with
+  `_upload_configs_version = 1` for future explicit migrations.
+  Regression tests in
+  `tests/unit/test_mixin_replay_schema_cross_loop_892_896.py`.
+- **NotificationMixin cross-loop restore — closes #896** —
+  `_restore_listen_channels` now detects when the
+  `PostgresNotifyListener` singleton is stranded on a closed event loop
+  (server restart with fresh ASGI loop, test harness per-test loops,
+  sticky-session LB cross-worker handoff) and calls a new
+  `PostgresNotifyListener.reset_for_new_loop()` classmethod to drop the
+  singleton before replay. The pre-check inspects
+  `listener._loop.is_closed()`; a per-channel `except RuntimeError`
+  branch handles the race where the loop closes between the pre-check
+  and the `ensure_listening` call (resets and retries once). Prevents
+  silent NOTIFY drops on cross-loop restore. Regression tests in
+  `tests/unit/test_mixin_replay_schema_cross_loop_892_896.py`.
+
+
 
 - **Observer JS — closes #879, #880, #881, #882** —
   **#879**: `37-dj-mutation.js` and `38-dj-sticky-scroll.js` document-level

--- a/docs/adr/009-mixin-side-effect-replay.md
+++ b/docs/adr/009-mixin-side-effect-replay.md
@@ -1,0 +1,230 @@
+# ADR-009: Mixin Side-Effect Replay on WebSocket State Restoration
+
+**Status**: Accepted
+**Date**: 2026-04-22
+**Deciders**: Project maintainers
+**Related**: [ADR-007](007-package-taxonomy-and-consolidation.md)
+
+---
+
+## Summary
+
+Mixins that register state into **process-wide singletons** during `mount()`
+must expose a `_restore_<concept>()` method that replays that registration.
+The WebSocket consumer's state-restoration path (which skips `mount()` when
+pre-rendered session state exists) calls each `_restore_*` method after
+`_restore_private_state()`. This ADR formalizes the pattern first shipped
+ad-hoc in PRs [#891](https://github.com/johnrtipton/djust/pull/891) (UploadMixin,
+issue #889) and [#895](https://github.com/johnrtipton/djust/pull/895)
+(PresenceMixin + NotificationMixin, issues #893 / #894).
+
+## Context
+
+### The state-restoration path skips `mount()`
+
+`python/djust/websocket.py:1540-1572` has a branch where, if the HTTP
+handshake produced pre-rendered session state for the view, the WS consumer
+restores that state directly instead of re-running `mount()`:
+
+```python
+if has_prerendered:
+    saved_state = await request.session.aget(view_key, {})
+    if saved_state:
+        for key, value in saved_state.items():
+            safe_setattr(self.view_instance, key, value, allow_private=False)
+        private_state = await request.session.aget(f"{view_key}__private", {})
+        if private_state:
+            await sync_to_async(self.view_instance._restore_private_state)(
+                private_state
+            )
+        # Issues #889, #893, #894 — replay process-wide side effects
+        # that mount() would have re-issued.
+        if hasattr(self.view_instance, "_restore_upload_configs"):
+            await sync_to_async(self.view_instance._restore_upload_configs)()
+        if hasattr(self.view_instance, "_restore_presence"):
+            await sync_to_async(self.view_instance._restore_presence)()
+        if hasattr(self.view_instance, "_restore_listen_channels"):
+            await sync_to_async(self.view_instance._restore_listen_channels)()
+```
+
+This exists because re-running `mount()` on the WS side is expensive (re-runs
+ORM queries, re-hits caches, re-builds state that was already computed on the
+HTTP side). Skipping it is a real performance win on pages with heavy mount
+logic.
+
+### What the session round-trip preserves and loses
+
+- **Preserved**: public instance attrs (via `__dict__` round-trip) and
+  `_private` user attrs (via `_restore_private_state()`). Both paths run
+  through `json.dumps` / `json.loads`.
+- **Lost**: any side effect `mount()` triggered against a **process-wide
+  singleton**. Singletons live in memory, not in the session. Concretely,
+  this affects:
+  - `PresenceManager` — holds join registrations keyed by presence key.
+  - `PostgresNotifyListener` — holds Postgres `LISTEN channel` subscriptions
+    on a dedicated `AsyncConnection`.
+  - `UploadManager` — per-session upload-slot configs, chunk buffers, temp
+    dirs.
+
+The symptom is always the same shape: the public flag attr says "yes I'm
+tracking presence / listening to `orders` / have an `avatar` upload slot",
+but the manager object doesn't actually know about this view. Requests that
+hit the manager fail with "no such configuration" messages.
+
+## Decision
+
+Each mixin that registers process-wide side effects in `mount()` MUST:
+
+1. **Persist the replay input as JSON-serializable attrs.** Whatever state
+   the `_restore_*` method reads (e.g. `self._presence_user_id`,
+   `self._upload_configs_saved`) MUST round-trip through `json.dumps` /
+   `json.loads` unchanged. Live manager instances, connection handles, and
+   class references are dropped by `_get_private_state()` and MUST be
+   reconstructable from the saved attrs.
+2. **Expose a `_restore_<concept>()` method** that replays the side effect
+   from those saved attrs. The name is `_restore_<concept>` (not
+   `_restore_<mixin>`) so multiple mixins with overlapping concerns stay
+   explicit.
+3. **Be called by `LiveViewConsumer` state restoration.** The consumer uses
+   `hasattr(view, "_restore_<name>")` to invoke each replay method in a
+   fixed order, after `_restore_private_state()` and before the component-
+   state loop.
+4. **Wrap replay in try/except at WARNING level.** Restoration MUST NEVER
+   kill the WS. A missing table, a postgres restart, a writer class that
+   was renamed in a later djust version — none of those should prevent the
+   WS handshake from completing. Log at WARNING, continue to the next mixin.
+5. **Be idempotent / convergent.** The replay may fire once per WS connect
+   (session-restore path) AND, in some edge cases, run alongside a fresh
+   `mount()` on the same process. `ensure_listening`, `join_presence`, and
+   `configure` all take "same key" as a no-op / overwrite, so calling the
+   replay N times yields the same process state as calling it once.
+
+### Naming and ordering
+
+The consumer calls replay methods in this order:
+
+1. `_restore_upload_configs` — rebuild UploadManager + slot configs.
+2. `_restore_presence` — rejoin PresenceManager for this user.
+3. `_restore_listen_channels` — re-issue Postgres `LISTEN` per channel.
+
+Order matters only if a later mixin depends on state a prior mixin
+restored; today the three are independent. Additions go at the end unless
+they have a documented dependency.
+
+### Error handling contract
+
+```python
+def _restore_<concept>(self) -> None:
+    for item in self._saved_list_of_things:
+        try:
+            self._replay_one(item)
+        except <narrow expected> as exc:
+            logger.warning(
+                "%sMixin._restore_%s: %s (issue #NNN)",
+                type(self).__name__, "<concept>", exc,
+            )
+        except Exception as exc:  # noqa: BLE001 — restoration must never kill the WS
+            logger.warning("...: unexpected error: %s", exc)
+```
+
+Narrow-catch for the *expected* failure modes (unsupported backend, schema
+change, cross-loop handoff) gets a targeted warning. The `Exception` fallback
+is the safety net. No `raise`.
+
+## Concrete examples
+
+### UploadMixin (PR [#891](https://github.com/johnrtipton/djust/pull/891), issue #889)
+
+- Saved attr: `self._upload_configs_saved` — list of dicts, one per
+  `allow_upload()` call, each JSON-serializable. `writer=` classes are
+  dropped and recorded as a `_had_writer` flag that triggers a WARNING at
+  replay time.
+- Replay: `_restore_upload_configs()` walks the list, calls
+  `self.allow_upload(**cfg)` for each. Rebuilds `self._upload_manager` as a
+  side effect of the first call.
+- Test: `tests/unit/test_upload_restoration_889.py`.
+
+### PresenceMixin (PR [#895](https://github.com/johnrtipton/djust/pull/895), issue #893)
+
+- Saved attrs: `self._presence_tracked`, `self._presence_user_id`,
+  `self._presence_meta`, plus whatever attrs the subclass's
+  `presence_key` format string references.
+- Replay: `_restore_presence()` calls `PresenceManager.join_presence(...)`
+  if `_presence_tracked` is True. `join_presence` is internally idempotent
+  on `(key, user_id)`.
+- Test: `tests/unit/test_mixin_restoration_893_894.py`.
+
+### NotificationMixin (PR [#895](https://github.com/johnrtipton/djust/pull/895), issue #894)
+
+- Saved attr: `self._listen_channels` — set of channel-name strings.
+- Replay: `_restore_listen_channels()` calls
+  `PostgresNotifyListener.instance().ensure_listening(channel)` for each.
+  `ensure_listening` is idempotent on known channels.
+- Cross-loop caveat (issue #896): if the process's listener singleton is
+  bound to a different event loop than the one the WS consumer is running
+  on, `ensure_listening` raises `RuntimeError` via `_assert_same_loop`.
+  The replay catches this, logs a warning, and continues — the listener
+  will be reset on the correct loop on the next fresh-mount path.
+- Test: `tests/unit/test_mixin_restoration_893_894.py`.
+
+## Alternatives considered
+
+### (A) Don't skip `mount()` on WS restoration
+
+**Rejected** on performance grounds. `mount()` is the user's ORM-query and
+cache-fill path; re-running it on every WS reconnect (which can happen on
+mobile network flaps) doubles the work the HTTP handshake already did.
+Session-state restore exists precisely to avoid this, and users have come
+to rely on its perf characteristics.
+
+### (B) Snapshot the entire mixin state (managers, connections, etc.)
+
+**Rejected** on serialization complexity. `UploadManager`, `PresenceManager`,
+and `PostgresNotifyListener` hold live resources: file handles, temp dirs,
+psycopg connections, asyncio tasks, threading locks. Serializing any of
+these is a non-starter. The replay approach accepts that "rebuild from
+simple attrs" is the right serialization boundary.
+
+### (C) Make the singletons re-hydrate from the session themselves
+
+**Rejected** on coupling grounds. This inverts the dependency: the
+`UploadManager` singleton would have to know about Django sessions. Today
+the singletons are pure in-memory process state with no framework knowledge;
+keeping them that way preserves their testability.
+
+### (D) Save the live managers to the session via pickle
+
+**Rejected** on security + format-stability grounds. Pickling live manager
+objects would (a) require the session backend to accept pickle (many
+production setups don't), (b) couple the session format to the manager's
+class layout (breaks cross-version restores), and (c) surface the live
+boto3 / psycopg / asyncio handles into storage — an attack surface.
+
+## Trade-offs
+
+- **Migration cost when a mixin's constructor signature changes.** A saved
+  dict from v0.5.4 might not be replayable in v0.6.0 if `allow_upload`
+  gained or renamed a kwarg. Each `_restore_*` method SHOULD wrap its
+  per-item replay in try/except and fall back to a minimum-viable replay
+  (e.g. `allow_upload(slot_name)` with no other config) when the signature
+  mismatches. See the UploadMixin schema-defensive replay (issue #892).
+- **Cross-loop handoff.** Mixins that touch asyncio-bound resources (today:
+  `PostgresNotifyListener`) must handle the case where the saved state was
+  created on a different event loop than the restore path runs on. The
+  convention is to detect the mismatch, reset the singleton, and log at
+  INFO — never assert.
+- **Replay ordering coupling.** The consumer's call order is fixed; a mixin
+  that implicitly depends on another mixin's replay having run first is a
+  latent bug. We document the order in this ADR and keep replays
+  independent when possible.
+
+## Verification
+
+- `python/djust/websocket.py:1558-1571` — the consumer's replay block is the
+  canonical integration point.
+- `tests/unit/test_upload_restoration_889.py` — end-to-end session
+  round-trip for UploadMixin.
+- `tests/unit/test_mixin_restoration_893_894.py` — PresenceMixin and
+  NotificationMixin.
+- `tests/unit/test_mixin_replay_schema_cross_loop_892_896.py` —
+  defensive-replay (#892) and cross-loop (#896) regression tests.

--- a/python/djust/db/notifications.py
+++ b/python/djust/db/notifications.py
@@ -143,6 +143,31 @@ class PostgresNotifyListener:
                 logger.debug("reset_for_tests: task cancel raised", exc_info=True)
 
     @classmethod
+    def reset_for_new_loop(cls) -> None:
+        """Discard the singleton when its event loop has gone away.
+
+        Issue #896: ``PostgresNotifyListener`` is bound to whichever event
+        loop first called ``ensure_listening``. If that loop has since been
+        closed / replaced (server restart with a fresh ASGI loop, test
+        harnesses that spin up per-test loops, sticky-session LB sending the
+        WS connection to a different worker thread), the singleton's
+        ``_conn`` / ``_task`` are bound to a dead loop and any later
+        coroutine call fails ``_assert_same_loop``.
+
+        The WS state-restoration path uses this to safely recycle the
+        singleton before replaying ``_restore_listen_channels``: if the
+        old loop is gone, drop the reference so the next
+        ``ensure_listening`` call from the current loop creates a fresh
+        singleton bound to this loop.
+
+        Unlike :meth:`reset_for_tests`, this is idempotent and makes NO
+        attempt to gracefully cancel the stale task — the old loop is
+        assumed unreachable. Garbage collection reaps the old instance.
+        """
+        with cls._class_lock:
+            cls._instance = None
+
+    @classmethod
     async def areset_for_tests(cls) -> None:
         """Async variant of :meth:`reset_for_tests` that awaits task cancellation.
 

--- a/python/djust/mixins/notifications.py
+++ b/python/djust/mixins/notifications.py
@@ -99,6 +99,16 @@ class NotificationMixin:
         on known channels) so calling it on the same process that
         initially registered is harmless. Exceptions are logged and
         swallowed — restoration must not break the WS.
+
+        Cross-loop handoff (issue #896): if the singleton's bound loop
+        is different from the loop currently running the consumer
+        (server restart with a fresh ASGI loop, test harnesses that
+        spin up per-test loops, or a worker thread that created its
+        own loop for ``async_to_sync``), ``ensure_listening`` would
+        raise ``RuntimeError`` via ``_assert_same_loop``. We detect
+        the mismatch up-front and call ``reset_for_new_loop()`` to
+        drop the stale singleton; the next ``ensure_listening`` call
+        creates a fresh instance bound to the current loop.
         """
         channels = getattr(self, "_listen_channels", None)
         if not channels:
@@ -109,9 +119,38 @@ class NotificationMixin:
             return
         from asgiref.sync import async_to_sync
 
+        # Issue #896: check for cross-loop mismatch before
+        # ``ensure_listening`` can raise. ``async_to_sync`` runs the
+        # coroutine on its own event loop in a worker thread, so
+        # ``asyncio.get_running_loop()`` here (sync context) gives us
+        # the *current-thread* loop — not the one the coroutine will
+        # actually run on. Use the singleton's own ``_loop`` attr to
+        # compare: if it's set AND its loop is closed, the singleton
+        # is stranded on a dead loop and must be reset.
+        listener = PostgresNotifyListener.instance()
+        stranded = False
+        bound_loop = getattr(listener, "_loop", None)
+        if bound_loop is not None:
+            try:
+                if bound_loop.is_closed():
+                    stranded = True
+            except Exception:  # noqa: BLE001
+                # Any error introspecting the loop means we should
+                # err on the side of resetting rather than risk a
+                # ``_assert_same_loop`` crash below.
+                stranded = True
+        if stranded:
+            logger.info(
+                "NotificationMixin._restore_listen_channels: existing "
+                "PostgresNotifyListener is bound to a closed event loop — "
+                "resetting singleton before replay (issue #896).",
+            )
+            PostgresNotifyListener.reset_for_new_loop()
+            listener = PostgresNotifyListener.instance()
+
         for channel in list(channels):
             try:
-                async_to_sync(PostgresNotifyListener.instance().ensure_listening)(channel)
+                async_to_sync(listener.ensure_listening)(channel)
             except DatabaseNotificationNotSupported:
                 # Non-postgres backend — ``listen()`` would have raised
                 # at the original call site, so seeing this here means
@@ -122,6 +161,38 @@ class NotificationMixin:
                     "available; channel %r will not receive NOTIFYs (issue #894).",
                     channel,
                 )
+            except RuntimeError as exc:
+                # _assert_same_loop guard (issue #896) or a deeper
+                # cross-loop race we didn't catch with the pre-check.
+                # Reset the singleton and try once more on a fresh
+                # instance — if that also fails, give up on this
+                # channel (without killing the WS).
+                if "event loop" in str(exc).lower() or "different" in str(exc).lower():
+                    logger.info(
+                        "NotificationMixin._restore_listen_channels: cross-loop "
+                        "ensure_listening failed for %r (%s) — resetting "
+                        "singleton and retrying once (issue #896).",
+                        channel,
+                        exc,
+                    )
+                    PostgresNotifyListener.reset_for_new_loop()
+                    listener = PostgresNotifyListener.instance()
+                    try:
+                        async_to_sync(listener.ensure_listening)(channel)
+                    except Exception as retry_exc:  # noqa: BLE001
+                        logger.warning(
+                            "NotificationMixin._restore_listen_channels: retry "
+                            "after cross-loop reset still failed for %r: %s",
+                            channel,
+                            retry_exc,
+                        )
+                else:
+                    logger.warning(
+                        "NotificationMixin._restore_listen_channels: failed to "
+                        "re-issue LISTEN %s (issue #894): %s",
+                        channel,
+                        exc,
+                    )
             except Exception as exc:  # noqa: BLE001 — restoration must never kill the WS
                 logger.warning(
                     "NotificationMixin._restore_listen_channels: failed to re-issue "

--- a/python/djust/uploads.py
+++ b/python/djust/uploads.py
@@ -982,6 +982,12 @@ class UploadMixin:
     # is not JSON-serializable and is silently dropped by
     # ``_get_private_state()``; this replay list is.
     _upload_configs_saved: Optional[List[Dict[str, Any]]] = None
+    # Issue #892: version tag for saved config dicts. Bumped whenever
+    # the replay contract changes (new kwarg added/renamed/removed on
+    # ``allow_upload``). ``_restore_upload_configs`` uses this to
+    # decide how defensively to replay — unknown / older versions fall
+    # back to the "bare-minimum replay" path. See ADR-009.
+    _upload_configs_version: int = 1
 
     def _ensure_upload_manager(self) -> UploadManager:
         if self._upload_manager is None:
@@ -1050,6 +1056,10 @@ class UploadMixin:
                 "auto_upload": auto_upload,
                 # writer deliberately omitted — see docstring caveat.
                 "_had_writer": writer is not None,
+                # Issue #892: tag each saved dict with the schema
+                # version that produced it, so restores in a later
+                # djust version can decide how defensively to replay.
+                "_version": self._upload_configs_version,
             }
         )
         return cfg
@@ -1068,6 +1078,18 @@ class UploadMixin:
         isn't session-round-trippable, so the restored config falls
         back to the default buffered writer. Apps relying on custom
         writers should arrange for a fresh-mount WS flow.
+
+        Schema-change defensive replay (issue #892): if a saved dict
+        contains kwargs the *current* ``allow_upload`` signature doesn't
+        recognize (djust upgrade between session save and WS connect),
+        or is missing a now-required kwarg, the per-dict ``**kwargs``
+        call raises ``TypeError``. We catch it, log a WARNING with the
+        slot + the mismatched keys, and fall back to
+        ``allow_upload(name)`` — bare-minimum replay — so uploads for
+        that slot still work, just without the custom config (extension
+        filter, size limit, etc.). Better than killing the whole
+        restoration and losing every other slot on the page. See
+        ADR-009 for the pattern.
         """
         saved = self._upload_configs_saved
         if not saved:
@@ -1077,7 +1099,11 @@ class UploadMixin:
         # across subsequent round-trips.
         self._upload_configs_saved = None
         for cfg in saved:
-            if cfg.pop("_had_writer", False):
+            # Strip bookkeeping-only keys before the ``**cfg`` splat —
+            # they're not ``allow_upload`` kwargs.
+            cfg.pop("_version", None)
+            had_writer = cfg.pop("_had_writer", False)
+            if had_writer:
                 logger.warning(
                     "UploadMixin._restore_upload_configs: upload slot %r was "
                     "originally configured with a custom writer= class, but "
@@ -1086,7 +1112,36 @@ class UploadMixin:
                     "caveats.",
                     cfg.get("name"),
                 )
-            self.allow_upload(**cfg)
+            try:
+                self.allow_upload(**cfg)
+            except TypeError as exc:
+                # Schema drift — djust version changed between save and
+                # restore. Fall back to a bare-minimum replay so the
+                # slot still works (issue #892).
+                slot_name = cfg.get("name")
+                logger.warning(
+                    "UploadMixin._restore_upload_configs: saved config for slot "
+                    "%r has kwargs incompatible with the current "
+                    "allow_upload() signature (%s) — falling back to "
+                    "allow_upload(%r) with defaults. See issue #892 / "
+                    "ADR-009.",
+                    slot_name,
+                    exc,
+                    slot_name,
+                )
+                if not slot_name:
+                    # Can't even recover a slot name — skip entirely,
+                    # don't want to crash the restore path.
+                    continue
+                try:
+                    self.allow_upload(slot_name)
+                except Exception as fallback_exc:  # noqa: BLE001
+                    logger.warning(
+                        "UploadMixin._restore_upload_configs: fallback "
+                        "allow_upload(%r) also failed: %s",
+                        slot_name,
+                        fallback_exc,
+                    )
 
     def consume_uploaded_entries(self, name: str) -> Generator[UploadEntry, None, None]:
         """

--- a/tests/unit/test_mixin_replay_schema_cross_loop_892_896.py
+++ b/tests/unit/test_mixin_replay_schema_cross_loop_892_896.py
@@ -1,0 +1,366 @@
+"""Regression tests for issues #892 and #896.
+
+Both harden the mixin-side-effect replay pattern (ADR-009) against
+failure modes that #889 / #893 / #894 didn't address:
+
+- **#892** — ``UploadMixin._restore_upload_configs`` splats each saved
+  dict into ``allow_upload(**kwargs)``. If the allow_upload signature
+  changed between the djust version that SAVED the session and the
+  djust version that RESTORES it (unknown kwarg added, required kwarg
+  renamed, etc.), the splat raises ``TypeError`` and kills the replay
+  for every remaining slot on the page.
+
+  Fix: wrap each replay in try/except TypeError; on mismatch log a
+  WARNING identifying the slot + the mismatch, fall back to
+  ``allow_upload(slot_name)`` — bare-minimum replay. Also: tag each
+  saved dict with ``_upload_configs_version`` so future migrations
+  have an explicit knob.
+
+- **#896** — ``NotificationMixin._restore_listen_channels`` calls
+  ``PostgresNotifyListener.instance().ensure_listening(channel)``.
+  The singleton is loop-bound; if the loop it was initialized on is
+  now closed (server restart with a fresh ASGI loop, test harness
+  spinning up per-test loops), ``_assert_same_loop`` raises
+  ``RuntimeError`` and the restore path silently drops NOTIFYs.
+
+  Fix: detect the stranded singleton before replay (check
+  ``listener._loop.is_closed()``) and call ``reset_for_new_loop()``
+  to drop it; the next ``ensure_listening`` creates a fresh instance
+  bound to the current loop. Also catch ``RuntimeError`` at the
+  per-channel level as a belt-and-suspenders fallback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Issue #892 — UploadMixin defensive replay for schema-changed configs
+# ---------------------------------------------------------------------------
+
+
+from djust.uploads import UploadMixin
+
+
+class _UploadView(UploadMixin):
+    """Concrete UploadMixin host."""
+
+
+class TestUploadConfigsSchemaDrift:
+    def test_saved_dict_has_version_tag(self):
+        """Every saved dict carries ``_version`` so future restores can
+        branch on it."""
+        v = _UploadView()
+        v.allow_upload("docs", accept=".jpg")
+        assert v._upload_configs_saved[0]["_version"] == 1
+
+    def test_restore_tolerates_unknown_kwarg(self, caplog):
+        """If a saved dict contains a kwarg the current allow_upload()
+        signature doesn't recognize (e.g. saved on a newer djust, being
+        restored on an older one, or the kwarg was renamed), the replay
+        MUST NOT raise. Falls back to allow_upload(name) with defaults.
+        """
+        v = _UploadView()
+        # Simulate a saved config with a kwarg that doesn't exist on
+        # the current allow_upload() — e.g. a future "priority" kwarg
+        # that was saved in a later version and is being replayed on
+        # an older one.
+        v._upload_configs_saved = [
+            {
+                "name": "docs",
+                "accept": ".jpg",
+                "max_entries": 3,
+                "max_file_size": 1_000_000,
+                "chunk_size": 64 * 1024,
+                "auto_upload": True,
+                "_had_writer": False,
+                "_version": 1,
+                # THIS is the unknown kwarg that would raise TypeError:
+                "priority": "high",
+            }
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="djust.uploads"):
+            v._restore_upload_configs()  # must not raise
+
+        # The slot still exists (fallback replay used defaults).
+        assert v._upload_manager is not None
+        assert "docs" in v._upload_manager._configs
+        # The fallback used defaults, not the saved accept=.jpg
+        # (we accept this trade-off — better to have a broken-but-
+        # usable slot than crash the whole page).
+        # The warning was logged identifying the slot.
+        assert any("docs" in r.message and "issue #892" in r.message for r in caplog.records)
+
+    def test_restore_with_missing_required_kwarg_falls_back_cleanly(self, caplog):
+        """Hypothetical: allow_upload() gained a required positional
+        kwarg in a future version, and the old saved dict doesn't have
+        it. Same code path — TypeError — same recovery.
+        """
+        v = _UploadView()
+        v._upload_configs_saved = [
+            {
+                # "name" is present — we need this to fall back
+                "name": "photos",
+                # But we inject an unknown kwarg to force TypeError
+                "mystery_kwarg": "x",
+            }
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="djust.uploads"):
+            v._restore_upload_configs()
+
+        assert v._upload_manager is not None
+        assert "photos" in v._upload_manager._configs
+
+    def test_restore_continues_past_broken_slot(self, caplog):
+        """One broken saved dict does NOT block later valid slots.
+        This is the whole point — before the fix, the first TypeError
+        killed the loop."""
+        v = _UploadView()
+        v._upload_configs_saved = [
+            {"name": "broken", "mystery": "x"},  # will TypeError
+            {
+                "name": "good",
+                "accept": ".png",
+                "max_entries": 2,
+                "max_file_size": 5_000_000,
+                "chunk_size": 64 * 1024,
+                "auto_upload": True,
+                "_had_writer": False,
+                "_version": 1,
+            },
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="djust.uploads"):
+            v._restore_upload_configs()
+
+        # BOTH slots exist on the manager (broken one via fallback,
+        # good one via normal replay).
+        assert v._upload_manager is not None
+        assert "broken" in v._upload_manager._configs
+        assert "good" in v._upload_manager._configs
+        # The good slot got its real config, not defaults:
+        good_cfg = v._upload_manager._configs["good"]
+        assert good_cfg.accept == ".png"
+        assert good_cfg.max_entries == 2
+
+    def test_restore_with_no_slot_name_and_bad_kwargs_skips_entry(self, caplog):
+        """If the saved dict is so broken it doesn't even have a
+        ``name`` key, the fallback can't construct a slot — skip it
+        rather than crash the restore path.
+        """
+        v = _UploadView()
+        v._upload_configs_saved = [
+            {"mystery": "x"},  # no name, no anything
+            {
+                "name": "good",
+                "accept": ".png",
+                "max_entries": 1,
+                "max_file_size": 1_000_000,
+                "chunk_size": 64 * 1024,
+                "auto_upload": True,
+                "_had_writer": False,
+                "_version": 1,
+            },
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="djust.uploads"):
+            v._restore_upload_configs()
+
+        # Good slot survives; broken one silently skipped.
+        assert v._upload_manager is not None
+        assert "good" in v._upload_manager._configs
+        assert "mystery" not in v._upload_manager._configs
+
+    def test_version_tag_stripped_before_replay(self):
+        """``_version`` is bookkeeping, not an allow_upload kwarg —
+        stripping it prevents a spurious TypeError on valid configs."""
+        v = _UploadView()
+        v._upload_configs_saved = [
+            {
+                "name": "docs",
+                "accept": ".jpg",
+                "max_entries": 1,
+                "max_file_size": 1_000_000,
+                "chunk_size": 64 * 1024,
+                "auto_upload": True,
+                "_had_writer": False,
+                "_version": 1,
+            }
+        ]
+        v._restore_upload_configs()
+        # No TypeError was raised, and the slot got the real config.
+        assert v._upload_manager is not None
+        cfg = v._upload_manager._configs["docs"]
+        assert cfg.accept == ".jpg"
+
+
+# ---------------------------------------------------------------------------
+# Issue #896 — NotificationMixin cross-loop restore
+# ---------------------------------------------------------------------------
+
+
+from djust.mixins.notifications import NotificationMixin  # noqa: E402
+
+
+class _NotifyView(NotificationMixin):
+    """Concrete NotificationMixin host."""
+
+
+class TestNotificationCrossLoopRestore:
+    def test_restore_detects_closed_loop_and_resets_singleton(self, caplog):
+        """If the singleton's bound loop is closed, the pre-check
+        calls ``reset_for_new_loop`` and a fresh instance handles
+        the replay. Verify the reset happened."""
+        from djust.db.notifications import PostgresNotifyListener
+
+        PostgresNotifyListener.reset_for_tests()  # clean start
+
+        # Build a stranded singleton: bind its _loop to a closed loop.
+        stale_loop = asyncio.new_event_loop()
+        stale_loop.close()  # now asyncio.get_event_loop().is_closed() == True
+        stale = PostgresNotifyListener.instance()
+        stale._loop = stale_loop  # pretend the old loop went away
+
+        # The stranded instance is the singleton right now.
+        assert PostgresNotifyListener._instance is stale
+
+        v = _NotifyView()
+        v._listen_channels = {"orders"}
+
+        called = []
+
+        async def _spy(ch):
+            called.append(ch)
+
+        # After reset_for_new_loop, instance() returns a NEW object.
+        # Patch that fresh instance's ensure_listening.
+        original_instance = PostgresNotifyListener.instance
+
+        def _instance_with_spy():
+            inst = original_instance()
+            # Only attach the spy if we got a fresh instance — we want
+            # to verify the stale one was discarded.
+            inst.ensure_listening = _spy
+            return inst
+
+        with patch.object(PostgresNotifyListener, "instance", _instance_with_spy):
+            with caplog.at_level(logging.INFO, logger="djust.mixins.notifications"):
+                v._restore_listen_channels()
+
+        # Ensure listening was called on the fresh singleton.
+        assert called == ["orders"]
+        # We logged the reset.
+        assert any(
+            "closed event loop" in r.message or "issue #896" in r.message for r in caplog.records
+        )
+        # The old stranded singleton is no longer the current one.
+        assert PostgresNotifyListener._instance is not stale
+
+        # Cleanup so other tests in the suite get a clean slate.
+        PostgresNotifyListener.reset_for_tests()
+
+    def test_restore_retry_path_on_runtime_error_mentioning_event_loop(self, caplog):
+        """Belt-and-suspenders: if the pre-check didn't catch the stale
+        loop (e.g. the listener initializes asynchronously and the
+        loop is fine *now* but goes away mid-call), the per-channel
+        ``except RuntimeError`` branch catches it, resets, and retries
+        once.
+        """
+        from djust.db.notifications import PostgresNotifyListener
+
+        PostgresNotifyListener.reset_for_tests()
+
+        v = _NotifyView()
+        v._listen_channels = {"orders"}
+
+        call_count = {"n": 0}
+
+        async def _flaky(ch):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError(
+                    "PostgresNotifyListener singleton is bound to a different "
+                    "event loop than the calling coroutine."
+                )
+            # Retry succeeds.
+
+        mock_listener = MagicMock()
+        mock_listener.ensure_listening = _flaky
+        # No _loop attr set => pre-check doesn't fire => we exercise
+        # the per-channel except RuntimeError branch.
+        mock_listener._loop = None
+
+        with patch(
+            "djust.db.notifications.PostgresNotifyListener.instance",
+            return_value=mock_listener,
+        ):
+            with patch(
+                "djust.db.notifications.PostgresNotifyListener.reset_for_new_loop"
+            ) as mock_reset:
+                with caplog.at_level(logging.INFO, logger="djust.mixins.notifications"):
+                    v._restore_listen_channels()
+
+        # Reset was called once (for the retry), and the retry succeeded
+        # (call_count == 2).
+        mock_reset.assert_called_once()
+        assert call_count["n"] == 2
+        assert any("cross-loop" in r.message for r in caplog.records)
+
+        PostgresNotifyListener.reset_for_tests()
+
+    def test_restore_no_reset_when_singleton_loop_is_open(self):
+        """Happy path: the singleton's loop is still open (or never
+        bound), no reset fires. Just verifies we don't over-eagerly
+        reset on every restore."""
+        from djust.db.notifications import PostgresNotifyListener
+
+        PostgresNotifyListener.reset_for_tests()
+
+        v = _NotifyView()
+        v._listen_channels = {"orders"}
+
+        called = []
+
+        async def _spy(ch):
+            called.append(ch)
+
+        mock_listener = MagicMock()
+        mock_listener.ensure_listening = _spy
+        mock_listener._loop = None  # never bound — no reset needed
+
+        with patch(
+            "djust.db.notifications.PostgresNotifyListener.instance",
+            return_value=mock_listener,
+        ):
+            with patch(
+                "djust.db.notifications.PostgresNotifyListener.reset_for_new_loop"
+            ) as mock_reset:
+                v._restore_listen_channels()
+
+        assert called == ["orders"]
+        mock_reset.assert_not_called()
+
+        PostgresNotifyListener.reset_for_tests()
+
+    def test_reset_for_new_loop_drops_singleton(self):
+        """Unit test for the new classmethod — isolates the
+        reset-on-closed-loop primitive from the mixin call site."""
+        from djust.db.notifications import PostgresNotifyListener
+
+        PostgresNotifyListener.reset_for_tests()
+
+        first = PostgresNotifyListener.instance()
+        assert PostgresNotifyListener._instance is first
+
+        PostgresNotifyListener.reset_for_new_loop()
+        assert PostgresNotifyListener._instance is None
+
+        second = PostgresNotifyListener.instance()
+        assert second is not first
+
+        PostgresNotifyListener.reset_for_tests()


### PR DESCRIPTION
## Summary

Hardens the mixin-side-effect replay pattern first shipped ad-hoc in PRs #891 (issue #889) and #895 (issues #893/#894) against three failure modes:

- **#897 — ADR-009**: formalizes the `_restore_<concept>()` pattern. New file `docs/adr/009-mixin-side-effect-replay.md` codifies serialization contract, error handling, convergence, naming, call ordering, and rejected alternatives.
- **#892 — UploadMixin defensive replay**: per-slot `TypeError` is caught, logged, falls back to `allow_upload(slot_name)` bare-minimum replay. Saved dicts now tagged with `_upload_configs_version = 1` for future explicit migrations. One broken saved dict no longer blocks replay for other slots on the page.
- **#896 — NotificationMixin cross-loop restore**: `_restore_listen_channels` detects stranded `PostgresNotifyListener` (closed event loop) and calls new `PostgresNotifyListener.reset_for_new_loop()` classmethod. Per-channel `except RuntimeError` branch catches the late-race case, resets, and retries once.

## Files changed

- `docs/adr/009-mixin-side-effect-replay.md` (NEW) — ADR
- `python/djust/uploads.py` — schema-drift try/except + version tag
- `python/djust/mixins/notifications.py` — cross-loop pre-check + retry
- `python/djust/db/notifications.py` — new `reset_for_new_loop()` classmethod
- `tests/unit/test_mixin_replay_schema_cross_loop_892_896.py` (NEW) — 10 regression tests
- `CHANGELOG.md` — Added (ADR-009) + Fixed (#892, #896)

## Test plan

- [x] 10 new regression tests pass (`test_mixin_replay_schema_cross_loop_892_896.py`)
- [x] 21 existing #889/#893/#894 tests still pass
- [x] Full Python suite: **3438 passed, 15 skipped** in 74s
- [x] Pre-commit hooks green (ruff, ruff-format, bandit, detect-secrets)
- [x] Pre-push hooks green (pytest)
- [x] CHANGELOG updated under `[Unreleased]` → `Added` (ADR) + `Fixed` (code)

Closes #892
Closes #896
Closes #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)