### PR TITLE
chore(tooling): CHANGELOG count validation + codeql-triage.sh + CodeQL MaD model (closes #908, #916, #934)

### DIFF
--- a/.github/codeql/README.md
+++ b/.github/codeql/README.md
@@ -1,0 +1,61 @@
+# CodeQL configuration for djust
+
+This directory holds the CodeQL scan configuration and a custom
+**MaD** (Models as Data) extension pack that teaches CodeQL about
+djust-specific sanitizers.
+
+## Files
+
+- `codeql-config.yml` — scan config referenced from
+  `.github/workflows/codeql.yml`. Controls `paths-ignore`,
+  `query-filters` (rules we suppress with documented justification),
+  and `packs:` (pointer to our local extension pack).
+- `models/qlpack.yml` — declares a library qlpack that extends
+  `codeql/python-queries`.
+- `models/djust-sanitizers.model.yml` — sanitizer tuples loaded as
+  data extensions into the Python taint-flow queries.
+
+## What the sanitizer model does (#934)
+
+`djust._log_utils.sanitize_for_log()` strips CR, LF, and other control
+chars from values before they reach `logger.*` calls. Without a model,
+CodeQL's `py/log-injection` query treats this helper as a no-op and
+flags every call like:
+
+```python
+logger.info("user %s did X", sanitize_for_log(request.GET["user"]))
+```
+
+as a log-injection finding, forcing us to dismiss each one individually.
+
+The data-extension tuple:
+
+```yaml
+- ["djust._log_utils", "", False, "sanitize_for_log", "", "", "Argument[0]", "ReturnValue", "log-injection"]
+```
+
+says: "for the log-injection query, the return value of
+`djust._log_utils.sanitize_for_log` is a sanitizer for the value passed
+as `Argument[0]`". Any log-injection alert whose flow terminates at a
+call wrapped in `sanitize_for_log(...)` is then suppressed by the flow
+analyzer itself rather than being emitted and later dismissed.
+
+## Verifying
+
+There is no way to fully verify a MaD model without running the CodeQL
+CLI. The next scheduled scan (weekly, Sunday 00:00 UTC) on `main` is the
+canonical verification — compare the open `py/log-injection` count
+before and after this PR lands.
+
+If the YAML syntax is rejected by the scanner, the CodeQL workflow run
+will fail at the init step with a message about the extension pack.
+Fix by inspecting the CLI log and consulting
+https://codeql.github.com/docs/codeql-language-guides/customizing-library-models-for-python/
+— the tuple shape varies slightly between CodeQL library versions.
+
+## Fallback plan
+
+If the MaD format does not work in production, the fallback is a
+hand-written `LogInjectionFlowConfiguration` override in
+`.github/codeql/queries/djust-sanitizers.ql` with an `isAdditionalSanitizer`
+predicate matching calls to `djust._log_utils.sanitize_for_log`.

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,9 +1,10 @@
 name: "djust CodeQL config"
 
 # Extension packs — teach CodeQL about djust-specific sanitizers/sinks.
-# See .github/codeql/models/djust-sanitizers.model.yml (closes #934).
+# Path is resolved relative to the repository root. See
+# .github/codeql/models/djust-sanitizers.model.yml (closes #934).
 packs:
-  - ./models
+  - .github/codeql/models
 
 paths-ignore:
   # JS source fragments — concatenated into client.js/debug-panel.js at build time.

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,5 +1,10 @@
 name: "djust CodeQL config"
 
+# Extension packs — teach CodeQL about djust-specific sanitizers/sinks.
+# See .github/codeql/models/djust-sanitizers.model.yml (closes #934).
+packs:
+  - ./models
+
 paths-ignore:
   # JS source fragments — concatenated into client.js/debug-panel.js at build time.
   # CodeQL cannot parse fragments individually (unclosed blocks, class method bodies).

--- a/.github/codeql/models/djust-sanitizers.model.yml
+++ b/.github/codeql/models/djust-sanitizers.model.yml
@@ -1,0 +1,24 @@
+# MaD (Models as Data) extension — djust-specific sanitizer models.
+#
+# Teaches CodeQL that djust's internal log-value sanitizer is a valid
+# sanitizer for the log-injection taint-flow query. Closes #934.
+#
+# Reference:
+#   https://codeql.github.com/docs/codeql-language-guides/customizing-library-models-for-python/
+#   https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#extending-codeql-coverage-with-codeql-model-packs
+#
+# sanitizerModel tuple shape (Python):
+#   [namespace, type, subtypes, name, signature, ext, input, kind]
+#
+# For log-injection, `input` is "Argument[0]" of the sanitize call and `kind`
+# is "log-injection". The easier form below uses the "extensible" form
+# (sinkSanitizerModel on a barrier), which expresses:
+#     "the ReturnValue of djust._log_utils.sanitize_for_log sanitizes data
+#      for the log-injection query".
+extensions:
+  - addsTo:
+      pack: codeql/python-queries
+      extensible: sanitizerModel
+    data:
+      # namespace, type, subtypes, name, signature, ext, input, output, kind
+      - ["djust._log_utils", "", False, "sanitize_for_log", "", "", "Argument[0]", "ReturnValue", "log-injection"]

--- a/.github/codeql/models/qlpack.yml
+++ b/.github/codeql/models/qlpack.yml
@@ -1,0 +1,7 @@
+name: djust-org/djust-codeql-extensions
+version: 0.0.1
+library: true
+extensionTargets:
+  codeql/python-queries: "*"
+dataExtensions:
+  - djust-sanitizers.model.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,6 +97,18 @@ repos:
         args: ['--baseline', '.secrets.baseline']
         exclude: package-lock\.json
 
+  # CHANGELOG validation — catches drift between claimed test counts and
+  # actual tests in referenced files. See scripts/check-changelog-test-counts.py
+  # and tests/test_changelog_test_counts.py. Closes #908.
+  - repo: local
+    hooks:
+      - id: check-changelog-test-counts
+        name: check CHANGELOG test counts
+        entry: python scripts/check-changelog-test-counts.py
+        language: python
+        files: ^CHANGELOG\.md$
+        pass_filenames: false
+
   # Pre-push hooks (slower checks that run before git push)
   - repo: local
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tooling: CHANGELOG test-count validator — closes #908** — new
+  `scripts/check-changelog-test-counts.py` parses phrases like
+  `N JSDOM cases`, `N regression tests`, `N unit tests`,
+  `N test cases`, `N parameterized cases` in the `[Unreleased]` section,
+  resolves every backticked `tests/js/*.test.js` / `python/djust/tests/*.py`
+  / `tests/unit/*.py` path inside the same bullet, counts test
+  functions in each, and fails if the claim doesn't match reality.
+  Delta phrases (`2 new cases`, `3 additional tests`) are deliberately
+  skipped — they can't be verified without git history. Wired into
+  `.pre-commit-config.yaml` as a local hook scoped to `^CHANGELOG\.md$`
+  and exposed as `make check-changelog`. Self-tested by 7 cases in
+  `tests/test_changelog_test_counts.py` covering match/mismatch,
+  JSDOM-vs-py file resolution, multi-file summing, delta ignore, and
+  missing-section tolerance.
+- **Tooling: CodeQL triage script — closes #916** —
+  `scripts/codeql-triage.sh [rule-id]` paginates
+  `/repos/{owner}/{repo}/code-scanning/alerts?state=open` via `gh api`
+  and emits a markdown triage doc grouped by `rule.id`, sorted within
+  each group by file/line. Optional positional arg filters to a single
+  rule for focused triage sessions. Turns the raw alert dump (noisy JSON)
+  into something reviewable in a PR comment or a doc. Documented in
+  `scripts/README.md`.
+- **Tooling: CodeQL sanitizer MaD model — closes #934** — new
+  extension pack at `.github/codeql/models/` (qlpack.yml +
+  `djust-sanitizers.model.yml`) teaches CodeQL that
+  `djust._log_utils.sanitize_for_log()` is a log-injection sanitizer.
+  Referenced from `.github/codeql/codeql-config.yml` via a new `packs:`
+  section. Closes the class of false-positive `py/log-injection` alerts
+  we've been dismissing individually. Verification lands with the next
+  main-branch CodeQL scan. See `.github/codeql/README.md` for the tuple
+  shape, fallback plan (hand-written `LogInjectionFlowConfiguration`
+  override), and links to CodeQL's data-extensions docs.
+
 - **ADR-009: Mixin side-effect replay on WebSocket state restoration —
   closes #897** — formalizes the `_restore_<concept>()` pattern first
   shipped ad-hoc in PRs #891 (UploadMixin, #889) and #895 (PresenceMixin

--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,10 @@ pre-commit-install: ## Install pre-commit hooks (run once after clone)
 .PHONY: check
 check: lint test ## Run linters and tests
 
+.PHONY: check-changelog
+check-changelog: ## Validate CHANGELOG test-count claims against actual tests (closes #908)
+	@.venv/bin/python scripts/check-changelog-test-counts.py
+
 ##@ Benchmarks
 
 .PHONY: benchmark

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -639,6 +639,48 @@ Done! The script adapts to TypeScript, runs your quality gates, and completes al
 
 ## Other Scripts
 
+### codeql-triage.sh
+
+Dumps open CodeQL alerts from the GitHub code-scanning API as a
+grouped markdown table (grouped by `rule.id`, sorted within each group
+by file/line). Pipe the output into a PR comment or a triage doc to
+turn a raw alert dump into something reviewable.
+
+```bash
+# All open alerts, every rule
+scripts/codeql-triage.sh
+
+# Just one rule
+scripts/codeql-triage.sh py/empty-except > /tmp/empty-except-triage.md
+```
+
+Output shape:
+
+```markdown
+# CodeQL open alerts — 2026-04-23
+
+Repo: `djust-org/djust` — state=open
+
+## py/empty-except (36)
+
+| # | file | line | severity | snippet |
+|---|------|------|----------|---------|
+| 2143 | components/function_component.py | 435 | note | Empty except clause |
+...
+
+## py/stack-trace-exposure (3)
+...
+```
+
+Requires: authenticated `gh` CLI + `jq`. Closes #916.
+
+### check-changelog-test-counts.py
+
+Validates test-count phrases in `CHANGELOG.md`'s `[Unreleased]` section
+against the actual tests in referenced files. See the docstring in
+`scripts/check-changelog-test-counts.py`. Wired into `.pre-commit-config.yaml`
+and available as `make check-changelog`. Closes #908.
+
 ### open_intellij.sh
 
 Opens the project in IntelliJ IDEA with proper Rust + Python configuration.

--- a/scripts/check-changelog-test-counts.py
+++ b/scripts/check-changelog-test-counts.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Validate test-count phrases in CHANGELOG.md ``[Unreleased]`` against reality.
+
+Scans the ``[Unreleased]`` section of ``CHANGELOG.md`` and, for each phrase
+like ``N JSDOM cases``, ``N regression tests``, ``N test cases``,
+``N unit tests``, or ``N parameterized cases`` that also names a concrete
+test file path (``tests/js/<name>.test.js`` or
+``python/djust/tests/<name>.py`` or ``tests/unit/<name>.py`` etc.), counts
+the actual tests in that file and compares.
+
+Exits 0 on match or when there's nothing to check.
+Exits 1 with a diff report on mismatch.
+
+Usage::
+
+    python scripts/check-changelog-test-counts.py [path/to/CHANGELOG.md]
+
+Closes #908.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+# Phrases we recognize as claims of a test count.
+# Note: "new" / "additional" signal a DELTA, not a total — we skip those
+# because counting "added in this release" requires git-blame-level analysis.
+# The validator only checks phrases that assert a current-total count of
+# tests in a named file.
+COUNT_PHRASE_RE = re.compile(
+    r"(?<!\w)(?P<count>\d+)\s+"
+    r"(?P<kind>JSDOM\s+cases|JSDOM\s+regression\s+cases|"
+    r"regression\s+tests|regression\s+cases|"
+    r"test\s+cases|unit\s+tests|parameterized\s+cases)",
+    re.IGNORECASE,
+)
+# Words that, if they appear immediately before a matched count phrase, mark
+# the phrase as a delta ("2 new cases", "3 additional tests") rather than a
+# total. We skip these because deltas can't be checked by simple file scan.
+DELTA_PREFIX_RE = re.compile(
+    r"\b(?:new|additional|more|extra|added)\s+$",
+    re.IGNORECASE,
+)
+
+# File-path references inside CHANGELOG prose (we allow single backticks).
+PY_TEST_PATH_RE = re.compile(
+    r"`((?:python/djust|tests|python)/[^\s`]*?tests?[^\s`]*?\.py)`"
+)
+JS_TEST_PATH_RE = re.compile(r"`(tests/js/[^\s`]+?\.test\.js)`")
+
+# Count test functions inside Python files. Matches top-level and class-level.
+PY_TEST_FN_RE = re.compile(r"^[ \t]*def\s+test_\w+\s*\(", re.MULTILINE)
+# Python pytest.mark.parametrize adds a case per tuple; count via rough sum
+# of ``parametrize(...)`` argument list lengths is out of scope here — a
+# ``test_*`` function is counted as ONE test, which mirrors ``pytest --collect-only -q``
+# at the nodeid level per-function (not per-param). If a CHANGELOG entry says
+# "parameterized cases" we still just count functions, which is the common
+# manual-count convention used in djust CHANGELOG entries today.
+
+# Count JS test/it() calls. Matches ``it(``, ``test(``, ``it.only(``, etc.
+# Deliberately loose — close enough for CHANGELOG sanity.
+JS_TEST_FN_RE = re.compile(
+    r"(?:^|[\s;{])(?:it|test)(?:\.only|\.skip)?\s*\(",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class Mismatch:
+    file: str
+    claimed: int
+    actual: int
+    phrase: str
+    source_line: int
+
+    def format(self) -> str:
+        delta = self.actual - self.claimed
+        sign = "+" if delta > 0 else ""
+        return (
+            f"  {self.file}: CHANGELOG says {self.claimed} ({self.phrase!r}) "
+            f"but file has {self.actual} ({sign}{delta}) "
+            f"[CHANGELOG.md line {self.source_line}]"
+        )
+
+
+def extract_unreleased(changelog: str) -> tuple[str, int]:
+    """Return the ``[Unreleased]`` section body and its start-line (1-based)."""
+    lines = changelog.splitlines()
+    start_idx: int | None = None
+    for i, line in enumerate(lines):
+        if re.match(r"^##\s*\[Unreleased\]", line, re.IGNORECASE):
+            start_idx = i + 1
+            break
+    if start_idx is None:
+        return "", 0
+    end_idx = len(lines)
+    for j in range(start_idx, len(lines)):
+        # next version heading => end of unreleased
+        if re.match(r"^##\s+\[[^\]]+\]", lines[j]):
+            end_idx = j
+            break
+    section_lines = lines[start_idx:end_idx]
+    return "\n".join(section_lines), start_idx + 1  # +1 => 1-based
+
+
+def count_tests_in_file(path: Path) -> int | None:
+    """Return the number of test cases/functions in *path*, or None if unreadable."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if path.suffix == ".py":
+        return len(PY_TEST_FN_RE.findall(text))
+    if path.name.endswith(".test.js") or path.suffix == ".js":
+        return len(JS_TEST_FN_RE.findall(text))
+    return None
+
+
+def find_mismatches(
+    unreleased_body: str,
+    body_start_line: int,
+    repo_root: Path,
+) -> list[Mismatch]:
+    """Walk the [Unreleased] body and return any (claim vs. reality) mismatches."""
+    mismatches: list[Mismatch] = []
+
+    # Slice the body into bullet "chunks" so a phrase and its file reference
+    # stay connected even across hard-wrapped lines. A chunk starts at a line
+    # that begins with "- " (possibly with leading whitespace) and runs to the
+    # next such line.
+    lines = unreleased_body.splitlines()
+    chunks: list[tuple[int, list[str]]] = []  # (line_offset_1based, lines)
+    cur: list[str] = []
+    cur_start = 0
+    for i, line in enumerate(lines):
+        if re.match(r"^\s*-\s+", line):
+            if cur:
+                chunks.append((cur_start, cur))
+            cur = [line]
+            cur_start = i
+        else:
+            if cur:
+                cur.append(line)
+    if cur:
+        chunks.append((cur_start, cur))
+
+    for offset, chunk_lines in chunks:
+        chunk = "\n".join(chunk_lines)
+        counts = list(COUNT_PHRASE_RE.finditer(chunk))
+        if not counts:
+            continue
+        py_paths = PY_TEST_PATH_RE.findall(chunk)
+        js_paths = JS_TEST_PATH_RE.findall(chunk)
+
+        # Heuristic: if the chunk mentions JSDOM, prefer js paths; otherwise
+        # prefer py paths. If both exist, check whichever matches the phrase's
+        # "kind" keyword.
+        for m in counts:
+            # Skip deltas: "2 new cases" cannot be validated without git
+            # history. Only check phrases that assert a file total.
+            prefix = chunk[max(0, m.start() - 30) : m.start()]
+            if DELTA_PREFIX_RE.search(prefix):
+                continue
+            claimed = int(m.group("count"))
+            kind = m.group("kind").lower()
+            phrase = m.group(0)
+            if "jsdom" in kind and js_paths:
+                candidates = js_paths
+            elif "unit" in kind and py_paths:
+                candidates = py_paths
+            elif py_paths:
+                candidates = py_paths
+            elif js_paths:
+                candidates = js_paths
+            else:
+                continue
+            # Sum counts across all candidate files in the chunk. If the
+            # CHANGELOG lists multiple files, we assume the stated count
+            # covers all of them — this matches the existing convention
+            # ("12 regression tests across foo.py, bar.py, baz.py").
+            total = 0
+            unresolved = False
+            for rel in candidates:
+                actual = count_tests_in_file(repo_root / rel)
+                if actual is None:
+                    unresolved = True
+                    break
+                total += actual
+            if unresolved:
+                continue
+            if total != claimed:
+                src_line = body_start_line + offset
+                mismatches.append(
+                    Mismatch(
+                        file=", ".join(candidates),
+                        claimed=claimed,
+                        actual=total,
+                        phrase=phrase,
+                        source_line=src_line,
+                    )
+                )
+    return mismatches
+
+
+def main(argv: list[str]) -> int:
+    changelog_path = Path(argv[1]) if len(argv) > 1 else DEFAULT_CHANGELOG
+    if not changelog_path.exists():
+        print(f"CHANGELOG not found at {changelog_path}", file=sys.stderr)
+        return 1
+    repo_root = changelog_path.resolve().parent
+    text = changelog_path.read_text(encoding="utf-8")
+    body, body_start_line = extract_unreleased(text)
+    if not body.strip():
+        # No Unreleased section or it's empty — nothing to validate.
+        return 0
+    mismatches = find_mismatches(body, body_start_line, repo_root)
+    if not mismatches:
+        return 0
+    print(
+        "CHANGELOG test-count drift — [Unreleased] claims do not match test files:\n",
+        file=sys.stderr,
+    )
+    for mm in mismatches:
+        print(mm.format(), file=sys.stderr)
+    print(
+        "\nFix: update CHANGELOG.md to match the actual test count, "
+        "or add the missing tests.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/codeql-triage.sh
+++ b/scripts/codeql-triage.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# codeql-triage.sh — dump open CodeQL alerts as a markdown triage table.
+#
+# Usage:
+#   scripts/codeql-triage.sh                 # all open alerts
+#   scripts/codeql-triage.sh py/empty-except # only alerts for that rule
+#
+# Requires: gh CLI, authenticated and scoped to the repo. Calls
+# /repos/{owner}/{repo}/code-scanning/alerts?state=open&per_page=100 with
+# --paginate and groups by rule.id. Sort within each group is file, line.
+#
+# Closes #916.
+
+set -euo pipefail
+
+RULE_FILTER="${1:-}"
+
+# Resolve repo owner/name from gh so the script works in any clone.
+repo_slug="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+today="$(date +%Y-%m-%d)"
+
+# Fetch all open alerts, paginated. The GitHub REST API returns one JSON
+# array per page; --paginate concatenates them into a single stream of
+# arrays. Use jq --slurp to flatten into one array, then sort/group.
+raw_json="$(gh api \
+    "/repos/${repo_slug}/code-scanning/alerts?state=open&per_page=100" \
+    --paginate)"
+
+# Build markdown. All the grouping/sorting happens in jq so the shell stays
+# small. If RULE_FILTER is set, prefilter before grouping.
+echo "# CodeQL open alerts — ${today}"
+echo ""
+echo "Repo: \`${repo_slug}\` — state=open"
+echo ""
+
+if [[ -z "$raw_json" || "$raw_json" == "[]" ]]; then
+    echo "_No open alerts._"
+    exit 0
+fi
+
+# group_by needs the input pre-sorted on the group key; we slurp (absorb all
+# pages into one array via --slurp + add), flatten, filter, then group.
+echo "$raw_json" | jq -r --arg filter "$RULE_FILTER" '
+    # Collapse paginated arrays into a single flat array.
+    if type == "array" then . else [.] end
+    | map(select(.state == "open"))
+    | if ($filter != "") then map(select(.rule.id == $filter)) else . end
+    | sort_by(.rule.id, .most_recent_instance.location.path, .most_recent_instance.location.start_line)
+    | group_by(.rule.id)
+    | map(
+        "## \(.[0].rule.id) (\(length))\n\n" +
+        "| # | file | line | severity | snippet |\n" +
+        "|---|------|------|----------|---------|\n" +
+        (
+          map(
+            "| \(.number)"
+            + " | \(.most_recent_instance.location.path // "?")"
+            + " | \(.most_recent_instance.location.start_line // "?")"
+            + " | \(.rule.severity // .rule.security_severity_level // "?")"
+            + " | \((.most_recent_instance.message.text // .rule.description // "") | gsub("\\|"; "\\|") | gsub("\n"; " ") | .[0:120])"
+            + " |"
+          ) | join("\n")
+        )
+    )
+    | join("\n\n")
+'

--- a/tests/test_changelog_test_counts.py
+++ b/tests/test_changelog_test_counts.py
@@ -1,0 +1,218 @@
+"""Self-test for ``scripts/check-changelog-test-counts.py`` (closes #908).
+
+Feeds the validator a synthetic CHANGELOG + synthetic test files and
+verifies that drift is detected and that correct counts pass.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check-changelog-test-counts.py"
+
+
+def _write_tree(tmp: Path, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        p = tmp / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+
+def _run(tmp: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(tmp / "CHANGELOG.md")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_matching_counts_pass(tmp_path: Path) -> None:
+    """CHANGELOG claim matches file reality — exit 0, no stderr noise."""
+    _write_tree(
+        tmp_path,
+        {
+            "CHANGELOG.md": textwrap.dedent(
+                """\
+                # Changelog
+
+                ## [Unreleased]
+
+                ### Fixed
+
+                - **foo** — 3 regression tests in `tests/unit/test_foo.py`.
+
+                ## [0.1.0] - 2026-01-01
+                - previous
+                """
+            ),
+            "tests/unit/test_foo.py": textwrap.dedent(
+                """\
+                def test_one(): pass
+                def test_two(): pass
+                def test_three(): pass
+                """
+            ),
+        },
+    )
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "drift" not in result.stderr
+
+
+def test_mismatched_count_fails(tmp_path: Path) -> None:
+    """CHANGELOG claim disagrees with reality — exit 1 with a diff."""
+    _write_tree(
+        tmp_path,
+        {
+            "CHANGELOG.md": textwrap.dedent(
+                """\
+                # Changelog
+
+                ## [Unreleased]
+
+                ### Fixed
+
+                - **foo** — 5 regression tests in `tests/unit/test_foo.py`.
+
+                ## [0.1.0] - 2026-01-01
+                """
+            ),
+            "tests/unit/test_foo.py": "def test_one(): pass\n",
+        },
+    )
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    assert "drift" in result.stderr
+    assert "CHANGELOG says 5" in result.stderr
+    assert "file has 1" in result.stderr
+
+
+def test_delta_phrase_is_ignored(tmp_path: Path) -> None:
+    """'2 new JSDOM cases' is a delta, not a total — not validated."""
+    _write_tree(
+        tmp_path,
+        {
+            "CHANGELOG.md": textwrap.dedent(
+                """\
+                # Changelog
+
+                ## [Unreleased]
+
+                ### Fixed
+
+                - **foo** — 2 new JSDOM cases in `tests/js/foo.test.js` (12/12 passing).
+
+                ## [0.1.0] - 2026-01-01
+                """
+            ),
+            "tests/js/foo.test.js": "\n".join(f"it('case{i}', () => {{}});" for i in range(12)),
+        },
+    )
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stderr
+
+
+def test_jsdom_phrase_checks_js_file(tmp_path: Path) -> None:
+    """'9 JSDOM cases' phrase resolves against the named .test.js file."""
+    _write_tree(
+        tmp_path,
+        {
+            "CHANGELOG.md": textwrap.dedent(
+                """\
+                # Changelog
+
+                ## [Unreleased]
+
+                ### Fixed
+
+                - **foo** — 9 JSDOM cases in `tests/js/foo.test.js`.
+
+                ## [0.1.0] - 2026-01-01
+                """
+            ),
+            "tests/js/foo.test.js": "\n".join(f"it('case{i}', () => {{}});" for i in range(7)),
+        },
+    )
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    assert "tests/js/foo.test.js" in result.stderr
+    assert "CHANGELOG says 9" in result.stderr
+    assert "file has 7" in result.stderr
+
+
+def test_multiple_files_summed(tmp_path: Path) -> None:
+    """'12 regression tests across a.py, b.py, c.py' sums across listed files."""
+    _write_tree(
+        tmp_path,
+        {
+            "CHANGELOG.md": textwrap.dedent(
+                """\
+                # Changelog
+
+                ## [Unreleased]
+
+                ### Fixed
+
+                - **foo** — 12 regression tests across `python/djust/tests/test_a.py`,
+                  `python/djust/tests/test_b.py` and `python/djust/tests/test_c.py`.
+
+                ## [0.1.0] - 2026-01-01
+                """
+            ),
+            "python/djust/tests/test_a.py": (
+                "def test_a1(): pass\ndef test_a2(): pass\ndef test_a3(): pass\n"
+                "def test_a4(): pass\n"
+            ),
+            "python/djust/tests/test_b.py": (
+                "def test_b1(): pass\ndef test_b2(): pass\ndef test_b3(): pass\n"
+                "def test_b4(): pass\n"
+            ),
+            "python/djust/tests/test_c.py": (
+                "def test_c1(): pass\ndef test_c2(): pass\ndef test_c3(): pass\n"
+                "def test_c4(): pass\n"
+            ),
+        },
+    )
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stderr
+
+
+def test_missing_unreleased_section_is_ok(tmp_path: Path) -> None:
+    """No [Unreleased] heading — nothing to validate — exit 0."""
+    _write_tree(
+        tmp_path,
+        {
+            "CHANGELOG.md": "# Changelog\n\n## [0.1.0] - 2026-01-01\n- prior\n",
+        },
+    )
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stderr
+
+
+def test_count_phrase_without_file_path_is_skipped(tmp_path: Path) -> None:
+    """'5 unit tests' with no file reference can't be validated — exit 0."""
+    _write_tree(
+        tmp_path,
+        {
+            "CHANGELOG.md": textwrap.dedent(
+                """\
+                # Changelog
+
+                ## [Unreleased]
+
+                ### Fixed
+
+                - **foo** — 5 unit tests cover this path.
+
+                ## [0.1.0] - 2026-01-01
+                """
+            ),
+        },
+    )
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Three small tooling additions.

- **#908** — `scripts/check-changelog-test-counts.py` validates test-count phrases in the `[Unreleased]` section of `CHANGELOG.md` against the actual test files referenced in the same bullet. Skips delta phrases ("2 new cases"). Wired into `.pre-commit-config.yaml` (local hook, `files: ^CHANGELOG\.md$`) and `make check-changelog`. Self-tested by 7 cases in `tests/test_changelog_test_counts.py`.
- **#916** — `scripts/codeql-triage.sh [rule-id]` dumps open alerts from GitHub's code-scanning API as a grouped markdown table. Used to replace hand-built triage docs. Documented in `scripts/README.md`.
- **#934** — `.github/codeql/models/` is a MaD (Models as Data) extension pack teaching CodeQL that `djust._log_utils.sanitize_for_log()` is a log-injection sanitizer. Referenced from `codeql-config.yml` via a new `packs:` section. Closes the class of false-positive `py/log-injection` alerts. See `.github/codeql/README.md` for the tuple shape and fallback plan.

CHANGELOG updated under `[Unreleased]` → `Added`.

## Test plan

- [x] `make check-changelog` → passes on current CHANGELOG
- [x] `pytest tests/test_changelog_test_counts.py` → 7/7 passes
- [x] `bash scripts/codeql-triage.sh` → clean markdown (no alerts currently open)
- [x] Pre-push hook ran full pytest suite → 3432 passed, 15 skipped
- [x] All YAML files (codeql-config, qlpack, model, .pre-commit-config) parse with PyYAML
- [ ] CodeQL MaD model verification — lands with next scheduled `main` scan (weekly Sun 00:00 UTC). If the YAML is rejected, the init step in `.github/workflows/codeql.yml` will fail and the fallback is `LogInjectionFlowConfiguration` override (documented in `.github/codeql/README.md`).

Closes #908
Closes #916
Closes #934

🤖 Generated with [Claude Code](https://claude.com/claude-code)