### PR TITLE
fix: 3 pre-existing test failures + redirect audit + dep ceilings + edge tests (closes #910, #921, #922, #935)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Security + cleanup: pre-existing test failures, redirect audit, dep ceilings, edge tests — closes #910, #921, #922, #935** —
+  **#935**: fixed 3 stale test assertions that were checking for leaked
+  exception-class names in API error responses. The implementations in
+  `api/dispatch.py`, `observability/views.py` deliberately sanitize
+  error payloads (don't echo `RuntimeError` / internal method names to
+  clients; send to server logs instead). Tests now verify the sanitized
+  contract (`"server logs"` in `error`, handler_name / session_id echo)
+  rather than the leaked details. Fixes
+  `test_api_response.py::test_dispatch_serialize_str_missing_method_returns_500`,
+  `test_observability_eval_handler.py::test_eval_500_when_handler_raises`,
+  and `test_observability_reset_view.py::test_reset_500_when_mount_raises`.
+  **#921**: expanded open-redirect audit beyond PR #920 — `mixins/request.py`
+  now validates `hook_redirect` returned by developer-defined `on_mount`
+  hooks via `url_has_allowed_host_and_scheme`, falling back to `"/"` and
+  logging a WARNING on unsafe targets. `auth/mixins.py`
+  `LoginRequiredLiveViewMixin.dispatch` now validates the computed login
+  URL as defense-in-depth against misconfigured `settings.LOGIN_URL`,
+  falling back to `"/accounts/login/"`.
+  **#922**: 7 new regression tests in
+  `python/djust/tests/test_security_redirects_paths.py` —
+  `javascript:` scheme rejection, HTTPS-to-HTTP downgrade, null-byte
+  path-injection, uppercase/case-sensitive allowlist, hook_redirect
+  off-site rejection, hook_redirect same-site acceptance, and off-site
+  `LOGIN_URL` fallback.
+  **#910**: added upper-bound ceilings to all runtime + dev dependencies in
+  `pyproject.toml` (e.g. `requests>=2.28,<3`, `orjson>=3.11.6,<4`,
+  `nh3>=0.2,<1`). Prevents uncontrolled major bumps during `uv lock`
+  refresh (see PR #909 which caught Django 6.x resolving under `>=4.2`).
+  Ceiling policy documented in a comment above `[project.dependencies]`.
+  Verified with `uv lock` — only material change is `redis` 7.3 -> 6.4
+  (stays under new `<7` ceiling).
 - **UploadMixin defensive replay for schema-changed configs — closes #892** —
   `_restore_upload_configs` now wraps each per-slot `allow_upload(**cfg)`
   in try/except `TypeError`. On signature mismatch (kwarg added / renamed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,54 +29,62 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
+# Dependency ceiling policy (#910):
+# Every runtime/dev dependency pins an upper bound at the next major version
+# to prevent uncontrolled major bumps during lockfile refreshes. This was
+# introduced after PR #909, where a `Django>=4.2` constraint allowed `uv lock`
+# to resolve to Django 6.x and break 4.2-compatible code paths. The ceiling
+# is the next major that has not yet been validated against djust's test
+# matrix (see `classifiers` above). Bumping a ceiling is a deliberate,
+# reviewed change — not something lockfile refresh should do silently.
 dependencies = [
     "Django>=4.2.29,<6",
-    "channels[daphne]>=4.0.0",
-    "msgpack>=1.0.0",
+    "channels[daphne]>=4.0.0,<5",
+    "msgpack>=1.0.0,<2",
 ]
 
 [project.optional-dependencies]
 redis = [
-    "redis>=5.0.0",
+    "redis>=5.0.0,<7",
 ]
 compression = [
-    "zstandard>=0.22.0",  # zstd compression for state backend
+    "zstandard>=0.22.0,<1",  # zstd compression for state backend
 ]
 performance = [
-    "orjson>=3.11.6",
-    "zstandard>=0.22.0",
+    "orjson>=3.11.6,<4",
+    "zstandard>=0.22.0,<1",
 ]
 theming = []  # No extra deps beyond djust core
 admin = []  # No extra deps beyond djust core
 deploy = [
-    "click>=8.0",
-    "requests>=2.28",
+    "click>=8.0,<9",
+    "requests>=2.28,<3",
 ]
 components = [
-    "markdown>=3.0",
-    "nh3>=0.2",
+    "markdown>=3.0,<4",
+    "nh3>=0.2,<1",
 ]
 all = [
     "djust[redis,compression,performance,admin,deploy,theming,components]",
 ]
 dev = [
     "maturin>=1.0,<2.0",
-    "pytest>=7.0",
-    "pytest-django>=4.5",
-    "pytest-asyncio>=0.21",
-    "pytest-xdist>=3.0",  # Parallel test execution
-    "pytest-benchmark>=4.0.0",  # Performance benchmarking
-    "ruff>=0.1",
-    "mypy>=1.0",
-    "uvicorn[standard]>=0.30.0",
-    "redis>=5.0.0",
-    "watchdog>=3.0.0",  # File system monitoring for hot reload
-    "zstandard>=0.22.0",  # Compression support
-    "orjson>=3.11.6",
-    "click>=8.0",  # Deploy CLI
-    "requests>=2.28",  # Deploy CLI
-    "requests-mock>=1.11",  # HTTP mocking for deploy CLI tests
-    "mcp[cli]>=1.2.0",  # djust.mcp server tests (test_mcp.py)
+    "pytest>=7.0,<10",
+    "pytest-django>=4.5,<6",
+    "pytest-asyncio>=0.21,<2",
+    "pytest-xdist>=3.0,<4",  # Parallel test execution
+    "pytest-benchmark>=4.0.0,<6",  # Performance benchmarking
+    "ruff>=0.1,<1",
+    "mypy>=1.0,<2",
+    "uvicorn[standard]>=0.30.0,<1",
+    "redis>=5.0.0,<7",
+    "watchdog>=3.0.0,<7",  # File system monitoring for hot reload
+    "zstandard>=0.22.0,<1",  # Compression support
+    "orjson>=3.11.6,<4",
+    "click>=8.0,<9",  # Deploy CLI
+    "requests>=2.28,<3",  # Deploy CLI
+    "requests-mock>=1.11,<2",  # HTTP mocking for deploy CLI tests
+    "mcp[cli]>=1.2.0,<2",  # djust.mcp server tests (test_mcp.py)
 ]
 
 [project.scripts]

--- a/python/djust/auth/mixins.py
+++ b/python/djust/auth/mixins.py
@@ -1,8 +1,12 @@
+import logging
 from urllib.parse import urlencode
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import redirect
+from django.utils.http import url_has_allowed_host_and_scheme
+
+logger = logging.getLogger(__name__)
 
 
 class LoginRequiredLiveViewMixin:
@@ -18,6 +22,20 @@ class LoginRequiredLiveViewMixin:
         if not request.user.is_authenticated:
             login_url = self.login_url or getattr(settings, "LOGIN_URL", "/accounts/login/")
             url = f"{login_url}?{urlencode({'next': request.get_full_path()})}"
+            # Defensive validation — login_url is developer-provided config,
+            # not user input, but we validate to prevent misconfigurations
+            # from producing open redirects.
+            if not url_has_allowed_host_and_scheme(
+                url=url,
+                allowed_hosts={request.get_host()},
+                require_https=request.is_secure(),
+            ):
+                logger.warning(
+                    "LoginRequiredLiveViewMixin: login_url %r is off-site; "
+                    "falling back to '/accounts/login/'",
+                    login_url,
+                )
+                return redirect("/accounts/login/")
             return redirect(url)
         return super().dispatch(request, *args, **kwargs)
 

--- a/python/djust/mixins/request.py
+++ b/python/djust/mixins/request.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.utils.decorators import method_decorator
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.db import models
 
@@ -72,6 +73,19 @@ class RequestMixin:
         # Run on_mount hooks (auth guards, etc.) before mount
         hook_redirect = run_on_mount_hooks(self, request, **kwargs)
         if hook_redirect:
+            # Validate hook-returned URL to prevent open-redirect via
+            # a developer-defined hook echoing untrusted request data.
+            # Falls back to "/" on any off-site/malicious target.
+            if not url_has_allowed_host_and_scheme(
+                url=hook_redirect,
+                allowed_hosts={request.get_host()},
+                require_https=request.is_secure(),
+            ):
+                logger.warning(
+                    "on_mount hook returned unsafe redirect URL for %s; " "falling back to '/'",
+                    self.__class__.__name__,
+                )
+                return HttpResponseRedirect("/")
             return HttpResponseRedirect(hook_redirect)
 
         # IMPORTANT: mount() must be called first to initialize clean state

--- a/python/djust/tests/test_api_response.py
+++ b/python/djust/tests/test_api_response.py
@@ -341,7 +341,10 @@ def test_dispatch_serialize_str_missing_method_returns_500(http_request):
     assert response.status_code == 500
     payload = json.loads(response.content)
     assert payload["error"] == "serialize_error"
-    assert "missing_method" in payload["message"]
+    # Error payload is sanitized (doesn't leak the serializer method name
+    # or exception internals to the client). Details go to server logs.
+    # Verify the generic sanitized message is returned.
+    assert "Response transform" in payload["message"]
 
 
 def test_dispatch_serializer_exception_returns_500(http_request):

--- a/python/djust/tests/test_observability_eval_handler.py
+++ b/python/djust/tests/test_observability_eval_handler.py
@@ -156,7 +156,11 @@ def test_eval_500_when_handler_raises():
     resp = eval_handler(_post({"handler_name": "explode"}))
     assert resp.status_code == 500
     data = json.loads(resp.content)
-    assert "RuntimeError" in data["error"]
+    # Error payload is sanitized (doesn't leak exception class names to the client).
+    # Details go to server logs. Verify we still surface a useful hint plus the
+    # handler_name echoed back for the client.
+    assert "server logs" in data["error"]
+    assert data["handler_name"] == "explode"
 
 
 @override_settings(DEBUG=True)

--- a/python/djust/tests/test_observability_reset_view.py
+++ b/python/djust/tests/test_observability_reset_view.py
@@ -127,7 +127,11 @@ def test_reset_500_when_mount_raises():
     resp = reset_view_state(rf.post("/?session_id=s"))
     assert resp.status_code == 500
     data = json.loads(resp.content)
-    assert "RuntimeError" in data["error"]
+    # Error payload is sanitized (no exception class leak to client). Details
+    # go to server logs. Verify the sanitized contract + session_id echo.
+    assert "mount()" in data["error"]
+    assert "server logs" in data["error"]
+    assert data["session_id"] == "s"
 
 
 @override_settings(DEBUG=False)

--- a/python/djust/tests/test_security_redirects_paths.py
+++ b/python/djust/tests/test_security_redirects_paths.py
@@ -80,3 +80,153 @@ def test_storybook_valid_component_name_still_works():
     # Either the file exists and returns non-empty OR it returns "" if the template
     # file isn't actually on disk. Both are fine — the point is no exception raised.
     assert isinstance(result, str)
+
+
+# Additional edge-case regression tests (#922)
+
+
+def test_signup_view_rejects_javascript_scheme(db, settings):
+    """SignupView must reject javascript: scheme (XSS via redirect)."""
+    from djust.auth.views import SignupView
+
+    factory = RequestFactory()
+    req = factory.post("/signup/", {"next": "javascript:alert(1)"})
+    req.META["HTTP_HOST"] = "example.com"
+
+    view = SignupView()
+    view.request = req
+    settings.LOGIN_REDIRECT_URL = "/home/"
+
+    # Django's url_has_allowed_host_and_scheme rejects javascript: by default.
+    assert view.get_success_url() == "/home/"
+
+
+def test_signup_view_rejects_https_to_http_downgrade(db, settings):
+    """When request is HTTPS, a same-host http:// next URL must be rejected."""
+    from djust.auth.views import SignupView
+
+    factory = RequestFactory()
+    # Same host, but http:// while the request is secure => downgrade attempt.
+    req = factory.post("/signup/", {"next": "http://example.com/dashboard/"}, secure=True)
+    req.META["HTTP_HOST"] = "example.com"
+
+    view = SignupView()
+    view.request = req
+    settings.LOGIN_REDIRECT_URL = "/home/"
+
+    # require_https=True (view passes request.is_secure()) rejects the http:// URL.
+    assert view.get_success_url() == "/home/"
+
+
+def test_storybook_rejects_null_byte():
+    """get_component_template_source must reject null-byte payloads."""
+    from djust.theming.gallery.storybook import get_component_template_source
+
+    # Null bytes are not in the allowlist -> "" fallback.
+    assert get_component_template_source("foo\x00.html") == ""
+    assert get_component_template_source("button\x00../../etc/passwd") == ""
+
+
+def test_storybook_rejects_uppercase():
+    """get_component_template_source allowlist is lowercase-only (case-sensitive)."""
+    from djust.theming.gallery.storybook import get_component_template_source
+
+    # Component names on disk are all lowercase; uppercase fails the allowlist.
+    assert get_component_template_source("FOO") == ""
+    assert get_component_template_source("BUTTON") == ""
+
+
+# Additional regression tests for the expanded redirect audit (#921)
+
+
+def test_request_mixin_rejects_unsafe_hook_redirect(db, settings):
+    """RequestMixin.get() must reject off-site URLs returned by on_mount hooks."""
+    from djust import LiveView
+    from djust.hooks import on_mount
+
+    @on_mount
+    def redirect_to_evil(view, request, **kwargs):
+        return "https://evil.com/steal"
+
+    class EvilHookView(LiveView):
+        template_name = "djust_theming/components/button.html"
+        on_mount = [redirect_to_evil]
+
+        def mount(self, request, **kwargs):
+            self.count = 0
+
+    factory = RequestFactory()
+    req = factory.get("/evil/")
+    req.META["HTTP_HOST"] = "example.com"
+
+    # Anonymous user (no auth required for this view)
+    from django.contrib.auth.models import AnonymousUser
+
+    req.user = AnonymousUser()
+
+    view = EvilHookView()
+    response = view.get(req)
+    # Off-site URL from the hook is replaced with "/" fallback
+    assert response.status_code == 302
+    assert response["Location"] == "/"
+
+
+def test_request_mixin_accepts_safe_hook_redirect(db, settings):
+    """Same-site hook redirects are preserved unchanged."""
+    from djust import LiveView
+    from djust.hooks import on_mount
+
+    @on_mount
+    def redirect_to_login(view, request, **kwargs):
+        return "/accounts/login/"
+
+    class SafeHookView(LiveView):
+        template_name = "djust_theming/components/button.html"
+        on_mount = [redirect_to_login]
+
+        def mount(self, request, **kwargs):
+            pass
+
+    factory = RequestFactory()
+    req = factory.get("/protected/")
+    req.META["HTTP_HOST"] = "example.com"
+
+    from django.contrib.auth.models import AnonymousUser
+
+    req.user = AnonymousUser()
+
+    view = SafeHookView()
+    response = view.get(req)
+    # Same-site relative URL is honored
+    assert response.status_code == 302
+    assert response["Location"] == "/accounts/login/"
+
+
+def test_login_required_mixin_rejects_offsite_login_url(db, settings):
+    """LoginRequiredLiveViewMixin falls back when settings.LOGIN_URL is off-site."""
+    from djust.auth.mixins import LoginRequiredLiveViewMixin
+
+    factory = RequestFactory()
+    req = factory.get("/protected/")
+    req.META["HTTP_HOST"] = "example.com"
+
+    class AnonUser:
+        is_authenticated = False
+
+    req.user = AnonUser()
+
+    settings.LOGIN_URL = "https://evil.com/login/"
+
+    class DummyBase:
+        def dispatch(self, request, *args, **kwargs):
+            raise AssertionError("super().dispatch() should not run for anon user")
+
+    class View(LoginRequiredLiveViewMixin, DummyBase):
+        pass
+
+    view = View()
+    response = view.dispatch(req)
+
+    # Off-site login_url must be replaced with safe fallback
+    assert response.status_code == 302
+    assert response["Location"].startswith("/accounts/login/")

--- a/uv.lock
+++ b/uv.lock
@@ -530,7 +530,7 @@ wheels = [
 
 [[package]]
 name = "djust"
-version = "0.5.5rc1"
+version = "0.5.6rc1"
 source = { editable = "." }
 dependencies = [
     { name = "channels", extra = ["daphne"] },
@@ -588,35 +588,35 @@ redis = [
 
 [package.metadata]
 requires-dist = [
-    { name = "channels", extras = ["daphne"], specifier = ">=4.0.0" },
-    { name = "click", marker = "extra == 'deploy'", specifier = ">=8.0" },
-    { name = "click", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "channels", extras = ["daphne"], specifier = ">=4.0.0,<5" },
+    { name = "click", marker = "extra == 'deploy'", specifier = ">=8.0,<9" },
+    { name = "click", marker = "extra == 'dev'", specifier = ">=8.0,<9" },
     { name = "django", specifier = ">=4.2.29,<6" },
     { name = "djust", extras = ["redis", "compression", "performance", "admin", "deploy", "theming", "components"], marker = "extra == 'all'" },
-    { name = "markdown", marker = "extra == 'components'", specifier = ">=3.0" },
+    { name = "markdown", marker = "extra == 'components'", specifier = ">=3.0,<4" },
     { name = "maturin", marker = "extra == 'dev'", specifier = ">=1.0,<2.0" },
-    { name = "mcp", extras = ["cli"], marker = "extra == 'dev'", specifier = ">=1.2.0" },
-    { name = "msgpack", specifier = ">=1.0.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
-    { name = "nh3", marker = "extra == 'components'", specifier = ">=0.2" },
-    { name = "orjson", marker = "extra == 'dev'", specifier = ">=3.11.6" },
-    { name = "orjson", marker = "extra == 'performance'", specifier = ">=3.11.6" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
-    { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "pytest-django", marker = "extra == 'dev'", specifier = ">=4.5" },
-    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0" },
-    { name = "redis", marker = "extra == 'dev'", specifier = ">=5.0.0" },
-    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0" },
-    { name = "requests", marker = "extra == 'deploy'", specifier = ">=2.28" },
-    { name = "requests", marker = "extra == 'dev'", specifier = ">=2.28" },
-    { name = "requests-mock", marker = "extra == 'dev'", specifier = ">=1.11" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'dev'", specifier = ">=0.30.0" },
-    { name = "watchdog", marker = "extra == 'dev'", specifier = ">=3.0.0" },
-    { name = "zstandard", marker = "extra == 'compression'", specifier = ">=0.22.0" },
-    { name = "zstandard", marker = "extra == 'dev'", specifier = ">=0.22.0" },
-    { name = "zstandard", marker = "extra == 'performance'", specifier = ">=0.22.0" },
+    { name = "mcp", extras = ["cli"], marker = "extra == 'dev'", specifier = ">=1.2.0,<2" },
+    { name = "msgpack", specifier = ">=1.0.0,<2" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0,<2" },
+    { name = "nh3", marker = "extra == 'components'", specifier = ">=0.2,<1" },
+    { name = "orjson", marker = "extra == 'dev'", specifier = ">=3.11.6,<4" },
+    { name = "orjson", marker = "extra == 'performance'", specifier = ">=3.11.6,<4" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0,<10" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21,<2" },
+    { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=4.0.0,<6" },
+    { name = "pytest-django", marker = "extra == 'dev'", specifier = ">=4.5,<6" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0,<4" },
+    { name = "redis", marker = "extra == 'dev'", specifier = ">=5.0.0,<7" },
+    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0,<7" },
+    { name = "requests", marker = "extra == 'deploy'", specifier = ">=2.28,<3" },
+    { name = "requests", marker = "extra == 'dev'", specifier = ">=2.28,<3" },
+    { name = "requests-mock", marker = "extra == 'dev'", specifier = ">=1.11,<2" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1,<1" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'dev'", specifier = ">=0.30.0,<1" },
+    { name = "watchdog", marker = "extra == 'dev'", specifier = ">=3.0.0,<7" },
+    { name = "zstandard", marker = "extra == 'compression'", specifier = ">=0.22.0,<1" },
+    { name = "zstandard", marker = "extra == 'dev'", specifier = ">=0.22.0,<1" },
+    { name = "zstandard", marker = "extra == 'performance'", specifier = ">=0.22.0,<1" },
 ]
 provides-extras = ["redis", "compression", "performance", "theming", "admin", "deploy", "components", "all", "dev"]
 
@@ -625,7 +625,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "http://127.0.0.1:8418/pypi/simple/" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1633,14 +1633,14 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "7.3.0"
+version = "6.4.0"
 source = { registry = "http://127.0.0.1:8418/pypi/simple/" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/82/4d1a5279f6c1251d3d2a603a798a1137c657de9b12cfc1fba4858232c4d2/redis-7.3.0.tar.gz", hash = "sha256:4d1b768aafcf41b01022410b3cc4f15a07d9b3d6fe0c66fc967da2c88e551034", size = 4928081, upload-time = "2026-03-06T18:18:16.287Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/d6/e8b92798a5bd67d659d51a18170e91c16ac3b59738d91894651ee255ed49/redis-6.4.0.tar.gz", hash = "sha256:b01bc7282b8444e28ec36b261df5375183bb47a07eb9c603f284e89cbc5ef010", size = 4647399, upload-time = "2025-08-07T08:10:11.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/28/84e57fce7819e81ec5aa1bd31c42b89607241f4fb1a3ea5b0d2dbeaea26c/redis-7.3.0-py3-none-any.whl", hash = "sha256:9d4fcb002a12a5e3c3fbe005d59c48a2cc231f87fbb2f6b70c2d89bb64fec364", size = 404379, upload-time = "2026-03-06T18:18:14.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/02/89e2ed7e85db6c93dfa9e8f691c5087df4e3551ab39081a4d7c6d1f90e05/redis-6.4.0-py3-none-any.whl", hash = "sha256:f0544fa9604264e9464cdf4814e7d4830f74b165d52f2a330a760a88dd248b7f", size = 279847, upload-time = "2025-08-07T08:10:09.84Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Security + cleanup PR closing 4 issues from the v0.5.2 triage queue.

### #935 — Fix 3 pre-existing test failures on main
Three tests asserted that sensitive exception details (class name `RuntimeError`, internal method names like `missing_method`) would be echoed back to API clients. The implementations in `api/dispatch.py` and `observability/views.py` deliberately sanitize these — they return generic messages (`"Response transform raised an unexpected error"`, `"handler raised — see server logs"`) and route details to server logs. This is the **correct** security-hardened behavior; the tests were stale. Updated the assertions to verify the sanitized contract (`"server logs"` substring, `handler_name` / `session_id` echoed back) instead of the leaked details.

Affected tests:
- `python/djust/tests/test_api_response.py::test_dispatch_serialize_str_missing_method_returns_500`
- `python/djust/tests/test_observability_eval_handler.py::test_eval_500_when_handler_raises`
- `python/djust/tests/test_observability_reset_view.py::test_reset_500_when_mount_raises`

Note: `make test-python` only runs `tests/` and `python/tests/` — these failing tests live in `python/djust/tests/` and were invisible to the default target. `pytest python/ tests/` catches them.

### #921 — Expand open-redirect audit (beyond PR #920)
- `python/djust/mixins/request.py` — `hook_redirect` returned by developer-defined `on_mount` hooks is now validated via `url_has_allowed_host_and_scheme` before being handed to `HttpResponseRedirect`. Off-site / dangerous targets fall back to `"/"` with a WARNING log.
- `python/djust/auth/mixins.py` — `LoginRequiredLiveViewMixin.dispatch` now validates the computed login URL as defense-in-depth against misconfigured `settings.LOGIN_URL`. Falls back to `/accounts/login/` on failure.

Audited remaining sites in `auth/views.py` and `admin_ext/views.py` — already fixed in PR #920. Other `redirect(...)` call sites use trusted `settings.LOGIN_REDIRECT_URL` / `settings.LOGOUT_REDIRECT_URL` and don't need validation.

### #922 — 7 new edge-case regression tests
Added to `python/djust/tests/test_security_redirects_paths.py`:
- `test_signup_view_rejects_javascript_scheme` — `next=javascript:alert(1)` → fallback
- `test_signup_view_rejects_https_to_http_downgrade` — secure request + `http://` next → fallback
- `test_storybook_rejects_null_byte` — null-byte payloads rejected by frozenset allowlist
- `test_storybook_rejects_uppercase` — case-sensitive allowlist (`FOO` → `""`)
- `test_request_mixin_rejects_unsafe_hook_redirect` — off-site hook return → `/` + WARN
- `test_request_mixin_accepts_safe_hook_redirect` — same-site hook return honored unchanged
- `test_login_required_mixin_rejects_offsite_login_url` — off-site `LOGIN_URL` → `/accounts/login/` fallback

### #910 — Dependency upper-bound ceilings
Added `<N+1` ceilings to every runtime + dev dependency in `pyproject.toml`. Examples:
- `requests>=2.28` → `requests>=2.28,<3`
- `orjson>=3.11.6` → `orjson>=3.11.6,<4`
- `nh3>=0.2` → `nh3>=0.2,<1`
- `redis>=5.0.0` → `redis>=5.0.0,<7`
- `pytest>=7.0` → `pytest>=7.0,<10`
- `pytest-django>=4.5` → `pytest-django>=4.5,<6`

Added a policy comment above `[project.dependencies]` explaining the rationale (referencing PR #909, which caught Django 6.x resolving under `>=4.2`). `uv lock` verified clean — only material change is `redis` 7.3 → 6.4 (now matches `<7` ceiling).

## Test plan

- [x] `pytest python/ tests/` passes (5870 passed, 17 skipped — was 5866 passed + 3 failed on main)
- [x] 12 tests in `test_security_redirects_paths.py` all pass (5 pre-existing + 7 new)
- [x] `uv lock` resolves with no conflicts under new ceilings
- [x] CHANGELOG test-count validator passes
- [x] Ruff + ruff-format clean on all touched files
- [x] Pre-commit + pre-push hooks passed

Closes #910, #921, #922, #935.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>