### PR TITLE
docs: dj-remove gotcha + dj-transition-group precedence + Django classifiers + dj-virtual guide (closes #902, #907, #912, #952)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Docs cleanup: 4 issues closed** — dj-remove no-CSS-transition gotcha (#902), dj-transition-group
+  long-form precedence (#907), Django 5.1 + 5.2 classifiers in `pyproject.toml` (#912), new guide
+  page for `dj-virtual` variable-height mode at `docs/website/guides/virtual-lists.md` (#952).
 - **dj-virtual variable-height items via ResizeObserver — closes #797** —
   PR #796 shipped `dj-virtual` with fixed-height items only. This adds
   opt-in variable-height support via a new `dj-virtual-variable-height`

--- a/docs/website/_config.yaml
+++ b/docs/website/_config.yaml
@@ -111,6 +111,11 @@ navigation:
         file: guides/large-lists.md
         order: 1.5
         level: intermediate
+      - title: Virtual Lists (`dj-virtual`)
+        slug: virtual-lists
+        file: guides/virtual-lists.md
+        order: 1.6
+        level: intermediate
       - title: Presence
         slug: presence
         file: guides/presence.md

--- a/docs/website/guides/declarative-ux-attrs.md
+++ b/docs/website/guides/declarative-ux-attrs.md
@@ -212,6 +212,11 @@ A 600 ms fallback timer finalizes the removal if `transitionend` never fires. Ov
 <li dj-remove="slide-out" dj-remove-duration="500">...</li>
 ```
 
+> **Gotcha — no CSS transition defined**: if the classes in your `dj-remove` spec don't define a
+> `transition:` property, `transitionend` will never fire. The element stays visible for the full
+> 600 ms fallback timer before being removed. Override with `dj-remove-duration="N"` (ms) if your
+> element should disappear faster when the transition is absent.
+
 ### Cancellation
 
 If a subsequent patch removes the `dj-remove` attribute from a pending element, the pending removal cancels: the applied exit classes are stripped, the fallback timer clears, and the element stays mounted.
@@ -261,6 +266,11 @@ The short form splits on `|` into enter / leave halves. Each half accepts the sa
 - Single token (one-class + `transitionend`): `"fade-out"`
 
 An empty half or a missing pipe makes the short form invalid (silently ignored) — use the long form if either half isn't needed.
+
+> **Precedence**: when both short-form (`dj-transition-group="enter | leave"`) and long-form
+> (`dj-group-enter="..."` / `dj-group-leave="..."`) attributes are present on the same parent,
+> the **long form wins**. This lets you use the compact short form as a default and selectively
+> override one half with the long form per-parent.
 
 ### Initial children
 

--- a/docs/website/guides/virtual-lists.md
+++ b/docs/website/guides/virtual-lists.md
@@ -1,0 +1,64 @@
+# Virtual lists (`dj-virtual`)
+
+Render large lists (1000s of items) with only the visible window in the DOM. Uses absolute
+positioning + translateY to maintain scroll semantics while reusing a small rendering window.
+
+## Quick start
+
+### Fixed-height items (simplest)
+
+```html
+<div dj-virtual dj-virtual-item-height="50">
+    {% for item in items %}
+        <div>{{ item }}</div>
+    {% endfor %}
+</div>
+```
+
+All items must render at the exact pixel height specified. Faster (no measurement needed) but
+breaks silently if your CSS or content produces a different height.
+
+### Variable-height items (opt-in)
+
+```html
+<div dj-virtual dj-virtual-variable-height dj-virtual-estimated-height="60">
+    {% for item in items %}
+        <div>{{ item.variable_content }}</div>
+    {% endfor %}
+</div>
+```
+
+A `ResizeObserver` measures each rendered item and caches its height. Unmeasured items (still
+off-screen) use `dj-virtual-estimated-height` (default `50`) as a placeholder.
+
+## Tuning `dj-virtual-estimated-height`
+
+The estimated height affects:
+- **Scrollbar stability**: if the estimate is much LOWER than actual average, the scrollbar
+  jumps when items scroll into view and reveal their true (larger) height. The container's
+  total-height estimate grows, pushing the scroll position.
+- **Blank tail regions**: if the estimate is much HIGHER than actual, the virtualizer reserves
+  more space than needed and you see blank area past the last item.
+
+Rule of thumb: set estimated to the **average expected height** of your items. For chat bubbles
+with variable text content, measuring a handful of representative items and averaging is enough.
+
+## Interaction with item reorders
+
+The current height cache is keyed by item index. If you reorder items (sort, insertion in the
+middle), cached heights bind to the wrong items until re-measurement happens when each scrolls
+back into view. For frequently-reordered lists, a `data-key`-based cache is planned (tracking
+issue #951).
+
+## When to use variable vs fixed
+
+- **Fixed**: stable, known-height content. Tables with fixed row heights, avatars-only lists,
+  CSS-grid-constrained items.
+- **Variable**: user-generated or dynamic content. Chat messages, markdown-rendered posts,
+  cards with variable internal layout.
+
+## See also
+
+- `dj-infinite-scroll` — pagination trigger on scroll-near-bottom
+- `stream` / `stream_append` / `stream_prune` — for large append-only data where virtualization
+  is overkill

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -38,6 +38,7 @@ How to build specific features.
 |                                                        |                                                           |
 | ------------------------------------------------------ | --------------------------------------------------------- |
 | **[Streaming](guides/streaming.md)**                   | Real-time partial DOM updates for LLM chat and live feeds |
+| **[Virtual Lists (`dj-virtual`)](guides/virtual-lists.md)** | Render 1000s of items with only the visible window in the DOM (fixed + variable height) |
 | **[Flash Messages](guides/flash-messages.md)**         | Transient notifications with `put_flash` (Phoenix-style)  |
 | **[Presence](guides/presence.md)**                     | Track online users, live cursors, typing indicators       |
 | **[Uploads](guides/uploads.md)**                       | Chunked binary file uploads via WebSocket                 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary

Single drain PR closing four documentation issues:

- **#902** — `dj-remove` no-CSS-transition gotcha. Added a callout to `docs/website/guides/declarative-ux-attrs.md` explaining that if the `dj-remove` spec lacks a `transition:` CSS property, `transitionend` never fires and the element stays visible for the full 600 ms fallback. Points to `dj-remove-duration="N"` as the override.
- **#907** — `dj-transition-group` long-form precedence. Added a callout in the same file clarifying that when both short-form (`dj-transition-group="enter | leave"`) and long-form (`dj-group-enter` / `dj-group-leave`) attributes are present, **long form wins**.
- **#912** — Added `Framework :: Django :: 5.1` and `Framework :: Django :: 5.2` classifiers to `pyproject.toml` alongside the existing 4.2 and 5.0 entries.
- **#952** — New `docs/website/guides/virtual-lists.md` guide covering `dj-virtual` fixed- vs variable-height modes, `dj-virtual-estimated-height` tuning, reorder caveats (tracking issue #951), and when to use each mode. Linked from `docs/website/index.md` and `docs/website/_config.yaml`.

CHANGELOG updated under `[Unreleased] → Added`.

## Test plan

- [x] `make test-python` — 3445 passed, 15 skipped (no regressions)
- [x] pre-commit hooks pass (CHANGELOG test-count validator included)
- [ ] Visual check that new guide renders on docs site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)