### PR TITLE
cleanup: hygiene batch — ruff bump + format drift + suspense nits + data-hook escape (closes #791, #794, #795, #818, #948)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 repos:
   # Python - Ruff for linting and formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.15.11
     hooks:
       # Linter
       - id: ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Hygiene batch (closes #791, #794, #795, #818, #948)** — bumped `ruff-pre-commit` from v0.8.4 to
+  v0.15.11 (#948) and applied `ruff format` to all resulting drift (#791 — expanded beyond the
+  original 5 files due to modern-ruff disagreements; 19 files total across `python/djust/` and
+  `tests/`). Added `logger.debug` notice in `components/suspense.py` when
+  `{% dj_suspense await=X %}` receives a non-AsyncResult value so a typo surfaces during
+  development (#794), simplified a redundant `or not value.ok` check near `suspense.py:138` given
+  the AsyncResult mutually-exclusive-flag invariant (#795), wrapped the namespaced `data-hook`
+  attribute value with `django.utils.html.escape()` for defense-in-depth in
+  `templatetags/live_tags.py` (#818), and corrected stale test-count claims in two historical
+  CHANGELOG bullets (`test_assign_async.py` 11 → 18, `test_suspense.py` 11 → 12) flagged by
+  the #795 reviewer. No behavior change.
+
 - **Security + cleanup: pre-existing test failures, redirect audit, dep ceilings, edge tests — closes #910, #921, #922, #935** —
   **#935**: fixed 3 stale test assertions that were checking for leaked
   exception-class names in API error responses. The implementations in
@@ -428,8 +440,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Tests
 
 - **Regression coverage for `temporary_assigns`** — `tests/unit/test_temporary_assigns.py` covers reset-after-render semantics, default-value cloning per type (list / dict / set / scalar), idempotent initialization, pre-existing-attribute preservation, instance-level override, and the empty-mapping no-op path.
-- **Unit tests for `assign_async` / `AsyncResult`** — `tests/unit/test_assign_async.py` (11 tests) covers state-flag invariants, frozen dataclass immutability, pending-is-set-immediately, success & failure propagation, multi-concurrent scheduling, cancellation interop with `cancel_async`, sync and async loaders, and args/kwargs forwarding.
-- **Unit tests for `{% dj_suspense %}`** — `tests/unit/test_suspense.py` (11 tests) covers ok → body, loading → fallback, failed → error-div, HTML-escaped error messages, no-`await=` passthrough, unknown / non-`AsyncResult` refs defaulting to loading, default spinner, Django template fallback, template-error graceful degradation, nesting, and whitespace-tolerant comma-separated lists.
+- **Unit tests for `assign_async` / `AsyncResult`** — `tests/unit/test_assign_async.py` (18 tests) covers state-flag invariants, frozen dataclass immutability, pending-is-set-immediately, success & failure propagation, multi-concurrent scheduling, cancellation interop with `cancel_async`, sync and async loaders, args/kwargs forwarding, and the generation-counter / stale-loader regression cases added in #793.
+- **Unit tests for `{% dj_suspense %}`** — `tests/unit/test_suspense.py` (12 tests) covers ok → body, loading → fallback, failed → error-div, HTML-escaped error messages, no-`await=` passthrough, unknown / non-`AsyncResult` refs defaulting to loading, default spinner, Django template fallback, template-error graceful degradation, nesting, and whitespace-tolerant comma-separated lists.
 - **Regression suite for `|safe` HTML blob diff ([#783](https://github.com/djust-org/djust/issues/783))** — `tests/test_rust_vdom_safe_diff_783.py` exercises the WizardMixin-style pattern where `field_html` is derived in `get_context_data()` from an instance attribute. Covers dict reassignment, in-place nested mutation, the `_force_full_html` codepath, an `{% if %}` branch swap, a `{% extends %}`/`{% block %}` inheritance chain, and the exact NYC-Claims-style `{% extends %} + {% if %} + {% include %}` structure that originally exhibited the bug. All variants assert non-empty VDOM patches on state change.
 - **Dep-extractor hardening ([#783](https://github.com/djust-org/djust/issues/783) follow-up, P0)** — Three-part hardening against silent dep-drop regressions in `crates/djust_templates/src/parser.rs::extract_from_nodes`:
   - **Rust unit tests for `extract_per_node_deps`** — table-driven assertions on representative AST shapes (simple Variable, If-wrapping-Include, For with tuple unpacking, With + body, InlineIf condition, nested For, Block recursion, plain Text). Explicit `"*"` wildcard membership checks for nested `Include` / `CustomTag` shapes.

--- a/python/djust/components/suspense.py
+++ b/python/djust/components/suspense.py
@@ -135,12 +135,23 @@ class SuspenseTagHandler:
                 if value.failed:
                     any_failed_error = value.error
                     break
-                if value.loading or not value.ok:
+                # AsyncResult guarantees exactly one of loading/ok/failed is
+                # True (see AsyncResult.__post_init__), so `not value.ok` is
+                # redundant once `failed` is ruled out — `value.loading` is
+                # sufficient.
+                if value.loading:
                     any_loading = True
             else:
                 # Unknown / missing / non-AsyncResult refs are treated as
                 # loading — defensive default so a typo doesn't silently
-                # render stale content.
+                # render stale content. Emit a debug log so the typo case
+                # surfaces during development.
+                if value is not None:
+                    logger.debug(
+                        "dj_suspense await=%s expected AsyncResult, got %s",
+                        ref_name,
+                        type(value).__name__,
+                    )
                 any_loading = True
 
         if any_failed_error is not None:

--- a/python/djust/mixins/request.py
+++ b/python/djust/mixins/request.py
@@ -82,7 +82,7 @@ class RequestMixin:
                 require_https=request.is_secure(),
             ):
                 logger.warning(
-                    "on_mount hook returned unsafe redirect URL for %s; " "falling back to '/'",
+                    "on_mount hook returned unsafe redirect URL for %s; falling back to '/'",
                     self.__class__.__name__,
                 )
                 return HttpResponseRedirect("/")

--- a/python/djust/templatetags/live_tags.py
+++ b/python/djust/templatetags/live_tags.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, Optional
 from django import template
 from django.conf import settings
 from django.template import Node, TemplateSyntaxError
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
 from .._html import build_tag
@@ -628,13 +629,18 @@ class ColocatedHookNode(Node):
         # the matched text inside the escaped form so the body remains
         # readable to a human auditor.
         safe_body = _SCRIPT_CLOSE_RE.sub(r"<\\/\1>", body)
+        # Escape the namespaced name for the data-hook attribute as
+        # defense-in-depth: names are developer-controlled (not user input),
+        # but a stray quote or HTML-special char would break the attribute.
+        # The banner uses the raw name — it's inside a JS comment, not markup.
+        safe_hook_name = escape(namespaced)
         banner = "/* COLOCATED HOOK: " + namespaced + " */"
         # Build the tag via concatenation (no f-string interpolation with
-        # mark_safe per CLAUDE.md rules). `namespaced` is a template-author
-        # supplied identifier; `safe_body` has been </script>-escaped above.
+        # mark_safe per CLAUDE.md rules). `safe_hook_name` is HTML-escaped
+        # above; `safe_body` has been </script>-escaped above.
         html = (
             '<script type="djust/hook" data-hook="'
-            + namespaced
+            + safe_hook_name
             + '">'
             + banner
             + "\n"

--- a/python/djust/tests/test_observability_dry_run.py
+++ b/python/djust/tests/test_observability_dry_run.py
@@ -117,9 +117,9 @@ def test_context_records_without_blocking_when_block_false():
     kinds = {v["kind"] for v in ctx.violations}
     assert "email" in kinds, "expected block=False to record an email violation"
     # 2. Original call-through actually fired.
-    assert (
-        fake_send.call_count == 1
-    ), "block=False must invoke the original callable — not just record the attempt"
+    assert fake_send.call_count == 1, (
+        "block=False must invoke the original callable — not just record the attempt"
+    )
 
 
 def test_context_unpatch_on_exit():
@@ -164,9 +164,9 @@ def test_context_uninstall_failure_is_logged_not_swallowed(caplog):
         ctx.__exit__(None, None, None)
 
     # _uninstall should have logged the failure, not silently swallowed.
-    assert any(
-        "failed to restore" in rec.getMessage() for rec in caplog.records
-    ), "DryRunContext._uninstall must log when setattr fails"
+    assert any("failed to restore" in rec.getMessage() for rec in caplog.records), (
+        "DryRunContext._uninstall must log when setattr fails"
+    )
     # And the patch table is cleared regardless.
     assert ctx._patches == []
 
@@ -315,9 +315,9 @@ def test_endpoint_dry_run_record_mode_no_block():
 
     # Recorded side effect surfaces in the response.
     recorded = data.get("recorded_side_effects", [])
-    assert any(
-        v.get("kind") == "http" for v in recorded
-    ), "dry_run_block=False must record the http attempt"
+    assert any(v.get("kind") == "http" for v in recorded), (
+        "dry_run_block=False must record the http attempt"
+    )
 
     # Original callable actually ran.
     assert fake_get.call_count == 1, "original requests.get should have been invoked"

--- a/python/djust/tests/test_tag_input_932.py
+++ b/python/djust/tests/test_tag_input_932.py
@@ -22,9 +22,9 @@ def test_tag_input_renders_name_attribute():
     comp = TagInput(name="skills", tags=["python", "rust"])
     html = comp._render_custom()
 
-    assert (
-        'name="skills"' in html
-    ), "TagInput output must carry a `name=` attribute so form POSTs include the field value"
+    assert 'name="skills"' in html, (
+        "TagInput output must carry a `name=` attribute so form POSTs include the field value"
+    )
 
 
 def test_tag_input_hidden_input_carries_csv_of_tags():

--- a/python/djust/tests/test_template_resolution.py
+++ b/python/djust/tests/test_template_resolution.py
@@ -138,6 +138,6 @@ def test_duplicate_base_templates_use_first():
             "templates/base.html MUST have dependencies_css block "
             "(this is the file Django finds first!)"
         )
-        assert (
-            "dependencies_css" in demo_app_content
-        ), "demo_app/templates/base.html should also have dependencies_css block for consistency"
+        assert "dependencies_css" in demo_app_content, (
+            "demo_app/templates/base.html should also have dependencies_css block for consistency"
+        )

--- a/python/djust/tests/test_theming_cross_theme_qa.py
+++ b/python/djust/tests/test_theming_cross_theme_qa.py
@@ -209,17 +209,17 @@ class TestCSSGeneration:
         """Generated CSS must be substantial — not a stub."""
         preset, design_system = theme_combo
         css = all_generated_css[(preset, design_system)]
-        assert (
-            len(css) >= 10_000
-        ), f"{preset}+{design_system}: CSS is only {len(css)} bytes — expected ≥10 KB"
+        assert len(css) >= 10_000, (
+            f"{preset}+{design_system}: CSS is only {len(css)} bytes — expected ≥10 KB"
+        )
 
     def test_css_layer_declaration(self, theme_combo, all_generated_css):
         """@layer declaration must appear and include expected layers."""
         preset, design_system = theme_combo
         css = all_generated_css[(preset, design_system)]
-        assert (
-            "@layer base, tokens, components" in css
-        ), f"{preset}+{design_system}: Missing @layer declaration"
+        assert "@layer base, tokens, components" in css, (
+            f"{preset}+{design_system}: Missing @layer declaration"
+        )
 
     def test_tokens_layer_present(self, theme_combo, all_generated_css):
         preset, design_system = theme_combo
@@ -243,18 +243,18 @@ class TestLightModeTokens:
     def test_root_selector_present(self, theme_combo, all_generated_css):
         preset, design_system = theme_combo
         css = all_generated_css[(preset, design_system)]
-        assert (
-            ":root {" in css or ":root\n{" in css
-        ), f"{preset}+{design_system}: No :root token block found"
+        assert ":root {" in css or ":root\n{" in css, (
+            f"{preset}+{design_system}: No :root token block found"
+        )
 
     @pytest.mark.parametrize("token", REQUIRED_LIGHT_TOKENS)
     def test_required_token_in_root(self, token, theme_combo, all_generated_css):
         preset, design_system = theme_combo
         css = all_generated_css[(preset, design_system)]
         # Token must appear somewhere in a :root-scope or html[data-theme="light"]
-        assert re.search(
-            rf"{re.escape(token)}\s*:", css
-        ), f"{preset}+{design_system}: Required token '{token}' not found in CSS"
+        assert re.search(rf"{re.escape(token)}\s*:", css), (
+            f"{preset}+{design_system}: Required token '{token}' not found in CSS"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -268,24 +268,24 @@ class TestDarkModeTokens:
     def test_dark_theme_selector_present(self, theme_combo, all_generated_css):
         preset, design_system = theme_combo
         css = all_generated_css[(preset, design_system)]
-        assert (
-            'html[data-theme="dark"]' in css
-        ), f"{preset}+{design_system}: No html[data-theme=dark] selector"
+        assert 'html[data-theme="dark"]' in css, (
+            f"{preset}+{design_system}: No html[data-theme=dark] selector"
+        )
 
     def test_prefers_color_scheme_dark_media_query(self, theme_combo, all_generated_css):
         preset, design_system = theme_combo
         css = all_generated_css[(preset, design_system)]
-        assert (
-            "@media (prefers-color-scheme: dark)" in css
-        ), f"{preset}+{design_system}: Missing prefers-color-scheme: dark media query"
+        assert "@media (prefers-color-scheme: dark)" in css, (
+            f"{preset}+{design_system}: Missing prefers-color-scheme: dark media query"
+        )
 
     def test_light_theme_explicit_selector(self, theme_combo, all_generated_css):
         """html[data-theme=light] must also be defined for explicit switching."""
         preset, design_system = theme_combo
         css = all_generated_css[(preset, design_system)]
-        assert (
-            'html[data-theme="light"]' in css
-        ), f"{preset}+{design_system}: No html[data-theme=light] explicit selector"
+        assert 'html[data-theme="light"]' in css, (
+            f"{preset}+{design_system}: No html[data-theme=light] explicit selector"
+        )
 
     @pytest.mark.parametrize("token", REQUIRED_DARK_TOKENS)
     def test_dark_block_contains_token(self, token, theme_combo, all_generated_css):
@@ -307,9 +307,9 @@ class TestDarkModeTokens:
                     break
         dark_block = css[brace_start:end]
 
-        assert re.search(
-            rf"{re.escape(token)}\s*:", dark_block
-        ), f"{preset}+{design_system}: Dark block missing token '{token}'"
+        assert re.search(rf"{re.escape(token)}\s*:", dark_block), (
+            f"{preset}+{design_system}: Dark block missing token '{token}'"
+        )
 
     def test_dark_background_differs_from_light(self, theme_combo, all_generated_css):
         """Dark --background must be a different value than light --background."""
@@ -319,16 +319,16 @@ class TestDarkModeTokens:
         light_match = re.search(r'html\[data-theme="light"\]\s*\{([^}]+)\}', css, re.DOTALL)
         dark_match = re.search(r'html\[data-theme="dark"\]\s*\{([^}]+)\}', css, re.DOTALL)
 
-        assert (
-            light_match and dark_match
-        ), f"{preset}+{design_system}: Could not find light/dark theme blocks"
+        assert light_match and dark_match, (
+            f"{preset}+{design_system}: Could not find light/dark theme blocks"
+        )
 
         light_bg = re.search(r"--background:\s*([^;]+);", light_match.group(1))
         dark_bg = re.search(r"--background:\s*([^;]+);", dark_match.group(1))
 
-        assert (
-            light_bg and dark_bg
-        ), f"{preset}+{design_system}: --background not found in light or dark block"
+        assert light_bg and dark_bg, (
+            f"{preset}+{design_system}: --background not found in light or dark block"
+        )
         assert light_bg.group(1).strip() != dark_bg.group(1).strip(), (
             f"{preset}+{design_system}: Light and dark --background are identical "
             f"({light_bg.group(1).strip()}) — dark mode has no effect"
@@ -355,9 +355,9 @@ class TestThemeSwitching:
         """Users with reduced-motion preference should not see transitions."""
         preset, design_system = theme_combo
         css = all_generated_css[(preset, design_system)]
-        assert (
-            "prefers-reduced-motion" in css
-        ), f"{preset}+{design_system}: Missing prefers-reduced-motion support"
+        assert "prefers-reduced-motion" in css, (
+            f"{preset}+{design_system}: Missing prefers-reduced-motion support"
+        )
 
     def test_root_tokens_before_dark_section(self, theme_combo, all_generated_css):
         """CSS cascade must define :root tokens before dark overrides."""
@@ -393,9 +393,9 @@ class TestComponentRendering:
         with patch.object(settings, "LIVEVIEW_CONFIG", {}, create=True):
             result = str(tag_fn(ctx, **args))
 
-        assert (
-            result is not None
-        ), f"{preset}+{design_system}/{component_name}: render returned None"
+        assert result is not None, (
+            f"{preset}+{design_system}/{component_name}: render returned None"
+        )
 
     @pytest.mark.parametrize("component_name", sorted(COMPONENT_MINIMAL_ARGS.keys()))
     def test_component_output_not_empty(self, component_name, theme_combo):
@@ -420,9 +420,9 @@ class TestComponentRendering:
         with patch.object(settings, "LIVEVIEW_CONFIG", {}, create=True):
             result = str(tag_fn(ctx, **args))
 
-        assert (
-            "<" in result
-        ), f"{preset}+{design_system}/{component_name}: output contains no HTML tags"
+        assert "<" in result, (
+            f"{preset}+{design_system}/{component_name}: output contains no HTML tags"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/python/djust/tests/test_theming_css_layers.py
+++ b/python/djust/tests/test_theming_css_layers.py
@@ -275,9 +275,9 @@ class TestStaticComponentsCSS:
         )
         # And no stray @layer blocks snuck in. (The substring "@layer" may
         # appear inside the header comment — match the actual block syntax.)
-        assert not re.search(
-            r"@layer\s+\w+\s*\{", css
-        ), "components.css should not contain any @layer blocks"
+        assert not re.search(r"@layer\s+\w+\s*\{", css), (
+            "components.css should not contain any @layer blocks"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/python/djust/tests/test_theming_manifest.py
+++ b/python/djust/tests/test_theming_manifest.py
@@ -343,9 +343,9 @@ class TestVersionValidation:
             manifest = ThemeManifest(name="test", version=version)
             errors = manifest.validate()
             version_errors = [e for e in errors if "version" in e.lower()]
-            assert (
-                version_errors == []
-            ), f"Version '{version}' should be valid but got: {version_errors}"
+            assert version_errors == [], (
+                f"Version '{version}' should be valid but got: {version_errors}"
+            )
 
     def test_invalid_semver_versions(self):
         for version in ("not-a-version", "1.0", "1", "v1.0.0", "1.0.0.0", "foo.bar.baz"):

--- a/python/djust/tests/test_theming_palette.py
+++ b/python/djust/tests/test_theming_palette.py
@@ -104,9 +104,9 @@ class TestOutputValidation:
         for mode_label, tokens in [("light", preset.light), ("dark", preset.dark)]:
             for field_name in field_names:
                 val = getattr(tokens, field_name)
-                assert isinstance(
-                    val, ColorScale
-                ), f"{mode_label}.{field_name} is {type(val).__name__}, expected ColorScale"
+                assert isinstance(val, ColorScale), (
+                    f"{mode_label}.{field_name} is {type(val).__name__}, expected ColorScale"
+                )
 
     def test_preset_name_generated(self, preset):
         assert isinstance(preset.name, str) and len(preset.name) > 0
@@ -185,16 +185,16 @@ class TestWCAGContrast:
     def test_all_fg_bg_pairs_pass_aa_light(self, preset):
         for name, fg, bg in _all_fg_bg_pairs(preset.light):
             ratio = self.validator.calculate_contrast_ratio(fg, bg)
-            assert (
-                ratio >= 4.5
-            ), f"Light {name}: contrast {ratio:.2f} < 4.5:1 (fg={fg.to_hsl()}, bg={bg.to_hsl()})"
+            assert ratio >= 4.5, (
+                f"Light {name}: contrast {ratio:.2f} < 4.5:1 (fg={fg.to_hsl()}, bg={bg.to_hsl()})"
+            )
 
     def test_all_fg_bg_pairs_pass_aa_dark(self, preset):
         for name, fg, bg in _all_fg_bg_pairs(preset.dark):
             ratio = self.validator.calculate_contrast_ratio(fg, bg)
-            assert (
-                ratio >= 4.5
-            ), f"Dark {name}: contrast {ratio:.2f} < 4.5:1 (fg={fg.to_hsl()}, bg={bg.to_hsl()})"
+            assert ratio >= 4.5, (
+                f"Dark {name}: contrast {ratio:.2f} < 4.5:1 (fg={fg.to_hsl()}, bg={bg.to_hsl()})"
+            )
 
     def test_border_contrast_minimum_light(self, preset):
         ratio = self.validator.calculate_contrast_ratio(

--- a/python/djust/tests/test_websocket_lifecycle_hooks.py
+++ b/python/djust/tests/test_websocket_lifecycle_hooks.py
@@ -87,9 +87,9 @@ class TestHandleMountLifecycleHooks:
             view._ensure_tenant(request)
         view.mount(request)
 
-        assert (
-            view._hook_called_before_mount_body
-        ), "_ensure_tenant() was not called before the mount() body executed"
+        assert view._hook_called_before_mount_body, (
+            "_ensure_tenant() was not called before the mount() body executed"
+        )
 
     def test_no_error_when_hook_absent(self):
         """Views without _ensure_tenant should mount without error."""

--- a/tests/test_query_optimizer_integration.py
+++ b/tests/test_query_optimizer_integration.py
@@ -181,9 +181,9 @@ class QueryOptimizationIntegrationTestCase(TestCase):
         queries_with = len(ctx_opt.captured_queries)
 
         # Should reduce queries significantly
-        assert (
-            queries_with < queries_without
-        ), f"Expected fewer queries with optimization: {queries_with} vs {queries_without}"
+        assert queries_with < queries_without, (
+            f"Expected fewer queries with optimization: {queries_with} vs {queries_without}"
+        )
         # Should ideally be 1 query
         assert queries_with <= 2, f"Expected <= 2 queries with optimization, got {queries_with}"
 
@@ -390,9 +390,9 @@ class PerformanceTestCase(TestCase):
 
         # Should reduce from ~41 queries to 1 query
         # (1 for leases + 20 for properties + 20 for tenants -> 1 query with JOINs)
-        assert (
-            queries_without >= 40
-        ), f"Expected >= 40 queries without optimization, got {queries_without}"
+        assert queries_without >= 40, (
+            f"Expected >= 40 queries without optimization, got {queries_without}"
+        )
         assert queries_with == 1, f"Expected 1 query with optimization, got {queries_with}"
 
         # Calculate improvement

--- a/tests/test_rust_vdom_safe_diff_783.py
+++ b/tests/test_rust_vdom_safe_diff_783.py
@@ -77,13 +77,13 @@ def _patches_list(patches_json):
 def _assert_produces_patch(html, patches_json, *, new_value, old_value=""):
     """Common assertions across all variants."""
     patches = _patches_list(patches_json)
-    assert (
-        f'value="{new_value}"' in html
-    ), f"rendered HTML must reflect the new |safe value; html={html!r}"
+    assert f'value="{new_value}"' in html, (
+        f"rendered HTML must reflect the new |safe value; html={html!r}"
+    )
     if old_value:
-        assert (
-            f'value="{old_value}"' not in html
-        ), f"rendered HTML must no longer contain the old value {old_value!r}"
+        assert f'value="{old_value}"' not in html, (
+            f"rendered HTML must no longer contain the old value {old_value!r}"
+        )
     assert patches is not None and len(patches) > 0, (
         f"expected non-empty patches; patches={patches!r} — "
         "empty patches with diff_ms=0 is the #783 symptom."
@@ -156,9 +156,9 @@ class TestDerivedSafeBlobDiff:
         # OR a None/absent patches field are both acceptable — the websocket
         # layer may emit a full-html update instead of patches when
         # _force_full_html is set.
-        assert not (
-            patches is not None and len(patches) == 0
-        ), f"empty patches with _force_full_html is the #783 symptom; got patches={patches!r}"
+        assert not (patches is not None and len(patches) == 0), (
+            f"empty patches with _force_full_html is the #783 symptom; got patches={patches!r}"
+        )
 
     def test_step_index_plus_data_change(self):
         """Simulates the ``demo_autofill`` → ``next_step`` sequence:
@@ -194,12 +194,12 @@ class TestDerivedSafeBlobDiff:
         html, patches_json, version = _simulate_event_cycle(view, mutate)
         patches = _patches_list(patches_json)
         assert version == 2
-        assert (
-            'name="incident_type"' in html
-        ), f"step swap must surface the new branch's field; html={html!r}"
-        assert (
-            patches is not None and len(patches) > 0
-        ), f"step swap must produce patches; patches={patches!r}"
+        assert 'name="incident_type"' in html, (
+            f"step swap must surface the new branch's field; html={html!r}"
+        )
+        assert patches is not None and len(patches) > 0, (
+            f"step swap must produce patches; patches={patches!r}"
+        )
 
 
 class TestDerivedSafeBlobDiffExtends:
@@ -322,12 +322,12 @@ class TestSafeBlobDiffNestedInclude:
         html, patches_json, version = _simulate_event_cycle(view, mutate)
         patches = _patches_list(patches_json)
         assert version == 2
-        assert (
-            html.count('class="active"') == 3
-        ), f"inline-if condition change must re-render the for body; html={html!r}"
-        assert (
-            patches is not None and len(patches) > 0
-        ), f"expected non-empty patches; got {patches!r} — latent #783 sibling."
+        assert html.count('class="active"') == 3, (
+            f"inline-if condition change must re-render the for body; html={html!r}"
+        )
+        assert patches is not None and len(patches) > 0, (
+            f"expected non-empty patches; got {patches!r} — latent #783 sibling."
+        )
 
     def test_if_include_wrapping_produces_patches(self, template_dir):
         class NestedWizard(_WizardLike):
@@ -596,10 +596,7 @@ class TestPartialRenderCorrectness:
 
         class StandaloneBlockView(LiveView):
             template = (
-                "<div dj-root>"
-                "{% block header %}<h1>{{ title }}</h1>{% endblock %}"
-                "<p>body</p>"
-                "</div>"
+                "<div dj-root>{% block header %}<h1>{{ title }}</h1>{% endblock %}<p>body</p></div>"
             )
 
             def mount(self, request, **kwargs):
@@ -639,9 +636,7 @@ class TestPartialRenderCorrectness:
         ``obj.field|filter|another``."""
 
         class FilterChainView(LiveView):
-            template = (
-                "<div dj-root>" "<span>{{ user.name|lower|truncatechars:10 }}</span>" "</div>"
-            )
+            template = "<div dj-root><span>{{ user.name|lower|truncatechars:10 }}</span></div>"
 
             def mount(self, request, **kwargs):
                 self.user = {"name": "Alice"}

--- a/tests/unit/test_assign_async.py
+++ b/tests/unit/test_assign_async.py
@@ -253,9 +253,9 @@ def test_stale_loader_cannot_overwrite_newer_pending_state():
     # returned). It must NOT write over the fresh pending state.
     slow_cb(*slow_args, **slow_kwargs)
     assert slow_returned == ["slow"]  # the loader actually ran
-    assert (
-        view.metrics.loading is True
-    ), "stale runner overwrote fresh pending state — #793 regression"
+    assert view.metrics.loading is True, (
+        "stale runner overwrote fresh pending state — #793 regression"
+    )
 
     # Now drain the fresh runner — it should succeed normally.
     fast_cb, fast_args, fast_kwargs = view._async_tasks.pop("assign_async:metrics")

--- a/tests/unit/test_client_minified.py
+++ b/tests/unit/test_client_minified.py
@@ -87,8 +87,7 @@ def _extract_client_src(html_with_injected_script: str) -> str:
     )
     if not m:
         raise AssertionError(
-            f"no djust client <script> tag found in injected HTML: "
-            f"{html_with_injected_script!r}"
+            f"no djust client <script> tag found in injected HTML: {html_with_injected_script!r}"
         )
     return m.group(1)
 
@@ -108,9 +107,9 @@ def test_debug_uses_unminified_client_js():
     view = _FakeView()
     injected = view._inject_client_script("<html><body></body></html>")
     src = _extract_client_src(injected)
-    assert src.endswith("client.js") and not src.endswith(
-        ".min.js"
-    ), f"expected client.js in debug; got {src!r}"
+    assert src.endswith("client.js") and not src.endswith(".min.js"), (
+        f"expected client.js in debug; got {src!r}"
+    )
 
 
 @override_settings(DEBUG=True, DJUST_CLIENT_JS_MINIFIED=True)
@@ -128,6 +127,6 @@ def test_explicit_override_forces_raw_in_production():
     view = _FakeView()
     injected = view._inject_client_script("<html><body></body></html>")
     src = _extract_client_src(injected)
-    assert src.endswith("client.js") and not src.endswith(
-        ".min.js"
-    ), f"override should force raw; got {src!r}"
+    assert src.endswith("client.js") and not src.endswith(".min.js"), (
+        f"override should force raw; got {src!r}"
+    )

--- a/tests/unit/test_colocated_hook_tag.py
+++ b/tests/unit/test_colocated_hook_tag.py
@@ -66,9 +66,9 @@ class TestScriptTagEscaping:
             # rfind to isolate the body region.)
             closing_idx = out.rfind("</script>")
             body_region = out[:closing_idx]
-            assert (
-                bad.lower() not in body_region.lower()
-            ), f"Raw {bad!r} leaked into body region: {body_region!r}"
+            assert bad.lower() not in body_region.lower(), (
+                f"Raw {bad!r} leaked into body region: {body_region!r}"
+            )
             # Escaped form preserves original casing.
             expected_escaped = bad.replace("</", "<\\/")
             assert expected_escaped in out, f"Expected escaped {expected_escaped!r} in {out!r}"

--- a/tests/unit/test_context_processor_caching.py
+++ b/tests/unit/test_context_processor_caching.py
@@ -145,6 +145,6 @@ class TestSettingChangedSignalClearsCaches:
             for r in receivers
             if r[1]() is not None
         )
-        assert (
-            handler_connected
-        ), "_clear_processor_caches is not connected to setting_changed signal"
+        assert handler_connected, (
+            "_clear_processor_caches is not connected to setting_changed signal"
+        )

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -596,12 +596,12 @@ class TestFormChoices:
 
         for field_name, choices in view.form_choices.items():
             for value, label in choices:
-                assert isinstance(
-                    value, str
-                ), f"{field_name} choice value {value!r} is not a string"
-                assert isinstance(
-                    label, str
-                ), f"{field_name} choice label {label!r} is not a string"
+                assert isinstance(value, str), (
+                    f"{field_name} choice value {value!r} is not a string"
+                )
+                assert isinstance(label, str), (
+                    f"{field_name} choice label {label!r} is not a string"
+                )
 
 
 class TestFormInstanceProperty:

--- a/tests/unit/test_jit_short_circuit.py
+++ b/tests/unit/test_jit_short_circuit.py
@@ -27,9 +27,12 @@ class TestJITShortCircuitNonDB:
 
         view = PlainView()
 
-        with patch.object(context_module, "JIT_AVAILABLE", True), patch.object(
-            view, "_get_template_content", wraps=view._get_template_content
-        ) as mock_gtc:
+        with (
+            patch.object(context_module, "JIT_AVAILABLE", True),
+            patch.object(
+                view, "_get_template_content", wraps=view._get_template_content
+            ) as mock_gtc,
+        ):
             ctx = view.get_context_data()
 
         mock_gtc.assert_not_called()
@@ -46,9 +49,12 @@ class TestJITShortCircuitNonDB:
 
         view = DictListView()
 
-        with patch.object(context_module, "JIT_AVAILABLE", True), patch.object(
-            view, "_get_template_content", wraps=view._get_template_content
-        ) as mock_gtc:
+        with (
+            patch.object(context_module, "JIT_AVAILABLE", True),
+            patch.object(
+                view, "_get_template_content", wraps=view._get_template_content
+            ) as mock_gtc,
+        ):
             ctx = view.get_context_data()
 
         mock_gtc.assert_not_called()
@@ -72,9 +78,10 @@ class TestJITShortCircuitWithDB:
 
         view = DBView()
 
-        with patch.object(context_module, "JIT_AVAILABLE", True), patch.object(
-            view, "_get_template_content", return_value=view.template
-        ) as mock_gtc:
+        with (
+            patch.object(context_module, "JIT_AVAILABLE", True),
+            patch.object(view, "_get_template_content", return_value=view.template) as mock_gtc,
+        ):
             view.get_context_data()
 
         mock_gtc.assert_called_once()
@@ -92,9 +99,10 @@ class TestJITShortCircuitWithDB:
         view = ModelView()
         view.profile = user
 
-        with patch.object(context_module, "JIT_AVAILABLE", True), patch.object(
-            view, "_get_template_content", return_value=view.template
-        ) as mock_gtc:
+        with (
+            patch.object(context_module, "JIT_AVAILABLE", True),
+            patch.object(view, "_get_template_content", return_value=view.template) as mock_gtc,
+        ):
             view.get_context_data()
 
         mock_gtc.assert_called_once()
@@ -112,9 +120,10 @@ class TestJITShortCircuitWithDB:
         view = ListModelView()
         view.users = users_list
 
-        with patch.object(context_module, "JIT_AVAILABLE", True), patch.object(
-            view, "_get_template_content", return_value=view.template
-        ) as mock_gtc:
+        with (
+            patch.object(context_module, "JIT_AVAILABLE", True),
+            patch.object(view, "_get_template_content", return_value=view.template) as mock_gtc,
+        ):
             view.get_context_data()
 
         mock_gtc.assert_called_once()
@@ -131,9 +140,12 @@ class TestJITShortCircuitEdgeCases:
 
         view = EmptyView()
 
-        with patch.object(context_module, "JIT_AVAILABLE", True), patch.object(
-            view, "_get_template_content", wraps=view._get_template_content
-        ) as mock_gtc:
+        with (
+            patch.object(context_module, "JIT_AVAILABLE", True),
+            patch.object(
+                view, "_get_template_content", wraps=view._get_template_content
+            ) as mock_gtc,
+        ):
             view.get_context_data()
 
         mock_gtc.assert_not_called()
@@ -150,9 +162,12 @@ class TestJITShortCircuitEdgeCases:
 
         view = MixedView()
 
-        with patch.object(context_module, "JIT_AVAILABLE", True), patch.object(
-            view, "_get_template_content", wraps=view._get_template_content
-        ) as mock_gtc:
+        with (
+            patch.object(context_module, "JIT_AVAILABLE", True),
+            patch.object(
+                view, "_get_template_content", wraps=view._get_template_content
+            ) as mock_gtc,
+        ):
             view.get_context_data()
 
         mock_gtc.assert_not_called()
@@ -167,9 +182,12 @@ class TestJITShortCircuitEdgeCases:
 
         view = EmptyListView()
 
-        with patch.object(context_module, "JIT_AVAILABLE", True), patch.object(
-            view, "_get_template_content", wraps=view._get_template_content
-        ) as mock_gtc:
+        with (
+            patch.object(context_module, "JIT_AVAILABLE", True),
+            patch.object(
+                view, "_get_template_content", wraps=view._get_template_content
+            ) as mock_gtc,
+        ):
             view.get_context_data()
 
         mock_gtc.assert_not_called()

--- a/tests/unit/test_serialize_model.py
+++ b/tests/unit/test_serialize_model.py
@@ -54,9 +54,9 @@ class TestSerializeModelSafelyPrimaryId:
         result = encoder._serialize_model_safely(obj)
 
         assert result["id"] == 42
-        assert isinstance(
-            result["id"], int
-        ), f"Expected int for 'id', got {type(result['id']).__name__!r}"
+        assert isinstance(result["id"], int), (
+            f"Expected int for 'id', got {type(result['id']).__name__!r}"
+        )
 
     def test_pk_is_native_int(self):
         encoder = DjangoJSONEncoder()
@@ -113,9 +113,9 @@ class TestSerializeModelSafelyShallowRepr:
         assert "owner" in result
         owner_repr = result["owner"]
         assert owner_repr["id"] == 77
-        assert isinstance(
-            owner_repr["id"], int
-        ), f"Expected int for shallow repr 'id', got {type(owner_repr['id']).__name__!r}"
+        assert isinstance(owner_repr["id"], int), (
+            f"Expected int for shallow repr 'id', got {type(owner_repr['id']).__name__!r}"
+        )
         assert owner_repr["pk"] == 77
         assert isinstance(owner_repr["pk"], int)
 
@@ -155,9 +155,9 @@ class TestJitSerializeModelNoJit:
         result = tmpl._jit_serialize_model(obj, "todo")
 
         assert result["id"] == 42
-        assert isinstance(
-            result["id"], int
-        ), f"Expected int for JIT-fallback 'id', got {type(result['id']).__name__!r}"
+        assert isinstance(result["id"], int), (
+            f"Expected int for JIT-fallback 'id', got {type(result['id']).__name__!r}"
+        )
 
     def test_fallback_pk_present_and_native_int(self, monkeypatch):
         import djust.template.rendering as rendering_module
@@ -203,9 +203,9 @@ class TestJitSerializeModelErrorFallback:
         result = tmpl._jit_serialize_model(obj, "todo")
 
         assert result["id"] == 42
-        assert isinstance(
-            result["id"], int
-        ), f"Expected int for error-fallback 'id', got {type(result['id']).__name__!r}"
+        assert isinstance(result["id"], int), (
+            f"Expected int for error-fallback 'id', got {type(result['id']).__name__!r}"
+        )
 
     def test_error_fallback_pk_present_and_native_int(self, monkeypatch):
         import djust.template.rendering as rendering_module

--- a/tests/unit/test_tenants.py
+++ b/tests/unit/test_tenants.py
@@ -159,9 +159,9 @@ class TestSubdomainResolver:
         with patch.object(
             resolver,
             "get_config",
-            side_effect=lambda key, default=None: ["www", "api", "admin"]
-            if key == "TENANT_SUBDOMAIN_EXCLUDE"
-            else default,
+            side_effect=lambda key, default=None: (
+                ["www", "api", "admin"] if key == "TENANT_SUBDOMAIN_EXCLUDE" else default
+            ),
         ):
             tenant = resolver.resolve(request)
 
@@ -178,9 +178,9 @@ class TestSubdomainResolver:
         with patch.object(
             resolver,
             "get_config",
-            side_effect=lambda key, default=None: ["www", "api", "admin"]
-            if key == "TENANT_SUBDOMAIN_EXCLUDE"
-            else default,
+            side_effect=lambda key, default=None: (
+                ["www", "api", "admin"] if key == "TENANT_SUBDOMAIN_EXCLUDE" else default
+            ),
         ):
             tenant = resolver.resolve(request)
 
@@ -253,11 +253,13 @@ class TestPathResolver:
         with patch.object(
             resolver,
             "get_config",
-            side_effect=lambda key, default=None: 1
-            if key == "TENANT_PATH_POSITION"
-            else ["admin", "api", "static", "media"]
-            if key == "TENANT_PATH_EXCLUDE"
-            else default,
+            side_effect=lambda key, default=None: (
+                1
+                if key == "TENANT_PATH_POSITION"
+                else ["admin", "api", "static", "media"]
+                if key == "TENANT_PATH_EXCLUDE"
+                else default
+            ),
         ):
             tenant = resolver.resolve(request)
 
@@ -275,11 +277,13 @@ class TestPathResolver:
         with patch.object(
             resolver,
             "get_config",
-            side_effect=lambda key, default=None: 2
-            if key == "TENANT_PATH_POSITION"
-            else ["admin", "api"]
-            if key == "TENANT_PATH_EXCLUDE"
-            else default,
+            side_effect=lambda key, default=None: (
+                2
+                if key == "TENANT_PATH_POSITION"
+                else ["admin", "api"]
+                if key == "TENANT_PATH_EXCLUDE"
+                else default
+            ),
         ):
             tenant = resolver.resolve(request)
 
@@ -297,11 +301,13 @@ class TestPathResolver:
         with patch.object(
             resolver,
             "get_config",
-            side_effect=lambda key, default=None: 1
-            if key == "TENANT_PATH_POSITION"
-            else ["admin", "api", "static", "media"]
-            if key == "TENANT_PATH_EXCLUDE"
-            else default,
+            side_effect=lambda key, default=None: (
+                1
+                if key == "TENANT_PATH_POSITION"
+                else ["admin", "api", "static", "media"]
+                if key == "TENANT_PATH_EXCLUDE"
+                else default
+            ),
         ):
             tenant = resolver.resolve(request)
 
@@ -331,11 +337,13 @@ class TestPathResolver:
         with patch.object(
             resolver,
             "get_config",
-            side_effect=lambda key, default=None: 1
-            if key == "TENANT_PATH_POSITION"
-            else []
-            if key == "TENANT_PATH_EXCLUDE"
-            else default,
+            side_effect=lambda key, default=None: (
+                1
+                if key == "TENANT_PATH_POSITION"
+                else []
+                if key == "TENANT_PATH_EXCLUDE"
+                else default
+            ),
         ):
             tenant = resolver.resolve(request)
 
@@ -356,11 +364,13 @@ class TestPathResolver:
             with patch.object(
                 resolver,
                 "get_config",
-                side_effect=lambda key, default=None: 1
-                if key == "TENANT_PATH_POSITION"
-                else []
-                if key == "TENANT_PATH_EXCLUDE"
-                else default,
+                side_effect=lambda key, default=None: (
+                    1
+                    if key == "TENANT_PATH_POSITION"
+                    else []
+                    if key == "TENANT_PATH_EXCLUDE"
+                    else default
+                ),
             ):
                 tenant = resolver.resolve(request)
 
@@ -443,9 +453,9 @@ class TestSessionResolver:
         with patch.object(
             resolver,
             "get_config",
-            side_effect=lambda key, default=None: "tenant_id"
-            if key in ("TENANT_SESSION_KEY", "TENANT_JWT_CLAIM")
-            else default,
+            side_effect=lambda key, default=None: (
+                "tenant_id" if key in ("TENANT_SESSION_KEY", "TENANT_JWT_CLAIM") else default
+            ),
         ):
             tenant = resolver.resolve(request)
 


### PR DESCRIPTION
## Summary

Batch of 5 hygiene/cosmetic issues (zero behavior change):

- **#948** — bump `ruff-pre-commit` from `v0.8.4` to `v0.15.11`.
- **#791** — apply `ruff format` to all drift from the version bump (19 files total in `python/djust/` and `tests/` — expanded beyond the original 5-file scope due to modern-ruff disagreements).
- **#794** — `logger.debug("dj_suspense await=%s expected AsyncResult, got %s", ...)` when the `{% dj_suspense await=X %}` handler receives a non-`AsyncResult` value, so a typo (`await=metric` instead of `await=metrics`) surfaces during development.
- **#795** — simplify redundant `or not value.ok` check at `components/suspense.py:138` (the `AsyncResult.__post_init__` invariant guarantees exactly one of `loading`/`ok`/`failed` is true, so once `failed` is ruled out, `loading` alone suffices). Also corrected two historical CHANGELOG test-count claims that had drifted: `test_assign_async.py` (11 → 18 with the #793 regression suite) and `test_suspense.py` (11 → 12).
- **#818** — wrap the namespaced `data-hook` attribute value with `django.utils.html.escape()` in `ColocatedHookNode.render` for defense-in-depth. Names are developer-controlled (template-author supplied), not user input — but escaping is cheap and defends against a stray quote breaking the attribute.

## Test plan

- [x] `make test-python` — 3445 passed, 15 skipped
- [x] `.venv/bin/ruff check python/djust/ tests/` — all checks passed with ruff 0.15.11
- [x] `.venv/bin/ruff format --check python/djust/ tests/` — no drift after apply
- [x] pre-commit hooks passed on commit
- [x] pre-push hooks (including full pytest) passed on push
- [x] `scripts/check-changelog-test-counts.py` — exit 0

Closes #791, #794, #795, #818, #948.

🤖 Generated with [Claude Code](https://claude.com/claude-code)