### PR TITLE
fix(framework): A010 proxy-trusted deployments + get_state() internal-attr filter (closes #762, #890)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Framework cleanup (closes #762, #890)** — djust.A010 / A011 system checks now recognize
+  proxy-trusted deployments: when `SECURE_PROXY_SSL_HEADER` + `DJUST_TRUSTED_PROXIES` are both set,
+  `ALLOWED_HOSTS=['*']` is accepted (supports AWS ALB, Cloudflare, Fly.io, and other L7 load
+  balancers where task private IPs rotate). Also filters ~25 framework-internal attrs
+  (`sync_safe`, `login_required`, `template_name`, `http_method_names`, `on_mount_count`,
+  `page_meta`, etc.) from `LiveView.get_state()`, the WS `_snapshot_assigns` change-detection
+  path, and the `_debug.state_sizes` observability payload — user's reactive state is no longer
+  swamped by framework config. Non-breaking fix via a new `live_view._FRAMEWORK_INTERNAL_ATTRS`
+  frozenset; attribute names unchanged. 14 new regression tests in
+  `python/djust/tests/test_a010_proxy_trusted_890.py` and
+  `python/djust/tests/test_get_state_filter_762.py`. Deployment guide updated with the
+  proxy-trusted escape-hatch pattern.
 - **JS-centric batch (closes #949, #951, #953)** — tag_input hidden-input payload now JSON-encoded
   instead of comma-separated, so tag values containing commas round-trip intact (#949). dj-virtual
   variable-height cache now keyed by `data-key` attribute (configurable via `dj-virtual-key-attr`),

--- a/docs/website/guides/deployment.md
+++ b/docs/website/guides/deployment.md
@@ -279,6 +279,38 @@ def health_check(request):
         return JsonResponse({'status': 'unhealthy', 'error': str(e)}, status=503)
 ```
 
+## Deploying Behind an L7 Load Balancer (AWS ALB, Cloudflare, Fly.io)
+
+When djust runs behind a trusted L7 load balancer that terminates TLS and health-checks
+task IPs directly (AWS ALB, Cloudflare, Fly.io, GCP External HTTP(S) LB, etc.), the task's
+private IP rotates on every redeploy or autoscale event. Enumerating them in
+`ALLOWED_HOSTS` is not feasible, and setting `ALLOWED_HOSTS = ['*']` normally trips
+the `djust.A010` system check.
+
+djust provides an explicit opt-in for this topology: set **both** `SECURE_PROXY_SSL_HEADER`
+and a new `DJUST_TRUSTED_PROXIES` list/tuple, and `djust.A010` / `djust.A011` will recognize
+that the trusted proxy has already performed Host validation at the edge.
+
+```python
+# settings.py — only when you really are behind a trusted L7 proxy
+
+ALLOWED_HOSTS = ['*']  # task IPs rotate; edge proxy performs Host validation
+
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+# Identify the trusted proxy terminating requests. Any non-empty list/tuple
+# opts in — contents are informational and can be used by your middleware.
+DJUST_TRUSTED_PROXIES = ['aws-alb']  # or ['cloudflare'], ['fly-edge'], etc.
+```
+
+**Security warning.** Only use this escape hatch if you are actually behind a trusted L7
+proxy that performs Host validation at the edge. On a raw VM / bare-metal with no proxy in
+front, `ALLOWED_HOSTS = ['*']` opens you up to Host-header attacks — don't paper over the
+system check with this setting.
+
+If only one of the two settings is present, `djust.A010` / `djust.A011` still fire — both are
+required so a single typo can't accidentally disable the check.
+
 ## Deployment Checklist
 
 ### Infrastructure

--- a/python/djust/checks.py
+++ b/python/djust/checks.py
@@ -566,7 +566,15 @@ def check_configuration(app_configs, **kwargs):
 
     # A010/A011/A012 -- ALLOWED_HOSTS wildcard footguns (#659)
     allowed_hosts = list(getattr(settings, "ALLOWED_HOSTS", []) or [])
-    if not getattr(settings, "DEBUG", False):
+    # Proxy-trusted escape hatch (#890): a deployer behind AWS ALB / Cloudflare /
+    # Fly.io / similar L7 load balancers can't enumerate rotating task private IPs.
+    # If both SECURE_PROXY_SSL_HEADER and DJUST_TRUSTED_PROXIES are set, the
+    # deployer is explicitly asserting a trusted proxy terminates requests, so
+    # the wildcard Host check at the Django layer is redundant.
+    trusted_proxies = getattr(settings, "DJUST_TRUSTED_PROXIES", None)
+    proxy_ssl_header = getattr(settings, "SECURE_PROXY_SSL_HEADER", None)
+    proxy_trusted = bool(trusted_proxies) and bool(proxy_ssl_header)
+    if not getattr(settings, "DEBUG", False) and not proxy_trusted:
         if "*" in allowed_hosts and len(allowed_hosts) == 1:
             errors.append(
                 DjustError(
@@ -575,12 +583,17 @@ def check_configuration(app_configs, **kwargs):
                         "Wildcard ALLOWED_HOSTS disables Django's Host header defense "
                         "entirely. Combined with AllowedHostsOriginValidator this also "
                         "re-opens CSWSH (#653) because the validator reads ALLOWED_HOSTS. "
-                        "Set ALLOWED_HOSTS to explicit hostnames."
+                        "Set ALLOWED_HOSTS to explicit hostnames, or set "
+                        "DJUST_TRUSTED_PROXIES + SECURE_PROXY_SSL_HEADER if you're behind "
+                        "a trusted proxy (AWS ALB, Cloudflare, Fly.io, etc.)."
                     ),
                     id="djust.A010",
                     fix_hint=(
                         "In settings.py, set ALLOWED_HOSTS to the explicit hostnames your "
-                        "app serves (e.g. ['myapp.example.com', 'api.example.com'])."
+                        "app serves (e.g. ['myapp.example.com', 'api.example.com']). "
+                        "Or, if you're behind a trusted L7 load balancer, set both "
+                        "SECURE_PROXY_SSL_HEADER=('HTTP_X_FORWARDED_PROTO', 'https') and "
+                        "DJUST_TRUSTED_PROXIES=['<proxy-identifier>'] to suppress A010."
                     ),
                 )
             )
@@ -593,12 +606,15 @@ def check_configuration(app_configs, **kwargs):
                         "Django accepts any Host header as soon as '*' is present, so "
                         "listing 'myapp.example.com' alongside '*' is a common footgun — "
                         "the explicit host is ignored. Remove '*' and keep only the "
-                        "explicit hostnames."
+                        "explicit hostnames, or set DJUST_TRUSTED_PROXIES + "
+                        "SECURE_PROXY_SSL_HEADER if you're behind a trusted proxy."
                     ),
                     id="djust.A011",
                     fix_hint=(
                         "In settings.py, remove '*' from ALLOWED_HOSTS and keep only the "
-                        "explicit hostnames."
+                        "explicit hostnames. Or, if you're behind a trusted L7 load "
+                        "balancer, set both SECURE_PROXY_SSL_HEADER and "
+                        "DJUST_TRUSTED_PROXIES to suppress A011."
                     ),
                 )
             )

--- a/python/djust/live_view.py
+++ b/python/djust/live_view.py
@@ -74,6 +74,52 @@ __all__ = [
 ]
 
 
+# Framework-internal attributes that MUST NOT be surfaced as reactive user state
+# in get_state(), _snapshot_assigns(), or observability debug payloads (#762).
+#
+# Three buckets of leakage:
+#   1. Django ``View``-inherited (set by ``as_view()``):
+#      http_method_names, args, kwargs, response_class, content_type
+#   2. djust ``LiveView``/mixin-set config attrs that happen to live on
+#      ``self.__dict__`` rather than on the class — without this filter they
+#      get mistaken for reactive state.
+#   3. Static config surfaced by mixins (PageMetadataMixin, LayoutMixin, etc.).
+#
+# This is the non-breaking fix: attribute names are unchanged. Renaming these
+# to ``_*`` would break every downstream template / integration that reads
+# e.g. ``template_name`` from the context.
+_FRAMEWORK_INTERNAL_ATTRS: frozenset = frozenset(
+    {
+        # Django View-inherited (set by as_view())
+        "http_method_names",
+        "args",
+        "kwargs",
+        "response_class",
+        "content_type",
+        # djust LiveView base config
+        "sync_safe",
+        "use_actors",
+        "view_is_async",
+        "tick_interval",
+        "login_required",
+        "login_url",
+        "permission_required",
+        "allowed_model_fields",
+        "on_mount",
+        "on_mount_count",
+        "static_assigns",
+        "static_assigns_count",
+        "template",
+        "template_name",
+        "base_template",
+        "page_meta",
+        "page_slug",
+        "page_title",
+        "temporary_assigns",
+    }
+)
+
+
 class LiveView(
     ContextProviderMixin,
     StreamsMixin,
@@ -545,6 +591,11 @@ class LiveView(
         state = {}
         for key, value in self.__dict__.items():
             if key.startswith("_"):
+                continue
+
+            # #762: Skip framework-internal attrs so they don't pollute
+            # user-facing reactive state.
+            if key in _FRAMEWORK_INTERNAL_ATTRS:
                 continue
 
             if callable(value):

--- a/python/djust/mixins/post_processing.py
+++ b/python/djust/mixins/post_processing.py
@@ -99,9 +99,15 @@ class PostProcessingMixin:
 
     def _debug_state_sizes(self) -> Dict[str, Dict[str, Any]]:
         """Return size breakdown of public state variables for debug toolbar."""
+        # #762: Filter framework-internal attrs from the observability payload
+        # so state_sizes reflects user-owned reactive state, not framework config.
+        from ..live_view import _FRAMEWORK_INTERNAL_ATTRS
+
         sizes: Dict[str, Dict[str, Any]] = {}
         for attr_name in sorted(vars(self)):
             if attr_name.startswith("_"):
+                continue
+            if attr_name in _FRAMEWORK_INTERNAL_ATTRS:
                 continue
             value = getattr(self, attr_name)
             if callable(value):
@@ -127,10 +133,15 @@ class PostProcessingMixin:
         this returns only the parts that change per event: variables and view class.
         Handlers are static and only sent on initial mount via get_debug_info().
         """
+        # #762: Filter framework-internal attrs from the observability payload.
+        from ..live_view import _FRAMEWORK_INTERNAL_ATTRS
+
         variables = {}
 
         for name in dir(self):
             if name.startswith("_"):
+                continue
+            if name in _FRAMEWORK_INTERNAL_ATTRS:
                 continue
 
             try:

--- a/python/djust/tests/test_a010_proxy_trusted_890.py
+++ b/python/djust/tests/test_a010_proxy_trusted_890.py
@@ -1,0 +1,114 @@
+"""
+Regression tests for #890 — djust.A010 / A011 recognize proxy-trusted deployments.
+
+When a deployer explicitly sets BOTH ``SECURE_PROXY_SSL_HEADER`` AND
+``DJUST_TRUSTED_PROXIES`` (new djust setting, non-empty list/tuple), they're
+asserting that a trusted L7 load balancer (AWS ALB, Cloudflare, Fly.io, etc.)
+terminates requests for them. In that topology ``ALLOWED_HOSTS=['*']`` is the
+only practical path (task private IPs rotate on every redeploy / autoscale).
+
+These tests make sure:
+
+* Existing behavior is preserved — A010 / A011 fire without the escape hatch.
+* The escape hatch needs BOTH settings — partial opt-in still fires.
+* The escape hatch suppresses both A010 and A011.
+"""
+
+from django.test import override_settings
+
+from djust.checks import check_configuration
+
+
+def _ids(errors):
+    return {getattr(e, "id", "") for e in errors}
+
+
+class TestA010ProxyTrustedEscapeHatch:
+    """Verify the DJUST_TRUSTED_PROXIES + SECURE_PROXY_SSL_HEADER escape hatch."""
+
+    @override_settings(DEBUG=False, ALLOWED_HOSTS=["*"])
+    def test_a010_fires_without_trusted_proxies(self):
+        """Baseline: A010 still fires when neither escape-hatch setting is set."""
+        errors = check_configuration(None)
+        assert "djust.A010" in _ids(errors), (
+            "A010 must keep firing when ALLOWED_HOSTS=['*'] and the deployer "
+            "has NOT opted into proxy-trusted mode."
+        )
+
+    @override_settings(
+        DEBUG=False,
+        ALLOWED_HOSTS=["*"],
+        SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"),
+        DJUST_TRUSTED_PROXIES=["aws-alb"],
+    )
+    def test_a010_suppressed_when_trusted_proxies_set(self):
+        """A010 is suppressed when both escape-hatch settings are set."""
+        errors = check_configuration(None)
+        ids = _ids(errors)
+        assert "djust.A010" not in ids, (
+            "A010 must NOT fire when SECURE_PROXY_SSL_HEADER + "
+            "DJUST_TRUSTED_PROXIES are both set — the deployer has explicitly "
+            "opted into proxy-trusted mode."
+        )
+
+    @override_settings(
+        DEBUG=False,
+        ALLOWED_HOSTS=["*"],
+        SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"),
+        # DJUST_TRUSTED_PROXIES intentionally unset
+    )
+    def test_a010_fires_when_only_proxy_ssl_header_set(self):
+        """Partial opt-in (only SECURE_PROXY_SSL_HEADER) must still fire."""
+        errors = check_configuration(None)
+        assert "djust.A010" in _ids(errors), (
+            "A010 must still fire when only SECURE_PROXY_SSL_HEADER is set — "
+            "both settings are required to opt into proxy-trusted mode."
+        )
+
+    @override_settings(
+        DEBUG=False,
+        ALLOWED_HOSTS=["*"],
+        DJUST_TRUSTED_PROXIES=["aws-alb"],
+        # SECURE_PROXY_SSL_HEADER intentionally unset
+    )
+    def test_a010_fires_when_only_trusted_proxies_set(self):
+        """Partial opt-in (only DJUST_TRUSTED_PROXIES) must still fire."""
+        errors = check_configuration(None)
+        assert "djust.A010" in _ids(errors), (
+            "A010 must still fire when only DJUST_TRUSTED_PROXIES is set — "
+            "both settings are required to opt into proxy-trusted mode."
+        )
+
+    @override_settings(
+        DEBUG=False,
+        ALLOWED_HOSTS=["*"],
+        SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"),
+        DJUST_TRUSTED_PROXIES=[],  # empty — shouldn't count as opt-in
+    )
+    def test_a010_fires_when_trusted_proxies_is_empty(self):
+        """Empty DJUST_TRUSTED_PROXIES list does NOT count as opting in."""
+        errors = check_configuration(None)
+        assert "djust.A010" in _ids(errors), "Empty DJUST_TRUSTED_PROXIES must not suppress A010."
+
+
+class TestA011ProxyTrustedEscapeHatch:
+    """A011 (wildcard mixed with explicit hosts) gets the same escape hatch."""
+
+    @override_settings(DEBUG=False, ALLOWED_HOSTS=["myapp.example.com", "*"])
+    def test_a011_fires_without_trusted_proxies(self):
+        errors = check_configuration(None)
+        assert "djust.A011" in _ids(errors)
+
+    @override_settings(
+        DEBUG=False,
+        ALLOWED_HOSTS=["myapp.example.com", "*"],
+        SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"),
+        DJUST_TRUSTED_PROXIES=["aws-alb"],
+    )
+    def test_a011_suppressed_when_trusted_proxies_set(self):
+        errors = check_configuration(None)
+        assert "djust.A011" not in _ids(errors), (
+            "A011 must NOT fire under proxy-trusted mode — same reasoning as "
+            "A010: the deployer explicitly asserts a trusted proxy terminates "
+            "requests."
+        )

--- a/python/djust/tests/test_get_state_filter_762.py
+++ b/python/djust/tests/test_get_state_filter_762.py
@@ -1,0 +1,192 @@
+"""
+Regression tests for #762 — framework-internal attrs leak into LiveView state.
+
+Before this fix, ``LiveView.get_state()``, ``_snapshot_assigns`` and the
+``state_sizes`` observability payload surfaced ~30 framework-set attrs
+(``template_name``, ``http_method_names``, ``login_required``, ``on_mount_count``,
+``page_meta``, etc.) as if they were reactive user state.
+
+The non-breaking fix introduces ``live_view._FRAMEWORK_INTERNAL_ATTRS``, a
+frozenset consulted by each of those code paths. Attribute names are unchanged.
+
+These tests make sure:
+
+* User-set assigns (``self.count = 5`` in ``mount``) still surface.
+* Framework-set attrs do NOT surface in any of the three code paths.
+"""
+
+from djust import LiveView
+from djust.live_view import _FRAMEWORK_INTERNAL_ATTRS
+from djust.websocket import _snapshot_assigns
+
+
+class TestGetStateFiltersFrameworkAttrs:
+    """``LiveView.get_state()`` should return only user-owned reactive state."""
+
+    def test_get_state_excludes_framework_attrs(self):
+        """No framework-internal attr name appears in get_state() output."""
+
+        class EmptyView(LiveView):
+            template_name = "test.html"
+
+            def mount(self, request, **kwargs):
+                pass  # no user state — only framework-set attrs should exist
+
+        view = EmptyView()
+        view.mount(None)
+
+        state = view.get_state()
+        leaked = set(state) & _FRAMEWORK_INTERNAL_ATTRS
+        assert not leaked, (
+            f"get_state() leaked framework-internal attrs: {sorted(leaked)}. "
+            f"These must be filtered via _FRAMEWORK_INTERNAL_ATTRS."
+        )
+
+    def test_get_state_includes_user_assigns(self):
+        """User-set public attrs MUST still surface — this is the whole point."""
+
+        class CounterView(LiveView):
+            template_name = "test.html"
+
+            def mount(self, request, **kwargs):
+                self.count = 5
+                self.name = "hello"
+
+        view = CounterView()
+        view.mount(None)
+
+        state = view.get_state()
+        assert state.get("count") == 5
+        assert state.get("name") == "hello"
+
+    def test_get_state_filters_django_view_inherited_attrs(self):
+        """Django ``View``-inherited attrs (http_method_names, args, kwargs) filtered."""
+
+        class FilteredView(LiveView):
+            template_name = "test.html"
+
+            def mount(self, request, **kwargs):
+                self.user_attr = "visible"
+
+        view = FilteredView()
+        # Simulate what View.as_view() does — set framework attrs on __dict__
+        view.http_method_names = ["get", "post"]
+        view.args = ()
+        view.kwargs = {}
+        view.mount(None)
+
+        state = view.get_state()
+        assert "http_method_names" not in state
+        assert "args" not in state
+        assert "kwargs" not in state
+        assert state.get("user_attr") == "visible"
+
+    def test_get_state_filters_djust_config_attrs(self):
+        """djust LiveView config attrs (sync_safe, login_required, template_name, ...) filtered."""
+
+        class ConfigView(LiveView):
+            template_name = "test.html"
+
+            def mount(self, request, **kwargs):
+                self.count = 1
+
+        view = ConfigView()
+        # Set the typical framework attrs that normally land on __dict__
+        view.template_name = "test.html"
+        view.sync_safe = True
+        view.login_required = False
+        view.use_actors = False
+        view.view_is_async = False
+        view.tick_interval = 0
+        view.on_mount_count = 0
+        view.page_meta = {}
+        view.static_assigns = []
+        view.temporary_assigns = {}
+        view.mount(None)
+
+        state = view.get_state()
+        for framework_key in (
+            "template_name",
+            "sync_safe",
+            "login_required",
+            "use_actors",
+            "view_is_async",
+            "tick_interval",
+            "on_mount_count",
+            "page_meta",
+            "static_assigns",
+            "temporary_assigns",
+        ):
+            assert framework_key not in state, (
+                f"get_state() still leaks framework attr '{framework_key}'"
+            )
+        assert state.get("count") == 1
+
+
+class TestSnapshotAssignsFiltersFrameworkAttrs:
+    """``_snapshot_assigns`` (WS change-detection) must also filter these."""
+
+    def test_snapshot_assigns_skips_framework_attrs(self):
+        class SnapshotView(LiveView):
+            template_name = "test.html"
+
+            def mount(self, request, **kwargs):
+                self.visible = "user-state"
+
+        view = SnapshotView()
+        # Set framework attrs the same way as-view() or a mixin would
+        view.template_name = "test.html"
+        view.login_required = False
+        view.http_method_names = ["get"]
+        view.on_mount_count = 0
+        view.mount(None)
+
+        snapshot = _snapshot_assigns(view)
+        leaked = set(snapshot) & _FRAMEWORK_INTERNAL_ATTRS
+        assert not leaked, f"_snapshot_assigns leaked framework attrs: {sorted(leaked)}"
+        assert "visible" in snapshot
+
+    def test_snapshot_assigns_includes_user_assigns(self):
+        """Non-underscore user-set attrs still show up in snapshot."""
+
+        class UserView(LiveView):
+            template_name = "test.html"
+
+            def mount(self, request, **kwargs):
+                self.count = 7
+                self.items = [1, 2, 3]
+
+        view = UserView()
+        view.mount(None)
+
+        snapshot = _snapshot_assigns(view)
+        assert "count" in snapshot
+        assert "items" in snapshot
+
+
+class TestDebugStateSizesFiltersFrameworkAttrs:
+    """The ``state_sizes`` observability payload (#762 signal source) must also filter."""
+
+    def test_state_sizes_debug_payload_skips_framework_attrs(self):
+        class DebugView(LiveView):
+            template_name = "test.html"
+
+            def mount(self, request, **kwargs):
+                self.visible = "user"
+
+        view = DebugView()
+        # Simulate framework-set attrs ending up on __dict__
+        view.template_name = "test.html"
+        view.login_required = False
+        view.http_method_names = ["get"]
+        view.on_mount_count = 0
+        view.page_meta = {}
+        view.mount(None)
+
+        sizes = view._debug_state_sizes()
+        leaked = set(sizes) & _FRAMEWORK_INTERNAL_ATTRS
+        assert not leaked, (
+            f"_debug_state_sizes leaked framework attrs: {sorted(leaked)}. "
+            f"Observability payloads must show user-reactive state only."
+        )
+        assert "visible" in sizes

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -172,10 +172,15 @@ def _snapshot_assigns(view_instance):
     are NOT detected. For those, use self._changed_keys or @event_handler
     which explicitly marks state as dirty.
     """
+    # #762: Filter framework-internal attrs so change detection doesn't fire
+    # on attrs like ``template_name`` / ``http_method_names`` that the user
+    # never touches.
+    from .live_view import _FRAMEWORK_INTERNAL_ATTRS
+
     _static_skip = set(getattr(view_instance, "static_assigns", []))
     snapshot = {}
     for k, v in view_instance.__dict__.items():
-        if k.startswith("_") or k in _static_skip:
+        if k.startswith("_") or k in _static_skip or k in _FRAMEWORK_INTERNAL_ATTRS:
             continue
         # Identity + shallow fingerprint for mutable containers
         vid = id(v)


### PR DESCRIPTION
Closes #890 and #762.

## Summary

- **#890 (djust.A010/A011 + proxy-trusted deployments)** — when `SECURE_PROXY_SSL_HEADER` and a new `DJUST_TRUSTED_PROXIES` list are both set, `ALLOWED_HOSTS=['*']` is accepted. Unblocks AWS ALB / Cloudflare / Fly.io / other L7-LB topologies where task private IPs rotate on every redeploy. A012 (USE_X_FORWARDED_HOST + wildcard) is deliberately unchanged — still a genuine Host-header-injection footgun even under a trusted proxy.
- **#762 (framework attrs leaked into LiveView state)** — new `live_view._FRAMEWORK_INTERNAL_ATTRS` frozenset (25 names) filters `template_name`, `login_required`, `http_method_names`, `page_meta`, `on_mount_count`, `sync_safe`, etc. out of `LiveView.get_state()`, `_snapshot_assigns` (WS change-detection), and `_debug_state_sizes` / `get_debug_update` (observability payloads). Non-breaking: attribute names unchanged.

## Files touched

- `python/djust/checks.py` — A010 / A011 proxy-trusted escape hatch + updated hint text
- `python/djust/live_view.py` — `_FRAMEWORK_INTERNAL_ATTRS` frozenset + `get_state()` filter
- `python/djust/websocket.py` — `_snapshot_assigns` filter
- `python/djust/mixins/post_processing.py` — `_debug_state_sizes` + `get_debug_update` filter
- `docs/website/guides/deployment.md` — new section "Deploying Behind an L7 Load Balancer"
- `CHANGELOG.md` — `[Unreleased]` → `Fixed` entry
- `python/djust/tests/test_a010_proxy_trusted_890.py` — 7 tests (baseline, full opt-in, partial opt-in x2, empty list, A011 variants)
- `python/djust/tests/test_get_state_filter_762.py` — 7 tests (get_state / snapshot_assigns / state_sizes)

## Test plan

- [x] `pytest python/djust/tests/test_a010_proxy_trusted_890.py python/djust/tests/test_get_state_filter_762.py -v` — 14/14 pass
- [x] `pytest python/tests/test_static_security_checks.py python/djust/tests/test_debug_state_sizes.py` — existing behavior preserved (32 passed)
- [x] `make test-python` — 3445 passed, 15 skipped (no regressions)
- [x] `ruff check` + `ruff format --check` — clean
- [x] Pre-commit hooks passed (bandit, detect-secrets, CHANGELOG test-count validator)
- [x] Pre-push hooks passed (pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)