### PR TITLE
feat(v0.7.0): Django admin widgets + bulk-action progress (DjustModelAdmin slots)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Admin widgets & bulk-action progress (v0.7.0)** — two additions to
+  `djust.admin_ext` close the most-requested gaps in the alternative
+  reactive admin:
+  - `DjustModelAdmin.change_form_widgets` / `change_list_widgets` class
+    attributes accept any list of `LiveView` subclasses; each is
+    embedded via `{% live_render %}` on the matching admin page.
+    Permission filtering honours `permission_required` on the widget
+    class. See
+    [docs/website/guides/admin-widgets.md](docs/website/guides/admin-widgets.md).
+  - `@admin_action_with_progress` (in `djust.admin_ext.progress`) turns
+    any `DjustModelAdmin` action into a background daemon thread and
+    redirects the user to a `BulkActionProgressWidget` page at
+    `<admin>/djust-progress/<job_id>/`. The page polls the job every
+    500 ms, re-renders the progress bar / message / log, and wires a
+    Cancel button that atomically flips `done` and `cancelled`. Queryset
+    is eagerly pinned to PKs before the thread starts (no lazy-eval
+    foot-guns). **Cancellation is cooperative** — clicking Cancel flips
+    `progress.cancelled = True`; the action body must periodically check
+    `if progress.cancelled: return` to actually stop (Python cannot
+    safely interrupt a running thread mid-statement).
+  - **Server-side permission enforcement** — `@admin_action_with_progress(permissions=[...])`
+    stamps `allowed_permissions` on the wrapped action; `ModelListView.run_action`
+    now calls `request.user.has_perms(allowed)` before dispatching the
+    action and raises `PermissionDenied` if the user lacks any declared
+    perm. Closes the gap where `has_*_permission` returns True for any
+    staff user.
+  - **Bounded server state:** `_JOBS` is LRU-capped at `_MAX_JOBS = 500`
+    (oldest entries evicted on insert once the cap is reached), and
+    `Job.message` / `Job.error` are individually truncated to
+    `_MAX_MESSAGE_CHARS = 4096` on each `progress.update(...)` call.
+    `Job.error` is a generic user-facing string ("Action failed — see
+    server logs for details"); the raw exception text lives only on the
+    server-side `Job._error_raw` attribute and is always logged at ERROR
+    level via `logger.exception` (logger name `djust.admin_ext.progress`).
+  - **New setting:** `DJUST_ASGI_WORKERS` (default `1`) — declares the
+    number of ASGI workers in the deployment. Gates the A073 system
+    check (fires only when `DJUST_ASGI_WORKERS > 1`) so single-worker
+    development stays silent.
+  - **Defense-in-depth allowlist:** `DJUST_LIVE_RENDER_ALLOWED_MODULES`
+    (optional) restricts the dotted-path module prefixes that
+    `{% live_render %}` will resolve — any widget slot path outside the
+    allowlist raises `TemplateSyntaxError` at render time.
+  - Two new system checks: `djust.A072` (warning) fires if a non-
+    `LiveView` class is registered in a widget slot; `djust.A073`
+    (info, gated on `DJUST_ASGI_WORKERS > 1`) fires at startup if any
+    admin site hosts a `@admin_action_with_progress`-decorated action,
+    noting the v0.7.0 single-worker `_JOBS` limitation and pointing at
+    the v0.7.1 channel-layer follow-up.
+  - 25 new tests: `python/djust/tests/test_bulk_progress.py` (12) +
+    `python/djust/tests/test_admin_widgets_per_page.py` (13); +A072/A073
+    check tests in `python/tests/test_checks.py`.
 - **`{% dj_activity %}` + `ActivityMixin` (v0.7.0)** — React 19.2
   `<Activity>` parity: pre-rendered hidden regions of a LiveView that
   preserve their local DOM state (form inputs, scroll, transient JS)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -905,7 +905,7 @@ class DashboardView(LiveView):
         # Charts panel pre-renders data in background
 ```
 
-**Django admin LiveView widgets** — Drop-in LiveView-powered widgets for Django's admin interface. `DjustAdminMixin` on any `ModelAdmin` enables real-time dashboards, live search/filter, inline editing, and bulk action progress within the admin. Use cases: real-time order status dashboards, live log viewers, monitoring panels, AI-powered admin actions with streaming output. This is a unique djust differentiator — no other LiveView-style framework integrates with an existing admin like Django's. Implementation: admin template overrides + a `DjustAdminWidget` base class that renders a mini LiveView inside admin change forms/list views. ~300 lines Python. *Django's admin is used by 90%+ of Django projects. Making it reactive with zero config is the single most effective demo of djust's value proposition — "add one mixin and your admin goes live."*
+~~**Django admin LiveView widgets**~~ ✅ **Shipped in v0.7.0** — Per-page widget slots (`change_form_widgets`, `change_list_widgets`) on `DjustModelAdmin` + `@admin_action_with_progress` decorator + `BulkActionProgressWidget` LiveView with cancel / log / progress bar + system checks A072 (non-LiveView slot) and A073 (multi-worker note). Shipped as extensions to the existing `DjustAdminSite` (ADR-007 Phase 4 adoption path) rather than a `DjustAdminMixin` on stock `admin.ModelAdmin` — avoids duplicating 60% of admin_ext infrastructure. See [docs/website/guides/admin-widgets.md](docs/website/guides/admin-widgets.md). Channel-layer backend for multi-worker `_JOBS` deferred to v0.7.1.
 
 **Prefetch on hover/intent** — Pre-load the next page's data when the user hovers over a link or shows navigation intent (mouse movement toward link, touch start). `<a dj-prefetch href="/dashboard">Dashboard</a>` triggers a lightweight prefetch request on hover, so the page loads instantly on click. Different from existing `22-prefetch.js` (which pre-fetches all visible links) — this is intent-based and targeted. Remix, Next.js, and Astro all use hover-prefetch as their primary strategy for fast navigation. Implementation: `mouseenter` listener with 65ms delay (avoids prefetch on fly-over), prefetch via `<link rel="prefetch">` or fetch API with abort on `mouseleave`. ~50 lines JS. *Combined with View Transitions API, this makes navigation feel literally instant — the page is already loaded before the user clicks.*
 
@@ -1042,7 +1042,7 @@ Open questions that inform future direction:
 | Islands of interactivity | — | Astro islands | Not started | v0.7.0 |
 | AI streaming primitives | — | — | Not started | v0.7.0 |
 | Server functions (RPC) | — | Server Actions | Not started | v0.7.0 |
-| Django admin LiveView widgets | — | — | Not started | v0.7.0 |
+| ~~Django admin LiveView widgets~~ | — | — | ✅ Shipped (v0.7.0) | v0.7.0 |
 | Prefetch on hover/intent | — | Remix prefetch | Not started | v0.7.0 |
 | **Keep-Alive / Activity** | — | **`<Activity>`** (19.2) | **Not started** | **v0.7.0** |
 | ~~**Document metadata**~~ | ~~`live_title`~~ | ~~**Native** (React 19)~~ | ✅ **Done** | v0.4.0 |
@@ -1123,7 +1123,7 @@ High-impact areas for contributions:
 39. ~~**Rust template engine parity**~~ ✅ — Closed in v0.5.0: getattr fallback, attr-context escape, assign-tag handler
 40. **AI streaming primitives** — Purpose-built LLM streaming components
 41. **Streaming initial render** — Chunked HTTP response with progressive content loading
-42. **Django admin LiveView widgets** — Real-time admin dashboards and inline editing
+42. ~~**Django admin LiveView widgets**~~ ✅ **Shipped in v0.7.0** — `change_form_widgets`/`change_list_widgets` slots + `@admin_action_with_progress` + `BulkActionProgressWidget` + A072/A073 checks. See `docs/website/guides/admin-widgets.md`.
 43. **Hot View Replacement** — State-preserving Python code reload in dev mode, ~200 lines Python
 44. **Server Actions (`@action`)** — React 19-style mutation handlers with auto pending/error states
 45. **Keyed for-loop change tracking** — Rust-side per-item change detection in `{% for %}` loops, ~200 lines Rust

--- a/docs/website/_config.yaml
+++ b/docs/website/_config.yaml
@@ -236,6 +236,11 @@ navigation:
         file: guides/server-functions.md
         order: 12.7
         level: advanced
+      - title: Admin Widgets (`change_form_widgets`, Bulk-Action Progress)
+        slug: admin-widgets
+        file: guides/admin-widgets.md
+        order: 12.8
+        level: intermediate
       - title: Deployment
         slug: deployment
         file: guides/deployment.md

--- a/docs/website/guides/admin-widgets.md
+++ b/docs/website/guides/admin-widgets.md
@@ -1,0 +1,345 @@
+# Admin Widgets — Per-Page LiveView Slots & Bulk-Action Progress (v0.7.0)
+
+`djust.admin_ext` ships a drop-in reactive replacement for Django's
+stock admin (`DjustAdminSite`, `DjustModelAdmin`, plugin system,
+dashboard widgets).  v0.7.0 adds two building blocks that close the gap
+with real-world admin requirements:
+
+1. **Per-page widget slots** on `DjustModelAdmin` — embed any LiveView
+   into a model's change-list or change-form page via
+   `change_list_widgets` / `change_form_widgets` class attributes.
+2. **Bulk-action progress** — turn any ModelAdmin action into a
+   background job with a live progress page using
+   `@admin_action_with_progress`.
+
+## Why this design (and why we didn't ship `DjustAdminMixin`)
+
+A lot of demos reach for "one mixin you sprinkle on `admin.ModelAdmin`
+and your admin goes live." We prototyped that.  In practice it
+duplicates ~60% of `DjustAdminSite`, fights Django's `change_view` /
+`changelist_view` MRO (20+ override points, complex
+`template_name` resolution, `ChangeList` introspection), and diverges
+from the recommended adoption path (ADR-007 Phase 4: `djust[admin]` =
+`DjustAdminSite`).
+
+Instead, v0.7.0:
+
+- Extends the existing `DjustModelAdmin` with **thin** per-page widget
+  slots that reuse the already-shipped `{% live_render %}` machinery.
+- Adds `BulkActionProgressWidget` as a first-class LiveView that any
+  ModelAdmin action can redirect to via a one-line decorator.
+
+Result: an admin page that wants a live revenue chart is
+
+```python
+class OrderAdmin(DjustModelAdmin):
+    change_list_widgets = [RevenueChartView]
+```
+
+...and the chart *is* a regular LiveView — same class you'd use on any
+page.  No new framework surface, nothing novel to learn.
+
+## Per-page widget slots
+
+### Quick start — `change_form_widgets`
+
+```python
+# myapp/djust_admin.py
+from djust import LiveView
+from djust.admin_ext import DjustModelAdmin, site
+from djust.decorators import event_handler, state
+from .models import Order
+
+
+class OrderActivityWidget(LiveView):
+    """Shows recent activity on the order currently being edited."""
+
+    template_name = "myapp/admin/order_activity.html"
+    label = "Recent activity"
+    size = "lg"  # "sm" | "md" | "lg" — controls grid column span
+
+    events = state(default=[])
+
+    def mount(self, request, object_id=None, **kwargs):
+        self.request = request
+        self.object_id = object_id
+        self.events = list(
+            Order.objects.get(pk=object_id).activity.order_by("-ts")[:10]
+        )
+
+    def get_context_data(self, **kwargs):
+        return {"events": self.events}
+
+
+@site.register(Order)
+class OrderAdmin(DjustModelAdmin):
+    change_form_widgets = [OrderActivityWidget]
+```
+
+That's it.  Open `/admin/myapp/order/42/change/` and the widget renders
+above the form, receives `object_id=42`, and behaves exactly like any
+other LiveView.
+
+### `change_list_widgets`
+
+Same deal, but on the list page. Widgets registered here receive no
+`object_id` (since the page isn't scoped to a single model instance).
+Typical uses:
+
+- Live KPI tiles (total orders today, open support tickets)
+- Filter-aware summaries (sum of currently-shown rows)
+- Pinned announcements / banners
+
+```python
+@site.register(Order)
+class OrderAdmin(DjustModelAdmin):
+    change_list_widgets = [TodayRevenueWidget, OpenTicketsWidget]
+```
+
+### Permissions
+
+Any widget class can declare `permission_required`. Users without the
+permission simply don't see the widget — no fallback placeholder is
+rendered.
+
+```python
+class InventoryAlertWidget(LiveView):
+    template_name = "myapp/admin/inventory_alert.html"
+    permission_required = "inventory.view_low_stock"
+    label = "Low stock alerts"
+```
+
+## Bulk-action progress
+
+### Quick start — `@admin_action_with_progress`
+
+```python
+# myapp/djust_admin.py
+from djust.admin_ext import DjustModelAdmin, site
+from djust.admin_ext.progress import admin_action_with_progress
+from .models import Order
+
+
+@site.register(Order)
+class OrderAdmin(DjustModelAdmin):
+    actions = ["refund_selected"]
+
+    @admin_action_with_progress(description="Refund selected orders")
+    def refund_selected(self, request, queryset, progress):
+        total = queryset.count()
+        progress.update(current=0, total=total, message="Starting refunds…")
+        for i, order in enumerate(queryset.iterator(), start=1):
+            order.refund()
+            progress.update(
+                current=i,
+                total=total,
+                message=f"Refunded order #{order.pk}",
+            )
+        progress.update(message="All done.")
+```
+
+When a user runs this action:
+
+1. The decorator pins the selected rows to a list of primary keys
+   (so lazy-queryset re-evaluation against the session can't affect
+   the thread).
+2. Spawns a daemon thread that runs the function body.
+3. Returns an `HttpResponseRedirect` to
+   `/admin/djust-progress/<job_id>/`, which is served by
+   `BulkActionProgressWidget`.
+4. The progress page polls `progress.current / total / message / log`
+   every 500 ms and re-renders the progress bar, status, and log.
+5. If the user clicks **Cancel**, both `done=True` and
+   `cancelled=True` flip on the job, and the polling loop exits on
+   the next tick.
+
+### Cancellation is cooperative
+
+> **Important.** Clicking **Cancel** on the progress page only flips
+> `progress.cancelled = True`. Python cannot safely interrupt a
+> running thread mid-statement, so the **action body must
+> periodically check `progress.cancelled` and return early** to
+> actually stop. If your loop body never checks, the action runs to
+> completion even though the user cancelled — and any destructive
+> side-effects (row updates, API calls) still happen.
+>
+> The pattern:
+>
+> ```python
+> @admin_action_with_progress(description="Sync with vendor")
+> def sync_vendor(self, request, queryset, progress):
+>     total = queryset.count()
+>     for i, obj in enumerate(queryset):
+>         if progress.cancelled:
+>             progress.update(message="Cancelled by user.")
+>             return
+>         obj.sync_with_vendor()
+>         progress.update(current=i + 1, total=total,
+>                         message=f"Synced {obj.pk}")
+> ```
+>
+> For actions that can't be safely interrupted, skip the check and
+> make it clear in the `description`: `"Finalize orders (cannot be
+> cancelled)"`.
+
+### Permissions (`permissions=[...]`)
+
+`@admin_action_with_progress(permissions=[...])` stamps an
+`allowed_permissions` attribute on the wrapped action function.
+**`DjustModelAdmin.run_action` enforces this server-side** — before
+dispatching the action it calls `request.user.has_perms(allowed)` and
+raises `PermissionDenied` if the user lacks any declared perm. This
+closes the gap where Django's default `has_*_permission` methods
+return `True` for any authenticated staff user, which would otherwise
+let a view-only staff user fire a destructive action just because the
+action dropdown rendered for them.
+
+```python
+@admin_action_with_progress(
+    description="Refund selected orders",
+    permissions=["orders.refund_order", "orders.view_order"],
+)
+def refund_selected(self, request, queryset, progress):
+    ...
+```
+
+Users without *all* of the listed perms see a `403` when they try to
+run the action; the progress page is never created.
+
+### Known limitations
+
+> **Single-worker only (v0.7.0).** The process-local `_JOBS` dict that
+> backs `BulkActionProgressWidget` is not shared across workers. If
+> your deployment has `gunicorn --workers 4` (or uvicorn with
+> `--workers > 1`), the progress-page redirect may land on a different
+> worker than the one running the background thread — producing a "Job
+> not found or expired." error.
+>
+> **Workarounds for v0.7.0:**
+>
+> - Run a single ASGI worker (`--workers 1`) on the service handling
+>   admin traffic.
+> - Enable sticky sessions (cookie-affinity) on your load balancer so
+>   the admin user stays on one worker.
+> - Don't use `@admin_action_with_progress` for workflows that need to
+>   survive worker crashes.
+>
+> **v0.7.1 plans** to back `_JOBS` with the project's channel layer
+> (same broker as `NotificationMixin.listen()`), making multi-worker
+> deploys work out of the box without changes to your action code.
+> A `djust.A073` system check fires at startup any time an admin site
+> has a `@admin_action_with_progress`-decorated action, so this
+> limitation is impossible to miss during `manage.py check`.
+
+Other edge cases worth knowing:
+
+- **Single-worker `_JOBS` + LRU cap.** `_JOBS` is a process-local dict
+  capped at `_MAX_JOBS = 500` entries (oldest entries evicted on insert
+  once the cap is reached). Combined with the single-worker limitation
+  above, this means you're always looking at the last 500 jobs on one
+  worker — fine for typical admin bulk-action workloads, but don't
+  treat `_JOBS` as a durable job store.
+- **Per-message truncation.** Both `Job.message` and `Job.error` are
+  individually truncated to `_MAX_MESSAGE_CHARS = 4096` characters on
+  each `progress.update(...)` call — longer strings get `"..."`
+  appended. Keeps the WebSocket payload and in-memory job size bounded
+  no matter how noisy the action is.
+- **Long-running actions keep running across user sessions** — closing
+  the browser tab doesn't cancel the job, only `cancel()` does. Jobs
+  live 30 seconds after completion so late-arriving progress pages can
+  still see the final state.
+- **Log is capped at 50 lines.** Call `progress.update(message=...)`
+  sparingly; the oldest entries are trimmed.
+- **Exceptions are captured** with full tracebacks logged at ERROR
+  level via ``logger.exception`` (logger name:
+  ``djust.admin_ext.progress``); `done=True` still flips in the
+  `finally` clause. The user-facing `job.error` is a generic
+  message — `"Action failed — see server logs for details"` — and the
+  raw exception text lives only on the server-side `_error_raw`
+  attribute (server-only, never sent to the client). Don't leak
+  exception messages to admin users.
+- **Queryset is pinned to PKs** before the thread starts. If you need
+  the freshest data, re-fetch inside the thread: we already pin to the
+  default manager's queryset but you can chain further filters.
+
+## Troubleshooting
+
+### `djust.A072` — non-LiveView in widget slot
+
+```
+Admin djust_admin — change_form_widgets on myapp.order contains
+non-LiveView class 'NotALiveView'. Widget slots can only embed djust
+LiveView subclasses.
+```
+
+You registered a plain class (or a stock `admin.ModelAdmin`-style
+widget) where a `LiveView` subclass was expected. The fix is to make
+your widget inherit from `djust.LiveView`:
+
+```python
+from djust import LiveView
+
+class MyWidget(LiveView):
+    template_name = "..."
+```
+
+Widget slots expect LiveViews because they're rendered via
+`{% live_render %}` — the same tag used for nested LiveViews
+elsewhere in your app. If you want a static server-rendered card, use
+the dashboard `AdminWidget` (from `djust.admin_ext.plugins`) instead —
+those are plain Django template renders.
+
+### `djust.A073` — multi-worker progress limitation
+
+```
+Admin djust_admin — uses @admin_action_with_progress with
+DJUST_ASGI_WORKERS=4. The v0.7.0 BulkActionProgressWidget keeps job
+state in a process-local dict (_JOBS); multi-worker deploys must pin
+the progress URL to the worker that started the job (sticky sessions)
+or run a single ASGI worker. v0.7.1 will back this with a channel
+layer.
+```
+
+An informational notice — NOT an error. A073 is gated on the
+`DJUST_ASGI_WORKERS` setting: it only fires when you set
+`DJUST_ASGI_WORKERS > 1` in your Django settings (so single-worker
+development stays silent). Unset it or leave it at `1` to indicate
+you're running a single worker.
+
+```python
+# settings.py
+DJUST_ASGI_WORKERS = 4  # This tells djust.A073 you're multi-worker.
+```
+
+See the "Known limitations" section above for the options. You can
+also silence this check with `DJUST_CONFIG = {"suppress_checks":
+["A073"]}` once you've picked a mitigation.
+
+### Defense-in-depth — `DJUST_LIVE_RENDER_ALLOWED_MODULES`
+
+Because widget slots resolve dotted paths via `{% live_render %}`, you
+can opt into an allowlist of acceptable module prefixes. Set
+`DJUST_LIVE_RENDER_ALLOWED_MODULES = ["myapp.widgets", "myorg.admin"]`
+in Django settings and any widget path that doesn't start with one of
+those prefixes will raise `TemplateSyntaxError` at render time. When
+unset (the default) all resolvable paths are permitted. This is not a
+bug fix — just an extra layer for deployments that want to constrain
+which modules the admin can reach through the live-render machinery.
+
+## Comparison with stock Django admin
+
+| Capability | Stock `admin.ModelAdmin` | `DjustModelAdmin` (v0.7.0) |
+| --- | --- | --- |
+| CRUD templates | full-page reload | real-time LiveView |
+| Search / filter / sort | full-page reload | WebSocket round-trip |
+| Add widgets to a change page | custom `change_form_template` + JS | `change_form_widgets = [LiveView, …]` |
+| Add widgets to a list page | custom `change_list_template` + JS | `change_list_widgets = [LiveView, …]` |
+| Bulk action with progress | none built-in | `@admin_action_with_progress` + live page |
+| Permission-filter widgets | manual template conditional | `permission_required` on widget class |
+| Multi-worker job routing | not applicable (no background jobs) | v0.7.0: single-worker; v0.7.1: channel layer |
+
+v0.7.0 is intentionally a **small** addition to an already-shipped
+admin.  If `DjustAdminSite` doesn't fit your project, you can still
+reach for a custom admin app — `BulkActionProgressWidget` is a plain
+LiveView and `admin_action_with_progress` is a plain decorator; both
+work outside `DjustAdminSite` if you route their URLs manually.

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -78,6 +78,7 @@ How to build specific features.
 | **[MCP Server](guides/mcp-server.md)**         | AI assistant integration via Model Context Protocol       |
 | **[HTTP API](guides/http-api.md)**             | Auto-generated HTTP endpoints + OpenAPI from `@event_handler` (ADR-008) |
 | **[Server Functions](guides/server-functions.md)** | `@server_function` + `djust.call()` — same-origin browser RPC without re-render (v0.7.0) |
+| **[Admin Widgets (v0.7.0)](guides/admin-widgets.md)** | Per-page LiveView slots on `DjustModelAdmin` + `@admin_action_with_progress` for bulk-action progress pages |
 
 ### Operations
 

--- a/examples/demo_project/demo_project/djust_admin.py
+++ b/examples/demo_project/demo_project/djust_admin.py
@@ -1,0 +1,98 @@
+"""Demo djust admin registrations — exercises v0.7.0 widget slots +
+@admin_action_with_progress.
+
+Wires up:
+
+- A ``DjustModelAdmin`` for ``djust_rentals.MaintenanceRequest``
+- A ``@admin_action_with_progress``-decorated bulk action ("close_selected")
+- A per-page ``change_form_widgets`` slot embedding a demo LiveView
+
+This is imported by ``autodiscover`` (see ``demo_project.urls`` /
+``demo_project.apps``) and demonstrates the docs/guide example end to end.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from djust import LiveView
+from djust.admin_ext import (
+    DjustAdminSite,
+    DjustModelAdmin,
+    admin_action_with_progress,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Per-project admin site (does not conflict with Django's stock admin).
+djust_admin_site = DjustAdminSite(name="djust_admin_demo")
+
+
+class DemoProgressViewWidget(LiveView):
+    """Tiny LiveView that renders next to the change form body."""
+
+    template_name = "djust_admin/demo/progress_widget.html"
+    label = "Change summary"
+    size = "md"
+
+    def mount(self, request, object_id=None, **kwargs):
+        self.request = request
+        self.object_id = object_id
+
+    def get_context_data(self, **kwargs):
+        return {"object_id": self.object_id}
+
+
+try:
+    from djust_rentals.models import MaintenanceRequest
+except Exception:
+    logger.debug(
+        "djust_rentals.MaintenanceRequest not importable; demo admin skipped", exc_info=True
+    )
+    MaintenanceRequest = None
+
+
+if MaintenanceRequest is not None:
+
+    @djust_admin_site.register(MaintenanceRequest)
+    class MaintenanceRequestDjustAdmin(DjustModelAdmin):
+        """Demo admin that embeds a widget and exposes a background action."""
+
+        list_display = ["__str__", "status"]
+        list_filter = ["status"]
+        search_fields = ["description"]
+
+        # Per-page widget slots (v0.7.0). Each entry is a LiveView subclass.
+        change_form_widgets = [DemoProgressViewWidget]
+        change_list_widgets = [DemoProgressViewWidget]
+
+        actions = ["close_selected"]
+
+        @admin_action_with_progress(description="Close selected maintenance requests")
+        def close_selected(self, request, queryset, progress):
+            """Close each selected MaintenanceRequest, reporting progress.
+
+            Runs in a daemon thread; progress is pushed to the
+            BulkActionProgressWidget via ``progress.update(...)``. This
+            action is **cooperatively cancellable** — we check
+            ``progress.cancelled`` before each row so the user clicking
+            Cancel on the progress page actually stops the loop.
+            """
+            total = queryset.count()
+            progress.update(current=0, total=total, message="Starting…")
+            for i, req in enumerate(queryset.iterator(), start=1):
+                if progress.cancelled:
+                    progress.update(message="Cancelled by user.")
+                    return
+                # Simulated work so the demo progress bar is visible.
+                time.sleep(0.1)
+                req.status = "closed"
+                req.save(update_fields=["status"])
+                progress.update(
+                    current=i,
+                    total=total,
+                    message=f"Closed request #{req.pk}",
+                )
+            progress.update(message="All done.")

--- a/examples/demo_project/demo_project/urls.py
+++ b/examples/demo_project/demo_project/urls.py
@@ -9,8 +9,16 @@ from django.urls import path, include
 from djust.pwa import service_worker_view, manifest_view
 from djust.sse import sse_urlpatterns
 
+# Import the demo djust admin site — registers DemoProgressViewWidget +
+# MaintenanceRequestDjustAdmin. Demonstrates v0.7.0 admin widget slots +
+# @admin_action_with_progress.
+from demo_project.djust_admin import djust_admin_site
+
 urlpatterns = [
     path("admin/", admin.site.urls),
+    # djust admin demo — exercises change_form_widgets / change_list_widgets
+    # / BulkActionProgressWidget end-to-end.
+    path("djust-admin-demo/", djust_admin_site.urls),
     # SSE fallback transport (server-sent events for corporate proxy environments)
     path("djust/", include(sse_urlpatterns)),
     # djust HTTP API — mounts ADR-008 dispatch + v0.7.0 @server_function

--- a/examples/demo_project/templates/djust_admin/demo/progress_widget.html
+++ b/examples/demo_project/templates/djust_admin/demo/progress_widget.html
@@ -1,0 +1,13 @@
+<div class="text-sm text-gray-700">
+    <p>
+        {% if object_id %}
+        Editing maintenance request <strong>#{{ object_id }}</strong>.
+        {% else %}
+        Demo list-page widget.
+        {% endif %}
+    </p>
+    <p class="mt-1 text-xs text-gray-500">
+        This widget is embedded via ``DjustModelAdmin.change_form_widgets`` /
+        ``change_list_widgets`` (v0.7.0).
+    </p>
+</div>

--- a/python/djust/admin_ext/__init__.py
+++ b/python/djust/admin_ext/__init__.py
@@ -12,6 +12,7 @@ from . import adapters  # noqa: F401
 from .decorators import action, display, register
 from .options import DjustModelAdmin
 from .plugins import AdminPage, AdminPlugin, AdminWidget, NavItem
+from .progress import BulkActionProgressWidget, admin_action_with_progress
 from .sites import DjustAdminSite
 
 # Default admin site instance
@@ -36,9 +37,11 @@ __all__ = [
     "AdminPlugin",
     "AdminPage",
     "AdminWidget",
+    "BulkActionProgressWidget",
     "NavItem",
     "register",
     "action",
+    "admin_action_with_progress",
     "display",
     "site",
     "autodiscover",

--- a/python/djust/admin_ext/options.py
+++ b/python/djust/admin_ext/options.py
@@ -49,6 +49,42 @@ class DjustModelAdmin:
     # Actions
     actions = ["delete_selected"]
 
+    # Per-page widget slots (v0.7.0). Each entry is a LiveView subclass
+    # that will be embedded via ``{% live_render %}`` on the given admin
+    # page. Honour ``permission_required`` on the widget class to filter
+    # per-user. See docs/website/guides/admin-widgets.md.
+    change_form_widgets: list = []
+    change_list_widgets: list = []
+
+    def get_change_form_widgets(self, request, obj=None):
+        """Return widget classes eligible for the change form page.
+
+        Filters ``change_form_widgets`` by each widget's
+        ``permission_required`` attribute (if present).
+        """
+        return [w for w in self.change_form_widgets if self._widget_has_permission(w, request)]
+
+    def get_change_list_widgets(self, request):
+        """Return widget classes eligible for the change list page."""
+        return [w for w in self.change_list_widgets if self._widget_has_permission(w, request)]
+
+    @staticmethod
+    def _widget_has_permission(widget_cls, request):
+        """Check whether the request.user has permission to see the widget.
+
+        A widget with no ``permission_required`` attribute is always
+        visible. A string value is treated as a single perm; an
+        iterable is treated as a set of perms that are ALL required.
+        """
+        perm = getattr(widget_cls, "permission_required", None)
+        if perm is None:
+            return True
+        perms = (perm,) if isinstance(perm, str) else tuple(perm)
+        user = getattr(request, "user", None)
+        if user is None:
+            return False
+        return user.has_perms(perms)
+
     # Permissions
     def has_add_permission(self, request):
         return True

--- a/python/djust/admin_ext/progress.py
+++ b/python/djust/admin_ext/progress.py
@@ -1,0 +1,444 @@
+"""Bulk-action progress widget for djust admin.
+
+Provides a LiveView-based progress widget plus a decorator
+(``@admin_action_with_progress``) that turns any ``DjustModelAdmin``
+action into a background job with a live progress page.
+
+Usage
+-----
+
+Define a ModelAdmin action::
+
+    from djust.admin_ext import DjustModelAdmin, site
+    from djust.admin_ext.progress import admin_action_with_progress
+
+    @site.register(Article)
+    class ArticleAdmin(DjustModelAdmin):
+        actions = ["republish_selected"]
+
+        @admin_action_with_progress(description="Republish selected articles")
+        def republish_selected(self, request, queryset, progress):
+            total = queryset.count()
+            for i, article in enumerate(queryset.iterator(), start=1):
+                article.publish()
+                progress.update(current=i, total=total,
+                                message=f"Republished {article.title}")
+
+Known limitation
+----------------
+
+The ``_JOBS`` registry is process-local. Under a multi-worker deploy
+(Gunicorn/Uvicorn with ``workers>1``) the redirect may land on a
+different worker than the one running the background thread, producing
+a "Job not found" error on the progress page.  For v0.7.0, run a single
+worker (``--workers 1``) or use sticky sessions. The v0.7.1 follow-up
+will back ``_JOBS`` with a channel layer so multi-worker deploys work
+out of the box.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from functools import wraps
+from typing import Callable, List, Optional
+
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+
+from djust import LiveView
+from djust.decorators import event_handler, state
+
+logger = logging.getLogger(__name__)
+
+# Process-local registry. v0.7.1 will back this with a channel layer for
+# multi-worker safety. See module docstring.
+#
+# LRU-capped OrderedDict so a long-running server that runs many bulk
+# actions doesn't grow _JOBS without bound. Oldest entries are evicted
+# when the cap is exceeded.
+_MAX_JOBS = 500
+_MAX_MESSAGE_CHARS = 4096  # per-message cap for Job.message / Job.error
+_JOBS: "OrderedDict[str, Job]" = OrderedDict()
+
+# User-facing error message when the action body raises. The raw
+# exception text is intentionally NOT surfaced to the browser — it may
+# carry sensitive internals (SQL, credentials). The raw trace is logged
+# via ``logger.exception`` at ERROR level for operators.
+_GENERIC_ERROR_USER_MESSAGE = "Action failed — see server logs for details."
+
+
+def _truncate(text: str, limit: int = _MAX_MESSAGE_CHARS) -> str:
+    """Clamp a string to ``limit`` chars, appending ``...`` if truncated."""
+    if text is None:
+        return text
+    s = str(text)
+    if len(s) <= limit:
+        return s
+    return s[: max(0, limit - 3)] + "..."
+
+
+def _store_job(job_id: str, job: "Job") -> None:
+    """Insert/refresh a job in the LRU registry and evict overflow.
+
+    Called from the decorator. Uses ``move_to_end`` for defensive
+    re-insertion (shouldn't happen with uuid4 keys but harmless) and
+    trims the dict down to ``_MAX_JOBS`` entries.
+    """
+    if job_id in _JOBS:
+        _JOBS.move_to_end(job_id)
+    _JOBS[job_id] = job
+    while len(_JOBS) > _MAX_JOBS:
+        _JOBS.popitem(last=False)  # FIFO eviction of the oldest
+
+
+@dataclass
+class Job:
+    """In-memory state for a single bulk-action run.
+
+    All fields are readable by the ``BulkActionProgressWidget`` LiveView
+    polling loop and writable by the decorated action body via
+    :meth:`update`.
+    """
+
+    job_id: str
+    action_label: str
+    user_id: Optional[int]
+    admin_site_name: str
+    redirect_url: str
+    current: int = 0
+    total: int = 0
+    message: str = ""
+    log: List[str] = field(default_factory=list)
+    done: bool = False
+    cancelled: bool = False
+    error: Optional[str] = None
+
+    # Private slot holding the raw exception message for server-side
+    # diagnostics. ``error`` (public) carries the user-safe message.
+    _error_raw: Optional[str] = None
+
+    def update(
+        self,
+        *,
+        current: Optional[int] = None,
+        total: Optional[int] = None,
+        message: str = "",
+    ) -> None:
+        """Advance the job's progress state.
+
+        Any non-None argument replaces the corresponding field. A
+        non-empty ``message`` is both set as the current message and
+        appended to ``log`` (trimmed to the last 50 entries). Messages
+        longer than ``_MAX_MESSAGE_CHARS`` are truncated with ``...``
+        to bound memory growth from error-happy actions.
+        """
+        if current is not None:
+            self.current = current
+        if total is not None:
+            self.total = total
+        if message:
+            safe = _truncate(message)
+            self.message = safe
+            self.log.append(safe)
+            if len(self.log) > 50:
+                self.log = self.log[-50:]
+
+    def set_error(
+        self,
+        exc: BaseException,
+        *,
+        user_message: Optional[str] = None,
+    ) -> None:
+        """Record an exception for the progress page.
+
+        ``self.error`` is set to a **generic, user-safe** message so the
+        raw exception text (which may include sensitive DB / credential
+        details) never reaches the browser. The raw text is retained in
+        ``self._error_raw`` for server-side introspection in tests.
+        Callers that want a specific user-facing string (e.g.
+        ``"Invalid order ID"`` for an expected validation error) can
+        pass ``user_message``.
+        """
+        raw = str(exc) if exc is not None else ""
+        self._error_raw = _truncate(raw)
+        self.error = _truncate(user_message or _GENERIC_ERROR_USER_MESSAGE)
+
+
+class BulkActionProgressWidget(LiveView):
+    """LiveView that reports progress of a background admin action.
+
+    Mounted at ``/<admin>/djust-progress/<job_id>/``. Authenticated
+    staff users only (re-checked in :meth:`mount`). Only the user who
+    launched the job can see it — any other user, even a staff user,
+    gets a 403.
+    """
+
+    template_name = "djust_admin/bulk_progress.html"
+    login_required = True
+
+    job_id = state(default="")
+    current = state(default=0)
+    total = state(default=0)
+    message = state(default="")
+    log_lines = state(default=[])
+    done = state(default=False)
+    cancelled = state(default=False)
+    error = state(default=None)
+    action_label = state(default="")
+    redirect_url = state(default="")
+
+    def mount(self, request, job_id: str = "", **kwargs) -> None:
+        """Verify auth and attach to the job, starting a polling loop.
+
+        Re-checks ``is_staff`` on top of ``login_required=True`` (the
+        mount attribute covers authentication; we also require staff)
+        and validates that the authenticated user is the job's owner.
+        """
+        self.request = request
+        if not getattr(request.user, "is_staff", False):
+            raise PermissionDenied("Admin-only progress view.")
+        self.job_id = job_id
+        job = _JOBS.get(job_id)
+        if job is None:
+            self.error = "Job not found or expired."
+            self.done = True
+            return
+        if job.user_id is not None and job.user_id != getattr(request.user, "pk", None):
+            raise PermissionDenied("Not your job.")
+        self._refresh_from_job(job)
+        self.start_async(self._poll, name="progress_poll")
+
+    def _poll(self) -> None:
+        """Background polling loop that pulls updates from ``_JOBS``.
+
+        Sleeps 30 seconds after the job finishes (done / cancelled /
+        error) before clearing the job from the registry, giving the
+        user a chance to read the final state before it disappears.
+        """
+        while True:
+            job = _JOBS.get(self.job_id)
+            if job is None:
+                return
+            self._refresh_from_job(job)
+            if job.done or job.cancelled or job.error:
+                time.sleep(30)
+                _JOBS.pop(self.job_id, None)
+                return
+            time.sleep(0.5)
+
+    def _refresh_from_job(self, job: Job) -> None:
+        """Copy the job's fields onto self so they render."""
+        self.current = job.current
+        self.total = job.total
+        self.message = job.message
+        self.log_lines = list(job.log)
+        self.done = job.done
+        self.cancelled = job.cancelled
+        self.error = job.error
+        self.action_label = job.action_label
+        self.redirect_url = job.redirect_url
+
+    @event_handler
+    def cancel(self, **kwargs) -> None:
+        """Cancel the running job — both flags flip atomically.
+
+        Terminal: sets ``cancelled=True`` AND ``done=True`` so the
+        polling loop exits on the next tick.
+        """
+        job = _JOBS.get(self.job_id)
+        if job and not job.done:
+            job.cancelled = True
+            job.done = True
+            self._refresh_from_job(job)
+
+    def get_context_data(self, **kwargs):
+        """Expose template-friendly fields."""
+        percent = 0
+        if self.total:
+            try:
+                percent = int(min(100, max(0, (self.current / self.total) * 100)))
+            except (ZeroDivisionError, TypeError):
+                percent = 0
+        return {
+            "job_id": self.job_id,
+            "action_label": self.action_label,
+            "current": self.current,
+            "total": self.total,
+            "percent": percent,
+            "message": self.message,
+            "log_lines": self.log_lines,
+            "done": self.done,
+            "cancelled": self.cancelled,
+            "error": self.error,
+            "redirect_url": self.redirect_url,
+        }
+
+
+def admin_action_with_progress(
+    description: Optional[str] = None,
+    permissions: Optional[List[str]] = None,
+) -> Callable:
+    """Decorator: turn a ModelAdmin action into a background job + progress page.
+
+    The decorated method is called in a background daemon thread with
+    the signature ``(self, request, queryset, progress)`` where
+    ``progress`` is a :class:`Job` instance. The method may call
+    ``progress.update(current=..., total=..., message=...)`` at any
+    time; the progress page polls this state and re-renders.
+
+    On invocation, the wrapped action returns an
+    :class:`~django.http.HttpResponseRedirect` to the progress URL.
+
+    Args:
+        description: Human-readable short_description for the admin
+            dropdown. Defaults to the method name, Title-Cased.
+        permissions: Permission strings required to run this action.
+            Stored as ``allowed_permissions`` for future integration
+            with admin's permission machinery (v0.7.1+).
+
+    Thread safety: the queryset is eagerly pinned to a list of primary
+    keys before the thread starts, so late-evaluated filters on the
+    request/session cannot affect the background run.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(self, request, queryset):
+            job_id = uuid.uuid4().hex
+            admin_site = self.admin_site
+            try:
+                progress_url = reverse(
+                    f"{admin_site.name}:djust_progress",
+                    kwargs={"job_id": job_id},
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to reverse djust_progress URL for %s", admin_site.name, exc_info=True
+                )
+                progress_url = f"/{admin_site.name}/djust-progress/{job_id}/"
+
+            try:
+                redirect_back = reverse(
+                    f"{admin_site.name}:"
+                    f"{self.model._meta.app_label}_"
+                    f"{self.model._meta.model_name}_changelist",
+                )
+            except Exception:
+                logger.debug("Failed to reverse changelist URL", exc_info=True)
+                redirect_back = "/"
+
+            job = Job(
+                job_id=job_id,
+                action_label=getattr(wrapper, "short_description", func.__name__),
+                user_id=getattr(request.user, "pk", None),
+                admin_site_name=admin_site.name,
+                redirect_url=redirect_back,
+            )
+            _store_job(job_id, job)
+
+            # Pin queryset to PKs so the thread doesn't re-evaluate the
+            # lazy queryset against a stale session / request.
+            try:
+                pks = list(queryset.values_list("pk", flat=True))
+            except Exception:
+                logger.debug("Failed to pin queryset PKs", exc_info=True)
+                pks = []
+
+            model = self.model
+            admin_instance = self
+
+            def _run():
+                try:
+                    pinned = model._default_manager.filter(pk__in=pks)
+                    func(admin_instance, request, pinned, job)
+                except Exception as exc:
+                    # Full traceback goes to the server log at ERROR
+                    # level via logger.exception. The user-facing
+                    # ``job.error`` is intentionally generic to avoid
+                    # leaking sensitive exception details to the admin
+                    # page.
+                    logger.exception("admin_action_with_progress: %s failed", func.__name__)
+                    job.set_error(exc)
+                finally:
+                    job.done = True
+
+            threading.Thread(
+                target=_run,
+                daemon=True,
+                name=f"djust-admin-action-{job_id}",
+            ).start()
+            return HttpResponseRedirect(progress_url)
+
+        wrapper.short_description = description or func.__name__.replace("_", " ").title()
+        wrapper.allowed_permissions = permissions or []
+        wrapper._djust_admin_action_with_progress = True
+        return wrapper
+
+    return decorator
+
+
+def _make_bulk_action_progress_view():
+    """Build ``BulkActionProgressView`` class.
+
+    Done lazily so we don't import ``AdminBaseMixin`` (from views.py) at
+    module load time, which would set up a circular import: views.py
+    imports from progress.py via sites.py indirectly.
+    """
+    from .views import AdminBaseMixin
+
+    class BulkActionProgressView(AdminBaseMixin, BulkActionProgressWidget):
+        """URL-routed admin view: the progress widget with full admin chrome.
+
+        This is what ``DjustAdminSite.get_urls`` wires to
+        ``djust-progress/<job_id>/``. It mixes in ``AdminBaseMixin`` so
+        the rendered page has the sidebar, breadcrumbs, and plugin nav
+        that the rest of the admin shares, and the mixin's ``as_view``
+        installs ``admin_login_required``.
+        """
+
+        # Declared as a class attr so ``as_view(_view_registry_id=...)``
+        # is accepted by Django's View.as_view signature check.
+        _view_registry_id = None
+
+        def mount(self, request, job_id: str = "", **kwargs) -> None:
+            # AdminBaseMixin.as_view installs admin_login_required; we
+            # still call the widget's mount for is_staff + owner checks.
+            BulkActionProgressWidget.mount(self, request, job_id=job_id, **kwargs)
+
+        def get_context_data(self, **kwargs):
+            base = BulkActionProgressWidget.get_context_data(self, **kwargs)
+            admin_ctx = self.get_admin_context()
+            return {
+                **admin_ctx,
+                **base,
+                "title": base.get("action_label") or "Progress",
+            }
+
+    return BulkActionProgressView
+
+
+def __getattr__(name):
+    """Lazy-construct ``BulkActionProgressView`` on first access.
+
+    This avoids the circular import (progress.py -> views.py -> sites.py
+    -> progress.py) that would happen at module load time.
+    """
+    if name == "BulkActionProgressView":
+        cls = _make_bulk_action_progress_view()
+        globals()["BulkActionProgressView"] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "BulkActionProgressWidget",
+    "BulkActionProgressView",  # noqa: F822 — lazy-constructed via __getattr__
+    "Job",
+    "admin_action_with_progress",
+]

--- a/python/djust/admin_ext/progress.py
+++ b/python/djust/admin_ext/progress.py
@@ -453,7 +453,14 @@ def __getattr__(name):
 
 __all__ = [
     "BulkActionProgressWidget",
-    "BulkActionProgressView",  # noqa: F822 — lazy-constructed via __getattr__
     "Job",
     "admin_action_with_progress",
 ]
+# NOTE: ``BulkActionProgressView`` is intentionally NOT in ``__all__``. It is
+# lazy-constructed via module ``__getattr__`` (see above) to avoid a circular
+# import (progress.py → views.py → sites.py → progress.py). Internal callers
+# use the explicit ``from djust.admin_ext.progress import
+# BulkActionProgressView`` form, which still triggers ``__getattr__``.
+# Exposing it in ``__all__`` trips CodeQL py/undefined-export; declaring it
+# under ``TYPE_CHECKING`` also doesn't help because the real class is built
+# at runtime from ``BulkActionProgressWidget``, not imported.

--- a/python/djust/admin_ext/progress.py
+++ b/python/djust/admin_ext/progress.py
@@ -65,6 +65,11 @@ logger = logging.getLogger(__name__)
 _MAX_JOBS = 500
 _MAX_MESSAGE_CHARS = 4096  # per-message cap for Job.message / Job.error
 _JOBS: "OrderedDict[str, Job]" = OrderedDict()
+# Guards concurrent ``_store_job`` callers so the length check + eviction
+# + insertion run atomically. Without this, N threads inserting at once
+# can each observe ``len(_JOBS) > _MAX_JOBS`` simultaneously and each
+# ``popitem`` — overshooting the FIFO invariant.
+_JOBS_LOCK = threading.Lock()
 
 # User-facing error message when the action body raises. The raw
 # exception text is intentionally NOT surfaced to the browser — it may
@@ -89,12 +94,16 @@ def _store_job(job_id: str, job: "Job") -> None:
     Called from the decorator. Uses ``move_to_end`` for defensive
     re-insertion (shouldn't happen with uuid4 keys but harmless) and
     trims the dict down to ``_MAX_JOBS`` entries.
+
+    Thread-safe: the length check + eviction + insertion run under
+    ``_JOBS_LOCK`` so concurrent inserters can't over-evict past the cap.
     """
-    if job_id in _JOBS:
-        _JOBS.move_to_end(job_id)
-    _JOBS[job_id] = job
-    while len(_JOBS) > _MAX_JOBS:
-        _JOBS.popitem(last=False)  # FIFO eviction of the oldest
+    with _JOBS_LOCK:
+        if job_id in _JOBS:
+            _JOBS.move_to_end(job_id)
+        _JOBS[job_id] = job
+        while len(_JOBS) > _MAX_JOBS:
+            _JOBS.popitem(last=False)  # FIFO eviction of the oldest
 
 
 @dataclass
@@ -333,9 +342,15 @@ def admin_action_with_progress(
                 logger.debug("Failed to reverse changelist URL", exc_info=True)
                 redirect_back = "/"
 
+            # Cap action_label at _MAX_MESSAGE_CHARS at construction time
+            # so a malicious / buggy action with a multi-MB
+            # ``short_description`` can't blow out memory via the _JOBS
+            # registry. Matches the per-message cap enforced by
+            # Job.update().
+            raw_label = getattr(wrapper, "short_description", func.__name__)
             job = Job(
                 job_id=job_id,
-                action_label=getattr(wrapper, "short_description", func.__name__),
+                action_label=_truncate(raw_label),
                 user_id=getattr(request.user, "pk", None),
                 admin_site_name=admin_site.name,
                 redirect_url=redirect_back,

--- a/python/djust/admin_ext/sites.py
+++ b/python/djust/admin_ext/sites.py
@@ -126,6 +126,7 @@ class DjustAdminSite:
 
     def get_urls(self):
         """Return URL patterns for the admin site (models + plugins)."""
+        from .progress import BulkActionProgressView
         from .views import (
             AdminIndexView,
             LoginView,
@@ -146,10 +147,19 @@ class DjustAdminSite:
         # Register index view
         index_id = f"{self.name}_index"
         register_admin_view(index_id, admin_site=self)
+
+        # Bulk-action progress view
+        progress_id = f"{self.name}_progress"
+        register_admin_view(progress_id, admin_site=self)
         urlpatterns = [
             path("login/", LoginView.as_view(_view_registry_id=login_id), name="login"),
             path("logout/", LogoutView.as_view(_view_registry_id=logout_id), name="logout"),
             path("", AdminIndexView.as_view(_view_registry_id=index_id), name="index"),
+            path(
+                "djust-progress/<str:job_id>/",
+                BulkActionProgressView.as_view(_view_registry_id=progress_id),
+                name="djust_progress",
+            ),
         ]
 
         # Add URLs for each registered model

--- a/python/djust/admin_ext/templates/djust_admin/_change_form_widgets.html
+++ b/python/djust/admin_ext/templates/djust_admin/_change_form_widgets.html
@@ -1,0 +1,17 @@
+{% load live_tags %}
+{% if change_form_widgets %}
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+    {% for w in change_form_widgets %}
+    <div class="bg-white rounded-lg shadow p-4 {% if w.size == 'lg' %}lg:col-span-2{% endif %}">
+        {% if w.label %}
+        <h3 class="text-sm font-medium text-gray-900 mb-3">{{ w.label }}</h3>
+        {% endif %}
+        {% if w.object_id %}
+            {% live_render w.view_path object_id=w.object_id %}
+        {% else %}
+            {% live_render w.view_path %}
+        {% endif %}
+    </div>
+    {% endfor %}
+</div>
+{% endif %}

--- a/python/djust/admin_ext/templates/djust_admin/_change_list_widgets.html
+++ b/python/djust/admin_ext/templates/djust_admin/_change_list_widgets.html
@@ -1,0 +1,13 @@
+{% load live_tags %}
+{% if change_list_widgets %}
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+    {% for w in change_list_widgets %}
+    <div class="bg-white rounded-lg shadow p-4 {% if w.size == 'lg' %}lg:col-span-2{% endif %}">
+        {% if w.label %}
+        <h3 class="text-sm font-medium text-gray-900 mb-3">{{ w.label }}</h3>
+        {% endif %}
+        {% live_render w.view_path %}
+    </div>
+    {% endfor %}
+</div>
+{% endif %}

--- a/python/djust/admin_ext/templates/djust_admin/bulk_progress.html
+++ b/python/djust/admin_ext/templates/djust_admin/bulk_progress.html
@@ -1,0 +1,77 @@
+{% extends "djust_admin/base.html" %}
+
+{% block breadcrumb_items %}
+<span class="mx-2 text-gray-400">/</span>
+<span class="text-gray-700">Progress</span>
+{% endblock %}
+
+{% block content %}
+<div class="max-w-3xl mx-auto">
+    <div class="mb-6">
+        <h1 class="text-2xl font-bold text-gray-900">
+            {% if action_label %}{{ action_label }}{% else %}Running action{% endif %}
+        </h1>
+    </div>
+
+    {% if error %}
+    <div class="mb-4 rounded-md bg-red-50 p-4 border border-red-200">
+        <h3 class="text-sm font-medium text-red-800">Error</h3>
+        <p class="mt-1 text-sm text-red-700">{{ error }}</p>
+    </div>
+    {% endif %}
+
+    {% if cancelled %}
+    <div class="mb-4 rounded-md bg-yellow-50 p-4 border border-yellow-200">
+        <p class="text-sm text-yellow-800">Cancelled.</p>
+    </div>
+    {% elif done %}
+    <div class="mb-4 rounded-md bg-green-50 p-4 border border-green-200">
+        <p class="text-sm text-green-800">Done — processed {{ current }} of {{ total }} item(s).</p>
+    </div>
+    {% endif %}
+
+    <div class="bg-white rounded-lg shadow p-6">
+        <div class="mb-2 flex items-center justify-between">
+            <span class="text-sm text-gray-700">{{ current }} / {{ total }}</span>
+            <span class="text-sm text-gray-500">{{ percent }}%</span>
+        </div>
+        <div class="w-full bg-gray-200 rounded-full h-3 overflow-hidden">
+            <div class="h-3 bg-indigo-600 transition-all"
+                 style="width: {{ percent }}%"></div>
+        </div>
+
+        {% if message %}
+        <p class="mt-3 text-sm text-gray-700">{{ message }}</p>
+        {% endif %}
+
+        <div class="mt-6 flex gap-3">
+            {% if not done %}
+            <button type="button"
+                    dj-click="cancel"
+                    class="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
+                Cancel
+            </button>
+            {% endif %}
+            {% if done and redirect_url %}
+            <a href="{{ redirect_url }}"
+               class="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700">
+                Back to list
+            </a>
+            {% endif %}
+        </div>
+    </div>
+
+    {% if log_lines %}
+    <div class="mt-6 bg-white rounded-lg shadow">
+        <div class="px-4 py-3 border-b border-gray-200">
+            <h3 class="text-sm font-medium text-gray-900">Log</h3>
+        </div>
+        <ul class="divide-y divide-gray-100 max-h-80 overflow-y-auto">
+            {% for line in log_lines %}
+            <li class="px-4 py-2 text-sm text-gray-700">{{ line }}</li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/python/djust/admin_ext/templates/djust_admin/model_detail.html
+++ b/python/djust/admin_ext/templates/djust_admin/model_detail.html
@@ -20,6 +20,9 @@
         <h1 class="text-2xl font-bold text-gray-900">{{ title }}</h1>
     </div>
 
+    {# Per-page widget slots (v0.7.0) #}
+    {% include "djust_admin/_change_form_widgets.html" %}
+
     <!-- Success message -->
     {% if save_success %}
     <div class="mb-4 rounded-md bg-green-50 p-4">

--- a/python/djust/admin_ext/templates/djust_admin/model_list.html
+++ b/python/djust/admin_ext/templates/djust_admin/model_list.html
@@ -21,6 +21,9 @@
         {% endif %}
     </div>
 
+    {# Per-page widget slots (v0.7.0) #}
+    {% include "djust_admin/_change_list_widgets.html" %}
+
     <div class="flex gap-6">
         <!-- Main content area -->
         <div class="{% if has_filters %}flex-1{% else %}w-full{% endif %}">

--- a/python/djust/admin_ext/views.py
+++ b/python/djust/admin_ext/views.py
@@ -10,6 +10,7 @@ from functools import wraps
 from urllib.parse import urlencode
 
 from django.contrib.auth import authenticate, logout
+from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
 from django.db.models import ForeignKey, OneToOneField, Q
 from django.http import HttpResponseRedirect
@@ -38,6 +39,25 @@ def register_admin_view(view_id, admin_site, model=None, model_admin=None):
 def get_admin_config(view_id):
     """Get admin config for a view."""
     return _VIEW_REGISTRY.get(view_id, {})
+
+
+def _serialize_widget_slots(widget_classes, *, object_id=None):
+    """Convert a list of LiveView widget classes into the dict shape
+    that ``_change_form_widgets.html`` / ``_change_list_widgets.html``
+    expect. Each entry carries the dotted ``view_path`` so
+    ``{% live_render %}`` can resolve it.
+    """
+    out = []
+    for widget_cls in widget_classes:
+        entry = {
+            "view_path": f"{widget_cls.__module__}.{widget_cls.__name__}",
+            "label": getattr(widget_cls, "label", ""),
+            "size": getattr(widget_cls, "size", "md"),
+        }
+        if object_id is not None:
+            entry["object_id"] = object_id
+        out.append(entry)
+    return out
 
 
 def admin_login_required(view_func):
@@ -314,6 +334,11 @@ class ModelListView(AdminBaseMixin, LiveView):
             except Exception:
                 logger.debug("Failed to build filter for %s", filter_field, exc_info=True)
 
+        # Per-page widget slots (v0.7.0)
+        change_list_widgets = _serialize_widget_slots(
+            self._model_admin.get_change_list_widgets(self.request)
+        )
+
         return {
             **self.get_admin_context(),
             "title": f"Select {self._model._meta.verbose_name} to change",
@@ -332,6 +357,7 @@ class ModelListView(AdminBaseMixin, LiveView):
                 f"{self._admin_site.name}:{self._model._meta.app_label}_{self._model._meta.model_name}_add",
             ),
             "has_add_permission": self._model_admin.has_add_permission(self.request),
+            "change_list_widgets": change_list_widgets,
         }
 
     @event_handler
@@ -383,7 +409,13 @@ class ModelListView(AdminBaseMixin, LiveView):
 
     @event_handler
     def run_action(self, action_name: str):
-        """Execute a bulk action on selected items."""
+        """Execute a bulk action on selected items.
+
+        Enforces ``allowed_permissions`` metadata stamped by decorators
+        (notably ``@admin_action_with_progress(permissions=[...])``).
+        Actions without ``allowed_permissions`` run unchanged, so this
+        is backward-compatible with actions decorated before v0.7.0.
+        """
         if not self.selected_ids:
             return None
 
@@ -391,8 +423,21 @@ class ModelListView(AdminBaseMixin, LiveView):
         if action_name not in actions:
             return None
 
-        queryset = self._model.objects.filter(pk__in=self.selected_ids)
         action_func = actions[action_name]["func"]
+
+        # Defense-in-depth: if the action declares required perms
+        # (via ``@admin_action_with_progress(permissions=[...])`` or an
+        # equivalent ``allowed_permissions`` attribute), block users who
+        # lack them BEFORE firing the action. This covers the gap where
+        # the default ``has_*_permission`` methods return True for any
+        # authenticated staff user -- a view-only staff user could
+        # otherwise fire a destructive action just by having an action
+        # entry in the dropdown.
+        allowed = getattr(action_func, "allowed_permissions", None) or []
+        if allowed and not self.request.user.has_perms(allowed):
+            raise PermissionDenied("User lacks required permissions for this action: %r" % allowed)
+
+        queryset = self._model.objects.filter(pk__in=self.selected_ids)
         result = action_func(self.request, queryset)
 
         self.selected_ids = []
@@ -480,13 +525,20 @@ class ModelDetailView(AdminBaseMixin, AdminFormMixin, LiveView):
                 }
             )
 
+        # Per-page widget slots (v0.7.0)
+        object_pk = self.object.pk if self.object else None
+        change_form_widgets = _serialize_widget_slots(
+            self._model_admin.get_change_form_widgets(self.request, self.object),
+            object_id=object_pk,
+        )
+
         return {
             **self.get_admin_context(),
             "title": f"Change {self.object}"
             if self.object
             else f"Add {self._model._meta.verbose_name}",
             "object": str(self.object) if self.object else None,
-            "object_pk": self.object.pk if self.object else None,
+            "object_pk": object_pk,
             "is_saving": self.is_saving,
             "save_success": self.save_success,
             "fieldsets": fieldsets_data,
@@ -499,6 +551,7 @@ class ModelDetailView(AdminBaseMixin, AdminFormMixin, LiveView):
             )
             if self.object
             else None,
+            "change_form_widgets": change_form_widgets,
         }
 
     @event_handler

--- a/python/djust/admin_ext/views.py
+++ b/python/djust/admin_ext/views.py
@@ -415,6 +415,15 @@ class ModelListView(AdminBaseMixin, LiveView):
         (notably ``@admin_action_with_progress(permissions=[...])``).
         Actions without ``allowed_permissions`` run unchanged, so this
         is backward-compatible with actions decorated before v0.7.0.
+
+        If the action returns an ``HttpResponseRedirect`` (as stock
+        Django admin actions and ``@admin_action_with_progress``-
+        decorated actions do), the redirect is intercepted and a
+        ``redirect`` push_event is dispatched to the client. This is
+        required because LiveView event handlers are invoked over the
+        WebSocket — raw HTTP responses have nowhere to go. Mirrors the
+        ``push_event("redirect", ...)`` pattern used by
+        ``LoginView.do_login``.
         """
         if not self.selected_ids:
             return None
@@ -442,6 +451,16 @@ class ModelListView(AdminBaseMixin, LiveView):
 
         self.selected_ids = []
         self.select_all = False
+
+        # WS-side redirect shim: Django-style admin actions return
+        # ``HttpResponseRedirect`` for post-action navigation. Over
+        # WebSocket, such responses would be silently dropped by the
+        # LiveView dispatcher — the browser would never navigate. Convert
+        # to a ``redirect`` push_event so the client navigates to the
+        # progress page (or wherever the action pointed).
+        if isinstance(result, HttpResponseRedirect):
+            self.push_event("redirect", {"url": result.url})
+            return None
         return result
 
     @event_handler

--- a/python/djust/checks.py
+++ b/python/djust/checks.py
@@ -2536,3 +2536,131 @@ def check_time_travel_debugging(app_configs, **kwargs):
         )
 
     return results
+
+
+# ---------------------------------------------------------------------------
+# Admin widget checks (A072 / A073) -- djust.admin_ext per-page widget slots
+# ---------------------------------------------------------------------------
+
+
+@register("djust")
+def check_admin_widgets(app_configs, _admin_sites=None, **kwargs):
+    """Audit widget-slot registrations on DjustModelAdmin subclasses.
+
+    - **A072** (Warning): non-LiveView class registered in
+      ``change_form_widgets`` / ``change_list_widgets``. Such widgets
+      cannot be embedded via ``{% live_render %}`` and will raise at
+      render time.
+    - **A073** (Info): runtime-detectable notice that the in-process
+      ``_JOBS`` registry backing ``BulkActionProgressWidget`` is
+      single-worker-only. Only emitted when (a) a ``DjustAdminSite``
+      has a registered admin action decorated with
+      ``@admin_action_with_progress`` AND (b) the ``DJUST_ASGI_WORKERS``
+      setting is greater than 1 (defaults to 1). In single-worker
+      development this check stays silent so ``manage.py check`` has
+      no noise. Multi-worker deploys must use sticky sessions or a
+      single ASGI worker until v0.7.1 ships the channel-layer backend.
+
+    The ``_admin_sites`` kwarg is for tests; production runs walk the
+    default admin site registry.
+    """
+    results = []
+
+    try:
+        from djust.admin_ext import site as default_site
+    except Exception:
+        logger.debug("admin_ext not importable; skipping A072/A073", exc_info=True)
+        return results
+
+    # Lazy import — avoids a circular import when checks.py is loaded
+    # during Django setup.
+    try:
+        from djust.live_view import LiveView
+    except Exception:
+        logger.debug("LiveView import failed; skipping admin widget audit", exc_info=True)
+        return results
+
+    sites = list(_admin_sites) if _admin_sites is not None else [default_site]
+
+    # A073 is gated on DJUST_ASGI_WORKERS > 1. In single-worker dev (the
+    # common case) the check stays silent; it only fires when the
+    # developer has deliberately declared a multi-worker deploy.
+    from django.conf import settings as _settings  # lazy import
+
+    asgi_workers = getattr(_settings, "DJUST_ASGI_WORKERS", 1)
+    try:
+        asgi_workers = int(asgi_workers)
+    except (TypeError, ValueError):
+        asgi_workers = 1
+    emit_a073 = asgi_workers > 1
+
+    for site in sites:
+        registry = getattr(site, "_registry", {}) or {}
+        site_name = getattr(site, "name", "djust_admin")
+        has_progress_action = False
+
+        for model, model_admin in registry.items():
+            model_label = "%s.%s" % (
+                getattr(model._meta, "app_label", "?"),
+                getattr(model._meta, "model_name", "?"),
+            )
+
+            for slot in ("change_form_widgets", "change_list_widgets"):
+                widgets = getattr(model_admin, slot, []) or []
+                for widget_cls in widgets:
+                    if not (isinstance(widget_cls, type) and issubclass(widget_cls, LiveView)):
+                        widget_name = getattr(widget_cls, "__name__", repr(widget_cls))
+                        results.append(
+                            DjustWarning(
+                                (
+                                    "Admin %s -- %s on %s contains non-LiveView class %r. "
+                                    "Widget slots can only embed djust LiveView subclasses."
+                                )
+                                % (site_name, slot, model_label, widget_name),
+                                hint=(
+                                    "Make %s a subclass of djust.LiveView, or remove it from %s."
+                                    % (widget_name, slot)
+                                ),
+                                id="djust.A072",
+                                fix_hint=(
+                                    "Change `class %s` to `class %s(LiveView):` or drop it from "
+                                    "`%s` on the ModelAdmin for `%s`."
+                                    % (widget_name, widget_name, slot, model_label)
+                                ),
+                            )
+                        )
+
+            # Scan actions for @admin_action_with_progress to drive A073.
+            actions = getattr(model_admin, "actions", []) or []
+            for action_name in actions:
+                func = (
+                    action_name
+                    if callable(action_name)
+                    else getattr(model_admin, str(action_name), None)
+                )
+                if func is not None and getattr(func, "_djust_admin_action_with_progress", False):
+                    has_progress_action = True
+                    break
+
+        if has_progress_action and emit_a073:
+            results.append(
+                DjustInfo(
+                    (
+                        "Admin %s -- uses @admin_action_with_progress with "
+                        "DJUST_ASGI_WORKERS=%d. The v0.7.0 BulkActionProgressWidget keeps "
+                        "job state in a process-local dict (_JOBS); multi-worker deploys "
+                        "must pin the progress URL to the worker that started the job "
+                        "(sticky sessions) or run a single ASGI worker. v0.7.1 will back "
+                        "this with a channel layer."
+                    )
+                    % (site_name, asgi_workers),
+                    hint=(
+                        "For v0.7.0, deploy with --workers 1 OR enable sticky sessions on "
+                        "your load balancer. Unset DJUST_ASGI_WORKERS (or set it to 1) to "
+                        "silence this check. See docs/website/guides/admin-widgets.md."
+                    ),
+                    id="djust.A073",
+                )
+            )
+
+    return results

--- a/python/djust/tests/test_admin_widgets_per_page.py
+++ b/python/djust/tests/test_admin_widgets_per_page.py
@@ -1,0 +1,410 @@
+"""Tests for per-page widget slots on ``DjustModelAdmin``.
+
+Per Action Tracker #124, the two "rule" tests here
+(``test_get_change_form_widgets_filters_by_permission``,
+``test_widget_slot_nonliveview_emits_A072``) were written BEFORE the
+corresponding implementation.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+pytestmark = pytest.mark.admin
+
+
+def _make_user(username="tester", *, is_staff=True, perms=()):
+    User = get_user_model()
+    user = User(username=username, is_staff=is_staff)
+    user.pk = 1
+    # Override has_perm / has_perms without hitting the DB.
+    perm_set = set(perms)
+    user.has_perm = lambda p: p in perm_set  # type: ignore[assignment]
+    user.has_perms = lambda ps: all(p in perm_set for p in ps)  # type: ignore[assignment]
+    return user
+
+
+class TestDefaultWidgetSlots(TestCase):
+    """Default widget slots should be empty."""
+
+    def test_change_form_widgets_attr_default_empty(self):
+        from djust.admin_ext import DjustModelAdmin
+
+        assert DjustModelAdmin.change_form_widgets == []
+
+    def test_change_list_widgets_attr_default_empty(self):
+        from djust.admin_ext import DjustModelAdmin
+
+        assert DjustModelAdmin.change_list_widgets == []
+
+
+class TestWidgetPermissions(TestCase):
+    """Widget slot permission filtering."""
+
+    def test_get_change_form_widgets_filters_by_permission(self):
+        """RULE #4: Widgets with ``permission_required`` must be hidden
+        from users that lack the perm."""
+        from djust import LiveView
+        from djust.admin_ext import DjustModelAdmin
+
+        class AllowedWidget(LiveView):
+            template_name = "x.html"
+
+        class RestrictedWidget(LiveView):
+            template_name = "x.html"
+            permission_required = "myapp.view_secret"
+
+        class MyAdmin(DjustModelAdmin):
+            change_form_widgets = [AllowedWidget, RestrictedWidget]
+
+        User = get_user_model()
+        admin = MyAdmin(User, None)
+
+        # User without perm sees only the allowed widget.
+        user_no_perm = _make_user(perms=())
+        from django.test import RequestFactory
+
+        req = RequestFactory().get("/")
+        req.user = user_no_perm
+        filtered = admin.get_change_form_widgets(req)
+        assert filtered == [AllowedWidget]
+
+        # User with perm sees both.
+        user_with_perm = _make_user(perms=("myapp.view_secret",))
+        req.user = user_with_perm
+        filtered = admin.get_change_form_widgets(req)
+        assert filtered == [AllowedWidget, RestrictedWidget]
+
+
+class TestWidgetSlotContext(TestCase):
+    """Widget slot values should end up in the view context."""
+
+    def test_change_form_widgets_rendered_in_context(self):
+        """``ModelDetailView.get_context_data`` serializes
+        ``change_form_widgets`` into ``change_form_widgets`` key."""
+        from djust import LiveView
+        from djust.admin_ext import DjustAdminSite, DjustModelAdmin
+
+        class DemoWidget(LiveView):
+            template_name = "x.html"
+            label = "Stats"
+
+        User = get_user_model()
+        site = DjustAdminSite(name="djust_admin")
+
+        class UserAdmin(DjustModelAdmin):
+            change_form_widgets = [DemoWidget]
+
+        site.register(User, UserAdmin)
+        model_admin = site._registry[User]
+
+        # Verify ``get_change_form_widgets`` returns the expected list.
+        from django.test import RequestFactory
+
+        req = RequestFactory().get("/")
+        req.user = _make_user()
+        widgets = model_admin.get_change_form_widgets(req)
+        assert widgets == [DemoWidget]
+
+    def test_change_list_widgets_rendered_in_context(self):
+        """``ModelListView.get_context_data`` exposes
+        ``change_list_widgets`` to the template."""
+        from djust import LiveView
+        from djust.admin_ext import DjustAdminSite, DjustModelAdmin
+
+        class DemoListWidget(LiveView):
+            template_name = "x.html"
+            label = "List widget"
+
+        User = get_user_model()
+        site = DjustAdminSite(name="djust_admin_2")
+
+        class UserAdmin(DjustModelAdmin):
+            change_list_widgets = [DemoListWidget]
+
+        site.register(User, UserAdmin)
+        model_admin = site._registry[User]
+
+        from django.test import RequestFactory
+
+        req = RequestFactory().get("/")
+        req.user = _make_user()
+        widgets = model_admin.get_change_list_widgets(req)
+        assert widgets == [DemoListWidget]
+
+    def test_change_form_widget_live_render_embeds_child(self):
+        """Widget dicts serialized for the template carry the dotted
+        view_path so ``{% live_render %}`` can resolve them."""
+        from djust import LiveView
+        from djust.admin_ext.options import DjustModelAdmin
+
+        class SomeWidget(LiveView):
+            template_name = "x.html"
+            label = "Some"
+            size = "lg"
+
+        class MyAdmin(DjustModelAdmin):
+            change_form_widgets = [SomeWidget]
+
+        User = get_user_model()
+        admin = MyAdmin(User, None)
+        from django.test import RequestFactory
+
+        req = RequestFactory().get("/")
+        req.user = _make_user()
+        widgets = admin.get_change_form_widgets(req)
+        assert widgets == [SomeWidget]
+        # Check the dotted-path composition (used in the serialized dict).
+        path = f"{SomeWidget.__module__}.{SomeWidget.__name__}"
+        assert "." in path
+        assert path.endswith("SomeWidget")
+
+    def test_multiple_widgets_preserve_order(self):
+        """Widget slot order is preserved by ``get_change_form_widgets``."""
+        from djust import LiveView
+        from djust.admin_ext import DjustModelAdmin
+
+        class W1(LiveView):
+            template_name = "x.html"
+
+        class W2(LiveView):
+            template_name = "x.html"
+
+        class W3(LiveView):
+            template_name = "x.html"
+
+        class MyAdmin(DjustModelAdmin):
+            change_form_widgets = [W2, W1, W3]
+
+        User = get_user_model()
+        admin = MyAdmin(User, None)
+        from django.test import RequestFactory
+
+        req = RequestFactory().get("/")
+        req.user = _make_user()
+        assert admin.get_change_form_widgets(req) == [W2, W1, W3]
+
+
+class TestA072Check(TestCase):
+    """A072 should flag non-LiveView classes registered in widget slots."""
+
+    def test_widget_slot_nonliveview_emits_A072(self):
+        """RULE #5: A non-LiveView class in a widget slot must be caught
+        at audit time by ``djust.checks`` (id ``djust.A072``)."""
+        from djust.admin_ext import DjustAdminSite, DjustModelAdmin
+        from djust.checks import check_admin_widgets
+
+        # Register a MODEL ADMIN with a non-LiveView widget class.
+        User = get_user_model()
+        site = DjustAdminSite(name="djust_admin_a072")
+
+        class NotALiveView:
+            """Plain class — deliberately NOT a LiveView subclass."""
+
+        class BadAdmin(DjustModelAdmin):
+            change_form_widgets = [NotALiveView]
+
+        site.register(User, BadAdmin)
+
+        errors = check_admin_widgets(None, _admin_sites=[site])
+        codes = [e.id for e in errors]
+        assert "djust.A072" in codes, f"Expected A072 in {codes!r}"
+
+
+class TestWidgetPermissionFilterInRenderedHTML(TestCase):
+    """End-to-end: widgets filtered out by permission_required must not
+    appear in the serialized widget-slot dicts that drive the rendered
+    HTML."""
+
+    def test_widget_filtered_by_permission_absent_in_rendered_html(self):
+        """A widget with ``permission_required`` the user lacks should
+        not appear in any serialized template context — exercising the
+        full filter + serialize path."""
+        from djust import LiveView
+        from djust.admin_ext import DjustModelAdmin
+        from djust.admin_ext.views import _serialize_widget_slots
+
+        class VisibleWidget(LiveView):
+            template_name = "x.html"
+            label = "Visible"
+
+        class SecretWidget(LiveView):
+            template_name = "x.html"
+            permission_required = "app.missing_perm"
+            label = "Secret"
+
+        class MyAdmin(DjustModelAdmin):
+            change_list_widgets = [VisibleWidget, SecretWidget]
+
+        User = get_user_model()
+        admin = MyAdmin(User, None)
+        from django.test import RequestFactory
+
+        req = RequestFactory().get("/")
+        req.user = _make_user(perms=())
+
+        filtered = admin.get_change_list_widgets(req)
+        serialized = _serialize_widget_slots(filtered)
+
+        # Flatten serialized dicts to a searchable blob and assert the
+        # excluded widget's view_path does NOT appear anywhere.
+        blob = str(serialized)
+        secret_path = f"{SecretWidget.__module__}.{SecretWidget.__name__}"
+        visible_path = f"{VisibleWidget.__module__}.{VisibleWidget.__name__}"
+        assert secret_path not in blob, (
+            "SecretWidget view_path leaked into serialized widget dicts "
+            "for a user lacking the required permission: %r" % serialized
+        )
+        assert visible_path in blob, "VisibleWidget should be present"
+
+
+class TestChangeFormWidgetsOnCreateView(TestCase):
+    """Per Rule #4 and the fix for the empty-object_id bug, the create
+    view (no object) must not pass ``object_id=""`` to child widgets."""
+
+    def test_change_form_widgets_on_create_view_omits_object_id(self):
+        """When no object exists (create view), the serialized widget
+        dicts must NOT carry an ``object_id`` key at all — so the
+        template falls through to ``{% live_render w.view_path %}``
+        without a stray empty string."""
+        from djust import LiveView
+        from djust.admin_ext.views import _serialize_widget_slots
+
+        class AnyWidget(LiveView):
+            template_name = "x.html"
+            label = "Any"
+
+        # Simulate ModelDetailView / ModelCreateView path:
+        # self.object is None => object_pk = None => _serialize_widget_slots(..., object_id=None)
+        entries = _serialize_widget_slots([AnyWidget], object_id=None)
+
+        assert len(entries) == 1
+        entry = entries[0]
+        # The critical invariant: no object_id key at all. Django's
+        # template engine resolves missing keys to "" (empty string).
+        # The template now guards with ``{% if w.object_id %}`` so
+        # omitting the key is the correct representation of "no object".
+        assert "object_id" not in entry, (
+            "Serialized widget entry for create-view must NOT include object_id key; got %r" % entry
+        )
+
+    def test_change_form_widgets_on_edit_view_carries_object_id(self):
+        """Sanity check: when an object IS present, object_id flows through."""
+        from djust import LiveView
+        from djust.admin_ext.views import _serialize_widget_slots
+
+        class AnyWidget(LiveView):
+            template_name = "x.html"
+
+        entries = _serialize_widget_slots([AnyWidget], object_id=42)
+        assert entries[0].get("object_id") == 42
+
+
+class TestRunActionPermissionEnforcement(TestCase):
+    """``run_action`` enforces ``allowed_permissions`` metadata on
+    decorated actions -- even if the default ``has_*_permission``
+    methods return True."""
+
+    def test_run_action_enforces_allowed_permissions(self):
+        """User lacking a decorator-declared permission gets 403."""
+        from django.core.exceptions import PermissionDenied
+        from django.test import RequestFactory
+
+        from djust.admin_ext import DjustAdminSite, DjustModelAdmin
+        from djust.admin_ext.progress import admin_action_with_progress
+        from djust.admin_ext.views import ModelListView, register_admin_view
+
+        User = get_user_model()
+
+        class RestrictedAdmin(DjustModelAdmin):
+            @admin_action_with_progress(
+                description="Destroy things", permissions=["app.change_foo"]
+            )
+            def destroy_selected(self, request, queryset, progress):
+                # Should not get here -- perms should block first.
+                progress.update(message="ran")
+
+            actions = ["destroy_selected"]
+
+        site = DjustAdminSite(name="djust_admin_perm_test")
+        site.register(User, RestrictedAdmin)
+        model_admin = site._registry[User]
+
+        # Wire up the view registry so ModelListView can resolve admin config.
+        view_id = "test_run_action_perm"
+        register_admin_view(view_id, site, model=User, model_admin=model_admin)
+
+        view = ModelListView()
+        view._view_registry_id = view_id
+        req = RequestFactory().post("/")
+        req.user = _make_user(is_staff=True, perms=())  # no perms
+        view.request = req
+        view.selected_ids = [1]
+        view.select_all = False
+        view.active_filters = {}
+        view.search_query = ""
+        view.current_page = 1
+        view.ordering = None
+
+        with pytest.raises(PermissionDenied):
+            view.run_action("destroy_selected")
+
+    def test_run_action_allows_when_user_has_perm(self):
+        """User WITH the required permission passes the perm check (the
+        only thing under test). We don't care whether the action body
+        itself runs to completion here -- just that PermissionDenied is
+        NOT raised."""
+        from django.core.exceptions import PermissionDenied
+        from django.test import RequestFactory
+
+        from djust.admin_ext import DjustAdminSite, DjustModelAdmin
+        from djust.admin_ext.views import ModelListView, register_admin_view
+
+        User = get_user_model()
+
+        def protected_action(request, queryset):
+            # Arity matches what ``get_actions`` feeds to ``run_action``.
+            return "ok"
+
+        protected_action.allowed_permissions = ["app.change_foo"]
+        protected_action.short_description = "Protected"
+
+        class PermAdmin(DjustModelAdmin):
+            def get_actions(self, request):
+                return {
+                    "protected_action": {
+                        "func": protected_action,
+                        "description": "Protected",
+                    }
+                }
+
+        site = DjustAdminSite(name="djust_admin_perm_test_ok")
+        site.register(User, PermAdmin)
+        model_admin = site._registry[User]
+
+        view_id = "test_run_action_perm_ok"
+        register_admin_view(view_id, site, model=User, model_admin=model_admin)
+
+        view = ModelListView()
+        view._view_registry_id = view_id
+        req = RequestFactory().post("/")
+        req.user = _make_user(is_staff=True, perms=("app.change_foo",))
+        view.request = req
+        view.selected_ids = [1]
+        view.select_all = False
+        view.active_filters = {}
+        view.search_query = ""
+        view.current_page = 1
+        view.ordering = None
+
+        # The only thing we assert: PermissionDenied does NOT fire.
+        # Anything else downstream (queryset DB access etc) is outside
+        # this test's scope and is acceptable.
+        try:
+            view.run_action("protected_action")
+        except PermissionDenied:
+            pytest.fail("user has perm; run_action should not raise PermissionDenied")
+        except Exception:
+            pass  # DB-access / queryset eval is fine.

--- a/python/djust/tests/test_bulk_progress.py
+++ b/python/djust/tests/test_bulk_progress.py
@@ -1,0 +1,462 @@
+"""Tests for BulkActionProgressWidget + @admin_action_with_progress.
+
+Per Action Tracker #124, the three "rule" tests here
+(``test_bulk_progress_job_cancel_flips_done_and_cancelled_flags``,
+``test_bulk_progress_non_owner_user_gets_403``,
+``test_bulk_progress_non_staff_gets_403``) were written BEFORE the
+implementation in ``djust/admin_ext/progress.py``.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.exceptions import PermissionDenied
+from django.test import RequestFactory, TestCase
+
+pytestmark = pytest.mark.admin
+
+
+def _make_user(username, *, is_staff=True, pk=1):
+    """Build a lightweight user stand-in (no DB required)."""
+    User = get_user_model()
+    user = User(username=username, is_staff=is_staff)
+    user.pk = pk
+    user.id = pk
+    return user
+
+
+class TestJobModel(TestCase):
+    """Tests for the Job dataclass."""
+
+    def test_job_update_appends_log_and_caps_at_50(self):
+        """Progress updates should append to the log and cap at 50 entries."""
+        from djust.admin_ext.progress import Job
+
+        job = Job(
+            job_id="x",
+            action_label="Test",
+            user_id=1,
+            admin_site_name="djust_admin",
+            redirect_url="/",
+        )
+        for i in range(60):
+            job.update(current=i, total=60, message=f"step {i}")
+        assert job.current == 59
+        assert job.total == 60
+        assert len(job.log) == 50
+        # Oldest entries trimmed, newest kept.
+        assert job.log[-1] == "step 59"
+        assert job.log[0] == "step 10"
+
+    def test_job_update_truncates_overlong_message(self):
+        """Very long messages are clamped to avoid unbounded memory growth."""
+        from djust.admin_ext.progress import Job, _MAX_MESSAGE_CHARS
+
+        job = Job(
+            job_id="trunc",
+            action_label="T",
+            user_id=1,
+            admin_site_name="djust_admin",
+            redirect_url="/",
+        )
+        long_msg = "x" * (_MAX_MESSAGE_CHARS + 500)
+        job.update(message=long_msg)
+        assert len(job.message) == _MAX_MESSAGE_CHARS
+        assert job.message.endswith("...")
+
+    def test_jobs_dict_lru_evicts_beyond_cap(self):
+        """Inserting more than ``_MAX_JOBS`` entries into ``_JOBS`` evicts
+        the oldest (FIFO)."""
+        from djust.admin_ext.progress import (
+            Job,
+            _JOBS,
+            _MAX_JOBS,
+            _store_job,
+        )
+
+        _JOBS.clear()
+        try:
+            # Fill to cap + 1.
+            first_id = None
+            for i in range(_MAX_JOBS + 1):
+                jid = f"job-{i}"
+                if first_id is None:
+                    first_id = jid
+                _store_job(
+                    jid,
+                    Job(
+                        job_id=jid,
+                        action_label="T",
+                        user_id=1,
+                        admin_site_name="djust_admin",
+                        redirect_url="/",
+                    ),
+                )
+            assert len(_JOBS) == _MAX_JOBS, "_JOBS should never exceed _MAX_JOBS; got %d" % len(
+                _JOBS
+            )
+            # Oldest entry (job-0) should have been evicted.
+            assert first_id not in _JOBS
+            # Newest entry should be present.
+            assert f"job-{_MAX_JOBS}" in _JOBS
+        finally:
+            _JOBS.clear()
+
+
+class TestAdminActionWithProgressDecorator(TestCase):
+    """Tests for @admin_action_with_progress."""
+
+    def _setup_site(self):
+        from djust.admin_ext import DjustAdminSite, DjustModelAdmin
+        from djust.admin_ext.progress import _JOBS, admin_action_with_progress
+
+        # Use User as a stand-in model since it ships with Django.
+        User = get_user_model()
+
+        site = DjustAdminSite(name="djust_admin")
+
+        class MyAdmin(DjustModelAdmin):
+            @admin_action_with_progress(description="Do thing")
+            def do_thing(self, request, queryset, progress):
+                progress.update(current=1, total=1, message="done")
+
+            actions = ["do_thing"]
+
+        site.register(User, MyAdmin)
+        return site, User, MyAdmin, _JOBS
+
+    def test_decorator_redirects_to_progress_url(self):
+        """Calling the decorated action returns an HTTP redirect."""
+        from django.http import HttpResponseRedirect
+
+        site, model, admin_cls, jobs = self._setup_site()
+        # Resolve URLs using the site's urlpatterns.
+
+        # We can't easily include urls. Instead: call the action and verify
+        # it raises NoReverseMatch (acceptable — decorator tried to reverse)
+        # or completes with a valid redirect. To keep the test hermetic, we
+        # monkey-patch django.urls.reverse to return a dummy URL.
+        from djust.admin_ext import progress as progress_mod
+
+        original_reverse = progress_mod.reverse
+
+        def fake_reverse(name, kwargs=None, *a, **kw):
+            if kwargs:
+                return "/fake/%s/" % list(kwargs.values())[0]
+            return "/fake/"
+
+        progress_mod.reverse = fake_reverse
+        try:
+            admin_instance = admin_cls(model, site)
+            request = RequestFactory().post("/")
+            request.user = _make_user("tester")
+            qs = model.objects.none()
+            response = admin_instance.do_thing(request, qs)
+            assert isinstance(response, HttpResponseRedirect)
+            assert response.url.startswith("/fake/")
+        finally:
+            progress_mod.reverse = original_reverse
+            jobs.clear()
+
+    def test_background_thread_runs_to_completion_and_sets_done(self):
+        """After the action fires, the background thread should complete
+        and flip ``done=True`` on the job."""
+        from djust.admin_ext import progress as progress_mod
+
+        site, model, admin_cls, jobs = self._setup_site()
+        done_event = threading.Event()
+
+        class TrackingAdmin(admin_cls):
+            @progress_mod.admin_action_with_progress(description="Track")
+            def do_thing(self, request, queryset, progress):
+                progress.update(current=5, total=5, message="complete")
+                done_event.set()
+
+            actions = ["do_thing"]
+
+        original_reverse = progress_mod.reverse
+        progress_mod.reverse = lambda *a, **kw: "/fake/"
+        try:
+            admin_instance = TrackingAdmin(model, site)
+            request = RequestFactory().post("/")
+            request.user = _make_user("tester2", pk=2)
+            admin_instance.do_thing(request, model.objects.none())
+            assert done_event.wait(timeout=2), "Background thread did not finish"
+            # Find the freshly created job.
+            job = next(iter(jobs.values()))
+            # Wait briefly for the finally-clause to set done=True.
+            for _ in range(20):
+                if job.done:
+                    break
+                threading.Event().wait(0.05)
+            assert job.done is True
+            assert job.current == 5
+        finally:
+            progress_mod.reverse = original_reverse
+            jobs.clear()
+
+    def test_progress_error_captured_in_job_error(self):
+        """An exception in the decorated body flips ``job.error`` to the
+        generic user-facing message, and the raw text is kept in the
+        private ``_error_raw`` slot for server-side diagnostics."""
+        from djust.admin_ext import progress as progress_mod
+
+        site, model, admin_cls, jobs = self._setup_site()
+        error_event = threading.Event()
+
+        class FailingAdmin(admin_cls):
+            @progress_mod.admin_action_with_progress(description="Fail")
+            def do_thing(self, request, queryset, progress):
+                error_event.set()
+                raise ValueError("boom")
+
+            actions = ["do_thing"]
+
+        original_reverse = progress_mod.reverse
+        progress_mod.reverse = lambda *a, **kw: "/fake/"
+        try:
+            admin_instance = FailingAdmin(model, site)
+            request = RequestFactory().post("/")
+            request.user = _make_user("tester3", pk=3)
+            admin_instance.do_thing(request, model.objects.none())
+            assert error_event.wait(timeout=2)
+            job = next(iter(jobs.values()))
+            for _ in range(20):
+                if job.done:
+                    break
+                threading.Event().wait(0.05)
+            assert job.done is True
+            # Public ``error`` is the generic user-facing message --
+            # raw exception text must NOT leak to the browser.
+            assert job.error is not None
+            assert "boom" not in job.error
+            # Raw exception text is retained privately for ops.
+            assert job._error_raw is not None
+            assert "boom" in job._error_raw
+        finally:
+            progress_mod.reverse = original_reverse
+            jobs.clear()
+
+    def test_progress_error_logged_at_error_level(self):
+        """Exceptions in the action body must be logged at ERROR level
+        with traceback (via ``logger.exception``). Locks Action Tracker
+        #124 — the doc claim was ambiguous in earlier versions."""
+        from djust.admin_ext import progress as progress_mod
+
+        site, model, admin_cls, jobs = self._setup_site()
+        error_event = threading.Event()
+
+        class FailingAdmin(admin_cls):
+            @progress_mod.admin_action_with_progress(description="Fail")
+            def do_thing(self, request, queryset, progress):
+                error_event.set()
+                raise ValueError("boom-err-level")
+
+            actions = ["do_thing"]
+
+        original_reverse = progress_mod.reverse
+        progress_mod.reverse = lambda *a, **kw: "/fake/"
+        try:
+            admin_instance = FailingAdmin(model, site)
+            request = RequestFactory().post("/")
+            request.user = _make_user("tester-err-level", pk=99)
+            with self.assertLogs("djust.admin_ext.progress", level="ERROR") as log_ctx:
+                admin_instance.do_thing(request, model.objects.none())
+                assert error_event.wait(timeout=2)
+                # Wait for the background thread's finally to flip done=True.
+                job = next(iter(jobs.values()))
+                for _ in range(40):
+                    if job.done:
+                        break
+                    threading.Event().wait(0.05)
+                assert job.done is True
+            # Confirm the expected ERROR record is present.
+            err_records = [r for r in log_ctx.records if r.levelname == "ERROR"]
+            assert err_records, "expected at least one ERROR-level record; got %r" % [
+                r.levelname for r in log_ctx.records
+            ]
+            # logger.exception() attaches exc_info to the record.
+            assert any(r.exc_info is not None for r in err_records), (
+                "expected an ERROR record with exc_info (i.e. via "
+                "logger.exception); got %r" % err_records
+            )
+            # The raw exception message is present in the server log --
+            # only the user-facing job.error is generic.
+            assert any(
+                "boom-err-level" in r.getMessage()
+                or (r.exc_info and "boom-err-level" in str(r.exc_info[1]))
+                for r in err_records
+            )
+        finally:
+            progress_mod.reverse = original_reverse
+            jobs.clear()
+
+    def test_action_error_user_facing_message_is_generic(self):
+        """Raw sensitive messages (e.g. credentials) must never surface
+        to the user via ``job.error``; the raw text lives only in
+        the server log + private ``_error_raw``."""
+        from djust.admin_ext import progress as progress_mod
+
+        site, model, admin_cls, jobs = self._setup_site()
+        error_event = threading.Event()
+        SECRET = "DB password is hunter2 — do NOT leak"
+
+        class LeakyAdmin(admin_cls):
+            @progress_mod.admin_action_with_progress(description="Leak")
+            def do_thing(self, request, queryset, progress):
+                error_event.set()
+                raise RuntimeError(SECRET)
+
+            actions = ["do_thing"]
+
+        original_reverse = progress_mod.reverse
+        progress_mod.reverse = lambda *a, **kw: "/fake/"
+        try:
+            admin_instance = LeakyAdmin(model, site)
+            request = RequestFactory().post("/")
+            request.user = _make_user("leak-tester", pk=7)
+            with self.assertLogs("djust.admin_ext.progress", level="ERROR") as log_ctx:
+                admin_instance.do_thing(request, model.objects.none())
+                assert error_event.wait(timeout=2)
+                job = next(iter(jobs.values()))
+                for _ in range(40):
+                    if job.done:
+                        break
+                    threading.Event().wait(0.05)
+                assert job.done is True
+            # User-facing error: generic, no sensitive substring.
+            assert SECRET not in (job.error or "")
+            assert "server logs" in (job.error or "").lower()
+            # Private slot retains raw text for operator debugging.
+            assert SECRET in (job._error_raw or "")
+            # Server log captured the raw exception (via logger.exception).
+            found = any(
+                SECRET in r.getMessage() or (r.exc_info and SECRET in str(r.exc_info[1]))
+                for r in log_ctx.records
+            )
+            assert found, "expected raw exception text in server log records"
+        finally:
+            progress_mod.reverse = original_reverse
+            jobs.clear()
+
+    def test_action_body_checking_cancelled_exits_early(self):
+        """Cooperative cancellation: when the action body polls
+        ``progress.cancelled`` and returns early, ``current`` remains
+        below ``total`` and the cancel message propagates to ``job.message``."""
+        from djust.admin_ext import progress as progress_mod
+
+        site, model, admin_cls, jobs = self._setup_site()
+        started = threading.Event()
+        proceed = threading.Event()
+
+        class CoopAdmin(admin_cls):
+            @progress_mod.admin_action_with_progress(description="Coop cancel")
+            def do_thing(self, request, queryset, progress):
+                total = 1000
+                progress.update(current=0, total=total, message="starting")
+                started.set()
+                # Block until the test flips cancelled from outside.
+                proceed.wait(timeout=2)
+                for i in range(total):
+                    if progress.cancelled:
+                        progress.update(message="Cancelled by user.")
+                        return
+                    progress.update(current=i + 1, total=total)
+
+            actions = ["do_thing"]
+
+        original_reverse = progress_mod.reverse
+        progress_mod.reverse = lambda *a, **kw: "/fake/"
+        try:
+            admin_instance = CoopAdmin(model, site)
+            request = RequestFactory().post("/")
+            request.user = _make_user("coop", pk=77)
+            admin_instance.do_thing(request, model.objects.none())
+            assert started.wait(timeout=2), "action body didn't start"
+            job = next(iter(jobs.values()))
+            # Simulate the user clicking Cancel on the progress page.
+            job.cancelled = True
+            proceed.set()
+            for _ in range(40):
+                if job.done:
+                    break
+                threading.Event().wait(0.05)
+            assert job.done is True
+            assert job.current < 1000, "cooperative cancel should have short-circuited the loop"
+            assert "cancel" in job.message.lower()
+        finally:
+            progress_mod.reverse = original_reverse
+            jobs.clear()
+
+
+class TestBulkProgressWidgetAuth(TestCase):
+    """Tests for BulkActionProgressWidget mount-time auth checks."""
+
+    def _make_job(self, user_pk=1, job_id="abc"):
+        from djust.admin_ext.progress import Job, _JOBS
+
+        job = Job(
+            job_id=job_id,
+            action_label="Test",
+            user_id=user_pk,
+            admin_site_name="djust_admin",
+            redirect_url="/",
+        )
+        _JOBS[job_id] = job
+        return job
+
+    def test_bulk_progress_non_staff_gets_403(self):
+        """RULE #3: Non-staff users get PermissionDenied, even if the job
+        exists. ``is_staff`` must be re-checked on top of
+        ``login_required=True``."""
+        from djust.admin_ext.progress import BulkActionProgressWidget, _JOBS
+
+        self._make_job(user_pk=42, job_id="job-nonstaff")
+        try:
+            widget = BulkActionProgressWidget()
+            request = RequestFactory().get("/")
+            request.user = _make_user("nonstaff", is_staff=False, pk=42)
+            with pytest.raises(PermissionDenied):
+                widget.mount(request, job_id="job-nonstaff")
+        finally:
+            _JOBS.clear()
+
+    def test_bulk_progress_non_owner_user_gets_403(self):
+        """RULE #2: User B hitting user A's progress URL gets 403.
+        Job IDs are UUIDs, but we still verify the owner."""
+        from djust.admin_ext.progress import BulkActionProgressWidget, _JOBS
+
+        self._make_job(user_pk=100, job_id="job-owner")
+        try:
+            widget = BulkActionProgressWidget()
+            request = RequestFactory().get("/")
+            # A different staff user (pk=101) tries to view user 100's job.
+            request.user = _make_user("intruder", is_staff=True, pk=101)
+            with pytest.raises(PermissionDenied):
+                widget.mount(request, job_id="job-owner")
+        finally:
+            _JOBS.clear()
+
+    def test_bulk_progress_job_cancel_flips_done_and_cancelled_flags(self):
+        """RULE #1: cancellation is terminal — both ``done`` and
+        ``cancelled`` must be set."""
+        from djust.admin_ext.progress import BulkActionProgressWidget, _JOBS
+
+        job = self._make_job(user_pk=50, job_id="job-cancel")
+        try:
+            widget = BulkActionProgressWidget()
+            request = RequestFactory().get("/")
+            request.user = _make_user("owner", is_staff=True, pk=50)
+            # Prevent the background polling thread from being spawned
+            # during this unit test.
+            widget.start_async = lambda *a, **kw: None
+            widget.mount(request, job_id="job-cancel")
+            # Simulate the user clicking "Cancel".
+            widget.cancel()
+            assert job.done is True
+            assert job.cancelled is True
+        finally:
+            _JOBS.clear()

--- a/python/djust/tests/test_bulk_progress.py
+++ b/python/djust/tests/test_bulk_progress.py
@@ -460,3 +460,195 @@ class TestBulkProgressWidgetAuth(TestCase):
             assert job.cancelled is True
         finally:
             _JOBS.clear()
+
+
+class TestStoreJobConcurrency(TestCase):
+    """Concurrency guarantees for ``_store_job`` (LRU + lock)."""
+
+    def test_store_job_concurrent_inserts_stay_under_cap(self):
+        """Many concurrent inserters must never push _JOBS over _MAX_JOBS.
+
+        Without the lock, N threads could each observe
+        ``len(_JOBS) > _MAX_JOBS`` at the same time and each
+        ``popitem`` — over-evicting past the FIFO invariant. This test
+        spawns 50 threads x 20 inserts (1000 total) and asserts the
+        final size is EXACTLY _MAX_JOBS.
+        """
+        from djust.admin_ext.progress import (
+            Job,
+            _JOBS,
+            _MAX_JOBS,
+            _store_job,
+        )
+
+        _JOBS.clear()
+        try:
+            threads = []
+            errors: list = []
+
+            def _insert(thread_idx: int) -> None:
+                try:
+                    for i in range(20):
+                        jid = f"t{thread_idx}-j{i}"
+                        _store_job(
+                            jid,
+                            Job(
+                                job_id=jid,
+                                action_label="T",
+                                user_id=1,
+                                admin_site_name="djust_admin",
+                                redirect_url="/",
+                            ),
+                        )
+                except Exception as exc:  # pragma: no cover — diagnostic
+                    errors.append(exc)
+
+            for t in range(50):
+                th = threading.Thread(target=_insert, args=(t,))
+                threads.append(th)
+                th.start()
+            for th in threads:
+                th.join(timeout=5)
+
+            assert not errors, f"unexpected exceptions from worker threads: {errors!r}"
+            # Exactly at the cap — never over (that's the lock's job)
+            # and never under (we inserted 1000, far more than 500).
+            assert len(_JOBS) == _MAX_JOBS, (
+                "expected _JOBS size == _MAX_JOBS under concurrent inserts; "
+                f"got {len(_JOBS)} (likely lock missing or broken)"
+            )
+        finally:
+            _JOBS.clear()
+
+
+class TestActionLabelBounded(TestCase):
+    """Fix #4 — ``action_label`` must respect _MAX_MESSAGE_CHARS."""
+
+    def test_action_label_truncated_at_max_chars(self):
+        """A multi-MB ``short_description`` must not blow out memory.
+
+        The decorator's ``description`` (which becomes
+        ``wrapper.short_description`` and then ``job.action_label``) is
+        clamped to _MAX_MESSAGE_CHARS at Job construction, matching the
+        existing per-message cap.
+        """
+        from djust.admin_ext import DjustAdminSite, DjustModelAdmin
+        from djust.admin_ext import progress as progress_mod
+        from djust.admin_ext.progress import (
+            _JOBS,
+            _MAX_MESSAGE_CHARS,
+            admin_action_with_progress,
+        )
+
+        User = get_user_model()
+        site = DjustAdminSite(name="djust_admin_label_trunc")
+
+        huge = "x" * 10_000
+
+        class HugeLabelAdmin(DjustModelAdmin):
+            @admin_action_with_progress(description=huge)
+            def do_thing(self, request, queryset, progress):
+                progress.update(current=1, total=1)
+
+            actions = ["do_thing"]
+
+        site.register(User, HugeLabelAdmin)
+
+        original_reverse = progress_mod.reverse
+        progress_mod.reverse = lambda *a, **kw: "/fake/"
+        try:
+            admin_instance = HugeLabelAdmin(User, site)
+            request = RequestFactory().post("/")
+            request.user = _make_user("label-trunc", pk=333)
+            admin_instance.do_thing(request, User.objects.none())
+            job = next(iter(_JOBS.values()))
+            assert len(job.action_label) == _MAX_MESSAGE_CHARS
+            assert job.action_label.endswith("...")
+        finally:
+            progress_mod.reverse = original_reverse
+            _JOBS.clear()
+
+
+class TestRunActionRedirectIntercept(TestCase):
+    """Fix #1 — ``ModelListView.run_action`` must convert an action's
+    HttpResponseRedirect return value into a client-side ``redirect``
+    push_event, since bare HTTP responses can't flow over the LiveView
+    WebSocket dispatcher."""
+
+    def test_admin_action_with_progress_triggers_client_redirect(self):
+        """End-to-end: decorating an action with @admin_action_with_progress
+        and dispatching it via ``run_action`` must queue a
+        ``push_event('redirect', {'url': <progress_url>})`` targeting the
+        progress page. Covers the blocker identified in the Stage 11
+        review: an HttpResponseRedirect returned to the WS handler is
+        otherwise silently dropped, leaving the user stuck on the
+        changelist."""
+        from django.http import HttpResponseRedirect
+
+        from djust.admin_ext import DjustAdminSite, DjustModelAdmin
+        from djust.admin_ext import progress as progress_mod
+        from djust.admin_ext.progress import _JOBS, admin_action_with_progress
+        from djust.admin_ext.views import (
+            ModelListView,
+            register_admin_view,
+        )
+
+        User = get_user_model()
+        site = DjustAdminSite(name="djust_admin_redir")
+
+        class MyAdmin(DjustModelAdmin):
+            @admin_action_with_progress(description="Do thing")
+            def do_thing(self, request, queryset, progress):
+                progress.update(current=1, total=1)
+
+            actions = ["do_thing"]
+
+        site.register(User, MyAdmin)
+
+        original_reverse = progress_mod.reverse
+        progress_mod.reverse = lambda *a, **kw: "/djust-admin/djust-progress/abc/"
+        try:
+            admin_instance = MyAdmin(User, site)
+
+            view_id = "test-run-action-redir"
+            register_admin_view(view_id, admin_site=site, model=User, model_admin=admin_instance)
+
+            view = ModelListView()
+            view._view_registry_id = view_id
+            request = RequestFactory().post("/")
+            request.user = _make_user("runner", pk=501)
+            view.request = request
+            view.selected_ids = [1, 2, 3]
+            view.select_all = False
+            view._pending_push_events = []
+
+            # ``@event_handler`` is pure metadata (returns the function
+            # unchanged), so we call the method directly — the same
+            # code path the WebSocket dispatcher walks.
+            view.run_action(action_name="do_thing")
+
+            # A redirect push_event must have been queued...
+            assert view._pending_push_events, (
+                "run_action should have queued a 'redirect' push_event; got empty list"
+            )
+            ev_name, payload = view._pending_push_events[0]
+            assert ev_name == "redirect", f"expected 'redirect' event, got {ev_name!r}"
+            assert "url" in payload
+            # ...and the URL must target the progress page.
+            assert "djust-progress" in payload["url"], (
+                f"expected djust-progress URL, got {payload['url']!r}"
+            )
+
+            # Sanity: the raw result (before push_event conversion) was
+            # an HttpResponseRedirect — confirms we tested the right code path.
+            job = next(iter(_JOBS.values()))
+            assert job is not None
+            # And verify HttpResponseRedirect is still the return type
+            # of the decorator (for backwards compatibility with stock
+            # Django admin actions).
+            admin_instance2 = MyAdmin(User, site)
+            raw_result = admin_instance2.do_thing(request, User.objects.none())
+            assert isinstance(raw_result, HttpResponseRedirect)
+        finally:
+            progress_mod.reverse = original_reverse
+            _JOBS.clear()

--- a/python/tests/test_checks.py
+++ b/python/tests/test_checks.py
@@ -2327,9 +2327,9 @@ class TestV008NonPrimitiveInMount:
             _check_non_primitive_assignments_in_mount(errors)
 
         v008 = [e for e in errors if e.id == "djust.V008"]
-        assert (
-            len(v008) == 0
-        ), "V008 should not duplicate V006 warnings for service/client/session patterns"
+        assert len(v008) == 0, (
+            "V008 should not duplicate V006 warnings for service/client/session patterns"
+        )
 
     def test_v008_fires_for_non_service_non_primitive(self, tmp_path):
         """V008 fires for custom types that are not in V006's service-pattern list."""
@@ -3341,9 +3341,9 @@ class TestV004LifecycleMethods:
             errors = check_liveviews(None)
             v004 = [e for e in errors if e.id == "djust.V004"]
             cls_name = f"V004Lifecycle_{method_name}"
-            assert not any(
-                cls_name in e.msg and method_name in e.msg for e in v004
-            ), f"V004 should not fire on lifecycle method {method_name!r}"
+            assert not any(cls_name in e.msg and method_name in e.msg for e in v004), (
+                f"V004 should not fire on lifecycle method {method_name!r}"
+            )
         finally:
             del cls
             _force_gc()
@@ -3391,9 +3391,9 @@ class TestT013TemplateVariableDjView:
 
         errors = check_templates(None)
         t013 = [e for e in errors if e.id == "djust.T013"]
-        assert (
-            len(t013) == 0
-        ), "dj-view='{{ view_path }}' is a valid pattern — T013 should not flag it"
+        assert len(t013) == 0, (
+            "dj-view='{{ view_path }}' is a valid pattern — T013 should not flag it"
+        )
 
     def test_t013_passes_template_variable_with_spaces(self, tmp_path, settings):
         """dj-view='{{ view_path }}' with whitespace padding should also pass."""
@@ -3784,3 +3784,76 @@ class TestSuppressChecks:
         errors = check_configuration(None)
         c003 = [e for e in errors if e.id == "djust.C003"]
         assert len(c003) == 0
+
+
+class TestA072A073AdminWidgetChecks:
+    """A072/A073 -- djust.admin_ext per-page widget slot audits (v0.7.0)."""
+
+    def test_A072_non_liveview_in_change_form_widgets_warns(self):
+        """A072 fires for a non-LiveView class in change_form_widgets."""
+        from django.contrib.auth import get_user_model
+
+        from djust.admin_ext import DjustAdminSite, DjustModelAdmin
+        from djust.checks import check_admin_widgets
+
+        class NotALiveView:
+            pass
+
+        class BadAdmin(DjustModelAdmin):
+            change_form_widgets = [NotALiveView]
+
+        site = DjustAdminSite(name="test_a072_site")
+        site.register(get_user_model(), BadAdmin)
+        errors = check_admin_widgets(None, _admin_sites=[site])
+        a072 = [e for e in errors if e.id == "djust.A072"]
+        assert len(a072) >= 1
+
+    def test_A073_not_emitted_with_default_single_worker_settings(self):
+        """A073 stays silent when DJUST_ASGI_WORKERS is unset or 1.
+
+        In single-worker dev the limitation doesn't apply, so ``manage.py
+        check`` should show no A073 -- otherwise every demo project sees
+        a spurious warning on every boot.
+        """
+        from django.contrib.auth import get_user_model
+
+        from djust.admin_ext import DjustAdminSite, DjustModelAdmin
+        from djust.admin_ext.progress import admin_action_with_progress
+        from djust.checks import check_admin_widgets
+
+        class AnAdmin(DjustModelAdmin):
+            @admin_action_with_progress(description="Do")
+            def slow_job(self, request, queryset, progress):
+                progress.update(current=1, total=1)
+
+            actions = ["slow_job"]
+
+        site = DjustAdminSite(name="test_a073_default_site")
+        site.register(get_user_model(), AnAdmin)
+        # Default settings have no DJUST_ASGI_WORKERS, so it falls through
+        # to 1 and A073 should not fire.
+        errors = check_admin_widgets(None, _admin_sites=[site])
+        a073 = [e for e in errors if e.id == "djust.A073"]
+        assert len(a073) == 0, f"Expected no A073 with default settings, got {a073!r}"
+
+    def test_A073_info_emitted_for_progress_action_site_with_multi_worker(self):
+        """A073 fires when the project declares DJUST_ASGI_WORKERS > 1."""
+        from django.contrib.auth import get_user_model
+
+        from djust.admin_ext import DjustAdminSite, DjustModelAdmin
+        from djust.admin_ext.progress import admin_action_with_progress
+        from djust.checks import check_admin_widgets
+
+        class AnAdmin(DjustModelAdmin):
+            @admin_action_with_progress(description="Do")
+            def slow_job(self, request, queryset, progress):
+                progress.update(current=1, total=1)
+
+            actions = ["slow_job"]
+
+        site = DjustAdminSite(name="test_a073_site")
+        site.register(get_user_model(), AnAdmin)
+        with override_settings(DJUST_ASGI_WORKERS=2):
+            errors = check_admin_widgets(None, _admin_sites=[site])
+        a073 = [e for e in errors if e.id == "djust.A073"]
+        assert len(a073) == 1, f"Expected exactly one A073 in {[e.id for e in errors]!r}"

--- a/python/tests/test_checks.py
+++ b/python/tests/test_checks.py
@@ -3857,3 +3857,50 @@ class TestA072A073AdminWidgetChecks:
             errors = check_admin_widgets(None, _admin_sites=[site])
         a073 = [e for e in errors if e.id == "djust.A073"]
         assert len(a073) == 1, f"Expected exactly one A073 in {[e.id for e in errors]!r}"
+
+    def test_A073_handles_string_setting_value(self):
+        """A073 must coerce a STRING ``DJUST_ASGI_WORKERS`` correctly.
+
+        Real deployments commonly read from env vars (12-factor) which
+        produce strings, not ints. Bare ``> 1`` comparison on a string
+        is a silent bug: ``'2' > 1`` raises under Py3. The check must
+        int-coerce defensively.
+        """
+        from django.contrib.auth import get_user_model
+
+        from djust.admin_ext import DjustAdminSite, DjustModelAdmin
+        from djust.admin_ext.progress import admin_action_with_progress
+        from djust.checks import check_admin_widgets
+
+        class AnAdmin(DjustModelAdmin):
+            @admin_action_with_progress(description="Do")
+            def slow_job(self, request, queryset, progress):
+                progress.update(current=1, total=1)
+
+            actions = ["slow_job"]
+
+        # Case 1: string "2" — should fire A073.
+        site = DjustAdminSite(name="test_a073_str_multi")
+        site.register(get_user_model(), AnAdmin)
+        with override_settings(DJUST_ASGI_WORKERS="2"):
+            errors = check_admin_widgets(None, _admin_sites=[site])
+        a073 = [e for e in errors if e.id == "djust.A073"]
+        assert len(a073) == 1, f"A073 should fire for string '2'; got {[e.id for e in errors]!r}"
+
+        # Case 2: string "1" — should NOT fire A073.
+        site2 = DjustAdminSite(name="test_a073_str_single")
+        site2.register(get_user_model(), AnAdmin)
+        with override_settings(DJUST_ASGI_WORKERS="1"):
+            errors2 = check_admin_widgets(None, _admin_sites=[site2])
+        a073_single = [e for e in errors2 if e.id == "djust.A073"]
+        assert len(a073_single) == 0, f"A073 should stay silent for string '1'; got {a073_single!r}"
+
+        # Case 3: bogus string — should fallback to 1 (no A073).
+        site3 = DjustAdminSite(name="test_a073_str_bogus")
+        site3.register(get_user_model(), AnAdmin)
+        with override_settings(DJUST_ASGI_WORKERS="not-a-number"):
+            errors3 = check_admin_widgets(None, _admin_sites=[site3])
+        a073_bogus = [e for e in errors3 if e.id == "djust.A073"]
+        assert len(a073_bogus) == 0, (
+            f"A073 should fallback to 1 for bogus setting; got {a073_bogus!r}"
+        )


### PR DESCRIPTION
## Summary

Third v0.7.0 batch — ship per-page widget slots on `DjustModelAdmin` + a `BulkActionProgressWidget` with the `@admin_action_with_progress` decorator. Closes the "add LiveView-powered widgets to admin" djust differentiator.

## Scope decision (Plan §1)

Option D+B per plan. **NOT shipped**: `DjustAdminMixin` for stock `admin.ModelAdmin`. Rationale: stock ModelAdmin has 20+ mixin methods — wiring a LiveView through that MRO duplicates 60% of admin_ext/ and contradicts the v0.5.0 recommended adoption path (`DjustAdminSite`). Per-model widget slots fit naturally into `DjustModelAdmin`; migration path from stock admin is documented.

## What shipped

### `DjustModelAdmin` widget slots
- `change_form_widgets: list[type[LiveView]] = []` — embedded on change_form page
- `change_list_widgets: list[type[LiveView]] = []` — embedded on changelist page
- `get_change_form_widgets()` / `get_change_list_widgets()` filter by `permission_required`
- Template partials `_change_form_widgets.html` / `_change_list_widgets.html` wired into the existing `model_detail.html` / `model_list.html` templates

### Bulk-action progress
- `BulkActionProgressWidget(LiveView)` — reports progress via polling loop, cooperative cancellation
- `@admin_action_with_progress(description=, permissions=)` — wraps an action; returns `HttpResponseRedirect` to a live progress page
- `ModelListView.run_action` now enforces the decorator's `allowed_permissions` server-side
- Process-local `_JOBS` `OrderedDict` capped at 500 (LRU eviction); `Job.message` / `Job.error` truncated to 4KB
- Generic user-facing error (raw exception stays server-side in `logger.exception`)
- `DJUST_ASGI_WORKERS` setting gates the A073 multi-worker check

### System checks
- `djust.A072` — non-LiveView subclass in `change_form_widgets` / `change_list_widgets` → warning
- `djust.A073` — progress widget + `DJUST_ASGI_WORKERS > 1` → info (single-worker default: silent)

### Tests (25 new, following Action Tracker #124 TDD discipline)

All 5 rule tests written RED before implementation and traced to GREEN post-impl:
- `test_bulk_progress_job_cancel_flips_done_and_cancelled_flags`
- `test_bulk_progress_non_owner_user_gets_403`
- `test_bulk_progress_non_staff_gets_403`
- `test_widget_slot_permission_required_hides_widget`
- `test_widget_slot_nonliveview_emits_A072`

Plus 20 coverage tests: LRU eviction, message truncation, cooperative cancel, generic-error, allowed_permissions enforcement, A073 worker-count gate, create-view omits object_id, XSS content check, etc.

Full suite: 6328 Python + 620 Rust + 1374 JS, zero regressions (4 pre-existing markdown-module failures unchanged).

## Review findings resolved before commit

Stage 7 Self-Review flagged 4 🟡 (all resolved):
1. Doc-vs-code log-level drift (WARNING vs ERROR) → docs corrected; test locks the claim
2. A073 semantic mismatch → gated on `DJUST_ASGI_WORKERS` setting
3. Permission filter only tested at list level → rendered-HTML test added
4. Create-view path passes empty `object_id` → template conditionally emits kwarg; regression test added

Stage 8 Security flagged 2 MEDIUM + 3 LOW (all resolved):
- MEDIUM: `cancel()` doesn't stop background thread → cooperative `progress.cancelled` pattern documented + demo updated
- MEDIUM: `_JOBS` unbounded → LRU cap at 500, message truncation at 4KB
- LOW: `job.error` leaks raw exceptions → generic user-facing message, raw preserved server-side
- LOW: `run_action` missing `allowed_permissions` enforcement → added server-side check
- LOW: `live_render` allowlist not documented → DoD section added

Zero 🔴, zero CRITICAL/HIGH.

## Known limitation

`_JOBS` is process-local. Multi-worker deploys without sticky sessions will see "Job not found" if the redirect hits a different worker. `DJUST_ASGI_WORKERS` setting triggers A073 info check. v0.7.1 will back with channel layer.

## Test plan

- [ ] Merge, pull main, run `make test`
- [ ] Start demo: `cd examples/demo_project && make start`
- [ ] Visit `/djust-admin-demo/<app>/maintenancerequest/` — confirm widget embedded
- [ ] Fire "Close selected" action — confirm redirect to progress page; progress bar updates
- [ ] Click Cancel mid-action — confirm job halts (action body checks `progress.cancelled`)
- [ ] User without `change` perm fires `close_selected` — confirm 403
- [ ] Set `DJUST_ASGI_WORKERS=2`, run `manage.py check` — confirm A073 info emitted

Closes v0.7.0 P2 matrix row "Django admin LiveView widgets" per ROADMAP.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)