### PR TITLE
feat(v0.7.0): streaming markdown renderer (pulldown-cmark + {% djust_markdown %})

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Streaming Markdown `{% djust_markdown %}` (v0.7.0)** — server-side
+  Markdown renderer built on `pulldown-cmark 0.12` with three safety
+  guarantees wired in at the crate level: raw HTML in the source is
+  escaped (`Options::ENABLE_HTML` is never set; because
+  pulldown-cmark 0.12 still emits `Event::Html` / `Event::InlineHtml`
+  when that flag is off, `sanitise_event` re-routes those events to
+  `Event::Text` so the writer escapes them), `javascript:` /
+  `vbscript:` / `data:` URL schemes in link/image destinations are
+  rewritten to `#` (case-insensitive, leading-whitespace tolerant),
+  and inputs larger than 10 MiB (per-call input cap, not a concurrency
+  limiter) are returned as an escaped
+  `<pre class="djust-md-toobig">` block without invoking the parser.
+  A provisional-line splitter renders a partially-typed trailing line
+  as escaped text inside `<p class="djust-md-provisional">`,
+  eliminating mid-token flicker for streaming LLM output. Exposed
+  three ways: the `{% djust_markdown expr [kwargs] %}` tag (registered
+  via the existing Rust tag-handler registry), the Python helper
+  `djust.render_markdown(src, **opts)` returning a `SafeString`, and
+  the PyO3 function `djust._rust.render_markdown`. Kwargs:
+  `provisional`, `tables`, `strikethrough`, `task_lists`. **Note on
+  deviation from plan**: `autolinks` was dropped from the public surface
+  — pulldown-cmark 0.12 does not expose a `GFM_AUTOLINK` /
+  `ENABLE_AUTOLINK` options flag, so plain-text URLs stay as text unless
+  wrapped in explicit `[text](url)` syntax. Will be reconsidered when
+  the upstream parser is bumped. Covered by **24 Rust tests**
+  (`crates/djust_templates/src/markdown.rs`, including regression cases
+  for `vbscript:`, `data:`, mixed-case `JavaScript:`, leading-whitespace
+  URLs, `<iframe>` escaping, image-src neutralisation, and the 10 MiB
+  cap) and **14 Python tests** (`python/djust/tests/test_markdown.py` +
+  `tests/unit/test_markdown_tag.py`) — 38 total. Demo at
+  `/demos/markdown-stream/`; full write-up in
+  [docs/website/guides/streaming-markdown.md](docs/website/guides/streaming-markdown.md).
 - **Admin widgets & bulk-action progress (v0.7.0)** — two additions to
   `djust.admin_ext` close the most-requested gaps in the alternative
   reactive admin:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for `vbscript:`, `data:`, mixed-case `JavaScript:`, leading-whitespace
   URLs, `<iframe>` escaping, image-src neutralisation, and the 10 MiB
   cap) and **14 Python tests** (`python/djust/tests/test_markdown.py` +
-  `tests/unit/test_markdown_tag.py`) — 38 total. Demo at
+  `tests/unit/test_markdown_tag.py`), plus **3 A090 system-check tests** —
+  41 total (24 Rust + 14 Python/tag + 3 A090). Demo at
   `/demos/markdown-stream/`; full write-up in
   [docs/website/guides/streaming-markdown.md](docs/website/guides/streaming-markdown.md).
 - **Admin widgets & bulk-action progress (v0.7.0)** — two additions to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "djust_components",
  "djust_core",
  "once_cell",
+ "pulldown-cmark",
  "pyo3",
  "regex",
  "serde",
@@ -960,6 +961,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "pyo3"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1493,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ This roadmap outlines what has been built, what is actively being worked on, and
 | **P2** | Accessibility (ARIA/WCAG) | 1.0 requirement; Phoenix was criticized for shipping without this | v1.0.0 |
 | ~~**P2**~~ | ~~Type-safe template validation~~ ✅ Shipped in v0.5.1 (`manage.py djust_typecheck`) | ~~Catch template variable typos at CI — unique differentiator vs all competitors~~ | ~~v0.5.1~~ |
 | **P2** | Keep-Alive / `dj-activity` | Pre-render hidden routes, preserve state — React 19.2 parity | v0.7.0 |
-| **P2** | Streaming markdown renderer | Incremental markdown for LLM output — strongest AI vertical signal | v0.7.0 |
+| ~~**P2**~~ | ~~Streaming markdown renderer~~ ✅ Shipped in v0.7.0 (`{% djust_markdown %}` + `djust.render_markdown`, pulldown-cmark backend, provisional-line splitter) | ~~Incremental markdown for LLM output — strongest AI vertical signal~~ | ~~v0.7.0~~ |
 | ~~**P1**~~ | ~~Database change notifications (pg_notify)~~ ✅ | ~~PostgreSQL LISTEN/NOTIFY → LiveView push — killer feature for reactive dashboards~~ | v0.5.0 |
 | ~~**P1**~~ | ~~Virtual/windowed lists (`dj-virtual`)~~ ✅ | ~~DOM virtualization for 100K+ rows at 60fps — mandatory for data-heavy apps~~ | v0.5.0 |
 | ~~**P2**~~ | ~~Multi-step wizard (`WizardMixin`)~~ ✅ Shipped in PR #632 (`python/djust/wizard.py`) | ~~#2 most common UI pattern after CRUD — no framework has this natively~~ | ~~v0.5.1~~ |
@@ -1047,7 +1047,7 @@ Open questions that inform future direction:
 | **Keep-Alive / Activity** | — | **`<Activity>`** (19.2) | **Not started** | **v0.7.0** |
 | ~~**Document metadata**~~ | ~~`live_title`~~ | ~~**Native** (React 19)~~ | ✅ **Done** | v0.4.0 |
 | **Type-safe template validation** | — | TypeScript | ✅ Shipped (v0.5.1) | v0.5.1 |
-| **Streaming markdown renderer** | — | — | **Not started** | **v0.7.0** |
+| ~~**Streaming markdown renderer**~~ | — | — | ✅ **Shipped (v0.7.0)** | **v0.7.0** |
 | ~~**DB change notifications**~~ ✅ | ~~**PubSub + Ecto**~~ | — | **Shipped** | **v0.5.0** |
 | ~~**Virtual/windowed lists**~~ ✅ | — | ~~**`react-window`**~~ | ~~**Not started**~~ **Shipped** | **v0.5.0** |
 | **Multi-step wizard** | — | **`react-hook-form`** | ✅ **Shipped (PR #632)** | **v0.5.1** |
@@ -1128,7 +1128,7 @@ High-impact areas for contributions:
 44. **Server Actions (`@action`)** — React 19-style mutation handlers with auto pending/error states
 45. **Keyed for-loop change tracking** — Rust-side per-item change detection in `{% for %}` loops, ~200 lines Rust
 46. ~~**Type-safe template validation**~~ ✅ **Shipped in v0.5.1** — `manage.py djust_typecheck` static analysis + `docs/website/guides/typecheck.md` guide + 14 tests.
-47. **Streaming markdown renderer** — Incremental Rust-side CommonMark parser for LLM streaming, ~500 lines Rust
+47. ~~**Streaming markdown renderer**~~ ✅ **Shipped in v0.7.0** — `{% djust_markdown %}` + `djust.render_markdown` backed by pulldown-cmark 0.12, raw-HTML escaping enforced in the event-filter layer, `javascript:` URLs neutralised, provisional-line splitter for flicker-free streaming. See `docs/website/guides/streaming-markdown.md`.
 48. **Keep-Alive / `dj-activity`** — Pre-render hidden routes with preserved state (React 19.2 parity), ~150 lines Python + ~60 lines JS
 49. ~~**Database change notifications**~~ ✅ Shipped in v0.5.0 — PostgreSQL LISTEN/NOTIFY → LiveView push (`@notify_on_save`, `self.listen`, `handle_info`). See `docs/website/guides/database-notifications.md`.
 50. ~~**Virtual/windowed lists**~~ ✅ Shipped in v0.5.0 — DOM virtualization for large lists (`29-virtual-list.js`, fixed-height v0.5.0; variable-height v0.5.1)

--- a/crates/djust_live/src/lib.rs
+++ b/crates/djust_live/src/lib.rs
@@ -859,6 +859,46 @@ impl RustLiveViewBackend {
     }
 }
 
+/// Render Markdown to sanitised HTML.
+///
+/// Wraps [`djust_templates::markdown::render_markdown`] for Python. Raw HTML
+/// is always escaped (`Options::ENABLE_HTML` is never set); `javascript:`,
+/// `vbscript:`, and `data:` URL schemes in links/images are neutralised to
+/// `#`. Inputs larger than 10 MiB are returned as an escaped `<pre>` without
+/// hitting the parser.
+///
+/// Args:
+///     src: Markdown source string.
+///     provisional: Split the trailing unfinished line off as escaped text
+///         (streaming-safe rendering). Default `True`.
+///     tables: Enable GFM tables. Default `True`.
+///     strikethrough: Enable `~~strikethrough~~`. Default `True`.
+///     task_lists: Enable `- [ ]` / `- [x]` checkboxes. Default `False`.
+///
+/// Returns:
+///     Sanitised HTML as a Python string.
+#[pyfunction]
+#[pyo3(
+    name = "render_markdown",
+    signature = (src, *, provisional=true, tables=true, strikethrough=true, task_lists=false)
+)]
+fn render_markdown_py(
+    py: Python<'_>,
+    src: String,
+    provisional: bool,
+    tables: bool,
+    strikethrough: bool,
+    task_lists: bool,
+) -> PyResult<String> {
+    let opts = djust_templates::markdown::RenderOpts {
+        provisional,
+        tables,
+        strikethrough,
+        task_lists,
+    };
+    Ok(py.allow_threads(|| djust_templates::markdown::render_markdown(&src, opts)))
+}
+
 /// Fast template rendering
 #[pyfunction]
 fn render_template(template_source: String, context: HashMap<String, Value>) -> PyResult<String> {
@@ -2585,6 +2625,7 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<RustLiveViewBackend>()?;
     m.add_function(wrap_pyfunction!(render_template, m)?)?;
     m.add_function(wrap_pyfunction!(render_template_with_dirs, m)?)?;
+    m.add_function(wrap_pyfunction!(render_markdown_py, m)?)?;
     m.add_function(wrap_pyfunction!(diff_html, m)?)?;
     m.add_function(wrap_pyfunction!(fast_json_dumps, m)?)?;
     m.add_function(wrap_pyfunction!(resolve_template_inheritance, m)?)?;

--- a/crates/djust_templates/Cargo.toml
+++ b/crates/djust_templates/Cargo.toml
@@ -18,6 +18,7 @@ regex.workspace = true
 once_cell.workspace = true
 thiserror.workspace = true
 chrono.workspace = true
+pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
 djust_core = { path = "../djust_core" }
 djust_components = { path = "../djust_components" }
 

--- a/crates/djust_templates/src/lib.rs
+++ b/crates/djust_templates/src/lib.rs
@@ -17,10 +17,13 @@ use std::sync::OnceLock;
 pub mod filters;
 pub mod inheritance;
 pub mod lexer;
+pub mod markdown;
 pub mod parser;
 pub mod registry;
 pub mod renderer;
 pub mod tags;
+
+pub use markdown::render_markdown;
 
 use inheritance::{build_inheritance_chain, TemplateLoader};
 use parser::Node;

--- a/crates/djust_templates/src/markdown.rs
+++ b/crates/djust_templates/src/markdown.rs
@@ -574,4 +574,27 @@ mod tests {
         // Empty.
         assert_eq!(split_provisional(""), ("", ""));
     }
+
+    #[test]
+    fn test_plain_text_url_is_not_autolinked() {
+        // pulldown-cmark 0.12 does not expose a GFM_AUTOLINK /
+        // ENABLE_AUTOLINK options flag, so bare URLs in plain text must
+        // remain plain text (not wrapped in an <a> tag). This regression
+        // test locks that current behavior — if a future pulldown-cmark
+        // upgrade flips the autolink default on, this test will fail and
+        // force us to re-evaluate the public surface of djust_markdown
+        // (since the guide documents "no autolinks in plain text").
+        let out = render_markdown(
+            "Visit https://example.com for info\n",
+            RenderOpts::default(),
+        );
+        assert!(
+            !out.contains("<a href=\"https://example.com\">"),
+            "plain-text URL should not be autolinked (got: {out})",
+        );
+        assert!(
+            out.contains("https://example.com"),
+            "plain-text URL should survive as literal text (got: {out})",
+        );
+    }
 }

--- a/crates/djust_templates/src/markdown.rs
+++ b/crates/djust_templates/src/markdown.rs
@@ -1,0 +1,577 @@
+//! Safe server-side Markdown rendering for streaming LLM output.
+//!
+//! This module wraps `pulldown-cmark` to convert Markdown source into HTML,
+//! with security-critical defaults for use with `{% djust_markdown %}`:
+//!
+//! - **Raw HTML in the source is NEVER rendered** (`Options::ENABLE_HTML` is
+//!   never set). HTML tags appear as escaped text.
+//! - `javascript:` URLs in links/images are neutralised.
+//! - A **provisional-line** split lets streaming LLM output render a partially
+//!   typed line as plain (escaped) text instead of mid-syntax malformed HTML.
+//! - Input is capped at `MAX_MD_INPUT_BYTES`; beyond that the source is
+//!   returned verbatim inside an escaped `<pre>`.
+//!
+//! Public API: [`render_markdown`], [`RenderOpts`], [`MAX_MD_INPUT_BYTES`].
+
+use pulldown_cmark::{html, CowStr, Event, LinkType, Options, Parser, Tag};
+
+/// Maximum input size in bytes. Inputs larger than this are returned as
+/// an escaped `<pre class="djust-md-toobig">` block without invoking the
+/// Markdown parser — a belt-and-braces DoS guard.
+pub const MAX_MD_INPUT_BYTES: usize = 10 * 1024 * 1024;
+
+/// Render-time options for [`render_markdown`].
+///
+/// Booleans default to the sensible on/off for LLM-chat use:
+///
+/// | field | default |
+/// |---|---|
+/// | `provisional` | `true` |
+/// | `tables` | `true` |
+/// | `strikethrough` | `true` |
+/// | `task_lists` | `false` |
+///
+/// Raw HTML embedded in the Markdown source is **always** escaped — there is
+/// no knob to enable `Options::ENABLE_HTML`.
+#[derive(Debug, Clone, Copy)]
+pub struct RenderOpts {
+    /// If true, split the trailing line off as "provisional" and render
+    /// it as escaped plain text — prevents mid-token flicker while streaming.
+    pub provisional: bool,
+    /// Enable GFM-style tables.
+    pub tables: bool,
+    /// Enable GFM `~~strikethrough~~`.
+    pub strikethrough: bool,
+    /// Enable GFM task lists (`- [ ] item`).
+    pub task_lists: bool,
+}
+
+impl Default for RenderOpts {
+    fn default() -> Self {
+        Self {
+            provisional: true,
+            tables: true,
+            strikethrough: true,
+            task_lists: false,
+        }
+    }
+}
+
+impl RenderOpts {
+    fn to_pulldown(self) -> Options {
+        let mut o = Options::empty();
+        if self.tables {
+            o.insert(Options::ENABLE_TABLES);
+        }
+        if self.strikethrough {
+            o.insert(Options::ENABLE_STRIKETHROUGH);
+        }
+        if self.task_lists {
+            o.insert(Options::ENABLE_TASKLISTS);
+        }
+        // SECURITY: Options::ENABLE_HTML is NEVER set. Raw HTML in the
+        // source is escaped by pulldown-cmark automatically.
+        o
+    }
+}
+
+/// Render Markdown source to a sanitised HTML string.
+///
+/// Safe by construction: `ENABLE_HTML` is never set, so tags in `src` are
+/// escaped. Long input is bounded by [`MAX_MD_INPUT_BYTES`].
+pub fn render_markdown(src: &str, opts: RenderOpts) -> String {
+    if src.is_empty() {
+        return String::new();
+    }
+    if src.len() > MAX_MD_INPUT_BYTES {
+        return format!("<pre class=\"djust-md-toobig\">{}</pre>", html_escape(src));
+    }
+
+    let (stable, trailing) = if opts.provisional {
+        split_provisional(src)
+    } else {
+        (src, "")
+    };
+
+    let parser = Parser::new_ext(stable, opts.to_pulldown());
+    // SECURITY: pulldown-cmark still emits Event::Html / Event::InlineHtml
+    // even when Options::ENABLE_HTML is unset — its push_html writer just
+    // passes those events through verbatim. To actually escape raw HTML
+    // in the source, we map those events to Text events, and we strip
+    // `javascript:` (and similar) URLs from link/image destinations.
+    let safe_events = parser.map(sanitise_event);
+    let mut out = String::with_capacity(stable.len() + 64);
+    html::push_html(&mut out, safe_events);
+
+    if !trailing.is_empty() {
+        out.push_str("<p class=\"djust-md-provisional\">");
+        out.push_str(&html_escape(trailing));
+        out.push_str("</p>");
+    }
+    out
+}
+
+/// Split `src` into `(stable, trailing)` — stable is handed to pulldown-cmark,
+/// trailing is rendered as escaped plain text.
+///
+/// The trailing split only happens when the last line looks mid-token:
+/// odd count of `**`, single `*`, backticks, unclosed brackets, or a dangling
+/// `](`. Otherwise everything is stable.
+pub(crate) fn split_provisional(src: &str) -> (&str, &str) {
+    if src.is_empty() || src.ends_with('\n') {
+        return (src, "");
+    }
+    if inside_unclosed_fence(src) {
+        // pulldown-cmark handles unclosed fenced code gracefully on its own.
+        return (src, "");
+    }
+    let last_nl = src.rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let trailing = &src[last_nl..];
+    if looks_unterminated(trailing) {
+        (&src[..last_nl], trailing)
+    } else {
+        (src, "")
+    }
+}
+
+fn inside_unclosed_fence(src: &str) -> bool {
+    src.lines()
+        .filter(|l| l.trim_start().starts_with("```"))
+        .count()
+        % 2
+        == 1
+}
+
+fn looks_unterminated(line: &str) -> bool {
+    // Unclosed bold (`**`).
+    let bold = line.matches("**").count();
+    if bold % 2 == 1 {
+        return true;
+    }
+    // Unclosed italic (`*`), after stripping `**` pairs.
+    let star = line.replace("**", "").matches('*').count();
+    if star % 2 == 1 {
+        return true;
+    }
+    // Unclosed inline code (`` ` ``).
+    let tick = line.matches('`').count();
+    if tick % 2 == 1 {
+        return true;
+    }
+    has_unclosed_bracket(line)
+}
+
+fn has_unclosed_bracket(line: &str) -> bool {
+    let mut depth: i32 = 0;
+    for ch in line.chars() {
+        match ch {
+            '[' => depth += 1,
+            ']' => depth -= 1,
+            _ => {}
+        }
+    }
+    if depth > 0 {
+        return true;
+    }
+    // Dangling `](` (link in progress: `[text](...`).
+    if let Some(idx) = line.rfind("](") {
+        if !line[idx + 2..].contains(')') {
+            return true;
+        }
+    }
+    false
+}
+
+/// Neutralise dangerous URL schemes by replacing them with `#`.
+///
+/// Matches (case-insensitive, with optional surrounding whitespace):
+/// `javascript:`, `vbscript:`, `data:`.
+///
+/// We block `data:` in both Link and Image destinations (stored as the
+/// same `CowStr` path); images could theoretically accept `data:image/*`,
+/// but it's safer to over-block since `data:image/svg+xml` can execute
+/// scripts.
+fn neutralise_url(url: &CowStr<'_>) -> CowStr<'static> {
+    let trimmed = url.trim_start();
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.starts_with("javascript:")
+        || lower.starts_with("vbscript:")
+        || lower.starts_with("data:")
+    {
+        return CowStr::Borrowed("#");
+    }
+    CowStr::Boxed(url.to_string().into_boxed_str())
+}
+
+/// Map one parser event to a sanitised form.
+/// - Raw HTML events become Text (so they are HTML-escaped by the writer).
+/// - Link / Image destinations pointing at dangerous schemes are rewritten.
+fn sanitise_event(event: Event<'_>) -> Event<'_> {
+    match event {
+        // Raw HTML — escape by re-routing through Text.
+        Event::Html(s) => Event::Text(s),
+        Event::InlineHtml(s) => Event::Text(s),
+        // Links / images — scrub hostile schemes.
+        Event::Start(Tag::Link {
+            link_type,
+            dest_url,
+            title,
+            id,
+        }) => Event::Start(Tag::Link {
+            link_type,
+            dest_url: neutralise_url(&dest_url),
+            title,
+            id,
+        }),
+        Event::Start(Tag::Image {
+            link_type,
+            dest_url,
+            title,
+            id,
+        }) => Event::Start(Tag::Image {
+            link_type,
+            dest_url: neutralise_url(&dest_url),
+            title,
+            id,
+        }),
+        other => other,
+    }
+}
+
+/// Silence the unused-variant lint emitted by some toolchains when
+/// `LinkType` is imported only for exhaustive matching.
+#[allow(dead_code)]
+fn _linktype_probe(_: LinkType) {}
+
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#x27;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------------------------------------------------------------
+    // Basic rendering
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_basic_paragraph() {
+        let out = render_markdown("Hello world\n", RenderOpts::default());
+        assert!(out.contains("<p>"));
+        assert!(out.contains("Hello world"));
+    }
+
+    #[test]
+    fn test_heading_one() {
+        let out = render_markdown("# Title\n", RenderOpts::default());
+        assert!(out.contains("<h1>"));
+        assert!(out.contains("Title"));
+    }
+
+    #[test]
+    fn test_fenced_code() {
+        let src = "```\nlet x = 1;\n```\n";
+        let out = render_markdown(src, RenderOpts::default());
+        assert!(out.contains("<pre>"));
+        assert!(out.contains("<code>"));
+        assert!(out.contains("let x = 1;"));
+    }
+
+    #[test]
+    fn test_unterminated_fence() {
+        // An unclosed ``` block should not panic; pulldown-cmark auto-closes.
+        let src = "```\nlet x = 1;\n";
+        let out = render_markdown(src, RenderOpts::default());
+        assert!(out.contains("let x = 1;"));
+    }
+
+    // ---------------------------------------------------------------
+    // ⭐ Rule tests (written RED first)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_xss_payload_rendered_as_escaped_text() {
+        // Classic XSS payload must not become a live <script>.
+        let src = "before <script>alert('xss')</script> after\n";
+        let out = render_markdown(src, RenderOpts::default());
+        assert!(
+            !out.contains("<script>"),
+            "raw <script> MUST be escaped, got: {}",
+            out
+        );
+        assert!(
+            out.contains("&lt;script&gt;"),
+            "expected escaped &lt;script&gt; in output, got: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_raw_html_is_escaped_not_rendered() {
+        let src = "<img src=x onerror=alert(1)>\n";
+        let out = render_markdown(src, RenderOpts::default());
+        assert!(
+            !out.contains("<img "),
+            "raw <img> MUST NOT be rendered live, got: {}",
+            out
+        );
+        assert!(out.contains("&lt;img"));
+    }
+
+    #[test]
+    fn test_javascript_url_in_link_href_is_neutralized() {
+        let src = "[click me](javascript:alert(1))\n";
+        let out = render_markdown(src, RenderOpts::default());
+        // pulldown-cmark's own escape logic already filters `javascript:`
+        // href values — verify the attribute isn't present as an active URL.
+        assert!(
+            !out.contains("href=\"javascript:alert(1)\""),
+            "javascript: href MUST be neutralised, got: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_javascript_url_rewritten_to_hash() {
+        // STRICT form: verify the neutralised URL appears as "#".
+        let src = "[x](javascript:alert(1))\n";
+        let out = render_markdown(src, RenderOpts::default());
+        assert!(
+            out.contains("href=\"#\""),
+            "javascript: href MUST be rewritten to '#', got: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_mixed_case_javascript_url_neutralized() {
+        // Case-insensitive match on the scheme.
+        let src = "[x](JavaScript:alert(1))\n";
+        let out = render_markdown(src, RenderOpts::default());
+        assert!(
+            out.contains("href=\"#\""),
+            "mixed-case javascript: URL MUST be neutralised to '#', got: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_leading_whitespace_javascript_url_neutralized() {
+        // Leading whitespace must not defeat the scheme check.
+        let src = "[x](  javascript:alert(1))\n";
+        let out = render_markdown(src, RenderOpts::default());
+        assert!(
+            out.contains("href=\"#\""),
+            "whitespace-prefixed javascript: URL MUST be neutralised to '#', got: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_vbscript_url_neutralized() {
+        let src = "[x](vbscript:msg())\n";
+        let out = render_markdown(src, RenderOpts::default());
+        assert!(
+            !out.contains("href=\"vbscript:"),
+            "vbscript: href MUST NOT survive in output, got: {}",
+            out
+        );
+        assert!(
+            out.contains("href=\"#\""),
+            "vbscript: href MUST be rewritten to '#', got: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_data_url_neutralized() {
+        let src = "[x](data:text/html,<script>)\n";
+        let out = render_markdown(src, RenderOpts::default());
+        assert!(
+            !out.contains("href=\"data:"),
+            "data: href MUST NOT survive in output, got: {}",
+            out
+        );
+        assert!(
+            out.contains("href=\"#\""),
+            "data: href MUST be rewritten to '#', got: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_image_with_javascript_src_neutralized() {
+        let src = "![alt](javascript:alert(1))\n";
+        let out = render_markdown(src, RenderOpts::default());
+        assert!(
+            !out.contains("src=\"javascript:"),
+            "javascript: image src MUST NOT survive in output, got: {}",
+            out
+        );
+        assert!(
+            out.contains("src=\"#\""),
+            "javascript: image src MUST be rewritten to '#', got: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_iframe_escaped() {
+        let src = "<iframe src=x></iframe>\n";
+        let out = render_markdown(src, RenderOpts::default());
+        assert!(
+            out.contains("&lt;iframe"),
+            "iframe tag MUST be escaped, got: {}",
+            out
+        );
+        assert!(
+            !out.contains("<iframe"),
+            "literal <iframe MUST NOT appear in output, got: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_provisional_mode_unclosed_bold_renders_as_text() {
+        // "Hello **wor" — unclosed bold on the trailing line.
+        let src = "Hello **wor";
+        let out = render_markdown(src, RenderOpts::default());
+        assert!(
+            out.contains("djust-md-provisional"),
+            "expected provisional wrapper in output: {}",
+            out
+        );
+        assert!(
+            !out.contains("<strong>"),
+            "unclosed ** must not be rendered as <strong>, got: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_size_cap_exceeded_returns_escaped_literal() {
+        // Build a source > MAX_MD_INPUT_BYTES containing a `<script>`
+        // — must not reach the parser.
+        let payload = "<script>a</script>";
+        let mut src = String::with_capacity(MAX_MD_INPUT_BYTES + 64);
+        while src.len() <= MAX_MD_INPUT_BYTES {
+            src.push_str(payload);
+        }
+        let out = render_markdown(&src, RenderOpts::default());
+        assert!(out.starts_with("<pre class=\"djust-md-toobig\">"));
+        assert!(
+            !out.contains("<script>"),
+            "size-capped output must still escape HTML"
+        );
+        assert!(out.contains("&lt;script&gt;"));
+    }
+
+    // ---------------------------------------------------------------
+    // Options
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_tables_enabled() {
+        let src = "| a | b |\n| - | - |\n| 1 | 2 |\n";
+        let out = render_markdown(src, RenderOpts::default());
+        assert!(out.contains("<table>"));
+    }
+
+    #[test]
+    fn test_strikethrough_enabled() {
+        let out = render_markdown("~~gone~~\n", RenderOpts::default());
+        assert!(out.contains("<del>") || out.contains("<s>"));
+    }
+
+    #[test]
+    fn test_task_lists_off_by_default() {
+        let src = "- [ ] todo\n- [x] done\n";
+        let out = render_markdown(src, RenderOpts::default());
+        // Default: no <input type="checkbox">.
+        assert!(!out.contains("type=\"checkbox\""));
+    }
+
+    #[test]
+    fn test_task_lists_on_when_enabled() {
+        let src = "- [ ] todo\n- [x] done\n";
+        let opts = RenderOpts {
+            task_lists: true,
+            ..Default::default()
+        };
+        let out = render_markdown(src, opts);
+        assert!(out.contains("type=\"checkbox\""));
+    }
+
+    // ---------------------------------------------------------------
+    // Provisional mode
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_provisional_off_no_split() {
+        let src = "Hello **wor";
+        let opts = RenderOpts {
+            provisional: false,
+            ..Default::default()
+        };
+        let out = render_markdown(src, opts);
+        assert!(
+            !out.contains("djust-md-provisional"),
+            "provisional=false must never emit the wrapper"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Edge cases
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_empty_input() {
+        let out = render_markdown("", RenderOpts::default());
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn test_unicode_roundtrip() {
+        let out = render_markdown("héllo — 世界\n", RenderOpts::default());
+        assert!(out.contains("héllo"));
+        assert!(out.contains("世界"));
+    }
+
+    #[test]
+    fn test_split_provisional_edge_cases() {
+        // Trailing newline: fully stable.
+        assert_eq!(split_provisional("foo\n"), ("foo\n", ""));
+        // Unclosed bold on trailing.
+        let (stable, tail) = split_provisional("line1\nHello **wor");
+        assert_eq!(stable, "line1\n");
+        assert_eq!(tail, "Hello **wor");
+        // Unclosed inline code on trailing.
+        let (stable, tail) = split_provisional("a\n`foo");
+        assert_eq!(stable, "a\n");
+        assert_eq!(tail, "`foo");
+        // Unclosed bracket on trailing.
+        let (stable, tail) = split_provisional("a\n[link");
+        assert_eq!(stable, "a\n");
+        assert_eq!(tail, "[link");
+        // Dangling `](`.
+        let (stable, tail) = split_provisional("a\n[text](http://ex");
+        assert_eq!(stable, "a\n");
+        assert_eq!(tail, "[text](http://ex");
+        // Fully-formed trailing line stays stable.
+        assert_eq!(split_provisional("ok"), ("ok", ""));
+        // Empty.
+        assert_eq!(split_provisional(""), ("", ""));
+    }
+}

--- a/docs/website/_config.yaml
+++ b/docs/website/_config.yaml
@@ -191,6 +191,11 @@ navigation:
         file: guides/activity.md
         order: 7.6
         level: intermediate
+      - title: Streaming Markdown (`{% djust_markdown %}`)
+        slug: streaming-markdown
+        file: guides/streaming-markdown.md
+        order: 7.7
+        level: intermediate
       - title: Authentication
         slug: authentication
         file: guides/authentication.md

--- a/docs/website/guides/streaming-markdown.md
+++ b/docs/website/guides/streaming-markdown.md
@@ -1,0 +1,221 @@
+---
+title: "Streaming Markdown"
+slug: streaming-markdown
+section: guides
+order: 24
+level: intermediate
+description: "Safely render streaming LLM output as Markdown on the server with {% djust_markdown %}."
+---
+
+# Streaming Markdown (v0.7.0)
+
+LLM chat UIs usually render Markdown character-by-character as it streams back
+from the model. Doing that safely in the browser means shipping a Markdown
+library plus a DOMPurify pass per token, watching the text flicker through
+half-parsed states, and worrying about every jailbreak that ends with a raw
+`<script>` tag.
+
+djust does this on the server, in Rust:
+
+```django
+{% djust_markdown llm_output %}
+```
+
+No client-side Markdown library. No DOMPurify. No flicker on partial input.
+Any raw HTML in the source is HTML-escaped before it reaches the browser.
+
+## When to use it
+
+- **Chat UIs** that stream token-by-token from an LLM.
+- **AI report / summary views** where the model writes Markdown and you want
+  it rendered as soon as each character arrives.
+- **Any user-authored Markdown** you want to render without bolting on a JS
+  library — blog bodies, comments, issue descriptions.
+
+If you have fully-formed, trusted Markdown that never streams, you can also
+call the helper directly from Python:
+
+```python
+from djust import render_markdown
+
+html = render_markdown("# hello\n")  # returns a SafeString
+```
+
+## The template tag
+
+```django
+{% djust_markdown llm_output %}
+```
+
+The first argument is a context variable containing Markdown source. The tag
+renders it to sanitised HTML. The rendered output is already safe to embed
+directly — no `|safe` needed, no double-escape.
+
+### Keyword arguments
+
+All arguments are optional booleans:
+
+| kwarg | default | effect |
+|---|---|---|
+| `provisional` | `True` | Split the trailing unfinished line off as escaped text (streaming-safe). Disable when the Markdown is complete. |
+| `tables` | `True` | Enable GFM tables (`\| a \| b \|`). |
+| `strikethrough` | `True` | Enable `~~strikethrough~~`. |
+| `task_lists` | `False` | Enable `- [ ]` / `- [x]` checkboxes. |
+
+```django
+{% djust_markdown post.body tables=False %}
+{% djust_markdown llm_output provisional=False %}
+```
+
+## How streaming safety works
+
+When the LLM has only emitted part of a line — say, `Hello **wor` — a naive
+Markdown renderer will see an unclosed `**` and do one of two things:
+
+1. Render the `**` as literal characters (the reader sees the raw syntax).
+2. Emit a half-open `<strong>` tag that tears open the rest of the page.
+
+Neither is good. `{% djust_markdown %}` splits the source at the *last
+newline*. Everything before the last newline is sent to the Markdown parser
+as usual; the partial trailing line is escaped and wrapped in:
+
+```html
+<p class="djust-md-provisional">Hello **wor</p>
+```
+
+When the model finishes the line and emits `\n`, the split disappears and
+the text is re-rendered by the Markdown parser as `<p>Hello <strong>word</strong></p>`.
+
+This behaviour is controlled by `provisional=True` (the default). Turn it
+off when you're rendering a finalised document.
+
+### Styling the provisional line
+
+The wrapper class is `djust-md-provisional`. Grey it out, italicise it,
+animate it — any plain CSS will do:
+
+```css
+.djust-md-provisional {
+    opacity: 0.55;
+    font-style: italic;
+}
+```
+
+## Security guarantees
+
+The Rust renderer is built to be **safe by construction**. These properties
+are enforced in the core crate and tested (see
+`crates/djust_templates/src/markdown.rs`):
+
+- **Raw HTML is escaped.** `Options::ENABLE_HTML` is never set on the
+  underlying pulldown-cmark parser. Anything that looks like a tag
+  (`<script>`, `<img onerror=…>`, `<iframe>`, …) becomes escaped text.
+- **`javascript:` / `vbscript:` / `data:` URLs are neutralised.** Links and
+  images pointing at those schemes are rewritten to `#`.
+- **Input is size-capped.** Anything larger than 10 MiB is returned as an
+  escaped `<pre class="djust-md-toobig">` block without hitting the parser.
+- **No panics.** pulldown-cmark's contract is panic-free on arbitrary input;
+  we don't wrap it in `catch_unwind`.
+
+The tag output is handed to Django via `SafeString`, but because we never
+emit HTML we didn't produce ourselves, the "safe" marker does not bypass
+any real escaping.
+
+### Operational limits
+
+The 10 MiB per-call input cap is a defence against an individual runaway
+Markdown source — it is **not** a concurrency limiter. If many users are
+streaming large replies at once you should still cap request concurrency at
+the operator level (ASGI worker count, load balancer limits, or a dedicated
+rate limiter on the LiveView event). Treat `{% djust_markdown %}` the way
+you'd treat any per-request render — fast, but not free, and ultimately
+bounded by the same infrastructure that bounds the rest of your app.
+
+## Example: streaming LLM reply
+
+Here's a minimal LiveView that simulates an LLM streaming one character at
+a time:
+
+```python
+from djust import LiveView
+from djust.decorators import background, event_handler
+
+
+REPLY = "# Hi\n\nHere is a **bold** reply.\n"
+
+
+class ChatView(LiveView):
+    template_name = "chat.html"
+
+    def mount(self, request, **kwargs):
+        self.llm_output = ""
+        self.streaming = False
+
+    @event_handler
+    def start(self, **kwargs):
+        self.streaming = True
+        self._stream()
+
+    @background
+    def _stream(self):
+        import time
+        for ch in REPLY:
+            self.llm_output += ch
+            time.sleep(0.025)
+        self.streaming = False
+```
+
+```django
+{# chat.html #}
+<article>
+    {% djust_markdown llm_output %}
+</article>
+
+<button dj-click="start">Send</button>
+```
+
+A live version is registered at `/demos/markdown-stream/` in the demo
+project.
+
+## Calling the renderer from Python
+
+If you need the HTML outside a template — e.g. in an API response, a report
+generator, or a test — import it directly:
+
+```python
+from djust import render_markdown
+
+html = render_markdown(
+    "# Title\n\nparagraph with <script>alert(1)</script>\n",
+    tables=True,
+    strikethrough=True,
+)
+# '<h1>Title</h1>\n<p>paragraph with &lt;script&gt;alert(1)&lt;/script&gt;</p>\n'
+```
+
+The return value is a `django.utils.safestring.SafeString`.
+
+## Limitations (v0.7.0)
+
+These are intentional — they'll be reconsidered in later releases:
+
+- **Tag-only API.** There is no `|djust_markdown` filter form. Deferred to
+  v0.7.1 if demand emerges.
+- **No syntax highlighting.** Fenced code blocks render as `<pre><code>`
+  with no language-class styling. Highlighting pulls in a multi-megabyte
+  dependency; roll your own client-side (Prism / highlight.js) if needed.
+- **No MathJax / LaTeX.**
+- **No autolinks in plain text.** `https://example.com` stays as text
+  unless wrapped in an explicit `[text](url)`. pulldown-cmark 0.12 does not
+  expose the GFM-autolink flag we'd need; we'll revisit when the pulled
+  parser version makes this cheap.
+- **Reference-style links across a streaming boundary.** If the reference
+  `[1]: https://…` line is still mid-stream when the body `[foo][1]`
+  already arrived, you'll get a moment where the link renders unresolved.
+  Cosmetic only — no correctness issue.
+
+## Related
+
+- [Template cheat sheet](template-cheatsheet.md) — full tag index.
+- [Background work & loading states](loading-states.md) — streaming LLM
+  output typically runs via `start_async` or `@background`.

--- a/docs/website/guides/template-cheatsheet.md
+++ b/docs/website/guides/template-cheatsheet.md
@@ -537,6 +537,7 @@ djust.hooks.chart = {
 | `{% static 'file' %}` | Static file URL |
 | `{% with var=value %}` | Local variable assignment |
 | `{% dj_activity "name" visible=expr eager=expr %}...{% enddj_activity %}` | Pre-rendered hidden panel with preserved local state (React 19.2 parity). See [Activity guide](activity.md). |
+| `{% djust_markdown expr [kwargs] %}` | Render Markdown to sanitised HTML in the Rust parser — raw HTML and `javascript:` URLs are neutralised; trailing-line provisional wrap makes streaming LLM output flicker-free. See [Streaming Markdown guide](streaming-markdown.md). |
 
 ### Filters (all 57 Django built-ins)
 

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -38,6 +38,7 @@ How to build specific features.
 |                                                        |                                                           |
 | ------------------------------------------------------ | --------------------------------------------------------- |
 | **[Streaming](guides/streaming.md)**                   | Real-time partial DOM updates for LLM chat and live feeds |
+| **[Streaming Markdown (`{% djust_markdown %}`)](guides/streaming-markdown.md)** | Server-side safe Markdown rendering for streaming LLM output — no client library, no flicker, XSS-safe (v0.7.0) |
 | **[Virtual Lists (`dj-virtual`)](guides/virtual-lists.md)** | Render 1000s of items with only the visible window in the DOM (fixed + variable height) |
 | **[Flash Messages](guides/flash-messages.md)**         | Transient notifications with `put_flash` (Phoenix-style)  |
 | **[Presence](guides/presence.md)**                     | Track online users, live cursors, typing indicators       |

--- a/examples/demo_project/djust_demos/templates/demos/markdown_stream_demo.html
+++ b/examples/demo_project/djust_demos/templates/demos/markdown_stream_demo.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% load live_tags %}
+
+{% block content %}
+<div dj-root dj-view="djust_demos.views.markdown_stream_demo.MarkdownStreamDemoView"
+     class="max-w-3xl mx-auto p-6">
+
+    <h1 class="text-2xl font-bold mb-2">Streaming Markdown demo</h1>
+    <p class="text-slate-600 mb-4">
+        Click <strong>Start stream</strong> and watch a fixed reply arrive one character at a
+        time. The entire Markdown body is re-rendered on every tick by the Rust parser,
+        server-side, with a <em>provisional-line</em> split so the trailing in-progress
+        line never flashes as half-parsed HTML. Any <code>&lt;script&gt;</code> payload in
+        the source is escaped — never rendered live.
+    </p>
+
+    <div class="flex gap-2 mb-4">
+        <button dj-click="start_stream"
+                class="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
+                {% if streaming %}disabled{% endif %}>
+            Start stream
+        </button>
+        <button dj-click="reset"
+                class="px-4 py-2 rounded border">
+            Reset
+        </button>
+        {% if streaming %}
+            <span class="px-3 py-2 text-sm text-slate-500">streaming…</span>
+        {% endif %}
+    </div>
+
+    <!-- The rendered Markdown. This is the only place {% djust_markdown %} is needed. -->
+    <article class="prose max-w-none border rounded p-4 bg-white min-h-[200px]">
+        {% djust_markdown llm_output %}
+    </article>
+
+    <!-- Provisional wrapper styling (scoped, one-shot). -->
+    <style>
+        .djust-md-provisional {
+            opacity: 0.55;
+            font-style: italic;
+        }
+    </style>
+</div>
+{% endblock %}

--- a/examples/demo_project/djust_demos/urls.py
+++ b/examples/demo_project/djust_demos/urls.py
@@ -55,4 +55,6 @@ urlpatterns = [
     path("server-function/", ServerFunctionDemoView.as_view(), name="server-function"),
     # v0.7.0 — {% dj_activity %} (React 19.2 <Activity> parity)
     path("activity/", ActivityDemoView.as_view(), name="activity"),
+    # v0.7.0 — streaming Markdown via {% djust_markdown %}
+    path("markdown-stream/", MarkdownStreamDemoView.as_view(), name="markdown-stream"),
 ]

--- a/examples/demo_project/djust_demos/views/__init__.py
+++ b/examples/demo_project/djust_demos/views/__init__.py
@@ -38,6 +38,7 @@ from .tenant_demo import TenantDemoView
 from .whats_new_042 import WhatsNew042View
 from .server_function_demo import ServerFunctionDemoView
 from .activity_demo import ActivityDemoView
+from .markdown_stream_demo import MarkdownStreamDemoView
 
 __all__ = [
     "CounterView",
@@ -74,4 +75,5 @@ __all__ = [
     "WhatsNew042View",
     "ServerFunctionDemoView",
     "ActivityDemoView",
+    "MarkdownStreamDemoView",
 ]

--- a/examples/demo_project/djust_demos/views/markdown_stream_demo.py
+++ b/examples/demo_project/djust_demos/views/markdown_stream_demo.py
@@ -1,0 +1,87 @@
+"""
+Streaming Markdown demo — simulates an LLM token-by-token reply and
+renders it safely via ``{% djust_markdown %}``.
+
+Showcases the v0.7.0 streaming-Markdown feature:
+
+- Safe rendering: any ``<script>`` / raw HTML in the "LLM output" is
+  escaped by the Rust parser, not rendered.
+- Provisional-line handling: while the last line is partially typed
+  (``**bol`` before it closes) it is shown as escaped plain text
+  instead of flashing as malformed HTML.
+- No client-side Markdown library needed.
+"""
+
+from djust.decorators import background, event_handler
+from djust_shared.views import BaseViewWithNavbar
+
+
+# A fixed sample "reply". Rendered one character at a time to simulate a
+# streaming LLM response. Includes bold, headings, a table, a code fence,
+# and an embedded ``<script>`` payload to demonstrate XSS-safe output.
+_SAMPLE_REPLY = """# Streaming Markdown demo
+
+This is a **streaming** reply, rendered one token at a time.
+
+djust renders incoming Markdown *safely* on the server — even hostile
+payloads like `<script>alert('xss')</script>` are HTML-escaped, never
+executed.
+
+## Features
+
+- Tables: | col | val |
+  | --- | --- |
+  | a | 1 |
+  | b | 2 |
+- Code: `rustc --version`
+- Fenced blocks:
+
+```
+fn main() {
+    println!("hello");
+}
+```
+
+Done.
+"""
+
+
+class MarkdownStreamDemoView(BaseViewWithNavbar):
+    """LiveView that streams a fixed Markdown reply character-by-character."""
+
+    template_name = "demos/markdown_stream_demo.html"
+
+    def mount(self, request, **kwargs):
+        # Public — auto-exposed to the template.
+        self.llm_output = ""
+        self.streaming = False
+
+    @event_handler
+    def start_stream(self, **kwargs):
+        """Reset and begin a fresh "LLM" stream."""
+        if self.streaming:
+            return
+        self.llm_output = ""
+        self.streaming = True
+        self._stream_chars()
+
+    @event_handler
+    def reset(self, **kwargs):
+        """Clear output."""
+        self.cancel_async("md_stream")
+        self.streaming = False
+        self.llm_output = ""
+
+    @background
+    def _stream_chars(self):
+        """Background task: append one character every ~25 ms until done."""
+        import time
+
+        for ch in _SAMPLE_REPLY:
+            if not self.streaming:
+                return
+            self.llm_output += ch
+            # Short sleep — the re-render after each assignment pushes a
+            # VDOM patch to the client.
+            time.sleep(0.025)
+        self.streaming = False

--- a/python/djust/__init__.py
+++ b/python/djust/__init__.py
@@ -40,6 +40,7 @@ from .mixins.flash import FlashMixin
 from .mixins.page_metadata import PageMetadataMixin
 from .mixins.notifications import NotificationMixin
 from .db import notify_on_save, send_pg_notify
+from .markdown import render_markdown as render_markdown
 
 # Import Rust functions
 try:
@@ -292,4 +293,6 @@ __all__ = [
     "NotificationMixin",
     "notify_on_save",
     "send_pg_notify",
+    # Safe server-side Markdown rendering
+    "render_markdown",
 ]

--- a/python/djust/_rust.pyi
+++ b/python/djust/_rust.pyi
@@ -68,6 +68,45 @@ def render_template_with_dirs(
     """
     ...
 
+def render_markdown(
+    src: str,
+    *,
+    provisional: bool = True,
+    tables: bool = True,
+    strikethrough: bool = True,
+    task_lists: bool = False,
+) -> str:
+    """
+    Render Markdown source to sanitised HTML.
+
+    Safe by construction:
+
+    - Raw HTML tags in ``src`` are HTML-escaped (``Options::ENABLE_HTML`` is
+      never set on the underlying pulldown-cmark parser).
+    - ``javascript:``, ``vbscript:``, and ``data:`` URL schemes in links/images
+      are replaced with ``#``.
+    - Inputs larger than 10 MiB are returned wrapped in an escaped
+      ``<pre class="djust-md-toobig">`` block without invoking the parser.
+
+    Args:
+        src: Markdown source string.
+        provisional: If True (default), split the trailing unfinished line off
+            as escaped plain text — avoids mid-syntax flicker during streaming
+            LLM output.
+        tables: Enable GFM tables.
+        strikethrough: Enable ``~~strikethrough~~``.
+        task_lists: Enable ``- [ ]`` / ``- [x]`` checkboxes.
+
+    Returns:
+        Sanitised HTML string.
+
+    Example::
+
+        html = render_markdown("**bold** and *italic*")
+        # '<p><strong>bold</strong> and <em>italic</em></p>\\n'
+    """
+    ...
+
 def diff_html(old_html: str, new_html: str) -> str:
     """
     Compute diff between two HTML strings.
@@ -755,6 +794,7 @@ __all__ = [
     # Core rendering
     "render_template",
     "render_template_with_dirs",
+    "render_markdown",
     "diff_html",
     "resolve_template_inheritance",
     # Serialization

--- a/python/djust/checks.py
+++ b/python/djust/checks.py
@@ -1932,6 +1932,10 @@ _DJ_EVENT_DIRECTIVES_RE = re.compile(
 )
 _DJ_COMPONENT_RE = re.compile(r"dj-component")
 _DEPRECATED_DATA_DJ_ID_RE = re.compile(r"""data-dj-id\s*=\s*["'][^"']*["']""")
+# A090 — scanner for {% djust_markdown %} (v0.7.0). Fires info-level once
+# per project when the tag is detected, confirming the Rust-side safe
+# renderer is in use (raw HTML escaped, provisional-line splitter active).
+_DJ_MARKDOWN_TAG_RE = re.compile(r"\{%\s*djust_markdown\b")
 
 
 @register("djust")
@@ -1941,6 +1945,12 @@ def check_templates(app_configs, **kwargs):
     tpl_dirs = _get_template_dirs()
     if not tpl_dirs:
         return errors
+
+    # A090 — project-wide counter for {% djust_markdown %} usage (v0.7.0).
+    # We emit a single info-level check after the per-file loop when at
+    # least one template uses the tag, so developers get explicit
+    # confirmation the Rust-side safe renderer is active.
+    djust_markdown_hits: list[tuple[str, int]] = []
 
     for filepath in _iter_template_files(tpl_dirs):
         try:
@@ -2161,6 +2171,33 @@ def check_templates(app_configs, **kwargs):
                 )
             else:
                 _seen_activity_names[name_literal] = lineno
+
+        # A090 — tally {% djust_markdown %} occurrences (v0.7.0). The
+        # actual Info-level check is emitted once per project after the
+        # per-file loop (below).
+        for match in _DJ_MARKDOWN_TAG_RE.finditer(content):
+            lineno = content[: match.start()].count("\n") + 1
+            djust_markdown_hits.append((relpath, lineno))
+
+    if djust_markdown_hits and not _is_check_suppressed("djust.A090"):
+        first_relpath, first_lineno = djust_markdown_hits[0]
+        count = len(djust_markdown_hits)
+        errors.append(
+            DjustInfo(
+                "{%% djust_markdown %%} is used in %d location(s) (first: %s:%d) — "
+                "djust is rendering Markdown server-side via the Rust pulldown-cmark "
+                "backend with safe-by-default escaping "
+                "(ENABLE_HTML never set, javascript: URLs neutralised, 10 MiB input cap)."
+                % (count, first_relpath, first_lineno),
+                hint=(
+                    "This is informational. Suppress with "
+                    "DJUST_CONFIG = {'suppress_checks': ['A090']} if you don't "
+                    "want this notice. See the Streaming Markdown guide for "
+                    "details: docs/website/guides/streaming-markdown.md."
+                ),
+                id="djust.A090",
+            )
+        )
 
     return errors
 

--- a/python/djust/markdown.py
+++ b/python/djust/markdown.py
@@ -1,0 +1,76 @@
+"""
+Safe Markdown rendering for djust LiveView templates.
+
+This module exposes a single high-level helper, :func:`render_markdown`, that
+wraps the Rust-side ``djust._rust.render_markdown`` function and returns a
+``SafeString`` — the HTML is already escaped where it matters (raw tags are
+neutralised, ``javascript:`` URLs are stripped), so marking it safe for
+Django's auto-escape pipeline is the correct thing to do.
+
+Typical use is through the ``{% djust_markdown %}`` template tag (see
+:mod:`djust.template_tags.markdown`), but the Python function is useful for
+tests, admin views, or pre-rendering outside a template.
+
+Example
+-------
+>>> from djust.markdown import render_markdown
+>>> render_markdown("# Hello\\n")
+'<h1>Hello</h1>\\n'
+"""
+
+from __future__ import annotations
+
+from django.utils.safestring import SafeString, mark_safe
+
+__all__ = ["render_markdown"]
+
+
+def render_markdown(
+    src: str,
+    *,
+    provisional: bool = True,
+    tables: bool = True,
+    strikethrough: bool = True,
+    task_lists: bool = False,
+) -> SafeString:
+    """
+    Render Markdown source to a sanitised ``SafeString``.
+
+    The Rust implementation guarantees:
+
+    - Raw HTML tags in ``src`` are HTML-escaped (never emitted live).
+    - ``javascript:`` / ``vbscript:`` / ``data:`` URLs are neutralised to ``#``.
+    - Inputs larger than 10 MiB are returned wrapped in a
+      ``<pre class="djust-md-toobig">`` block, never parsed.
+
+    Because of those guarantees the return value is marked safe for Django's
+    template auto-escape.
+
+    Parameters
+    ----------
+    src:
+        Markdown source. Must be ``str``.
+    provisional:
+        If ``True`` (the default) the trailing partially-typed line is rendered
+        as escaped plain text so streaming LLM output does not flicker mid-syntax.
+    tables, strikethrough, task_lists:
+        Toggle optional GFM features.
+
+    Returns
+    -------
+    SafeString
+        HTML safe to interpolate unescaped.
+    """
+    # Import locally so that the module is importable (with a clear error) even
+    # when the Rust extension has not yet been built.
+    from djust._rust import render_markdown as _rust_render_markdown
+
+    html = _rust_render_markdown(
+        src,
+        provisional=provisional,
+        tables=tables,
+        strikethrough=strikethrough,
+        task_lists=task_lists,
+    )
+    # html is already sanitised by the Rust side.
+    return mark_safe(html)

--- a/python/djust/template_tags/__init__.py
+++ b/python/djust/template_tags/__init__.py
@@ -229,6 +229,7 @@ def _register_builtins():
         from . import pwa  # noqa: F401
         from . import templatetag  # noqa: F401
         from . import flash  # noqa: F401
+        from . import markdown  # noqa: F401
     except ImportError as e:
         logger.debug("Could not import built-in handlers: %s", e)
 

--- a/python/djust/template_tags/markdown.py
+++ b/python/djust/template_tags/markdown.py
@@ -1,0 +1,120 @@
+"""
+Django ``{% djust_markdown %}`` template tag handler for djust.
+
+Registered on module import via the :func:`djust.template_tags.register`
+decorator (same pattern as ``{% url %}`` and ``{% static %}``). The handler
+dispatches to the Rust-side :func:`djust._rust.render_markdown` function which
+is safe-by-default — raw HTML in the source is escaped, ``javascript:`` URLs
+are neutralised, and inputs are size-capped before parsing.
+
+Usage in templates
+------------------
+
+.. code-block:: django
+
+    {% djust_markdown body %}
+    {% djust_markdown post.content tables=False %}
+    {% djust_markdown llm_output provisional=True %}
+
+Accepted keyword arguments (all booleans):
+
+- ``provisional`` (default ``True``) — split trailing in-progress line as
+  escaped text, preventing mid-token flicker during streaming renders.
+- ``tables`` (default ``True``) — enable GFM tables.
+- ``strikethrough`` (default ``True``) — enable ``~~strikethrough~~``.
+- ``task_lists`` (default ``False``) — enable ``- [ ]`` / ``- [x]`` checkboxes.
+
+Unknown kwargs are logged at WARNING level and ignored.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+from . import TagHandler, register
+
+logger = logging.getLogger(__name__)
+
+# Keep these in sync with the Rust-side RenderOpts defaults.
+_BOOL_KWARGS = frozenset({"provisional", "tables", "strikethrough", "task_lists"})
+_DEFAULTS: Dict[str, bool] = {
+    "provisional": True,
+    "tables": True,
+    "strikethrough": True,
+    "task_lists": False,
+}
+
+
+def _coerce_bool(val: Any) -> bool:
+    """Coerce a resolved template argument into a ``bool``.
+
+    Accepts native ``bool``, common falsy strings (``"false"``, ``"0"``,
+    ``"no"``, ``"off"``, empty string), or falls back to truthiness.
+    """
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val.strip().lower() not in {"false", "0", "no", "off", ""}
+    return bool(val)
+
+
+@register("djust_markdown")
+class MarkdownTagHandler(TagHandler):
+    """Handler for ``{% djust_markdown <expr> [kwargs] %}``.
+
+    Resolves the first argument to a Markdown source string and passes it
+    through :func:`djust._rust.render_markdown` with the requested GFM options.
+    The Rust side guarantees the output is safe HTML; we do not apply
+    additional escaping.
+
+    If the Rust extension is unavailable (e.g. in a degraded CI environment)
+    the handler falls back to Django ``escape()`` on the raw source so the
+    template still renders — just without formatting.
+    """
+
+    def render(self, args: List[str], context: Dict[str, Any]) -> str:
+        if not args:
+            logger.warning(
+                "{%% djust_markdown %%} called without a source argument — returning empty string"
+            )
+            return ""
+
+        try:
+            from djust._rust import render_markdown as _rust_render_markdown
+        except ImportError:
+            logger.error(
+                "djust._rust.render_markdown not available — Rust extension "
+                "not built. Falling back to escape()."
+            )
+            from django.utils.html import escape
+
+            src_fallback = self._resolve_arg(args[0], context)
+            return escape("" if src_fallback is None else str(src_fallback))
+
+        src_raw = self._resolve_arg(args[0], context)
+        src = "" if src_raw is None else str(src_raw)
+
+        kwargs: Dict[str, bool] = dict(_DEFAULTS)
+        for arg in args[1:]:
+            resolved = self._resolve_arg(arg, context)
+            if isinstance(resolved, tuple):
+                key, value = resolved
+                if key in _BOOL_KWARGS:
+                    kwargs[key] = _coerce_bool(value)
+                else:
+                    logger.warning(
+                        "{%% djust_markdown %%}: ignoring unknown kwarg %r",
+                        key,
+                    )
+            else:
+                logger.warning(
+                    "{%% djust_markdown %%}: ignoring positional arg %r "
+                    "after source (expected kwargs only)",
+                    arg,
+                )
+
+        # Rust output is already HTML-escaped where appropriate; it is safe
+        # to insert into the rendered page without further escaping. The Rust
+        # template engine's CustomTag path trusts the returned string.
+        return _rust_render_markdown(src, **kwargs)

--- a/python/djust/tests/test_markdown.py
+++ b/python/djust/tests/test_markdown.py
@@ -1,0 +1,83 @@
+"""Tests for :mod:`djust.markdown` and the underlying Rust binding.
+
+Covers:
+
+- Roundtrip through the Python helper.
+- Kwargs propagation to the Rust side.
+- XSS neutralisation at the Python entry point.
+- Thread safety of concurrent renders (GIL release).
+- Streaming append stability — the prefix of a completed line does not
+  change when more characters are appended.
+- Return type is ``SafeString``.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+from django.utils.safestring import SafeString
+
+from djust.markdown import render_markdown
+
+
+def test_roundtrip_basic():
+    out = render_markdown("# Title\n\nparagraph\n")
+    assert "<h1>Title</h1>" in out
+    assert "<p>paragraph</p>" in out
+
+
+def test_kwarg_tables_disabled():
+    src = "| a | b |\n| - | - |\n| 1 | 2 |\n"
+    with_tables = render_markdown(src, tables=True)
+    without_tables = render_markdown(src, tables=False)
+    assert "<table>" in with_tables
+    assert "<table>" not in without_tables
+
+
+def test_python_render_markdown_escapes_xss():
+    out = render_markdown("<script>alert(1)</script>\n")
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+
+
+def test_concurrent_renders_thread_safe():
+    # Render the same non-trivial doc from many threads and confirm:
+    #  (a) no deadlock / panic,
+    #  (b) every thread gets a non-empty string back.
+    src = "# heading\n\nsome **bold** text and `code`\n"
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        results = list(pool.map(lambda _: render_markdown(src), range(128)))
+    assert len(results) == 128
+    assert all("<h1>heading</h1>" in r for r in results)
+
+
+def test_stream_append_prefix_stable_for_completed_line():
+    # Completed line ("hello\n") should render the same way regardless of
+    # what comes after it, as long as the trailing line keeps matching the
+    # provisional heuristic (so pulldown-cmark only sees the stable prefix).
+    prefix = "hello\n"
+    # Append characters that keep the trailing line "mid-token": "**wor".
+    chunks = ["**w", "**wo", "**wor"]
+    stable_renders = []
+    for chunk in chunks:
+        full = prefix + chunk
+        out = render_markdown(full)
+        # The <p>hello</p> for the completed line must appear in every render.
+        assert "<p>hello</p>" in out
+        # Extract everything before the provisional wrapper.
+        head, _, _ = out.partition('<p class="djust-md-provisional">')
+        stable_renders.append(head)
+    # All "stable" (non-provisional) prefixes must be identical.
+    assert stable_renders[0] == stable_renders[1] == stable_renders[2]
+
+
+def test_returns_safestring():
+    out = render_markdown("hi\n")
+    assert isinstance(out, SafeString)
+
+
+def test_completed_line_renders_strong():
+    # Fully-closed bold with a trailing newline should render as <strong>.
+    # The provisional splitter must NOT steal the completed line.
+    out = render_markdown("Hello **word**\n")
+    assert "<strong>word</strong>" in out

--- a/python/tests/test_checks.py
+++ b/python/tests/test_checks.py
@@ -3904,3 +3904,82 @@ class TestA072A073AdminWidgetChecks:
         assert len(a073_bogus) == 0, (
             f"A073 should fallback to 1 for bogus setting; got {a073_bogus!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# A090 — {% djust_markdown %} info-level confirmation check (v0.7.0)
+# ---------------------------------------------------------------------------
+
+
+class TestA090DjustMarkdownCheck:
+    """The A090 info-level check fires once per project when the
+    ``{% djust_markdown %}`` tag is used, confirming the Rust-side safe
+    renderer is active.
+    """
+
+    def test_check_a090_info_level(self, tmp_path, settings):
+        """A090 should fire as an INFO-level check when the tag is used."""
+        tpl_dir = tmp_path / "templates"
+        tpl_dir.mkdir()
+        (tpl_dir / "chat.html").write_text("<article>{% djust_markdown body %}</article>")
+        settings.TEMPLATES = [
+            {
+                "DIRS": [str(tpl_dir)],
+                "BACKEND": "django.template.backends.django.DjangoTemplateBackend",
+            }
+        ]
+
+        from django.core.checks import INFO
+
+        from djust.checks import check_templates
+
+        errors = check_templates(None)
+        a090 = [e for e in errors if e.id == "djust.A090"]
+        assert len(a090) == 1, (
+            "A090 should fire exactly once when {%% djust_markdown %%} is used; got %r"
+            % [e.id for e in errors]
+        )
+        assert a090[0].level == INFO, "A090 must be INFO-level; got level=%r" % a090[0].level
+        # Confirmation message mentions the Rust backend and safety guarantees.
+        msg = a090[0].msg
+        assert "pulldown-cmark" in msg
+        assert "javascript:" in msg
+
+    def test_a090_silent_when_tag_not_used(self, tmp_path, settings):
+        """A090 must not fire when no template uses the tag."""
+        tpl_dir = tmp_path / "templates"
+        tpl_dir.mkdir()
+        (tpl_dir / "plain.html").write_text("<p>Hello world</p>")
+        settings.TEMPLATES = [
+            {
+                "DIRS": [str(tpl_dir)],
+                "BACKEND": "django.template.backends.django.DjangoTemplateBackend",
+            }
+        ]
+
+        from djust.checks import check_templates
+
+        errors = check_templates(None)
+        a090 = [e for e in errors if e.id == "djust.A090"]
+        assert len(a090) == 0
+
+    def test_a090_fires_once_even_with_multiple_uses(self, tmp_path, settings):
+        """Multiple occurrences still produce exactly one A090 Info."""
+        tpl_dir = tmp_path / "templates"
+        tpl_dir.mkdir()
+        (tpl_dir / "a.html").write_text("{% djust_markdown body %}")
+        (tpl_dir / "b.html").write_text("{% djust_markdown body %}\n{% djust_markdown other %}")
+        settings.TEMPLATES = [
+            {
+                "DIRS": [str(tpl_dir)],
+                "BACKEND": "django.template.backends.django.DjangoTemplateBackend",
+            }
+        ]
+
+        from djust.checks import check_templates
+
+        errors = check_templates(None)
+        a090 = [e for e in errors if e.id == "djust.A090"]
+        assert len(a090) == 1
+        # Message includes the total count (3).
+        assert "3 location(s)" in a090[0].msg

--- a/tests/unit/test_markdown_tag.py
+++ b/tests/unit/test_markdown_tag.py
@@ -1,0 +1,136 @@
+"""Tests for the ``{% djust_markdown %}`` template tag.
+
+The tag is registered via the djust Rust tag-handler registry (same
+mechanism as ``{% url %}`` / ``{% static %}``), so these tests drive it
+by calling :func:`djust._rust.render_template` with the appropriate
+template source.
+
+Covers:
+
+- Basic rendering of a context variable into HTML.
+- ``provisional=False`` kwarg disables the streaming wrapper.
+- ``tables=False`` kwarg disables GFM tables.
+- **⭐ rule test**: ``<script>`` source payload is rendered as escaped text.
+- Rendering inside a ``{% for %}`` loop.
+- Streaming append sequence — the stable HTML for an already-completed line
+  does not change as more characters are appended to the trailing line.
+- (A090 info-level check lives in ``python/tests/test_checks.py``.)
+"""
+
+from __future__ import annotations
+
+# Make sure the tag handler is registered before tests run. Importing the
+# package executes ``template_tags/__init__._register_builtins()`` which in
+# turn imports ``template_tags.markdown`` and triggers @register.
+import djust  # noqa: F401
+
+from djust._rust import render_template
+from djust.template_tags.markdown import MarkdownTagHandler
+
+
+def test_tag_basic_render():
+    out = render_template(
+        "{% djust_markdown body %}",
+        {"body": "**bold** and *em*"},
+    )
+    assert "<strong>bold</strong>" in out
+    assert "<em>em</em>" in out
+
+
+def test_tag_provisional_kwarg_off():
+    # Trailing mid-token line — with provisional=False the splitter is bypassed
+    # and pulldown-cmark sees the unclosed ** as literal text.
+    out = render_template(
+        "{% djust_markdown body provisional=False %}",
+        {"body": "Hello **wor"},
+    )
+    assert 'class="djust-md-provisional"' not in out
+    # With the default (provisional=True) we'd see the wrapper.
+    out_default = render_template(
+        "{% djust_markdown body %}",
+        {"body": "Hello **wor"},
+    )
+    assert 'class="djust-md-provisional"' in out_default
+
+
+def test_tag_tables_kwarg():
+    src = "| a | b |\n| - | - |\n| 1 | 2 |\n"
+    on = render_template(
+        "{% djust_markdown body %}",
+        {"body": src},
+    )
+    off = render_template(
+        "{% djust_markdown body tables=False %}",
+        {"body": src},
+    )
+    assert "<table>" in on
+    assert "<table>" not in off
+
+
+def test_tag_escapes_script_tags():
+    """⭐ Rule test: a <script> payload in the Markdown source is escaped."""
+    out = render_template(
+        "{% djust_markdown body %}",
+        {"body": "<script>alert('xss')</script>"},
+    )
+    assert "<script>" not in out, "tag MUST NOT emit raw <script> from source text; got: %s" % out
+    assert "&lt;script&gt;" in out
+
+
+def test_tag_inside_for_loop():
+    out = render_template(
+        "{% for msg in msgs %}<div>{% djust_markdown msg %}</div>{% endfor %}",
+        {"msgs": ["**one**", "`two`", "# three"]},
+    )
+    assert "<strong>one</strong>" in out
+    assert "<code>two</code>" in out
+    assert "<h1>three</h1>" in out
+    # Three wrapping divs.
+    assert out.count("<div>") == 3
+
+
+def test_tag_streaming_append_sequence():
+    """Simulate an LLM streaming one character at a time into `llm_output`.
+
+    Assertion: once a line has ended with '\\n', its HTML must remain
+    byte-stable across subsequent appends to the in-progress trailing line.
+    """
+    prefix = "hello world\n"
+    out_prev = None
+    for tail in ["", "*", "**w", "**wor", "**word"]:
+        body = prefix + tail
+        out = render_template(
+            "{% djust_markdown body %}",
+            {"body": body},
+        )
+        head, _, _ = out.partition('<p class="djust-md-provisional">')
+        if out_prev is not None:
+            assert head == out_prev, (
+                "stable prefix changed between stream chunks:\n"
+                "prev: %r\ncurrent: %r" % (out_prev, head)
+            )
+        out_prev = head
+        # Paragraph for 'hello world' always present.
+        assert "<p>hello world</p>" in out
+
+
+def test_tag_import_error_fallback(monkeypatch):
+    """If djust._rust.render_markdown is unavailable, the handler falls
+    back to Django's escape() — the page still renders, just without
+    Markdown formatting.
+    """
+    # Delete the attribute so `from djust._rust import render_markdown`
+    # raises ImportError, exercising the fallback branch.
+    monkeypatch.delattr(
+        "djust._rust.render_markdown",
+        raising=False,
+    )
+
+    handler = MarkdownTagHandler()
+    out = handler.render(
+        ["body"],
+        {"body": "<script>alert(1)</script>"},
+    )
+    assert out == "&lt;script&gt;alert(1)&lt;/script&gt;", (
+        "fallback path must Django-escape the source, got: %r" % out
+    )


### PR DESCRIPTION
## Summary

Fourth v0.7.0 feature — Rust-side CommonMark parser for LLM streaming output. The headline AI-vertical positioning feature. Safe, fast, incremental rendering of markdown tokens as they arrive.

## Architecture

- **Rust impl** (`crates/djust_templates/src/markdown.rs`, 330 LOC): `pulldown-cmark` 0.12 parser; `RenderOpts` dataclass; `split_provisional` mid-stream safety (unclosed `**`, `*`, `` ` ``, `[`, `](` in last line → plain-text trailing span); `sanitise_event` re-routes raw HTML events to escaped Text; `neutralise_url` rewrites `javascript:`/`vbscript:`/`data:` → `#` (case-insensitive, whitespace-trimmed); 10 MiB per-call hard cap.
- **PyO3 binding** (`crates/djust_live/src/lib.rs`): `py.allow_threads` for GIL-released parse.
- **Python helper** (`python/djust/markdown.py`): `mark_safe` wrapper.
- **Template tag** (`python/djust/template_tags/markdown.py`): `{% djust_markdown var [kwargs] %}` with fail-closed Django `escape()` fallback on ImportError.
- **System check** (A090): info-level confirmation of safe-mode active when tag is in use.

## Scope

- `djust.render_markdown(src, *, provisional=True, tables=True, strikethrough=True, task_lists=False)` Python API
- `{% djust_markdown var [provisional=] [tables=] [strikethrough=] [task_lists=] %}` template tag
- 38 tests (24 Rust + 8 Python + 6 tag + A090 ×3)

## Deviation from plan

- **`autolinks` kwarg DROPPED** — pulldown-cmark 0.12 has no `ENABLE_GFM_AUTOLINK` / `ENABLE_AUTOLINK` flag. Documented in guide Limitations + CHANGELOG.
- **`sanitise_event` custom filter** — plan assumed omitting `Options::ENABLE_HTML` suppresses raw HTML. It does NOT in 0.12: parser still emits `Event::Html` / `Event::InlineHtml`. Required a custom event filter mapping these to `Event::Text` (escaped on write).

## Action Tracker discipline applied

- **Action #124** (rule tests RED before impl): 6 ⭐ Rust rule tests written as stubs first, confirmed failing with stub `render_markdown` returning empty string, then implemented to green.
- **Action #125** (doc-claim-verbatim tests): Stage 7 flagged 8 🟡 doc claims without tests. Fix pass added 9 regression tests — all pass on first run (code already correct; tests lock behavior).

## Review findings resolved

- **Stage 7** (4 🟡): log-level drift — N/A; A073 worker-count — N/A (that was admin PR); 8 🟡 Action #125 items — all covered by added regression tests.
- **Stage 8** (zero CRITICAL/HIGH/MEDIUM; 3 INFO): XSS-vector grid covering 25+ bypass attempts (mixed case, entity-encoded, data:image/svg+xml, reference-style, autolink form) — ALL neutralized. 10 MB cap trip-tested. Concurrent-render note moved to docs "Operational limits".

## Security guarantees verified

- Raw HTML is escaped via event re-routing (not relying on `ENABLE_HTML` flag semantics).
- Unsafe URL schemes neutralized in Link AND Image destinations.
- Case-insensitive + whitespace-trimmed scheme detection.
- Entity-decoded by pulldown-cmark before hitting our sanitizer.
- Python-side fails closed to `escape()` on ImportError (Rust missing).

## Test plan

- [ ] Merge, pull main, run `make test` — baseline green
- [ ] Start demo: `cd examples/demo_project && make start`; visit `/demos/markdown-stream/` — watch LLM-simulated stream render
- [ ] DevTools: inspect rendered HTML — no `<script>`, no `javascript:` hrefs
- [ ] In a REPL: `from djust import render_markdown; print(render_markdown("# Hi **world**"))` — returns `SafeString`

Closes v0.7.0 P2 matrix row "Streaming markdown renderer" per ROADMAP.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)