### PR TITLE
refactor(tests): replace hand-rolled Redis mock with fakeredis (closes #961)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ dev = [
     "requests>=2.28,<3",  # Deploy CLI
     "requests-mock>=1.11,<2",  # HTTP mocking for deploy CLI tests
     "mcp[cli]>=1.2.0,<2",  # djust.mcp server tests (test_mcp.py)
+    "fakeredis>=2.20,<3",  # In-memory Redis for test_security_upload_resumable.py (closes #961)
 ]
 
 [project.scripts]

--- a/tests/unit/test_security_upload_resumable.py
+++ b/tests/unit/test_security_upload_resumable.py
@@ -9,9 +9,10 @@ CI security job measures coverage across them.
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 from unittest.mock import MagicMock
 
+import fakeredis
 import pytest
 from django.test import RequestFactory
 
@@ -183,76 +184,55 @@ class TestInMemoryUploadState:
 
 
 # ===========================================================================
-# RedisUploadState (with fake client)
+# RedisUploadState (with fakeredis)
 # ===========================================================================
-
-
-class FakeRedisClient:
-    """A minimal redis-py-compatible mock (no pipeline)."""
-
-    def __init__(self):
-        self.data: Dict[str, bytes] = {}
-        self.ttls: Dict[str, int] = {}
-
-    def get(self, key: str):
-        return self.data.get(key)
-
-    def set(self, key, value, ex=None):
-        self.data[key] = value if isinstance(value, bytes) else str(value).encode()
-        if ex is not None:
-            self.ttls[key] = ex
-
-    def setex(self, key, ttl, value):
-        self.data[key] = value if isinstance(value, bytes) else str(value).encode()
-        self.ttls[key] = ttl
-
-    def delete(self, key):
-        self.data.pop(key, None)
-        self.ttls.pop(key, None)
-
-    def ttl(self, key):
-        return self.ttls.get(key, -1)
+# We use ``fakeredis.FakeRedis`` (a full in-memory Redis implementation) in
+# place of a hand-rolled mock. It implements the complete redis-py surface
+# — including TTL semantics, atomic pipelines, and error modes — so tests
+# exercise the real call sequence our ``RedisUploadState`` uses in prod.
+# Closes #961.
 
 
 class TestRedisUploadStateNoPipeline:
     """Redis store exercising the non-atomic fallback path (no pipeline)."""
 
     def test_set_and_get(self):
-        client = FakeRedisClient()
+        client = fakeredis.FakeRedis()
         store = RedisUploadState(client)
         store.set("u1", {"a": 1}, ttl=60)
         assert store.get("u1") == {"a": 1}
 
     def test_get_missing_returns_none(self):
-        client = FakeRedisClient()
+        client = fakeredis.FakeRedis()
         store = RedisUploadState(client)
         assert store.get("nonexistent") is None
 
     def test_get_corrupt_json_discards_entry(self):
-        client = FakeRedisClient()
-        client.data["djust:upload:u1"] = b"not-json{"
+        client = fakeredis.FakeRedis()
+        client.set("djust:upload:u1", b"not-json{")
         store = RedisUploadState(client)
         assert store.get("u1") is None
         # Corrupt entry should be deleted after discovery.
-        assert "djust:upload:u1" not in client.data
+        assert client.exists("djust:upload:u1") == 0
 
     def test_setex_fallback_for_older_redis_py(self):
         """Older redis-py raises TypeError on ``ex=`` kwarg — store falls
         back to setex positional form."""
 
-        class OldRedis(FakeRedisClient):
-            def set(self, key, value, ex=None):
+        class OldRedis(fakeredis.FakeRedis):
+            def set(self, name, value, ex=None, *args, **kwargs):
                 if ex is not None:
                     raise TypeError("old redis doesn't support ex kwarg")
-                super().set(key, value, ex=None)
+                return super().set(name, value, *args, **kwargs)
 
         client = OldRedis()
         store = RedisUploadState(client)
         store.set("u1", {"a": 1}, ttl=30)
-        assert client.ttls["djust:upload:u1"] == 30
+        # fakeredis uses real wall-clock; allow ±1s slack between set and read.
+        assert 29 <= client.ttl("djust:upload:u1") <= 30
 
     def test_update_no_pipeline_reads_and_rewrites(self):
-        client = FakeRedisClient()
+        client = fakeredis.FakeRedis()
         store = RedisUploadState(client)
         store.set("u1", {"a": 1}, ttl=60)
         merged = store.update("u1", {"b": 2})
@@ -260,20 +240,20 @@ class TestRedisUploadStateNoPipeline:
         assert store.get("u1") == {"a": 1, "b": 2}
 
     def test_update_no_pipeline_missing_entry_returns_none(self):
-        client = FakeRedisClient()
+        client = fakeredis.FakeRedis()
         store = RedisUploadState(client)
         assert store.update("missing", {"x": 1}) is None
 
     def test_set_too_large_raises(self):
-        client = FakeRedisClient()
+        client = fakeredis.FakeRedis()
         store = RedisUploadState(client)
         huge = {"data": "x" * (MAX_STATE_SIZE_BYTES + 100)}
         with pytest.raises(UploadStateTooLarge):
             store.set("u1", huge, ttl=60)
 
     def test_delete_catches_redis_errors(self, caplog):
-        class BrokenRedis(FakeRedisClient):
-            def delete(self, key):
+        class BrokenRedis(fakeredis.FakeRedis):
+            def delete(self, *names):
                 raise RuntimeError("redis down")
 
         store = RedisUploadState(BrokenRedis())
@@ -281,10 +261,10 @@ class TestRedisUploadStateNoPipeline:
         store.delete("u1")
 
     def test_custom_key_prefix(self):
-        client = FakeRedisClient()
+        client = fakeredis.FakeRedis()
         store = RedisUploadState(client, key_prefix="myapp:ups:")
         store.set("u1", {"a": 1}, ttl=60)
-        assert "myapp:ups:u1" in client.data
+        assert client.exists("myapp:ups:u1") == 1
 
 
 class TestRedisUploadStateWithPipeline:

--- a/uv.lock
+++ b/uv.lock
@@ -588,7 +588,7 @@ wheels = [
 
 [[package]]
 name = "djust"
-version = "0.6.1rc1"
+version = "0.7.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "channels", extra = ["daphne"] },
@@ -625,6 +625,7 @@ deploy = [
 ]
 dev = [
     { name = "click" },
+    { name = "fakeredis" },
     { name = "maturin" },
     { name = "mcp", extra = ["cli"] },
     { name = "mypy" },
@@ -672,6 +673,7 @@ requires-dist = [
     { name = "click", marker = "extra == 'dev'", specifier = ">=8.0,<9" },
     { name = "django", specifier = ">=4.2.29,<6" },
     { name = "djust", extras = ["redis", "compression", "performance", "admin", "deploy", "theming", "components", "s3", "gcs", "azure"], marker = "extra == 'all'" },
+    { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.20,<3" },
     { name = "google-cloud-storage", marker = "extra == 'gcs'", specifier = ">=2.10,<4" },
     { name = "markdown", marker = "extra == 'components'", specifier = ">=3.0,<4" },
     { name = "maturin", marker = "extra == 'dev'", specifier = ">=1.0,<2.0" },
@@ -722,6 +724,20 @@ source = { registry = "http://127.0.0.1:8418/pypi/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "fakeredis"
+version = "2.35.1"
+source = { registry = "http://127.0.0.1:8418/pypi/simple/" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/50/b748233c02fa77e5105238190cc9bb58b852eb1c8b1d0763230d3a5b745a/fakeredis-2.35.1.tar.gz", hash = "sha256:5bae5eba7b9d93cb968944ac40936373cf2397ff71667d4b595df65c3d2e413f", size = 189118, upload-time = "2026-04-12T17:05:58.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/27/b8b057a23f7777177e92d3a602fd866751b6b45014964548997e92e048fd/fakeredis-2.35.1-py3-none-any.whl", hash = "sha256:67d97e11f562b7870e11e5c30cf182270bfb2dd37f6707dba47cc6d91628d1b9", size = 129678, upload-time = "2026-04-12T17:05:56.86Z" },
 ]
 
 [[package]]
@@ -2234,6 +2250,15 @@ source = { registry = "http://127.0.0.1:8418/pypi/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "http://127.0.0.1:8418/pypi/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Third v0.7.1 PR — test-only refactor. Replace hand-rolled \`FakeRedisClient\` in \`test_security_upload_resumable.py\` with \`fakeredis.FakeRedis\`. Net -19 LOC, more accurate Redis semantics.

## Why

From PR #959 retro: hand-rolled mock (~30 LOC) implemented a minimal get/set/setex/delete/ttl surface — enough at the time but drifts from redis-py behavior. \`fakeredis\` is a full in-memory Redis used by many projects.

## Scope

- \`tests/unit/test_security_upload_resumable.py\` — drop \`FakeRedisClient\`; 7 instantiation sites → \`fakeredis.FakeRedis()\`; \`OldRedis\`/\`BrokenRedis\` subclasses now inherit from \`fakeredis.FakeRedis\` with redis-py method signatures; direct \`.data[]\`/\`.ttls[]\` access → real Redis commands (\`client.set()\`, \`client.ttl()\`, \`client.exists()\`).
- \`pyproject.toml\` — add \`fakeredis>=2.20,<3\` to \`[dev]\`.
- \`uv.lock\` — regenerated.

## Test tolerance

\`test_setex_fallback_for_older_redis_py\` previously asserted \`client.ttls[...] == 30\` (exact). \`fakeredis\` uses real wall-clock (±1s slack between \`set()\` and \`ttl()\`). Loosened to \`29 <= client.ttl(...) <= 30\` — mirrors what a real Redis-backed integration test would see.

## Test plan

- [ ] \`pytest tests/unit/test_security_upload_resumable.py\` — 70/70 pass locally ✅
- [ ] CI full suite green

Closes #961.

🤖 Generated with [Claude Code](https://claude.com/claude-code)