### PR TITLE
fix(dev_server): module importable without watchdog (closes #994)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`djust.dev_server` NameError on module load when `watchdog` is
+  not installed (v0.7.2, #994)** — the `try/except ImportError` block
+  at `dev_server.py:13-19` sets `WATCHDOG_AVAILABLE = False` but the
+  class statement `class DjustFileChangeHandler(FileSystemEventHandler)`
+  on line 25 referenced the symbol unconditionally. When watchdog is
+  absent, class definition time crashes with `NameError: name
+  'FileSystemEventHandler' is not defined`, which in turn breaks
+  `python manage.py check` in any djust install without the `[dev]`
+  extra (because `djust.checks.check_hot_view_replacement` imports
+  `WATCHDOG_AVAILABLE` from `djust.dev_server`). Latent since at least
+  v0.5.4rc1 — the pattern predates the v0.5.x refactor; only surfaces
+  when an install omits watchdog. Fix: the `except ImportError` branch
+  now defines stub `FileSystemEventHandler`, `FileSystemEvent`, and
+  `Observer` classes purely to satisfy the class statements below at
+  import time. `HotReloadServer.start()` already short-circuits on
+  `WATCHDOG_AVAILABLE = False`, so the stubs are never instantiated in
+  a running process. Covered by **3 regression tests** in
+  `tests/test_dev_server_watchdog_missing.py` that block watchdog via
+  a `sys.meta_path` finder and verify (a) `djust.dev_server` imports
+  cleanly, (b) `HotReloadServer.start()` no-ops with the documented
+  warning, (c) `djust.checks.check_hot_view_replacement`'s downstream
+  import path survives.
+
 ## [0.7.1rc1] - 2026-04-24
 
 ### Added

--- a/python/djust/dev_server.py
+++ b/python/djust/dev_server.py
@@ -18,6 +18,28 @@ try:
 except ImportError:
     WATCHDOG_AVAILABLE = False
 
+    # Stubs so the module is importable without watchdog. Hot reload is a
+    # dev-only feature (`djust[dev]` extra); production installs that only
+    # need `manage.py check` must be able to import this module — and
+    # `djust.checks.check_hot_view_replacement` imports
+    # `WATCHDOG_AVAILABLE` from here. Without these stubs, the class
+    # definitions below reference undefined names and the whole module
+    # fails to load. HotReloadServer.start() already short-circuits on
+    # `WATCHDOG_AVAILABLE = False`, so these stubs are never instantiated
+    # in a running process; they exist purely to satisfy the class
+    # statements at import time.
+    class FileSystemEventHandler:  # type: ignore[no-redef]
+        pass
+
+    class FileSystemEvent:  # type: ignore[no-redef]
+        src_path: str = ""
+        is_directory: bool = False
+
+    class Observer:  # type: ignore[no-redef]
+        """Stub — real Observer never instantiated without watchdog."""
+
+        pass
+
 
 logger = logging.getLogger(__name__)
 

--- a/python/djust/tests/test_dev_server_watchdog_missing.py
+++ b/python/djust/tests/test_dev_server_watchdog_missing.py
@@ -1,0 +1,112 @@
+"""Regression test for #994 — `djust.dev_server` must be importable even
+when the optional `watchdog` package is not installed.
+
+Before the fix, `DjustFileChangeHandler(FileSystemEventHandler)` on
+line 25 referenced an undefined symbol whenever the `try: import
+watchdog` block fell through to `except ImportError`. The class
+statement crashed with `NameError: name 'FileSystemEventHandler' is
+not defined`, which in turn broke `python manage.py check` in any
+djust install without the `[dev]` extra (because
+`djust.checks.check_hot_view_replacement` imports `WATCHDOG_AVAILABLE`
+from `djust.dev_server`).
+
+This test blocks `watchdog` at the import-hook level, reloads
+`djust.dev_server`, and asserts the module loads cleanly and
+`HotReloadServer.start()` short-circuits with the documented warning.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.abc
+import logging
+import sys
+
+import pytest
+
+
+class _BlockWatchdog(importlib.abc.MetaPathFinder):
+    """Meta-path finder that raises ImportError for any `watchdog*` import."""
+
+    def find_spec(self, name, path, target=None):  # noqa: ARG002
+        if name == "watchdog" or name.startswith("watchdog."):
+            raise ImportError(f"blocked for #994 regression test: {name}")
+        return None
+
+
+@pytest.fixture
+def block_watchdog():
+    """Force `import watchdog` (and submodules) to raise ImportError."""
+    # Drop any cached watchdog modules first so the re-import sees
+    # our blocker, not the previously-imported real module.
+    for mod in list(sys.modules):
+        if mod == "watchdog" or mod.startswith("watchdog."):
+            del sys.modules[mod]
+
+    blocker = _BlockWatchdog()
+    sys.meta_path.insert(0, blocker)
+    try:
+        yield
+    finally:
+        sys.meta_path.remove(blocker)
+
+
+def test_dev_server_imports_without_watchdog(block_watchdog):
+    """#994: module must load — not raise NameError — when watchdog is absent.
+
+    The fix adds stub `FileSystemEventHandler`, `FileSystemEvent`, and
+    `Observer` classes in the `except ImportError` branch so the class
+    statements at module scope can resolve their base / annotation
+    references.
+    """
+    if "djust.dev_server" in sys.modules:
+        del sys.modules["djust.dev_server"]
+    # Importing must not raise NameError or any exception.
+    module = importlib.import_module("djust.dev_server")
+    assert module.WATCHDOG_AVAILABLE is False
+    # Class statements must have executed — DjustFileChangeHandler
+    # exists as a class, not a module-level NameError crash.
+    assert isinstance(module.DjustFileChangeHandler, type)
+    assert isinstance(module.HotReloadServer, type)
+    assert module.hot_reload_server is not None
+
+
+def test_hot_reload_server_start_no_ops_without_watchdog(block_watchdog, caplog):
+    """#994: HotReloadServer.start() must short-circuit with a warning.
+
+    Even though the module is now importable, starting the server
+    without watchdog must be a clean no-op (the existing
+    `if not WATCHDOG_AVAILABLE` branch at dev_server.py:136 handles
+    this). Locking the behavior so a future refactor doesn't drop the
+    guard.
+    """
+    if "djust.dev_server" in sys.modules:
+        del sys.modules["djust.dev_server"]
+    module = importlib.import_module("djust.dev_server")
+
+    with caplog.at_level(logging.WARNING, logger="djust.dev_server"):
+        module.hot_reload_server.start(watch_dirs=["/tmp"], on_change=lambda _p: None)
+
+    assert "watchdog not installed" in caplog.text
+    # And no observer was ever created — short-circuit occurred before
+    # `self.observer = Observer()` ran.
+    assert module.hot_reload_server.observer is None
+    assert module.hot_reload_server._started is False
+
+
+def test_check_hot_view_replacement_survives_without_watchdog(block_watchdog):
+    """#994 downstream: `djust.checks.check_hot_view_replacement`
+    imports `WATCHDOG_AVAILABLE` from `dev_server`; before the fix the
+    whole module import would crash, breaking `manage.py check`. After
+    the fix, the import succeeds and the check runs normally."""
+    # Evict both modules so checks.py re-imports dev_server through
+    # our blocker.
+    for mod in ("djust.dev_server", "djust.checks"):
+        if mod in sys.modules:
+            del sys.modules[mod]
+    # Must not raise.
+    checks_mod = importlib.import_module("djust.checks")
+    # Function must still be callable — we're not asserting its
+    # output here (that would require full Django setup). The claim
+    # under test is "import succeeds", which is the bug.
+    assert callable(checks_mod.check_hot_view_replacement)


### PR DESCRIPTION
## Summary

Fix #994 — `djust/dev_server.py` crashed at module import when `watchdog` was not installed.

The `try/except ImportError` block at lines 13–19 set `WATCHDOG_AVAILABLE = False`, but the class statement on line 25 referenced `FileSystemEventHandler` unconditionally, raising `NameError` at module load. That broke `python manage.py check` in any djust install without the `[dev]` extra, because `djust.checks.check_hot_view_replacement` imports `WATCHDOG_AVAILABLE` from `djust.dev_server`.

## Root cause

Latent since ≥v0.5.4rc1 — the pattern predates the v0.5.x refactor. Only surfaces when the install omits `watchdog`, so dev environments (which pull in `djust[dev]`) never saw it. First reported against v0.7.0rc1 by a user running `manage.py check` in a CI env without the extra.

## Fix

The `except ImportError` branch now defines stub `FileSystemEventHandler`, `FileSystemEvent`, and `Observer` classes — purely to satisfy the module-level class statements at import time. `HotReloadServer.start()` already short-circuits on `WATCHDOG_AVAILABLE = False`, so the stubs are never instantiated in a running process; they exist only so Python can evaluate the class definitions.

## Test plan

- [x] `pytest python/djust/tests/test_dev_server_watchdog_missing.py` — 3/3 pass (new file)
- [x] `pytest tests/unit/test_hot_view_replacement.py` — 24/24 pass (no regression on the existing C401 check)
- [x] Manual: `import djust.dev_server` in a fresh env without watchdog (simulated via `sys.meta_path` blocker) loads cleanly, WATCHDOG_AVAILABLE is False
- [x] Manual: real-watchdog path still resolves `FileSystemEventHandler.__module__ == 'watchdog.events'`
- [x] `HotReloadServer.start()` still emits the documented "watchdog not installed" warning when short-circuited

## Regression coverage

3 new tests in `tests/test_dev_server_watchdog_missing.py` that block `watchdog` imports via a `sys.meta_path` finder and assert:

1. `djust.dev_server` imports cleanly (no NameError)
2. `HotReloadServer.start()` no-ops with the documented warning
3. `djust.checks.check_hot_view_replacement`'s downstream import path survives — i.e. `manage.py check` doesn't break

CHANGELOG entry added under `[Unreleased]` for v0.7.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)