### PR TITLE
fix(rust): honor __str__ key in Value::Object Display (closes #968)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Rust renderer honors `__str__` key on serialized model dicts
+  (v0.7.2, #968)** — `djust.serialization._serialize_model_safely`
+  sets `"__str__": str(obj)` on every dict it produces so `{{ obj }}`
+  in a Rust-engine template can match Django's default `str(obj)`
+  semantics. The Rust `Value::Object` Display impl
+  (`crates/djust_core/src/lib.rs`) previously ignored the key and
+  emitted the literal `"[Object]"` for any dict. This broke FK
+  display silently in LiveView templates — `{{ claim.claimant }}`
+  (where `claimant` serializes to a nested dict) rendered as
+  `[Object]` instead of the claimant's string representation, since
+  the page still returned 200 the only way to notice was visual
+  inspection. Reported by the NYC Comptroller Claims Processing
+  prototype team who hit six occurrences in a single project. Fix:
+  when the value is `Value::Object` and contains a
+  `"__str__": Value::String(...)` entry, render the string. Non-model
+  dicts (no `__str__`, or `__str__` not a string) keep the existing
+  `"[Object]"` fallback. Plain Python objects with custom `__str__`
+  were already correct (handled by `FromPyObject`). Covered by **5
+  Rust unit tests** in `crates/djust_core/src/lib.rs::tests` and **13
+  Python integration tests** in `tests/test_rust_renderer_str_key.py`
+  (model dict, nested FK, HTML-auto-escape, dotted-access, plain-dict
+  fallback, null/int `__str__` edge cases, empty-string `__str__`,
+  backwards-compat for plain Python objects + lists + scalars).
 - **`djust.dev_server` NameError on module load when `watchdog` is
   not installed (v0.7.2, #994)** — the `try/except ImportError` block
   at `dev_server.py:13-19` sets `WATCHDOG_AVAILABLE = False` but the

--- a/crates/djust_core/src/lib.rs
+++ b/crates/djust_core/src/lib.rs
@@ -157,6 +157,21 @@ impl Value {
 }
 
 // Implement Display trait instead of inherent to_string method
+//
+// For serialized Django-model dicts the Python-side serializer sets
+// `"__str__": str(obj)` on every dict it produces (see
+// `python/djust/serialization.py::_serialize_model_safely`). This
+// matches Django's default template semantics: `{{ obj }}` in a
+// Django template calls `str(obj)`, so a rendered FK like
+// `{{ claim.claimant }}` produces the claimant's `__str__`, not a
+// placeholder.
+//
+// Before the #968 fix the Rust renderer ignored the `__str__` key
+// and emitted the literal `"[Object]"` for any dict, breaking the
+// Django semantic for LiveView templates. The current
+// implementation checks for a `"__str__"` entry first and renders
+// its string value when present, falling back to `"[Object]"` only
+// for dicts that weren't produced by the model serializer.
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -166,7 +181,10 @@ impl fmt::Display for Value {
             Value::Float(fl) => write!(f, "{fl}"),
             Value::String(s) => write!(f, "{s}"),
             Value::List(_) => write!(f, "[List]"),
-            Value::Object(_) => write!(f, "[Object]"),
+            Value::Object(o) => match o.get("__str__") {
+                Some(Value::String(s)) => write!(f, "{s}"),
+                _ => write!(f, "[Object]"),
+            },
         }
     }
 }
@@ -269,5 +287,64 @@ mod tests {
         assert!(!Value::Integer(0).is_truthy());
         assert!(Value::String("hello".to_string()).is_truthy());
         assert!(!Value::String("".to_string()).is_truthy());
+    }
+
+    /// #968 — `Value::Object` with a `"__str__"` key renders that
+    /// string, matching Django's default `{{ obj }}` semantics.
+    /// Serialized Django-model dicts carry `"__str__": str(obj)` from
+    /// `python/djust/serialization.py::_serialize_model_safely`; the
+    /// Rust Display impl previously dropped it and emitted `[Object]`.
+    #[test]
+    fn test_display_object_with_str_key() {
+        let mut map = HashMap::new();
+        map.insert("id".to_string(), Value::Integer(1));
+        map.insert(
+            "__str__".to_string(),
+            Value::String("<Claim: 2026PD000075>".to_string()),
+        );
+        let obj = Value::Object(map);
+        assert_eq!(obj.to_string(), "<Claim: 2026PD000075>");
+    }
+
+    /// Fallback: plain dicts without a `"__str__"` key keep rendering
+    /// as `"[Object]"` — non-model data (e.g. a context dict passed
+    /// directly from user code) was never meant to hit `__str__`
+    /// semantics.
+    #[test]
+    fn test_display_object_without_str_key() {
+        let mut map = HashMap::new();
+        map.insert("a".to_string(), Value::Integer(1));
+        map.insert("b".to_string(), Value::Integer(2));
+        let obj = Value::Object(map);
+        assert_eq!(obj.to_string(), "[Object]");
+    }
+
+    /// Edge: `"__str__"` key present but not a `String` (e.g. an
+    /// upstream bug produces `"__str__": null`). Fall back to
+    /// `"[Object]"` rather than emit `null` or crash.
+    #[test]
+    fn test_display_object_str_key_non_string_falls_back() {
+        let mut map = HashMap::new();
+        map.insert("__str__".to_string(), Value::Null);
+        let obj = Value::Object(map);
+        assert_eq!(obj.to_string(), "[Object]");
+    }
+
+    /// Empty string `"__str__"` is still a valid override — Django
+    /// template would render an empty string if `str(obj) == ""`,
+    /// and the Rust engine must match.
+    #[test]
+    fn test_display_object_empty_str_key() {
+        let mut map = HashMap::new();
+        map.insert("__str__".to_string(), Value::String("".to_string()));
+        let obj = Value::Object(map);
+        assert_eq!(obj.to_string(), "");
+    }
+
+    /// Regression-lock: bare `[List]` fallback for lists unchanged.
+    #[test]
+    fn test_display_list_unchanged() {
+        let list = Value::List(vec![Value::Integer(1), Value::Integer(2)]);
+        assert_eq!(list.to_string(), "[List]");
     }
 }

--- a/python/djust/tests/test_rust_renderer_str_key.py
+++ b/python/djust/tests/test_rust_renderer_str_key.py
@@ -1,0 +1,143 @@
+"""Integration tests for #968 — Rust renderer honors the ``"__str__"``
+key on serialized model dicts.
+
+The Python-side serializer (`djust.serialization._serialize_model_safely`)
+sets ``"__str__": str(obj)`` on every dict it produces so Rust-engine
+templates can match Django's default ``{{ obj }}`` semantics. Before
+the #968 fix, the Rust `Value::Object` Display impl emitted the
+literal ``"[Object]"`` for any dict, silently breaking FK display:
+``{{ claim.claimant }}`` (where `claimant` serializes to a nested
+dict) rendered as ``[Object]`` instead of the claimant's string.
+
+These tests exercise the Rust renderer via the PyO3 `render_template`
+entry point so the full Python→Rust→Display path is covered. Native
+Rust unit tests for `Value::Object` Display live in
+`crates/djust_core/src/lib.rs` alongside the impl.
+"""
+
+from __future__ import annotations
+
+from djust._rust import render_template
+
+
+class TestModelDictStrKey:
+    """``Value::Object`` with ``"__str__"`` key → renders the string."""
+
+    def test_model_dict_renders_str_value(self):
+        """Canonical case: ``{{ claim }}`` on a serialized-model dict."""
+        out = render_template(
+            "{{ claim }}",
+            {"claim": {"id": 1, "__str__": "Claim 2026PD000075", "claim_number": "2026PD000075"}},
+        )
+        assert out == "Claim 2026PD000075"
+
+    def test_model_dict_str_value_is_html_escaped(self):
+        """Auto-escape applies to ``__str__`` output — `<Claim: ...>` → `&lt;Claim: ...&gt;`."""
+        out = render_template(
+            "{{ claim }}",
+            {"claim": {"__str__": "<Claim: 2026PD000075>"}},
+        )
+        # Full HTML escape: angle brackets encoded.
+        assert out == "&lt;Claim: 2026PD000075&gt;"
+
+    def test_model_dict_dotted_access_unchanged(self):
+        """Dotted access to scalar fields still works; doesn't hit ``__str__``."""
+        out = render_template(
+            "{{ claim.claim_number }}",
+            {"claim": {"__str__": "parent-str", "claim_number": "ABC"}},
+        )
+        assert out == "ABC"
+
+    def test_nested_fk_dict_renders_str(self):
+        """Nested FK (the #968 canonical bug): ``{{ claim.claimant }}`` →
+        claimant's ``__str__`` instead of ``[Object]``."""
+        out = render_template(
+            "{{ claim.claimant }}",
+            {
+                "claim": {
+                    "__str__": "parent",
+                    "claimant": {"__str__": "John Doe", "first_name": "John"},
+                }
+            },
+        )
+        assert out == "John Doe"
+
+
+class TestPlainDictFallback:
+    """Dicts WITHOUT a string ``"__str__"`` key keep rendering ``[Object]``
+    — non-model data (context dict passed directly, etc.) was never meant
+    to hit ``__str__`` semantics."""
+
+    def test_plain_dict_no_str_key(self):
+        out = render_template("{{ x }}", {"x": {"a": 1, "b": 2}})
+        assert out == "[Object]"
+
+    def test_empty_dict(self):
+        out = render_template("{{ x }}", {"x": {}})
+        assert out == "[Object]"
+
+    def test_str_key_is_none(self):
+        """``"__str__": None`` → treat as absent; fall back to ``[Object]``."""
+        out = render_template("{{ x }}", {"x": {"__str__": None, "id": 1}})
+        assert out == "[Object]"
+
+    def test_str_key_is_integer(self):
+        """``"__str__": 42`` → not a String variant; fall back. Guards
+        against Display emitting coerced type names."""
+        out = render_template("{{ x }}", {"x": {"__str__": 42}})
+        assert out == "[Object]"
+
+
+class TestStrKeyEdgeCases:
+    """Edge cases around the ``"__str__"`` key resolution."""
+
+    def test_empty_str_value_renders_empty(self):
+        """Django semantic: if ``str(obj) == ''`` the template renders
+        empty. Rust engine must match — not fall back to ``[Object]``."""
+        out = render_template("{{ x }}", {"x": {"__str__": ""}})
+        assert out == ""
+
+    def test_str_key_among_many_fields(self):
+        """``__str__`` resolution works regardless of dict ordering or
+        number of other keys."""
+        big = {f"field_{i}": i for i in range(20)}
+        big["__str__"] = "canonical"
+        out = render_template("{{ x }}", {"x": big})
+        assert out == "canonical"
+
+
+class TestBackwardsCompatibility:
+    """Paths that worked before the fix must still work."""
+
+    def test_plain_python_object_str_unchanged(self):
+        """Plain Python objects with ``__str__`` continued to work
+        through `FromPyObject` — string-extract path. #968 was about
+        the dict case specifically; the object case was already
+        correct."""
+
+        class Obj:
+            def __str__(self):
+                return "My Custom Str"
+
+        out = render_template("{{ x }}", {"x": Obj()})
+        assert out == "My Custom Str"
+
+    def test_list_still_renders_list_placeholder(self):
+        """``[List]`` fallback for lists unchanged — only `Value::Object`
+        was touched."""
+        out = render_template("{{ x }}", {"x": [1, 2, 3]})
+        assert out == "[List]"
+
+    def test_scalar_types_unchanged(self):
+        """Sanity: integer/bool/string/null Display unchanged.
+
+        Note: Rust's built-in ``{}`` format for bool emits lowercase
+        ``true`` / ``false`` — pre-existing djust behavior, out of
+        scope for #968. This test locks the current (pre-fix) behavior
+        so #968's change to the `Object` arm doesn't accidentally
+        regress any other variant.
+        """
+        assert render_template("{{ x }}", {"x": 42}) == "42"
+        assert render_template("{{ x }}", {"x": True}) == "true"
+        assert render_template("{{ x }}", {"x": "hello"}) == "hello"
+        assert render_template("{{ x }}", {"x": None}) == ""


### PR DESCRIPTION
## Summary

Fix #968 — Rust renderer's `Value::Object` Display impl ignored the `"__str__"` key on serialized-model dicts, emitting the literal `"[Object]"` placeholder where Django's template engine would call `str(obj)`.

## Root cause

`djust.serialization._serialize_model_safely` sets `"__str__": str(obj)` on every dict it produces (and on nested FK dicts). The Rust `fmt::Display` impl for `Value` at `crates/djust_core/src/lib.rs:169` matched all `Value::Object` cases and wrote `"[Object]"` — the `__str__` key was present but never consumed.

Result: `{{ claim }}` or `{{ claim.claimant }}` (the latter resolves to a nested FK dict) rendered `[Object]` silently. 200 OK, no traceback, only caught by visual inspection.

## Fix

```rust
Value::Object(o) => match o.get("__str__") {
    Some(Value::String(s)) => write!(f, "{s}"),
    _ => write!(f, "[Object]"),
},
```

- **`__str__` present + String variant** → emit the string (matches Django semantics).
- **No `__str__` / null / int** → keep the `[Object]` fallback (guards against upstream serialization bugs emitting `null` or coerced types).
- **Auto-escape unaffected** — the Rust template engine's escape layer runs on the Display output as before.

## Test plan

- [x] `cargo test -p djust_core` — 14/14 (5 new + 9 existing)
- [x] `pytest python/djust/tests/test_rust_renderer_str_key.py` — 13/13
- [x] `pytest python/djust/tests/ -k "render or template or serializ"` (template-adjacent regression sweep) — 920 passed, 1 skipped, 0 failed
- [x] Manual end-to-end: `{{ claim }}` on a serialized-model dict with `__str__: "Claim 2026PD000075"` renders correctly; `{{ claim.claimant }}` on a nested FK dict with `__str__: "John Doe"` renders correctly; plain dict without `__str__` still renders `[Object]`

## Coverage

**Rust unit tests** (`crates/djust_core/src/lib.rs::tests`):
1. `test_display_object_with_str_key` — canonical case
2. `test_display_object_without_str_key` — plain dict fallback
3. `test_display_object_str_key_non_string_falls_back` — `__str__: null` / wrong variant
4. `test_display_object_empty_str_key` — `__str__: ""` renders empty (not fallback)
5. `test_display_list_unchanged` — `[List]` fallback for lists untouched

**Python integration tests** (`tests/test_rust_renderer_str_key.py`, 13 tests across 4 classes):
- `TestModelDictStrKey` — model dict, HTML auto-escape, dotted access preserved, nested FK
- `TestPlainDictFallback` — no `__str__`, empty dict, null/int `__str__`
- `TestStrKeyEdgeCases` — empty string, many siblings
- `TestBackwardsCompatibility` — plain Python object (`FromPyObject` path), `[List]` unchanged, scalar variants unchanged

CHANGELOG entry under `[Unreleased]` for v0.7.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)