### PR TITLE
docs(s3_events): key_template UUID convention + debug-warn on fallback (closes #964)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **`key_template` UUID-prefix convention for `s3_events` (v0.7.2,
+  #964)** — `djust.contrib.uploads.s3_events.parse_s3_event` extracts
+  `upload_id` by finding the first UUID-shaped path segment in the
+  S3 object key; apps whose `key_template` doesn't produce such a
+  segment silently fall back to the full key as `upload_id`, and
+  hooks registered against the UUID then don't fire. This was the
+  #1 source of "my hook isn't being called" reports from v0.5.7+
+  users. Fix: (a) the module docstring now documents the convention
+  prominently with two recommended `key_template` shapes
+  (`uploads/<uuid>/<filename>` and `<tenant>/<uuid>/<filename>`);
+  (b) a `DEBUG` log entry fires on the
+  `djust.contrib.uploads.s3_events` logger whenever fallback
+  happens, naming the offending key — so enabling `DEBUG` logging
+  once is enough to diagnose a silent hook; (c) a "Key-template
+  convention for `s3_events`" section has been added to
+  `docs/website/guides/uploads.md` with a debugging recipe and a
+  pointer to the "custom upload-id routing" escape hatch (via
+  `x-amz-meta-upload-id` / JWT / DB lookup). Covered by **3 new
+  regression tests** in `tests/test_presigned_s3_820.py` (no-UUID
+  fallback + DEBUG log, happy path emits no log, UUID segment
+  position doesn't matter).
+
 ### Fixed
 
 - **Rust renderer honors `__str__` key on serialized model dicts

--- a/docs/website/guides/uploads.md
+++ b/docs/website/guides/uploads.md
@@ -332,6 +332,37 @@ If your own `abort()` implementation raises, djust logs the traceback and swallo
 - **`entry.data` / `entry.file` are empty.** The raw bytes never sat anywhere djust could hand them to you. Use `entry.writer_result` (whatever `close()` returned) instead.
 - **No temp file cleanup required.** Because no temp file was created, `entry.cleanup()` is a no-op for writer uploads.
 
+### Key-template convention for `s3_events`
+
+When you use the S3 event webhook (`djust.contrib.uploads.s3_events.s3_event_webhook`) to receive `ObjectCreated` notifications and fire the `on_upload_complete(...)` hook, djust needs a way to map the incoming S3 key back to the `upload_id` that your app registered a hook against.
+
+`parse_s3_event` does this by finding the **first UUID-shaped path segment** (32–36 hex/dash characters) in the object key. That means your presign step must produce keys that follow the convention:
+
+```
+uploads/<upload_id_uuid>/<original_filename>
+```
+
+or, when bucketing by tenant:
+
+```
+<tenant_id>/<upload_id_uuid>/<original_filename>
+```
+
+Both work because the parser scans **every** segment, not just the first — the first UUID-shaped segment wins.
+
+**If no path segment looks UUID-shaped**, `upload_id` silently falls back to the full key, a `DEBUG` log entry is emitted on the `djust.contrib.uploads.s3_events` logger, and your hook **will not fire** (because it was registered under a UUID, not the full key). This is the #1 source of "my hook isn't being called" reports.
+
+Debugging a silent hook:
+
+```python
+import logging
+logging.getLogger("djust.contrib.uploads.s3_events").setLevel(logging.DEBUG)
+```
+
+Re-run the webhook delivery. The log will show the key that failed to match and the convention you need to follow.
+
+**Alternative: custom upload-id routing.** If you embed the upload id elsewhere — an `x-amz-meta-upload-id` header, a JWT in the key prefix, a DB lookup keyed on the S3 key — parse the SNS payload yourself and bypass `parse_s3_event` entirely. The helper is a best-effort convention for the common case; it's not mandatory.
+
 ## Best Practices
 
 - **Set `max_file_size`** based on your needs. Client-side validation rejects oversized files before upload begins; server-side validates after all chunks arrive.

--- a/python/djust/contrib/uploads/s3_events.py
+++ b/python/djust/contrib/uploads/s3_events.py
@@ -149,10 +149,40 @@ def parse_s3_event(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
             ...
         ]
 
-    ``upload_id`` is extracted from the S3 object key's first path
-    segment if it looks UUID-shaped; otherwise it's the full key. Apps
-    that embed upload_id elsewhere (e.g. x-amz-meta-upload-id) can
-    parse ``payload`` themselves and bypass this helper.
+    Key-template convention (#964)
+    ------------------------------
+
+    ``upload_id`` is extracted from the S3 object key by finding the
+    **first path segment that looks UUID-shaped** (32-36 hex/dash
+    characters). Apps that follow the convention — i.e. include a
+    UUID as a leading path component — get automatic upload-id
+    routing with no custom parsing.
+
+    Recommended key template::
+
+        uploads/<upload_id_uuid>/<original_filename>
+
+    or, when bucketing by tenant::
+
+        <tenant_id>/<upload_id_uuid>/<original_filename>
+
+    Both work because ``parse_s3_event`` scans **every** segment, not
+    just the first. The first UUID-shaped segment wins.
+
+    If no path segment looks UUID-shaped, ``upload_id`` **silently
+    falls back to the full key** and a DEBUG log entry is emitted
+    (``djust.contrib.uploads.s3_events`` logger). The fallback is
+    strictly a best-effort — your hook registered via
+    :func:`register_upload_hook` will receive the full key as the
+    ``upload_id`` and will likely not match. If you're debugging a
+    "hook not firing" report, enable DEBUG logging on this module
+    and re-run the webhook delivery; the missing UUID segment will
+    show up in the log.
+
+    Apps that embed upload_id elsewhere (e.g. ``x-amz-meta-upload-id``
+    header, a registry table, a signed JWT in the key prefix) should
+    call their own parser and bypass this helper entirely — see the
+    "Custom upload-id routing" section of the uploads guide.
     """
     import re as _re
 
@@ -175,13 +205,30 @@ def parse_s3_event(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
         key = obj.get("key", "")
         size = int(obj.get("size", 0))
         etag = obj.get("eTag", "").strip('"')
-        # Derive upload_id from first path segment if UUID-shaped.
+        # Derive upload_id from first UUID-shaped path segment. If
+        # none matches, fall back to the full key and emit a DEBUG
+        # log entry — the app is violating the documented
+        # key_template convention and its hook will likely not match.
+        # See module docstring + docs/website/guides/uploads.md
+        # "Key-template convention for s3_events" for the template to
+        # follow.
         segments = key.split("/")
         upload_id = key
+        matched_uuid = False
         for seg in segments:
             if uuid_re.match(seg):
                 upload_id = seg
+                matched_uuid = True
                 break
+        if not matched_uuid:
+            logger.debug(
+                "S3 webhook: no UUID-shaped segment in key %s — "
+                "falling back to full key as upload_id. App must "
+                "either follow the documented key_template convention "
+                "('uploads/<upload_id_uuid>/<filename>') or register "
+                "hooks against the full key.",
+                key,
+            )
         out.append(
             {
                 "upload_id": upload_id,

--- a/python/djust/tests/test_presigned_s3_820.py
+++ b/python/djust/tests/test_presigned_s3_820.py
@@ -287,6 +287,68 @@ class TestS3EventWebhook:
         resp = s3_event_webhook(req)
         assert resp.status_code == 200
 
+    # ------------------------------------------------------------------
+    # #964 — key_template UUID-prefix convention
+    # ------------------------------------------------------------------
+    #
+    # parse_s3_event extracts upload_id by finding the first
+    # UUID-shaped path segment in the key. When the app's
+    # key_template does NOT produce such a segment (e.g. legacy
+    # `my-uploads/2024/foo.bin`), upload_id silently falls back to
+    # the full key and the hook registered by the app's upload-id
+    # won't match. A DEBUG log entry makes this diagnosable.
+
+    def test_parse_s3_event_no_uuid_segment_emits_debug_log(self, caplog):
+        """#964: key without UUID segment → upload_id falls back to full key
+        AND a DEBUG log is emitted so the developer can diagnose a
+        silent `hook not firing` report."""
+        import logging as _logging
+
+        key = "uploads/2024/legacy/foo.bin"  # no UUID segment
+        payload = {"Records": [{"s3": {"object": {"key": key, "size": 1, "eTag": "t"}}}]}
+
+        with caplog.at_level(_logging.DEBUG, logger="djust.contrib.uploads.s3_events"):
+            got = parse_s3_event(payload)
+
+        assert got[0]["upload_id"] == key, "fallback should be the full key"
+        assert "no UUID-shaped segment" in caplog.text
+        assert key in caplog.text, "DEBUG log must name the offending key"
+
+    def test_parse_s3_event_uuid_segment_no_debug_log(self, caplog):
+        """Happy path: key follows the convention → no DEBUG log fires.
+
+        Locks the inverse of the previous test — we don't want the
+        warning on every delivery, only when the convention is
+        broken."""
+        import logging as _logging
+
+        uid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        key = f"uploads/{uid}/my_file.bin"
+        payload = {"Records": [{"s3": {"object": {"key": key, "size": 1, "eTag": "t"}}}]}
+
+        with caplog.at_level(_logging.DEBUG, logger="djust.contrib.uploads.s3_events"):
+            got = parse_s3_event(payload)
+
+        assert got[0]["upload_id"] == uid
+        assert "no UUID-shaped segment" not in caplog.text
+
+    def test_parse_s3_event_uuid_segment_not_first(self, caplog):
+        """The scan is tolerant of leading non-UUID segments — the
+        first UUID-shaped segment anywhere in the path wins. Locks
+        the behavior documented in the module docstring ('both
+        ``uploads/<uuid>/...`` and ``<tenant>/<uuid>/...`` work')."""
+        import logging as _logging
+
+        uid = "11112222-3333-4444-5555-666677778888"
+        key = f"tenant-foo/{uid}/file.bin"
+        payload = {"Records": [{"s3": {"object": {"key": key, "size": 1, "eTag": "t"}}}]}
+
+        with caplog.at_level(_logging.DEBUG, logger="djust.contrib.uploads.s3_events"):
+            got = parse_s3_event(payload)
+
+        assert got[0]["upload_id"] == uid
+        assert "no UUID-shaped segment" not in caplog.text
+
 
 # ----------------------------------------------------------------------
 # Error taxonomy smoke test — keeps the root import path live


### PR DESCRIPTION
## Summary

Fix #964 — document the `key_template` UUID-prefix convention for `s3_events` and emit a DEBUG log when apps violate it, so the silent "hook not firing" failure mode becomes diagnosable.

## Problem

`djust.contrib.uploads.s3_events.parse_s3_event` extracts `upload_id` by finding the first UUID-shaped path segment in the S3 object key. When the app's `key_template` doesn't produce such a segment (e.g. a legacy `uploads/2024/foo.bin`), `upload_id` silently falls back to the full key — and the hook registered under the UUID never fires.

This was flagged in PR #958 retro as the #1 "my hook isn't being called" report from v0.5.7+ users. The silent fallback gave no signal.

## Changes

### 1. Module docstring (authoritative)

`s3_events.py::parse_s3_event` now documents the convention explicitly with two recommended key_template shapes:

- `uploads/<upload_id_uuid>/<original_filename>`
- `<tenant_id>/<upload_id_uuid>/<original_filename>` (both work — the scan is tolerant of leading non-UUID segments)

### 2. DEBUG log on fallback

When no UUID-shaped segment matches, the parser emits a DEBUG log entry on the `djust.contrib.uploads.s3_events` logger naming the offending key. Enabling DEBUG once is enough to diagnose a silent hook. No behavior change in the happy path — normal deliveries don't emit the log.

### 3. Upload guide section

`docs/website/guides/uploads.md` grows a "Key-template convention for `s3_events`" section under the writer-path chapter with the recommended template, the fallback semantics, a debugging recipe, and a pointer to custom upload-id routing (via `x-amz-meta-upload-id` / JWT / DB-lookup) as the escape hatch.

## Test plan

- [x] `pytest python/djust/tests/test_presigned_s3_820.py` — 22/22 (3 new)
- [x] Happy-path delivery: UUID-prefix key → hook fires, no DEBUG log
- [x] Bad-key delivery: no UUID segment → upload_id = full key, DEBUG log names the key
- [x] Tolerance: UUID not in first position (`tenant/<uuid>/file.bin`) still matches
- [x] Existing 19 tests still pass — no regression in signature-verify path, hook registry, SNS unwrap, or webhook error handling

## Coverage

3 new regression tests:
- `test_parse_s3_event_no_uuid_segment_emits_debug_log`
- `test_parse_s3_event_uuid_segment_no_debug_log`
- `test_parse_s3_event_uuid_segment_not_first`

CHANGELOG entry under `[Unreleased]` / Documentation subsection for v0.7.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)