### PR TITLE
feat(forms): inline radio buttons via [data-dj-inline] CSS contract (closes #991)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Inline radio buttons via `data-dj-inline` attribute (v0.7.2,
+  #991)** — opt-in horizontal layout for `forms.RadioSelect` fields
+  without writing any new Python. Users add
+  `widget=forms.RadioSelect(attrs={"data-dj-inline": "true"})` to a
+  `ChoiceField` and load `{% static 'djust/djust-forms.css' %}` once
+  in their base template; the bundled stylesheet uses the CSS
+  `:has()` parent selector (Selectors Level 4 — Chromium 105+,
+  Safari 15.4+, Firefox 121+, all stable since 2023) to walk up from
+  each marked `<input type="radio">` and lay out its containing
+  wrapper as `inline-flex` with sensible spacing, full keyboard
+  navigation, and the browser's native focus ring preserved.
+  Composes with anything that renders a Django `RadioSelect`
+  (plain `forms.Form`, `LiveViewForm`, ModelForms, Django admin,
+  djust-theming form templates) — the same `[data-dj-inline]`
+  selector targets both the stock `<ul><li>` markup and
+  djust-theming's `<div>`-wrapped variant. Skip-able: don't link the
+  CSS file → the attribute is inert. Override-able: write your own
+  CSS rule keyed on `[data-dj-inline]` for any visual treatment
+  (segmented controls, CSS Grid columns, etc.). New file:
+  `python/djust/static/djust/djust-forms.css`. Documented in a new
+  "Inline Radio Buttons" section of `docs/website/guides/forms.md`
+  with the API, the why-data-attribute reasoning, and examples for
+  customizing the visual treatment + multi-field forms. Covered by
+  **12 regression tests** in `tests/test_inline_radios_991.py` (3
+  Django-render contract tests + 5 CSS-ships-and-targets-correctly
+  tests + 2 backwards-compat tests + 2 edge cases).
+
 ### Decisions
 
 - **ADR-012: `_FRAMEWORK_INTERNAL_ATTRS` filter is the right tool;

--- a/docs/website/guides/forms.md
+++ b/docs/website/guides/forms.md
@@ -290,6 +290,88 @@ class FilterView(LiveView):
 
 See the [Model Binding guide](model-binding) for details.
 
+## Inline Radio Buttons
+
+Django's default `RadioSelect` renders each choice on its own line (vertical list). For segmented controls, filter pills, toolbar choices, or short Yes/No fields, you usually want them inline. djust ships a small opt-in CSS helper that does this without you writing any new Python:
+
+```python
+class FilterForm(forms.Form):
+    status = forms.ChoiceField(
+        widget=forms.RadioSelect(attrs={"data-dj-inline": "true"}),
+        choices=[("all", "All"), ("open", "Open"), ("closed", "Closed")],
+    )
+```
+
+In your base template, after djust's `client.js`, link the form helper stylesheet:
+
+```html
+{% load static %}
+<link rel="stylesheet" href="{% static 'djust/djust-forms.css' %}">
+```
+
+**That's it.** Django's widget mechanics put `attrs={...}` onto each `<input type="radio">`, so the rendered HTML looks like:
+
+```html
+<ul>
+  <li><label><input type="radio" name="status" value="all" data-dj-inline="true"> All</label></li>
+  <li><label><input type="radio" name="status" value="open" data-dj-inline="true"> Open</label></li>
+  ...
+</ul>
+```
+
+The bundled CSS uses the `:has()` parent selector to walk up from the marked input and lay out the containing `<ul>` (or `<div>` if you're using djust-theming's form templates) as inline-flex. Result: full keyboard navigation, native focus ring preserved, no extra Python required. Browser support: Chromium 105+, Safari 15.4+, Firefox 121+ — all stable since 2023.
+
+### Why a `data-` attribute and not a custom widget?
+
+Three reasons:
+
+- **Zero new Python.** `RadioSelect(attrs={...})` is already supported by Django; we just document the attribute name.
+- **Composes with anything.** Works with `forms.Form`, `LiveViewForm`, third-party form libraries, ModelForms, Django admin — anything that renders a `RadioSelect`.
+- **Skip-able.** Don't want our CSS? Don't link the file. Want different styling? Write your own rule on `[data-dj-inline]` — the contract is the attribute name, not the visual treatment.
+
+### Customizing the visual treatment
+
+Override the bundled rules in your own stylesheet (loaded after `djust-forms.css`):
+
+```css
+ul[data-dj-inline] {
+    /* Replace the default flex with a CSS Grid for fixed columns: */
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+}
+
+/* Or turn it into a segmented-control: */
+ul[data-dj-inline] > li > label {
+    border: 1px solid #ccc;
+    padding: 0.4em 0.8em;
+    border-radius: 4px;
+}
+ul[data-dj-inline] > li > label:has(input:checked) {
+    background: #1e88e5;
+    color: white;
+}
+```
+
+The `[data-dj-inline]` selector is the documented contract. The default styling is a starting point.
+
+### Multiple inline fields on one form
+
+Just add the attribute to each field's widget:
+
+```python
+class FilterForm(forms.Form):
+    status = forms.ChoiceField(
+        widget=forms.RadioSelect(attrs={"data-dj-inline": "true"}),
+        choices=STATUS_CHOICES,
+    )
+    priority = forms.ChoiceField(
+        widget=forms.RadioSelect(attrs={"data-dj-inline": "true"}),
+        choices=PRIORITY_CHOICES,
+    )
+```
+
+Each `<ul>` gets the attribute independently. No form-level config, no class hierarchy.
+
 ## Tips
 
 - **Always include `{% csrf_token %}`** inside `dj-submit` forms (needed for HTTP fallback).

--- a/python/djust/static/djust/djust-forms.css
+++ b/python/djust/static/djust/djust-forms.css
@@ -1,0 +1,76 @@
+/*
+ * djust-forms.css — opt-in form layout helpers (#991).
+ *
+ * djust ships zero opinions on form aesthetics by default — bring your
+ * own CSS framework, theme, or stylesheet. This file is the small
+ * exception: a single layout helper for inline radio buttons, opt-in
+ * via a documented HTML data-attribute contract.
+ *
+ * Usage:
+ *
+ *   class MyForm(forms.Form):
+ *       status = forms.ChoiceField(
+ *           widget=forms.RadioSelect(attrs={"data-dj-inline": "true"}),
+ *           choices=STATUSES,
+ *       )
+ *
+ * Then in your base template:
+ *
+ *   <link rel="stylesheet" href="{% static 'djust/djust-forms.css' %}">
+ *
+ * Django widget mechanics: `attrs={...}` on a widget lands on each
+ * rendered form-control element, not on the wrapping container. So
+ * `data-dj-inline="true"` ends up on every `<input type="radio">`.
+ * The CSS rules below use the `:has()` parent selector (CSS Selectors
+ * Level 4 — Chromium 105+, Safari 15.4+, Firefox 121+, all stable in
+ * 2026) to walk up from the marked input and lay out its containing
+ * wrappers inline-flex.
+ *
+ * Manifesto: principle 7 — opinionated where it matters (the contract
+ * is `[data-dj-inline]` on the radio, and it's stable forever),
+ * flexible where it doesn't (the actual styling is replaceable;
+ * override or skip the file entirely).
+ */
+
+/* The outermost wrapper around all radios in a single field. Both
+ * Django's stock RadioSelect template (<ul>...) and djust-theming's
+ * div-based template are covered by enumerating `ul, ol, div`.
+ *
+ * Two `:has()` selectors — one for templates that wrap each choice in
+ * an inline element (<li> / nested <div>), one for templates that put
+ * the <label> directly under the outer wrapper. */
+:is(ul, ol, div):has(> :is(li, div) > label > input[type="radio"][data-dj-inline="true"]),
+:is(ul, ol, div):has(> label > input[type="radio"][data-dj-inline="true"]) {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5em 1em;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+/* Each per-choice wrapper (<li> in stock Django, <div> in
+ * djust-theming) laid out inline so the label and radio sit
+ * side-by-side without a forced line break. */
+:is(li, div):has(> label > input[type="radio"][data-dj-inline="true"]) {
+    display: inline-flex;
+    align-items: center;
+    margin: 0;
+}
+
+/* Make the entire <label> a single click target with the radio and
+ * its text aligned cleanly across browsers. Preserves the browser's
+ * native focus ring — no `outline: none`. */
+label:has(> input[type="radio"][data-dj-inline="true"]) {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3em;
+    cursor: pointer;
+}
+
+/* Reset margin on the radio itself so the gap rule above does the
+ * spacing. */
+input[type="radio"][data-dj-inline="true"] {
+    margin: 0;
+}

--- a/python/djust/tests/test_inline_radios_991.py
+++ b/python/djust/tests/test_inline_radios_991.py
@@ -1,0 +1,242 @@
+"""Tests for #991 — inline radio buttons via ``data-dj-inline`` attr.
+
+The contract documented in `docs/website/guides/forms.md` has two
+parts:
+
+1. ``forms.RadioSelect(attrs={"data-dj-inline": "true"})`` lands the
+   attribute on every rendered ``<input type="radio">`` element.
+   That's standard Django widget behavior — `attrs` propagate to the
+   form-control element, not to the wrapper. Verified to lock the
+   contract so a future Django upgrade or template override doesn't
+   silently drop it.
+
+2. The bundled ``djust/djust-forms.css`` stylesheet exists, contains
+   rules keyed on ``[data-dj-inline]``, and uses the CSS ``:has()``
+   parent selector (since the attribute lands on the input rather
+   than the wrapper, the rule must walk up the tree). Locks the
+   "ship CSS in the wheel" half of the contract — without the
+   file, the attribute is inert.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import tests.conftest  # noqa: F401  -- configure Django settings
+
+import django  # noqa: E402
+from django import forms  # noqa: E402
+
+
+CHOICES = [("a", "Apples"), ("b", "Bananas"), ("c", "Cherries")]
+
+
+class _InlineRadioForm(forms.Form):
+    fruit = forms.ChoiceField(
+        widget=forms.RadioSelect(attrs={"data-dj-inline": "true"}),
+        choices=CHOICES,
+    )
+
+
+class _PlainRadioForm(forms.Form):
+    fruit = forms.ChoiceField(
+        widget=forms.RadioSelect(),
+        choices=CHOICES,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Widget render contract
+# ---------------------------------------------------------------------------
+
+
+def test_data_dj_inline_attr_lands_on_each_radio_input():
+    """Django's widget machinery propagates ``attrs`` onto each
+    rendered form-control element. Documented contract — locked here
+    so a Django upgrade or template override that drops the attribute
+    would fail this test.
+
+    The rendered output puts the attribute on every <input> tag (one
+    per choice). Three choices → three occurrences."""
+    form = _InlineRadioForm()
+    rendered = str(form["fruit"])
+    # The attribute must appear on every radio <input>, not on a
+    # wrapper element (Django mechanics).
+    assert rendered.count('data-dj-inline="true"') == len(CHOICES)
+    # And specifically on each <input type="radio">, not just lying
+    # around in the markup.
+    assert (
+        'type="radio" name="fruit" value="a" data-dj-inline="true"' in rendered
+        or 'data-dj-inline="true" type="radio" name="fruit" value="a"' in rendered
+        or (
+            'data-dj-inline="true"' in rendered
+            and 'type="radio"' in rendered
+            and 'name="fruit"' in rendered
+        )
+    ), f"attribute not adjacent to a radio input. Got:\n{rendered}"
+
+
+def test_plain_radioselect_does_not_get_attribute():
+    """Negative: a `RadioSelect` without `attrs={"data-dj-inline":...}`
+    must NOT produce the attribute. Locks the opt-in semantics — no
+    field is "secretly inline" by default."""
+    form = _PlainRadioForm()
+    rendered = str(form["fruit"])
+    assert "data-dj-inline" not in rendered
+
+
+def test_each_choice_renders_label_input_pair():
+    """Sanity: the inline attribute doesn't change the per-choice
+    structure. Each choice still renders as a <label> wrapping an
+    <input type="radio">. The bundled CSS rules
+    (`label:has(> input[type=radio][data-dj-inline])`) target this
+    structure."""
+    form = _InlineRadioForm()
+    rendered = str(form["fruit"])
+    # Three radio inputs (one per choice).
+    assert rendered.count('type="radio"') == len(CHOICES)
+    # Three labels wrapping them.
+    assert rendered.count("<label") == len(CHOICES)
+
+
+def test_attribute_quoting_survives_special_values():
+    """Django escapes attr values; the documented value `"true"` is
+    safe. Verifies that the attribute serializes as expected — guards
+    against an accidental change to `True` (Python bool) which Django
+    would coerce differently."""
+    # The string "true" is what the docs prescribe.
+    form = _InlineRadioForm()
+    rendered = str(form["fruit"])
+    assert 'data-dj-inline="true"' in rendered
+
+
+def test_attribute_does_not_disturb_input_attrs():
+    """The inline attribute must not interfere with Django's required
+    attrs on each <input> (`name`, `value`, `id`, `required`). Locks
+    the documented promise that a11y attributes survive."""
+    form = _InlineRadioForm()
+    rendered = str(form["fruit"])
+    assert 'name="fruit"' in rendered
+    assert 'id="id_fruit_0"' in rendered
+    # The form is unbound + required — Django emits the `required`
+    # attr on each radio input.
+    assert "required" in rendered
+
+
+# ---------------------------------------------------------------------------
+# 2. CSS file ships in the wheel
+# ---------------------------------------------------------------------------
+
+
+def _static_root() -> Path:
+    """Return the path to djust's bundled static dir."""
+    import djust
+
+    return Path(djust.__file__).resolve().parent / "static" / "djust"
+
+
+def test_djust_forms_css_ships_in_static():
+    """The CSS file must exist in the package's static dir so
+    `{% static 'djust/djust-forms.css' %}` resolves. Locks the
+    ship-as-package-data invariant."""
+    css = _static_root() / "djust-forms.css"
+    assert css.exists(), f"expected {css} to ship with the package"
+
+
+def test_djust_forms_css_targets_data_dj_inline():
+    """The bundled CSS must contain at least one rule keyed on
+    `[data-dj-inline="true"]`. Without the rule, the attribute is
+    inert and the documented user workflow doesn't do anything
+    visible. Locks the contract from the CSS side."""
+    css = _static_root() / "djust-forms.css"
+    text = css.read_text(encoding="utf-8")
+    assert '[data-dj-inline="true"]' in text or "[data-dj-inline]" in text, (
+        "djust-forms.css must contain at least one rule keyed on "
+        "[data-dj-inline] — the documented contract."
+    )
+
+
+def test_djust_forms_css_uses_has_parent_selector():
+    """Since `attrs={...}` lands on each <input>, the bundled CSS
+    must use `:has()` to walk up from the marked input to its
+    container. Without `:has()`, the rule would only match the
+    inputs themselves, which is the wrong layout target.
+
+    `:has()` is supported in all stable browsers since late 2023
+    (Chromium 105+, Safari 15.4+, Firefox 121+). Locks the
+    architectural choice so a future "simplify the CSS" PR doesn't
+    accidentally regress to a non-functional rule."""
+    css = _static_root() / "djust-forms.css"
+    text = css.read_text(encoding="utf-8")
+    assert ":has(" in text, (
+        "djust-forms.css must use the :has() parent selector — the "
+        "documented mechanism for layouting the wrapper of an input "
+        "marked with data-dj-inline."
+    )
+
+
+def test_djust_forms_css_uses_inline_layout():
+    """The rule must use a non-vertical layout (flex/inline-flex/grid).
+    Locks the actual visual behavior against accidental regressions
+    to `display: block`. If the user wants different visual treatment
+    they're free to override; this test guards the *bundled default*."""
+    css = _static_root() / "djust-forms.css"
+    text = css.read_text(encoding="utf-8")
+    # Allow flex / inline-flex / grid — anything that lays out
+    # children non-vertically. Block / list-item are explicitly NOT
+    # in the allowed set.
+    assert any(
+        kw in text
+        for kw in (
+            "display: inline-flex",
+            "display:inline-flex",
+            "display: flex",
+            "display:flex",
+            "display: grid",
+            "display:grid",
+        )
+    ), "djust-forms.css must use a non-vertical layout for [data-dj-inline]"
+
+
+def test_djust_forms_css_preserves_native_focus_ring():
+    """Locks the documented a11y promise: the bundled CSS must NOT
+    remove `outline` from the radios. Future "polish" PRs that add
+    `outline: none` would silently break keyboard accessibility."""
+    css = _static_root() / "djust-forms.css"
+    text = css.read_text(encoding="utf-8")
+    # Strip comments so we don't false-positive on the "no outline:
+    # none" comment we deliberately wrote into the file.
+    import re
+
+    code = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    assert "outline: none" not in code and "outline:none" not in code, (
+        "djust-forms.css must not strip the native focus ring "
+        "(found `outline: none` in the rules — would break a11y)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Backwards compatibility — forms without the attr unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_existing_radio_forms_render_without_attribute():
+    """Forms that don't opt into `data-dj-inline` must continue to
+    render exactly as Django/djust-theming render them today —
+    specifically, the `data-dj-inline` attribute must be absent.
+    Smoke-test against a future 'auto-inline by default' regression."""
+    form = _PlainRadioForm()
+    rendered = str(form["fruit"])
+    assert "data-dj-inline" not in rendered
+    # Sanity: the markup still has radio inputs (we didn't break the
+    # plain render path).
+    assert 'type="radio"' in rendered
+    assert "fruit" in rendered
+
+
+def test_django_version_baseline():
+    """Lock the supported Django version range — the test suite
+    runs against Django 5.x, where the widget rendering chain we
+    rely on is stable. If this fails, the conftest's Django version
+    has been bumped to something we haven't validated."""
+    assert django.VERSION >= (5, 0), f"Django >= 5.0 expected, got {django.VERSION}"


### PR DESCRIPTION
## Summary

Closes #991 — opt-in inline radio button layout for `forms.RadioSelect` fields. Zero new Python; pure CSS contract via the `data-dj-inline="true"` attribute on the widget's `attrs`.

## API

```python
class FilterForm(forms.Form):
    status = forms.ChoiceField(
        widget=forms.RadioSelect(attrs={"data-dj-inline": "true"}),
        choices=STATUS_CHOICES,
    )
```

In the base template:

```html
{% load static %}
<link rel="stylesheet" href="{% static 'djust/djust-forms.css' %}">
```

## How it works

Django's widget machinery puts `attrs={...}` onto each rendered `<input>`, **not** onto the wrapping element. So `data-dj-inline="true"` lands on every `<input type="radio">`. The bundled CSS uses the `:has()` parent selector to walk up from each marked input and lay out its containing wrapper (`<ul>` for stock Django, `<div>` for djust-theming) as `inline-flex`.

Browser support: `:has()` is stable in Chromium 105+, Safari 15.4+, Firefox 121+ — all shipped since late 2023.

## Why this design (vs. form-level flag / template tag)

- **Zero new Python** — `RadioSelect(attrs={...})` already supported by Django
- **Composes with anything** — works with `forms.Form`, `LiveViewForm`, ModelForms, Django admin, djust-theming templates
- **Skip-able** — don't link the CSS file → attribute is inert
- **Override-able** — write your own rule keyed on `[data-dj-inline]` for any visual treatment (segmented controls, CSS Grid columns, etc.)
- **Matches manifesto principle 7** — opinionated where it matters (the contract is `[data-dj-inline]` on the radio, stable forever); flexible where it doesn't (the visual styling is fully replaceable)

## Bundled CSS

- Per-field wrapper: `display: flex; flex-wrap: wrap; gap: 0.5em 1em`
- Each per-choice `<li>`/`<div>`: `display: inline-flex`
- `<label>`: `inline-flex` click target with `0.3em` gap between radio and text
- Resets `margin` on the radio so the gap rule does spacing
- **Preserves the native focus ring** — no `outline: none`

## Test plan

- [x] `pytest python/djust/tests/test_inline_radios_991.py -v` — 12/12 pass
- [x] Django-render contract: attr lands on each `<input>` (verified across 3-choice form), plain `RadioSelect` produces no attribute, attr value quoting survives, `name`/`id`/`required` attrs preserved
- [x] CSS ships in the wheel, targets `[data-dj-inline]`, uses `:has()`, uses non-vertical layout, doesn't strip focus ring
- [x] Backwards-compat: forms without the attribute render unchanged

## Coverage

12 regression tests in `tests/test_inline_radios_991.py`, organized by contract face:

1. **Widget render contract (3 tests)** — attr propagation, opt-in semantics, value quoting
2. **A11y / structure (1 test)** — `name`/`id`/`required` preserved on each input
3. **CSS-ships-correctly (5 tests)** — file exists, targets `[data-dj-inline]`, uses `:has()`, uses inline layout, preserves focus ring (regex-stripped of comments to avoid false positives)
4. **Backwards-compat (2 tests)** — plain `RadioSelect` unchanged, Django version baseline locked
5. **Edge case (1 test)** — multiple choices' `<label>` structure intact

CHANGELOG entry under `[Unreleased]` / Added for v0.7.2.
Forms guide grows a new "Inline Radio Buttons" section with the API, design reasoning, and customization examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)