### PR TITLE
feat(theming): W001 contrast-checks active preset only by default (closes #1005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`djust_theming.W001` contrast-checks the active preset only by
+  default (v0.7.3, #1005)** — `check_preset_contrast` previously
+  iterated `get_registry().list_presets().items()` and ran WCAG AA
+  contrast checks on every registered preset × mode × token pair.
+  With djust's 65+ built-in presets, that produced hundreds of
+  warnings on every `manage.py check` / pod start (in one observed
+  project: 491 issues → ~480 W001 noise + ~11 real). The S/N ratio
+  was bad enough that the warnings got ignored, which is the
+  opposite of what you want from a check. Fix: new
+  `_contrast_check_scope()` helper reads `DJUST_THEMING.contrast_check_scope`
+  (default: `"active"`) and the active scope iterates only the
+  preset configured in `LIVEVIEW_CONFIG.theme.preset` — same setting
+  `check_preset_valid` reads. Theme-pack authors who want the full
+  exhaustive sweep opt in via:
+
+  ```python
+  DJUST_THEMING = {"contrast_check_scope": "all"}
+  ```
+
+  Unknown values fall back to `"active"` (signal-preserving). When
+  the configured preset is missing from the registry, the check
+  yields zero warnings — `check_preset_valid` already fires E002 for
+  that misconfiguration, so we don't double-warn. **Behavior change
+  for existing users**: dropping into the `"active"` default
+  silences hundreds of warnings about presets the project never
+  uses; real W001 hits on the active preset still surface as before.
+  Covered by **4 new regression tests** (active-only default, opt-in
+  all-scope, missing-active-preset edge case, unknown-scope-value
+  fallback) plus **6 existing tests** updated to opt into the
+  exhaustive scope (they exercise the loop body, not the scope
+  selector).
+
 ### Fixed
 
 - **`djust.A070` no longer false-positives on `{% verbatim %}`-wrapped

--- a/python/djust/tests/test_theming_checks.py
+++ b/python/djust/tests/test_theming_checks.py
@@ -54,7 +54,20 @@ class TestHslToRgbBugFix:
 
 
 class TestCheckPresetContrast:
-    """Tests for the check_preset_contrast system check."""
+    """Tests for the check_preset_contrast system check.
+
+    #1005 — these tests exercise the loop body (CONTRAST_PAIRS × mode)
+    and need the "all" scope so a single fixture preset is checked
+    regardless of `LIVEVIEW_CONFIG["theme"]["preset"]`. Scope-default
+    behavior is locked separately in `TestCheckPresetContrastScope`.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _opt_into_all_scope(self, settings):
+        """Opt into the exhaustive-sweep scope for these tests so a
+        fixture-injected preset gets contrast-checked even when its
+        name isn't the configured `LIVEVIEW_CONFIG.theme.preset`."""
+        settings.DJUST_THEMING = {"contrast_check_scope": "all"}
 
     def test_check_runs_without_error(self):
         """The system check executes against all built-in presets without crashing."""
@@ -202,6 +215,171 @@ class TestCheckPresetContrast:
             # Should mention a real preset name and light/dark
             assert "light" in w.msg or "dark" in w.msg
             assert "contrast ratio" in w.msg
+
+
+# ---------------------------------------------------------------------------
+# #1005 — W001 scope (active preset only by default, all if opted-in)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPresetContrastScope:
+    """Tests for the #1005 scope rule: W001 only fires for the active preset
+    by default, with an opt-in for theme-pack authors who want the full
+    exhaustive sweep.
+
+    These tests intentionally do NOT inherit the `_opt_into_all_scope`
+    fixture from the broader behavior class — they exercise the
+    scope-decision path itself and need the default ("active") to hold."""
+
+    def _make_bad_preset(self, name: str) -> ThemePreset:
+        """Return a preset whose every contrast pair is white-on-near-white
+        (~0 contrast). Same fixture shape as the broader behavior tests."""
+        white = ColorScale(h=0, s=0, lightness=100)
+        near_white = ColorScale(h=0, s=0, lightness=98)
+        bad_tokens = ThemeTokens(
+            background=white,
+            foreground=near_white,
+            card=white,
+            card_foreground=near_white,
+            popover=white,
+            popover_foreground=near_white,
+            primary=white,
+            primary_foreground=near_white,
+            secondary=white,
+            secondary_foreground=near_white,
+            muted=white,
+            muted_foreground=near_white,
+            accent=white,
+            accent_foreground=near_white,
+            destructive=white,
+            destructive_foreground=near_white,
+            success=white,
+            success_foreground=near_white,
+            warning=white,
+            warning_foreground=near_white,
+            info=white,
+            info_foreground=near_white,
+            link=white,
+            link_hover=white,
+            code=white,
+            code_foreground=near_white,
+            selection=white,
+            selection_foreground=near_white,
+            brand=white,
+            brand_foreground=near_white,
+            border=white,
+            input=white,
+            ring=white,
+            surface_1=white,
+            surface_2=white,
+            surface_3=white,
+        )
+        return ThemePreset(
+            name=name,
+            display_name=name,
+            light=bad_tokens,
+            dark=bad_tokens,
+            description="Intentionally bad contrast",
+        )
+
+    def test_default_scope_is_active_only(self, settings):
+        """#1005 default: W001 only fires for the configured active
+        preset. Two bad presets registered, only ONE configured as
+        active — only that one's warnings appear."""
+        bad_active = self._make_bad_preset("active-bad")
+        bad_inactive = self._make_bad_preset("inactive-bad")
+        registry_dict = {"active-bad": bad_active, "inactive-bad": bad_inactive}
+
+        # No DJUST_THEMING setting → default scope ("active")
+        if hasattr(settings, "DJUST_THEMING"):
+            del settings.DJUST_THEMING
+
+        with (
+            patch("djust.theming.checks.get_registry") as mock_reg,
+            patch("djust.theming.checks.get_theme_config") as mock_cfg,
+        ):
+            mock_reg.return_value.list_presets.return_value = registry_dict
+            mock_reg.return_value.has_preset.side_effect = lambda n: n in registry_dict
+            mock_cfg.return_value = {"preset": "active-bad"}
+            warnings = check_preset_contrast(app_configs=None)
+
+        # Only `active-bad` should produce warnings (inactive-bad is
+        # registered but not the configured active preset).
+        assert all("active-bad" in w.msg for w in warnings)
+        assert not any("inactive-bad" in w.msg for w in warnings)
+        # 13 contrast pairs × 2 modes = 26 warnings for the bad active preset
+        # (verifying we still get a full sweep on the active preset).
+        assert len(warnings) == len(CONTRAST_PAIRS) * 2
+
+    def test_opt_in_all_scope_checks_every_preset(self, settings):
+        """`DJUST_THEMING = {"contrast_check_scope": "all"}` restores
+        the v0.7.2-and-earlier behavior of checking every registered
+        preset. Opt-in for theme-pack authors who explicitly want
+        exhaustive validation."""
+        bad_a = self._make_bad_preset("pack-a")
+        bad_b = self._make_bad_preset("pack-b")
+        registry_dict = {"pack-a": bad_a, "pack-b": bad_b}
+
+        settings.DJUST_THEMING = {"contrast_check_scope": "all"}
+
+        with (
+            patch("djust.theming.checks.get_registry") as mock_reg,
+            patch("djust.theming.checks.get_theme_config") as mock_cfg,
+        ):
+            mock_reg.return_value.list_presets.return_value = registry_dict
+            mock_reg.return_value.has_preset.side_effect = lambda n: n in registry_dict
+            mock_cfg.return_value = {"preset": "pack-a"}
+            warnings = check_preset_contrast(app_configs=None)
+
+        # Both presets are checked → 2 presets × 13 pairs × 2 modes = 52
+        assert len(warnings) == 2 * len(CONTRAST_PAIRS) * 2
+        assert any("pack-a" in w.msg for w in warnings)
+        assert any("pack-b" in w.msg for w in warnings)
+
+    def test_active_scope_when_active_preset_missing_yields_no_warnings(self, settings):
+        """If `LIVEVIEW_CONFIG.theme.preset` names a preset that isn't
+        registered, the contrast check produces no warnings —
+        `check_preset_valid` already fires E002 for the misconfiguration,
+        so we don't double-warn."""
+        bad_other = self._make_bad_preset("registered-but-inactive")
+        registry_dict = {"registered-but-inactive": bad_other}
+
+        if hasattr(settings, "DJUST_THEMING"):
+            del settings.DJUST_THEMING
+
+        with (
+            patch("djust.theming.checks.get_registry") as mock_reg,
+            patch("djust.theming.checks.get_theme_config") as mock_cfg,
+        ):
+            mock_reg.return_value.list_presets.return_value = registry_dict
+            mock_reg.return_value.has_preset.side_effect = lambda n: n in registry_dict
+            mock_cfg.return_value = {"preset": "missing-preset-name"}
+            warnings = check_preset_contrast(app_configs=None)
+
+        assert warnings == []
+
+    def test_unknown_scope_value_falls_back_to_active(self, settings):
+        """Unknown values for `contrast_check_scope` fall back to the
+        signal-preserving default ("active"), not "all". Locks the
+        safe-default contract."""
+        bad_a = self._make_bad_preset("active")
+        bad_b = self._make_bad_preset("other")
+        registry_dict = {"active": bad_a, "other": bad_b}
+
+        settings.DJUST_THEMING = {"contrast_check_scope": "garbage-value"}
+
+        with (
+            patch("djust.theming.checks.get_registry") as mock_reg,
+            patch("djust.theming.checks.get_theme_config") as mock_cfg,
+        ):
+            mock_reg.return_value.list_presets.return_value = registry_dict
+            mock_reg.return_value.has_preset.side_effect = lambda n: n in registry_dict
+            mock_cfg.return_value = {"preset": "active"}
+            warnings = check_preset_contrast(app_configs=None)
+
+        # Only "active" is checked — unknown scope falls back to active.
+        assert all("active" in w.msg for w in warnings)
+        assert not any('"other"' in w.msg for w in warnings)
 
 
 class TestContrastPairsCompleteness:

--- a/python/djust/theming/checks.py
+++ b/python/djust/theming/checks.py
@@ -26,13 +26,63 @@ CONTRAST_PAIRS = [
 ]
 
 
+def _contrast_check_scope() -> str:
+    """Return the configured W001 contrast-check scope.
+
+    #1005 — defaults to ``"active"`` (only the configured preset is
+    contrast-checked) since djust ships 65+ built-in presets and an
+    "all" sweep on every ``manage.py check`` produces hundreds of
+    warnings for presets the project never uses, drowning real signal.
+
+    Theme-pack authors who want to exhaustively validate every preset
+    can opt in via::
+
+        DJUST_THEMING = {"contrast_check_scope": "all"}
+
+    Returns ``"all"`` or ``"active"``. Unknown values fall back to
+    ``"active"`` (the safer signal-preserving default).
+    """
+    cfg = getattr(settings, "DJUST_THEMING", {}) or {}
+    scope = cfg.get("contrast_check_scope", "active")
+    return "all" if scope == "all" else "active"
+
+
+def _presets_to_check():
+    """Yield ``(preset_name, preset)`` pairs for W001 contrast checks.
+
+    Honors the scope returned by ``_contrast_check_scope()``: in
+    ``"active"`` mode only the configured preset is yielded (resolved
+    via the same ``LIVEVIEW_CONFIG["theme"]["preset"]`` setting that
+    ``check_preset_valid`` reads); in ``"all"`` mode every registered
+    preset is yielded.
+
+    If the configured active preset is missing from the registry, no
+    pairs are yielded — ``check_preset_valid`` will already have fired
+    a more direct E002 error pointing at the misconfiguration.
+    """
+    registry = get_registry()
+    if _contrast_check_scope() == "all":
+        yield from registry.list_presets().items()
+        return
+
+    active_name = get_theme_config().get("preset", "default")
+    if not registry.has_preset(active_name):
+        return
+    yield active_name, registry.list_presets()[active_name]
+
+
 @register(Tags.compatibility)
 def check_preset_contrast(app_configs, **kwargs):
-    """Validate all registered theme presets meet WCAG AA contrast ratios."""
+    """Validate the active theme preset meets WCAG AA contrast ratios.
+
+    #1005 — scoped by default to the active preset only. Set
+    ``DJUST_THEMING = {"contrast_check_scope": "all"}`` to validate
+    every registered preset (theme-pack-authoring mode).
+    """
     warnings = []
     validator = AccessibilityValidator()
 
-    for preset_name, preset in get_registry().list_presets().items():
+    for preset_name, preset in _presets_to_check():
         for mode_name in ("light", "dark"):
             tokens = getattr(preset, mode_name)
             for fg_attr, bg_attr, label in CONTRAST_PAIRS:


### PR DESCRIPTION
## Summary

Closes #1005 — `djust_theming.W001` (preset contrast validation) now scopes to the **active** preset by default instead of sweeping every registered preset. Eliminates the ~480 false-signal warnings that drowned real ones in the existing behavior.

## Why

`check_preset_contrast` iterated `get_registry().list_presets().items()`, which includes djust's 65+ built-in presets. With every preset × mode × token-pair combination producing a candidate W001, the typical project saw hundreds of warnings on every `manage.py check` / pod start — most of them about presets the project never uses (they're discovered purely because they ship with djust).

Reported by docs.djust.org team: 491 system-check issues seen in one project — ~480 W001 noise on unused packs, ~11 real. The S/N ratio was bad enough that the warnings were getting silenced wholesale via `SILENCED_SYSTEM_CHECKS`, hiding real W001 fires on the active pack too.

## Fix

New `_contrast_check_scope()` helper reads `DJUST_THEMING.contrast_check_scope`:

| Value | Behavior |
|---|---|
| (default / unset) | `"active"` — only the configured `LIVEVIEW_CONFIG.theme.preset` is contrast-checked |
| `"active"` | same as default |
| `"all"` | exhaustive sweep — every registered preset is checked (theme-pack-authoring mode) |
| any other value | falls back to `"active"` (signal-preserving) |

Theme-pack authors who want exhaustive validation opt in:

```python
DJUST_THEMING = {"contrast_check_scope": "all"}
```

Edge case: if the configured active preset is missing from the registry, the contrast check yields zero warnings. `check_preset_valid` (E002) already fires for that misconfiguration, so we don't double-warn.

## Behavior change for existing users

Dropping into the `"active"` default silences hundreds of warnings about presets the project never uses. Real W001 fires on the active preset surface as before — and now they're actually visible because they aren't drowned by noise. Users who relied on `SILENCED_SYSTEM_CHECKS = ['djust_theming.W001']` to suppress the noise can drop that suppression and start seeing real signal again.

## Test plan

- [x] `pytest python/djust/tests/test_theming_checks.py::TestCheckPresetContrast python/djust/tests/test_theming_checks.py::TestCheckPresetContrastScope -v` — 10/10 (4 new + 6 existing kept green)

## Coverage

**4 new regression tests in `TestCheckPresetContrastScope`**:
1. Default scope is active-only — 2 bad presets registered, only the active one warns
2. Opt-in `"all"` scope checks every preset
3. Missing active preset → no warnings (E002 carries the load)
4. Unknown scope value falls back to active

**6 existing `TestCheckPresetContrast` tests**: opt into `"all"` scope via an autouse fixture so they exercise the loop body (`CONTRAST_PAIRS × mode`) regardless of the active-preset setting. Scope semantics are locked separately in `TestCheckPresetContrastScope`.

CHANGELOG entry under `[Unreleased]` / Changed for v0.7.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)