### PR TITLE
feat(tooling): make roadmap-lint + pre-push noqa-F822 hook (closes #1057, #1061)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -138,3 +138,15 @@ repos:
         types: [rust]
         pass_filenames: false
         stages: [pre-push]
+
+      # Flag new `# noqa: F822` annotations in __all__ (Action #146)
+      # Ruff silences py/undefined-export but CodeQL flags it; prefer
+      # TYPE_CHECKING-conditional imports (PR #924 pattern). See
+      # scripts/check-noqa-f822.sh for rationale + override path.
+      - id: check-noqa-f822
+        name: check noqa F822
+        entry: bash scripts/check-noqa-f822.sh
+        language: system
+        types: [python]
+        pass_filenames: false
+        stages: [pre-push]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`make roadmap-lint` — mechanical ROADMAP-vs-codebase drift check (Action #142, closes #1057)** —
+  `scripts/roadmap-lint.py` parses the "Not started" entries in `ROADMAP.md`,
+  extracts grep-able tokens from each feature name, and reports entries
+  whose tokens have zero hits in code paths (`python/`, `crates/`,
+  `static/`, `scripts/`, `tests/`, `Makefile`). Pure mechanical check —
+  for semantic auditing (LLM reads each entry, decides if the cited
+  feature actually ships) use the `pipeline-roadmap-audit` skill instead.
+  Exit code 0 unless drift exceeds threshold (25 suspect entries).
+  Run via `make roadmap-lint` or `make roadmap-lint VERBOSE=1`.
+
+- **Pre-push hook for `# noqa: F822` in `__all__` patterns (Action #146, closes #1061)** —
+  `scripts/check-noqa-f822.sh` flags new `noqa: F822` annotations
+  introduced in `python/**/*.py` or `tests/**/*.py` since the last push.
+  Ruff silences `py/undefined-export` with `noqa: F822`, but CodeQL flags
+  it as a security alert later — the canonical fix is a
+  `TYPE_CHECKING`-conditional import (PR #924 pattern). Hook fires only
+  on changed files (incremental); pass `--all` to scan the whole tree
+  manually.
+
 ## [0.8.0rc1] - 2026-04-25
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ dev-build: ## Build Rust extensions in development mode
 
 ##@ Testing & Quality
 
+.PHONY: roadmap-lint
+roadmap-lint: ## Mechanical ROADMAP-vs-codebase drift check (use pipeline-roadmap-audit skill for semantic audit)
+	@.venv/bin/python scripts/roadmap-lint.py $(if $(VERBOSE),--verbose,)
+
 .PHONY: test
 test: ## Run all tests (Python + JavaScript + Rust) in parallel
 	@echo "$(GREEN)Running all tests in parallel...$(NC)"

--- a/scripts/check-noqa-f822.sh
+++ b/scripts/check-noqa-f822.sh
@@ -27,6 +27,11 @@ else
     if [ -z "$changed_files" ]; then
         exit 0
     fi
+    # Note: xargs -I {} runs one grep per file. Single-file grep is intentional —
+    # it preserves the file path in the output and keeps line numbers accurate
+    # per file. djust PR sizes are small enough (typically <50 changed .py files)
+    # that the per-file overhead is negligible. Don't "optimize" this to a single
+    # grep call without preserving filename:line:match formatting.
     matches=$(echo "$changed_files" | xargs -I {} grep -HnE "$PATTERN" {} 2>/dev/null || true)
 fi
 

--- a/scripts/check-noqa-f822.sh
+++ b/scripts/check-noqa-f822.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Pre-push hook: flag `noqa: F822` annotations in __all__ patterns.
+#
+# Ruff silences py/undefined-export with `noqa: F822` but CodeQL flags it
+# anyway. Centralizing the check here lets us catch new instances at push
+# time and remediate via TYPE_CHECKING blocks (see PR #924) before CodeQL
+# alerts pile up. Filed as Action Tracker #146 / GH #1061.
+#
+# Strategy:
+#   1. Find every `noqa: F822` in tracked Python files.
+#   2. For each, check if the file has been modified vs origin/main.
+#   3. If yes, fail the push with a helpful pointer.
+#
+# Run manually:
+#   bash scripts/check-noqa-f822.sh
+#   bash scripts/check-noqa-f822.sh --all   # include unchanged files
+set -euo pipefail
+
+INCLUDE_ALL="${1:-}"
+PATTERN="noqa: *F822"
+
+if [ "$INCLUDE_ALL" = "--all" ]; then
+    matches=$(git grep -nE "$PATTERN" -- 'python/**/*.py' 'tests/**/*.py' 2>/dev/null || true)
+else
+    # Limit to files changed in this push (vs origin/main).
+    changed_files=$(git diff --name-only --diff-filter=ACMR origin/main..HEAD -- 'python/**/*.py' 'tests/**/*.py' 2>/dev/null || true)
+    if [ -z "$changed_files" ]; then
+        exit 0
+    fi
+    matches=$(echo "$changed_files" | xargs -I {} grep -HnE "$PATTERN" {} 2>/dev/null || true)
+fi
+
+if [ -z "$matches" ]; then
+    exit 0
+fi
+
+echo "ERROR: \`# noqa: F822\` annotations in __all__ are deprecated."
+echo
+echo "$matches" | sed 's/^/  /'
+echo
+echo "Why: Ruff silences py/undefined-export with noqa: F822 but CodeQL"
+echo "flags it as a security issue. Use TYPE_CHECKING-conditional imports"
+echo "instead (see PR #924 for the canonical pattern):"
+echo
+echo "    from typing import TYPE_CHECKING"
+echo "    if TYPE_CHECKING:"
+echo "        from .submodule import SymbolName"
+echo
+echo "If the symbol is needed at runtime (not just for type hints), import"
+echo "it eagerly at module top — don't \`noqa: F822\` it."
+echo
+echo "To override (truly unfixable case): run \`git push --no-verify\`"
+echo "but file a tech-debt issue with the rationale."
+exit 1

--- a/scripts/roadmap-lint.py
+++ b/scripts/roadmap-lint.py
@@ -46,7 +46,7 @@ SKIP_SECTIONS = {
 STOPWORDS = {
     "the", "and", "or", "of", "for", "to", "in", "on", "with", "from",
     "via", "by", "at", "an", "a", "is", "are", "be", "as", "if", "not",
-    "via", "into", "out", "up", "down", "over", "across",
+    "into", "out", "up", "down", "over", "across",
 }
 
 # Code paths that count as "shipped". Skip docs, ROADMAP itself, retros, CHANGELOG.

--- a/scripts/roadmap-lint.py
+++ b/scripts/roadmap-lint.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Lint ROADMAP.md against the actual codebase.
+
+Catches the failure mode where a ROADMAP feature is listed as "Not started"
+but the code is already live (or vice versa). Two strikes during v0.5.0
+motivated this — see Action Tracker #142 / GH #1057.
+
+Usage:
+    python3 scripts/roadmap-lint.py
+    make roadmap-lint
+
+Exit code:
+    0 — no drift detected (or all drift is in known-irrelevant sections)
+    1 — drift detected; run with --verbose to see why
+
+This is the cheap, mechanical version. For semantic auditing (LLM reads each
+entry, decides if the cited feature actually ships), use the
+pipeline-roadmap-audit skill instead.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+ROADMAP_PATH = Path("ROADMAP.md")
+
+# Sections to skip — purely descriptive, not gated on code existence.
+SKIP_SECTIONS = {
+    "## Investigate",
+    "## Differentiators",
+    "## Future",
+    "## Contributing",
+    "## Parity Tracker",
+    "## Completed",
+    "## Investigate & Decide",
+}
+
+# Keyword tokens that we extract from a feature name and grep for in the
+# codebase. Single-word camelCase / snake_case identifiers are more useful
+# signals than common English words.
+STOPWORDS = {
+    "the", "and", "or", "of", "for", "to", "in", "on", "with", "from",
+    "via", "by", "at", "an", "a", "is", "are", "be", "as", "if", "not",
+    "via", "into", "out", "up", "down", "over", "across",
+}
+
+# Code paths that count as "shipped". Skip docs, ROADMAP itself, retros, CHANGELOG.
+CODE_PATHS = ("python/", "crates/", "static/", "scripts/", "tests/", "Makefile")
+
+
+class Entry(NamedTuple):
+    line_no: int
+    section: str
+    name: str
+    raw: str  # full line
+
+
+def parse_roadmap(text: str) -> list[Entry]:
+    """Pull pending entries from priority-matrix tables and milestone sections."""
+    entries: list[Entry] = []
+    cur_section = ""
+    for i, line in enumerate(text.split("\n"), start=1):
+        if line.startswith("## ") or line.startswith("### "):
+            cur_section = line.strip()
+            continue
+
+        if any(cur_section.startswith(skip) for skip in SKIP_SECTIONS):
+            continue
+
+        # Strikethrough or ✅ → already done, skip
+        if "~~" in line or "✅" in line:
+            continue
+
+        # Priority-matrix rows: `| **P2** | **<name>** | <desc> | ... |`
+        if line.startswith("|") and "Not started" in line:
+            cells = [c.strip() for c in line.split("|")[1:-1]]
+            if len(cells) >= 2:
+                # Feature name is typically the second cell, often bold-wrapped
+                name = re.sub(r"\*\*", "", cells[1])
+                if name:
+                    entries.append(Entry(i, cur_section, name, line))
+            continue
+
+        # Milestone bullet entries: `**<name>** — <desc>`
+        m = re.match(r"^\*\*([^*]+)\*\*\s+—", line)
+        if m and cur_section.startswith("### Milestone:"):
+            name = m.group(1).strip()
+            entries.append(Entry(i, cur_section, name, line))
+    return entries
+
+
+def extract_keywords(name: str) -> list[str]:
+    """Pull grep-able tokens out of a feature name."""
+    # Remove markdown formatting / parens / common decoration
+    cleaned = re.sub(r"[`*()]", "", name)
+    cleaned = re.sub(r"#\d+", "", cleaned)  # drop issue numbers
+    cleaned = cleaned.replace("/", " ")  # split alternatives
+    tokens = re.findall(r"[A-Za-z_][A-Za-z0-9_-]+", cleaned)
+    # Keep only tokens that look like identifiers (3+ chars, not a stopword)
+    return [t for t in tokens if len(t) >= 4 and t.lower() not in STOPWORDS]
+
+
+def grep_codebase(token: str) -> int:
+    """Return number of code-path matches for a token. 0 = not found."""
+    try:
+        result = subprocess.run(
+            ["git", "grep", "-l", token, "--", *CODE_PATHS],
+            capture_output=True, text=True, check=False
+        )
+    except FileNotFoundError:
+        return 0
+    if result.returncode == 1:  # git grep returns 1 when no matches
+        return 0
+    return len([line for line in result.stdout.splitlines() if line.strip()])
+
+
+def lint(verbose: bool = False) -> int:
+    if not ROADMAP_PATH.exists():
+        print(f"ERROR: {ROADMAP_PATH} not found (run from project root)", file=sys.stderr)
+        return 2
+
+    entries = parse_roadmap(ROADMAP_PATH.read_text())
+    drift_count = 0
+    suspect: list[tuple[Entry, list[str]]] = []
+
+    for entry in entries:
+        keywords = extract_keywords(entry.name)
+        if not keywords:
+            continue
+
+        # If ANY keyword has zero hits in code paths, that's suspect
+        unfound = [k for k in keywords if grep_codebase(k) == 0]
+        if len(unfound) == len(keywords):
+            # No keyword found anywhere — suspect (could be ROADMAP-only feature)
+            suspect.append((entry, unfound))
+            drift_count += 1
+
+    print(f"ROADMAP entries scanned: {len(entries)}")
+    print(f"Suspect entries (no keyword hits in {', '.join(CODE_PATHS)}): {drift_count}")
+
+    if suspect and verbose:
+        print()
+        print("=" * 60)
+        for entry, unfound in suspect:
+            print(f"\nL{entry.line_no} [{entry.section}]")
+            print(f"  Name:    {entry.name}")
+            print(f"  Tokens:  {', '.join(unfound)}")
+
+    if drift_count > 0 and not verbose:
+        print()
+        print("Run with --verbose to see entries.")
+        print("Note: 'suspect' = no keyword from name appears in code paths.")
+        print("      Some are legitimately not-started; others may be stale.")
+        print("      For semantic verification, use the pipeline-roadmap-audit skill.")
+
+    # Return non-zero only if drift count is "high" — single-digit drift is
+    # normal-and-OK because some not-started features intentionally have
+    # generic names. Threshold is 25 → tune as ROADMAP grows.
+    return 0 if drift_count < 25 else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--verbose", "-v", action="store_true", help="list every suspect entry")
+    args = parser.parse_args()
+    return lint(verbose=args.verbose)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

v0.8.1 reconcile drain — Group D (tooling, 2 issues bundled).

- **Closes #1057** — \`make roadmap-lint\` Makefile target. Mechanical ROADMAP-vs-codebase drift check via \`scripts/roadmap-lint.py\` (~175 LOC). Parses \"Not started\" entries, extracts grep-able tokens from feature names, reports entries whose tokens have zero hits in code paths. Threshold-based exit (suspect-count >= 25 → exit 1). For semantic auditing, the existing \`pipeline-roadmap-audit\` skill remains the LLM-mediated answer.
- **Closes #1061** — pre-push hook for \`# noqa: F822\` in \`__all__\`. New \`scripts/check-noqa-f822.sh\` (~54 LOC) wired into \`.pre-commit-config.yaml\` with \`stages: [pre-push]\`. Flags new \`noqa: F822\` annotations on changed .py files; ruff silences py/undefined-export but CodeQL flags it later. Helpful error message points at the canonical fix (TYPE_CHECKING-conditional imports, PR #924 pattern) and the override path.

CHANGELOG.md: two Unreleased entries under \"Added\".

## Test plan

- [x] \`make roadmap-lint\` runs clean against the current ROADMAP (44 entries scanned, 0 suspect — mechanical lint, no false alarms).
- [x] \`bash scripts/check-noqa-f822.sh --all\` returns exit 0 (no existing \`noqa: F822\` in code).
- [x] Pre-push hook fired during the push of this PR — \`check noqa F822\` passed.
- [x] \`make test\` passed during the same pre-push run (pytest line above).
- [x] Both scripts pass \`ruff check\` and shellcheck-style review.

## Notes

The \`make roadmap-lint\` script is intentionally mechanical (regex + \`git grep\`), not semantic. The complementary \`pipeline-roadmap-audit\` skill is the LLM-mediated audit when stakes warrant it (release-cut, milestone-start, large refactor). Both now exist as different tools for different cadences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>