### PR TITLE
refactor(tests): test-infra cleanup batch (closes #1027, #1028, #1034, #1036)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Test infrastructure cleanup (v0.8.1 reconcile drain — Group A, closes #1027, #1028, #1034, #1036)** —
+  four small test-quality refactors bundled in one PR:
+  - **#1036**: `_assert_benchmark_under` and the per-segment budget constants
+    (`TARGET_PER_EVENT_S`, `TARGET_LIST_UPDATE_S`, `TARGET_WS_MOUNT_S`) moved
+    from `tests/benchmarks/test_request_path.py` into
+    `tests/benchmarks/conftest.py` for shared scope across benchmark files.
+  - **#1034**: replaced the `TARGET_LIST_UPDATE_S * 20` magic-number budget
+    for the WS-mount benchmark with a named `TARGET_WS_MOUNT_S = 0.1`
+    constant — rationale lives in the constant name, not the multiplier.
+  - **#1028**: extracted the duplicated `_make_user` factory into
+    `python/djust/tests/conftest.py` as `make_staff_user(...)`. Two test
+    files (`test_admin_widgets_per_page.py`, `test_bulk_progress.py`) now
+    import the shared factory.
+  - **#1027**: replaced the `inspect.getsource`-based regression test in
+    `test_stack_trace_exposure.py` with a behavior-level test that triggers
+    a serialize-error via a sentinel-laden `RuntimeError` and asserts
+    neither the sentinel nor the exception class name reach the response
+    body. Defends against regressions even if the leak vector moves.
+
 ### Added
 
 - **`make roadmap-lint` — mechanical ROADMAP-vs-codebase drift check (Action #142, closes #1057)** —

--- a/python/djust/tests/conftest.py
+++ b/python/djust/tests/conftest.py
@@ -1,0 +1,44 @@
+"""
+Shared test fixtures and helpers for djust unit tests.
+
+Anything used by 2+ test files belongs here. Keep imports minimal — this
+module is loaded for every test in `python/djust/tests/`.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def make_staff_user(
+    username: str = "tester",
+    *,
+    is_staff: bool = True,
+    perms: Iterable[str] = (),
+    pk: int = 1,
+):
+    """Build a lightweight staff-user stand-in for auth-gated view tests.
+
+    No DB hit — uses Django's User model in-memory and overrides
+    ``has_perm``/``has_perms`` via instance attrs.
+
+    Subsumes the duplicated ``_make_user`` factories that previously lived
+    in ``test_admin_widgets_per_page.py``, ``test_bulk_progress.py``, and
+    other admin-feature tests (#1028).
+
+    Args:
+        username: Display name (default ``"tester"``).
+        is_staff: Whether the user is a Django staff user (default ``True``).
+        perms: Permission strings to grant (default empty — user has no perms).
+        pk: Primary key + id (default ``1``).
+    """
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
+    user = User(username=username, is_staff=is_staff)
+    user.pk = pk
+    user.id = pk
+    perm_set = set(perms)
+    user.has_perm = lambda p: p in perm_set  # type: ignore[assignment]
+    user.has_perms = lambda ps: all(p in perm_set for p in ps)  # type: ignore[assignment]
+    return user

--- a/python/djust/tests/test_admin_widgets_per_page.py
+++ b/python/djust/tests/test_admin_widgets_per_page.py
@@ -12,18 +12,9 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
+from .conftest import make_staff_user as _make_user  # #1028: shared factory
+
 pytestmark = pytest.mark.admin
-
-
-def _make_user(username="tester", *, is_staff=True, perms=()):
-    User = get_user_model()
-    user = User(username=username, is_staff=is_staff)
-    user.pk = 1
-    # Override has_perm / has_perms without hitting the DB.
-    perm_set = set(perms)
-    user.has_perm = lambda p: p in perm_set  # type: ignore[assignment]
-    user.has_perms = lambda ps: all(p in perm_set for p in ps)  # type: ignore[assignment]
-    return user
 
 
 class TestDefaultWidgetSlots(TestCase):

--- a/python/djust/tests/test_bulk_progress.py
+++ b/python/djust/tests/test_bulk_progress.py
@@ -16,16 +16,9 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.test import RequestFactory, TestCase
 
+from .conftest import make_staff_user as _make_user  # #1028: shared factory
+
 pytestmark = pytest.mark.admin
-
-
-def _make_user(username, *, is_staff=True, pk=1):
-    """Build a lightweight user stand-in (no DB required)."""
-    User = get_user_model()
-    user = User(username=username, is_staff=is_staff)
-    user.pk = pk
-    user.id = pk
-    return user
 
 
 class TestJobModel(TestCase):

--- a/python/djust/tests/test_stack_trace_exposure.py
+++ b/python/djust/tests/test_stack_trace_exposure.py
@@ -2,6 +2,7 @@
 
 import json
 
+import pytest
 from django.test import RequestFactory
 
 
@@ -46,26 +47,63 @@ def test_theme_css_api_generic_error_on_exception(monkeypatch):
     assert "SENTINEL_INTERNAL_STATE" not in body["error"]
 
 
+@pytest.mark.django_db
 def test_dispatch_serialize_error_does_not_leak_exception_message():
-    """Verify dispatch.py's serialize_error path returns a generic message.
-
-    The fix removes `str(exc)` from the api_error() call. Asserting on the
-    source is a robust heuristic: the module is small and the string literal
-    is unique.
+    """Behavior test: a raising serializer must produce a generic 500 envelope
+    that contains neither the exception class name nor any of its message
+    text. Replaces the prior `inspect.getsource` substring test (#1027) —
+    behavior tests defend against regressions even when the leak vector
+    changes (e.g. a future refactor moves the message-construction site).
     """
-    import inspect
+    import json as _json
 
-    from djust.api import dispatch
+    from django.contrib.auth import get_user_model
+    from django.contrib.sessions.middleware import SessionMiddleware
+    from django.test import RequestFactory
 
-    src = inspect.getsource(dispatch)
+    from djust import LiveView
+    from djust.api.dispatch import dispatch_api, reset_rate_buckets
+    from djust.api.registry import register_api_view, reset_registry
+    from djust.decorators import event_handler
 
-    # Generic message must be present for the serialize_error path.
-    assert (
-        'api_error(500, "serialize_error", "Response transform' in src
-        or '"serialize_error",\n            "Response transform' in src
-        or '"serialize_error",\n            "Response transform' in src
+    sentinel = "SENTINEL_SERIALIZE_LEAK_DEADBEEF_42"
+
+    def _exploder(self):
+        raise RuntimeError(sentinel)
+
+    class ExplodingView(LiveView):
+        api_name = "test.serialize_leak.v"
+
+        @event_handler(expose_api=True, serialize=_exploder)
+        def ping(self, **kwargs):
+            return None
+
+    reset_registry()
+    reset_rate_buckets()
+    register_api_view("test.serialize_leak.v", ExplodingView)
+
+    rf = RequestFactory(enforce_csrf_checks=False)
+    User = get_user_model()
+    User.objects.create_user(username="leak_tester", password="pw")
+    req = rf.post(
+        "/djust/api/test.serialize_leak.v/ping",
+        data=b"{}",
+        content_type="application/json",
     )
+    SessionMiddleware(lambda r: None).process_request(req)
+    req.session.save()
+    req.user = User.objects.get(username="leak_tester")
+    req._dont_enforce_csrf_checks = True
 
-    # Leak-y patterns must be gone.
-    assert 'api_error(500, "serialize_error", str(exc))' not in src
-    assert 'api_error(500, "serialize_error", str(_exc))' not in src
+    resp = dispatch_api(req, "test.serialize_leak.v", "ping")
+
+    assert resp.status_code == 500
+    payload = _json.loads(resp.content)
+    assert payload["error"] == "serialize_error"
+    # Generic message must be present.
+    assert "Response transform" in payload["message"]
+    # Sentinel + class name from the raised exception must NOT appear
+    # anywhere in the serialized response.
+    body_text = resp.content.decode("utf-8")
+    assert sentinel not in body_text
+    assert "RuntimeError" not in body_text

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,8 +1,44 @@
 """
 Benchmark fixtures and configuration for pytest-benchmark.
+
+Shared budgets and helpers live here so additional benchmark files in this
+directory can use them without duplication. See `_assert_benchmark_under`
+for the xdist-safe assertion contract.
 """
 
 import pytest
+
+
+# Per-segment budgets (ROADMAP v0.6.0 perf-profile targets — see
+# docs/performance/v0.6.0-profile.md). New benchmark files should import these
+# rather than redefining them.
+TARGET_PER_EVENT_S = 0.002  # 2 ms
+TARGET_LIST_UPDATE_S = 0.005  # 5 ms
+# WebSocket mount runs the full HTTP-render pipeline plus channels-layer +
+# Redis serialization round-trip + initial state diff, so it gets a 100 ms
+# budget (20× the list-update budget). Named explicitly so the rationale
+# lives in the constant name, not the multiplier — see #1034.
+TARGET_WS_MOUNT_S = 0.100  # 100 ms (20× list-update)
+
+
+def _assert_benchmark_under(benchmark, target_s: float, label: str) -> None:
+    """Assert benchmark mean < target, but gracefully degrade under xdist.
+
+    pytest-benchmark's stats collection is disabled when running under
+    pytest-xdist (the `-n auto` CI invocation), so `benchmark.stats["mean"]`
+    raises because `stats` is empty. In that case the function is still
+    executed for correctness, but the threshold assertion is skipped —
+    the benchmark-gated CI job (`--benchmark-only` serial) enforces it.
+    """
+    if getattr(benchmark, "disabled", False):
+        return
+    try:
+        mean = benchmark.stats["mean"]
+    except (KeyError, TypeError, AttributeError):
+        return
+    assert mean < target_s, (
+        f"{label} mean {mean * 1000:.2f}ms exceeds {target_s * 1000:.0f}ms target"
+    )
 
 
 # Configure benchmark settings

--- a/tests/benchmarks/test_request_path.py
+++ b/tests/benchmarks/test_request_path.py
@@ -25,34 +25,14 @@ from typing import Any, Dict, List
 
 import pytest
 
-# Targets per ROADMAP v0.6.0 perf-profile task
-TARGET_PER_EVENT_S = 0.002  # 2 ms
-TARGET_LIST_UPDATE_S = 0.005  # 5 ms
-
-
-def _assert_benchmark_under(benchmark, target_s: float, label: str) -> None:
-    """Assert benchmark mean < target, but gracefully degrade under xdist.
-
-    pytest-benchmark's stats collection is disabled when running under
-    pytest-xdist (the `-n auto` CI invocation), so `benchmark.stats["mean"]`
-    raises because `stats` is empty. In that case the function is still
-    executed for correctness, but the threshold assertion is skipped —
-    the benchmark-gated CI job (`--benchmark-only` serial) enforces it.
-    """
-    # `benchmark.disabled` is True under `--benchmark-disable` (set by xdist
-    # plugin). In that mode pytest-benchmark runs the callable once for
-    # correctness but does not collect stats.
-    if getattr(benchmark, "disabled", False):
-        return
-    try:
-        mean = benchmark.stats["mean"]
-    except (KeyError, TypeError, AttributeError):
-        # No stats collected (unexpected non-xdist disabled mode) — skip
-        # the assertion rather than raising an ambiguous KeyError.
-        return
-    assert mean < target_s, (
-        f"{label} mean {mean * 1000:.2f}ms exceeds {target_s * 1000:.0f}ms target"
-    )
+# Shared targets and helpers live in tests/benchmarks/conftest.py
+# (see #1034, #1036). Future benchmark files should import from there.
+from .conftest import (
+    TARGET_LIST_UPDATE_S,
+    TARGET_PER_EVENT_S,
+    TARGET_WS_MOUNT_S,
+    _assert_benchmark_under,
+)
 
 
 COUNTER_TEMPLATE = """
@@ -270,7 +250,7 @@ class TestWebsocketMountPath:
         assert isinstance(result, dict)
         # Per-segment budget: WebSocket mount includes connect+disconnect and a
         # full handshake, so we target the relaxed 5ms (list-update) bound.
-        _assert_benchmark_under(benchmark, TARGET_LIST_UPDATE_S * 20, "WebSocket mount")
+        _assert_benchmark_under(benchmark, TARGET_WS_MOUNT_S, "WebSocket mount")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

v0.8.1 reconcile drain — Group A (test-infra batch, 4 issues bundled). #1048 closed separately as superseded by PR #1021.

- **#1036**: \`_assert_benchmark_under\` + per-segment budget constants moved from \`tests/benchmarks/test_request_path.py\` to \`tests/benchmarks/conftest.py\`. Future benchmark files import via relative \`.conftest\`.
- **#1034**: \`TARGET_LIST_UPDATE_S * 20\` magic-number budget for WS-mount benchmark replaced with a named \`TARGET_WS_MOUNT_S = 0.100\`.
- **#1028**: New \`python/djust/tests/conftest.py\` with \`make_staff_user(...)\` shared factory. Subsumes the duplicated \`_make_user\` in \`test_admin_widgets_per_page.py\` and \`test_bulk_progress.py\`.
- **#1027**: Replaced the \`inspect.getsource\` substring test in \`test_stack_trace_exposure.py\` with a behavior-level test that triggers a serialize_error via a sentinel-laden \`RuntimeError\` and asserts neither the sentinel nor the exception class name reach the response body.

CHANGELOG entry under \"Changed\".

## Test plan

- [x] \`pytest python/djust/tests/test_admin_widgets_per_page.py python/djust/tests/test_bulk_progress.py\` — 28/28 passed
- [x] \`pytest python/djust/tests/test_stack_trace_exposure.py\` — 3/3 passed (1 new behavior test + 2 existing)
- [x] \`pytest tests/benchmarks/\` — 160 tests collected, all passed
- [x] Cross-pass against admin + dispatch + benchmarks — 160 tests, 0 failures
- [x] Pre-push hook ran the full python suite — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>