### PR TITLE
docs(roadmap): v0.9.0 backlog for 5 deferred features from v0.8.1 reconcile

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1198,8 +1198,18 @@ class TodoView(LiveView):
 
 **Medium (P2)** — larger but still v0.8.1-eligible:
 
-- **#1031** — Version-probe fallback for `mount_batch` — older servers produce generic "unknown msg type"; client should fall back gracefully. Back-compat protocol work.
-- **#1032** — Dashboard→Dashboard re-mount limitation in sticky LiveView demo. `{% live_render %}` should auto-detect preserved stickies.
+- ~~**#1031**~~ ✅ — Version-probe fallback for `mount_batch` — older servers produce generic "unknown msg type"; client should fall back gracefully. **Shipped in PR #1068.**
+- ~~**#1032**~~ — Dashboard→Dashboard re-mount limitation in sticky LiveView demo. **Closed as deferred to v0.9.0+ feature item** — requires server-side template-tag intelligence + client preserved-sticky tracking; non-trivial. See v0.9.0 backlog below.
+
+### Milestone: v0.9.0 — Backlog (deferred features from v0.8.1 reconcile)
+
+Five tech-debt issues from the 2026-04-25 reconcile pass were closed-as-relocated because they're real feature work, not 1-PR drain items. Filing them as v0.9.0+ planning candidates so they aren't lost:
+
+- **Component-level time-travel** (was #1041) — Phase 1 records against parent; full component capture. v0.6.2+ candidate.
+- **Forward-replay through branched timeline** (was #1042) — Redux DevTools parity. v0.6.2+ candidate.
+- **Phase 2 streaming** (was #1043) — lazy-child render + true server overlap. v0.6.1 shipped Phase 1 (transport-layer); Phase 2 is the deferred remainder.
+- **ADR-006 AI-generated UIs** (was #1044) — deferred due to AssistantMixin/LLM-provider dependency chain.
+- **`{% live_render %}` auto-detect preserved stickies** (was #1032) — server-side template-tag intelligence to emit slot markers (`dj-sticky-slot`) when the client already holds the sticky. Removes the Dashboard→Dashboard re-mount limitation in the sticky LiveView demo. Requires: (a) server detection mechanism (cookie/header/WS handshake carrying preserved-sticky IDs); (b) tag conditional output; (c) test matrix covering return-trip vs fresh-tab.
 
 ---
 


### PR DESCRIPTION
## Summary

Files the 5 issues closed-as-relocated during the v0.8.1 reconcile drain into a v0.9.0 backlog section so they aren't lost.

Also marks **#1031** (mount_batch fallback) as ✅ shipped in PR #1068.

## Deferred to v0.9.0+

- **#1041** — Component-level time-travel
- **#1042** — Forward-replay through branched timeline (Redux DevTools parity)
- **#1043** — Phase 2 streaming (lazy-child render + true server overlap; v0.6.1 shipped Phase 1)
- **#1044** — ADR-006 AI-generated UIs (deferred due to AssistantMixin/LLM-provider dependency chain)
- **#1032** — \`{% live_render %}\` auto-detect preserved stickies (server-side template-tag intelligence + client preserved-sticky tracking)

## v0.8.1 reconcile drain summary

- **7 PRs merged**: #1064, #1065, #1066, #1067, #1068
- **11 issues closed-as-shipped**: #1029, #1035, #1057, #1061, #1027, #1028, #1034, #1036, #1026, #1030, #1031
- **4 issues closed at Stage 4 as moot/superseded**: #1033 (intentional naming divergence), #1045 (already centralized), #1048 (covered by PR #1021), #1062 (process-already-in-effect)
- **5 issues deferred to v0.9.0**: this commit
- **3 issues closed wontfix in initial triage**: #1025, #1054, #1062

Group breakdown: C done, D done, A done, B done, E closed-moot, F done, G closed-deferred. 5/7 groups landed code; 2/7 (E, G) closed without code with rationale.

## Test plan

- [x] DOCS_ONLY change. Pre-commit hooks ran clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>