### PR TITLE
feat(theming): theming polish batch (closes #1009, #1011, #1012, #1013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`{% theme_css_link %}` cache-busting helper tag (v0.8.2 drain — Group T, closes #1012)** —
+  Chrome's `Vary: Cookie` handling is unreliable for per-cookie dynamic CSS;
+  after a pack switch the browser often serves the prior pack's stylesheet
+  from its own HTTP cache and the page renders with stale palette. The new
+  `{% theme_css_link %}` tag in `djust.theming.templatetags.theme_tags`
+  emits `<link href="/_theming/theme.css?p=<pack>&m=<mode>&r=<preset>">`
+  with cache-busting query params derived from the same `ThemeManager.get_state()`
+  the view itself reads. Different pack/mode = different URL = guaranteed
+  fresh fetch. Usage: `<link rel="stylesheet" href="{% theme_css_link %}">`.
+
+- **`prose.css` for `@tailwindcss/typography` ↔ pack bridge (v0.8.2 drain — Group T, closes #1009)** —
+  new `djust_theming/static/djust_theming/css/prose.css` ships pack-aware
+  overrides for the typography plugin's `--tw-prose-*` variables. Opt in
+  by adding `prose-djust` alongside `prose` on your `<article>`. Reads
+  `--color-brand-*` tokens the active pack emits, so flipping packs at
+  runtime updates prose without a stylesheet swap. Includes both light-mode
+  and dark-mode invert variables. Pulled from docs.djust.org's reference
+  implementation. ~95 lines.
+
+- **`enable_client_override` flag for `LIVEVIEW_CONFIG['theme']` (v0.8.2 drain — Group T, closes #1013)** —
+  `ThemeManager.get_state()` reads `djust_theme_pack` / `djust_theme_preset`
+  cookies with priority over config defaults. Default behavior unchanged
+  (back-compat `True`). Sites without a user-facing theme switcher can set
+  `LIVEVIEW_CONFIG['theme']['enable_client_override']: False` to ignore
+  cookie reads — prevents cross-project bleed on localhost where multiple
+  djust apps share a cookie jar.
+
+### Fixed
+
+- **`.card` / `.alert` overflow:hidden for clean rounded corners (v0.8.2 drain — Group T, closes #1011)** —
+  `djust_theming/static/djust_theming/css/components.css` `.card` and
+  `.alert` selectors now set `overflow: hidden`. Without this, child
+  borders (e.g. `.card-header { border-bottom: ... }`) cross the
+  parent's rounded arc and produce a visible 1-2 px notch at the
+  corners. Affects every theme pack.
+
 - **`mount_batch` fallback for old-server compat (v0.8.1 reconcile drain — Group F, closes #1031)** —
   the `mount_batch` WebSocket frame was added in v0.6.0 (PR #970) for lazy-
   hydration efficiency. A v0.6.0+ client talking to a pre-v0.6.0 server

--- a/python/djust/tests/test_theming_v082_drain.py
+++ b/python/djust/tests/test_theming_v082_drain.py
@@ -1,0 +1,167 @@
+"""Regression tests for v0.8.2 drain — Group T (theming polish).
+
+Covers:
+- #1011 — `.card` / `.alert` overflow:hidden in components.css
+- #1012 — `{% theme_css_link %}` cache-busting tag
+- #1013 — `enable_client_override` flag in `LIVEVIEW_CONFIG['theme']`
+- #1009 — `prose.css` shipped for `@tailwindcss/typography` ↔ pack bridge
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from django.template import Context, Template
+from django.test import RequestFactory
+
+
+# Path to the package's static dir so we can inspect shipped CSS files
+THEMING_PKG = Path(__file__).resolve().parent.parent / "theming"
+STATIC_CSS = THEMING_PKG / "static" / "djust_theming" / "css"
+
+
+# ---------------------------------------------------------------------------
+# #1011 — .card / .alert overflow:hidden
+# ---------------------------------------------------------------------------
+
+
+def test_components_css_card_has_overflow_hidden():
+    """The `.card` selector must set `overflow: hidden` so child borders
+    don't poke through the rounded corners (#1011)."""
+    text = (STATIC_CSS / "components.css").read_text()
+    # Find the .card { ... } block (the canonical one near "Card" comment).
+    start = text.find("\n.card {\n")
+    assert start > 0, "could not find .card selector"
+    end = text.find("\n}\n", start)
+    block = text[start:end]
+    assert "overflow: hidden" in block, f".card block missing overflow: hidden\n---\n{block}\n---"
+
+
+def test_components_css_alert_has_overflow_hidden():
+    """The `.alert` selector must set `overflow: hidden` (#1011)."""
+    text = (STATIC_CSS / "components.css").read_text()
+    start = text.find("\n.alert {\n")
+    assert start > 0, "could not find .alert selector"
+    end = text.find("\n}\n", start)
+    block = text[start:end]
+    assert "overflow: hidden" in block, f".alert block missing overflow: hidden\n---\n{block}\n---"
+
+
+# ---------------------------------------------------------------------------
+# #1012 — {% theme_css_link %} cache-busting tag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_theme_css_link_emits_url_with_pack_and_mode_params():
+    """The {% theme_css_link %} tag emits a URL with `?p=<pack>&m=<mode>`
+    so different pack/mode = different URL → guaranteed fresh fetch
+    even when Chrome ignores Vary: Cookie (#1012)."""
+    rf = RequestFactory()
+    req = rf.get("/")
+    # No cookies set → falls back to defaults from settings
+    tmpl = Template("{% load theme_tags %}{% theme_css_link %}")
+    rendered = tmpl.render(Context({"request": req})).strip()
+    assert rendered.startswith("/_theming/theme.css") or "/theme.css" in rendered, (
+        f"unexpected URL: {rendered!r}"
+    )
+    # Either pack or mode (or both) should appear as a query param
+    assert "?" in rendered, (
+        f"theme_css_link should emit cache-busting query string; got {rendered!r}"
+    )
+    # At least one of the canonical keys
+    assert "p=" in rendered or "m=" in rendered, (
+        f"theme_css_link should include p= or m=; got {rendered!r}"
+    )
+
+
+@pytest.mark.django_db
+def test_theme_css_link_url_changes_with_pack_cookie():
+    """Different pack cookie → different URL. This is the actual cache-bust
+    contract — same URL for stale cache → guaranteed fresh fetch on switch."""
+    rf = RequestFactory()
+    tmpl = Template("{% load theme_tags %}{% theme_css_link %}")
+
+    # Render with one pack cookie
+    req1 = rf.get("/")
+    req1.COOKIES["djust_theme_pack"] = "djust"
+    url1 = tmpl.render(Context({"request": req1})).strip()
+
+    # Render with a different pack cookie
+    req2 = rf.get("/")
+    req2.COOKIES["djust_theme_pack"] = "nyc_core"
+    url2 = tmpl.render(Context({"request": req2})).strip()
+
+    assert url1 != url2, (
+        f"theme_css_link must produce different URLs for different packs; got {url1!r} and {url2!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1013 — enable_client_override flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_get_state_reads_cookies_when_enable_client_override_true():
+    """Default behavior (enable_client_override=True): cookies override
+    config. Existing back-compat (#1013)."""
+    from djust.theming.manager import ThemeManager
+
+    rf = RequestFactory()
+    req = rf.get("/")
+    req.COOKIES["djust_theme_pack"] = "nyc_core"
+    req.session = {}
+
+    mgr = ThemeManager(request=req)
+    # Pin config defaults relevant to this test (others come from settings)
+    mgr.config = dict(mgr.config, pack="djust", enable_client_override=True)
+    state = mgr.get_state()
+    # Cookie wins over config (back-compat default)
+    assert state.pack == "nyc_core", (
+        f"expected cookie pack to win when enable_client_override=True; got pack={state.pack!r}"
+    )
+
+
+@pytest.mark.django_db
+def test_get_state_ignores_cookies_when_enable_client_override_false():
+    """When `enable_client_override=False`, config wins — sites without a
+    user-facing switcher won't get hijacked by stale localhost cookies (#1013)."""
+    from djust.theming.manager import ThemeManager
+
+    rf = RequestFactory()
+    req = rf.get("/")
+    req.COOKIES["djust_theme_pack"] = "nyc_core"
+    req.session = {}
+
+    mgr = ThemeManager(request=req)
+    mgr.config = dict(mgr.config, pack="djust", enable_client_override=False)
+    state = mgr.get_state()
+    # Config wins over cookie
+    assert state.pack == "djust", (
+        f"expected config pack to win when enable_client_override=False; got pack={state.pack!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1009 — prose.css shipped
+# ---------------------------------------------------------------------------
+
+
+def test_prose_css_file_shipped():
+    """`prose.css` must exist in the package's static dir for sites that
+    `@tailwindcss/typography` to pick up via the `prose-djust` opt-in
+    class (#1009)."""
+    prose_path = STATIC_CSS / "prose.css"
+    assert prose_path.exists(), f"prose.css missing at {prose_path}"
+    text = prose_path.read_text()
+    assert ".prose.prose-djust" in text, (
+        "prose.css must scope under .prose.prose-djust opt-in class"
+    )
+    # Sanity: pack-aware token references
+    assert "--color-brand-rust" in text, "prose.css should reference pack tokens"
+    # Sanity: dark-mode invert variables present
+    assert "--tw-prose-invert-body" in text, (
+        "prose.css must include the typography plugin's invert variables for dark mode"
+    )

--- a/python/djust/theming/manager.py
+++ b/python/djust/theming/manager.py
@@ -275,12 +275,20 @@ class ThemeManager:
         registry = get_registry()
         session_data = self._get_session_data()
 
-        # Check cookies for theme, preset, and pack (set by JavaScript)
+        # Check cookies for theme, preset, and pack (set by JavaScript).
+        #
+        # #1013 — sites WITHOUT a user-facing theme switcher can disable cookie
+        # reads via ``LIVEVIEW_CONFIG['theme']['enable_client_override']: False``
+        # to prevent cross-project cookie bleed on localhost (every djust site
+        # answering on localhost shares a cookie jar — `djust_theme_pack` set
+        # by project A pins the palette for project B). Default ``True`` for
+        # back-compat: sites with a user-facing switcher keep working.
         theme = None
         preset = None
         pack = None
         layout = ""
-        if self.request:
+        enable_client_override = bool(self.config.get("enable_client_override", True))
+        if self.request and enable_client_override:
             theme = self.request.COOKIES.get("djust_theme")
             preset = self.request.COOKIES.get("djust_theme_preset")
             pack = self.request.COOKIES.get("djust_theme_pack")
@@ -288,6 +296,8 @@ class ThemeManager:
             logger.debug(
                 "Cookies: theme=%s, preset=%s, pack=%s, layout=%s", theme, preset, pack, layout
             )
+        elif self.request:
+            logger.debug("Cookies skipped — LIVEVIEW_CONFIG.theme.enable_client_override=False")
 
         # Fall back to session, then config default
         if not theme:

--- a/python/djust/theming/static/djust_theming/css/components.css
+++ b/python/djust/theming/static/djust_theming/css/components.css
@@ -21,6 +21,8 @@
     padding: 1rem;
     border-radius: var(--radius);
     border: 1px solid;
+    /* #1011 — keep child borders inside the rounded corners. */
+    overflow: hidden;
 }
 
 .alert-content {
@@ -227,6 +229,10 @@
     border: 1px solid hsl(var(--border));
     border-radius: calc(var(--radius) + 2px);
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    /* #1011 — keep child elements (e.g. .card-header border-bottom) inside
+       the rounded corners. Without this, child borders cross the rounded
+       arc and produce a visible 1-2px notch at the corners. */
+    overflow: hidden;
 }
 
 .card-header {

--- a/python/djust/theming/static/djust_theming/css/prose.css
+++ b/python/djust/theming/static/djust_theming/css/prose.css
@@ -1,0 +1,91 @@
+/*
+ * djust prose.css — pack-aware overrides for @tailwindcss/typography
+ * =================================================================
+ *
+ * Sites that use the @tailwindcss/typography plugin to render markdown
+ * (docs, blogs, in-app help) get baseline body / heading / link / code
+ * styling via the `.prose` class. The plugin emits its own
+ * `--tw-prose-*` variables tuned for a light background, so on dark
+ * themes the prose looks washed out unless every site re-implements
+ * the bridge to the active djust pack's `--color-brand-*` tokens.
+ *
+ * This file is the canonical bridge. Opt in by adding `prose-djust`
+ * alongside `prose` on your <article>:
+ *
+ *   <article class="prose prose-djust">
+ *       {{ rendered_markdown|safe }}
+ *   </article>
+ *
+ * Pack-aware: reads the same `--color-brand-*` tokens the active pack
+ * emits, so flipping pack at runtime updates prose without a stylesheet
+ * swap. Mode-aware: the existing pack scope (`html.dark`, etc.) carries
+ * the dark-mode overrides; this file just re-uses pack tokens.
+ *
+ * Closes #1009. Pulled from docs.djust.org's input.css reference impl.
+ *
+ * NOT in @layer on purpose: the typography plugin emits `.prose`
+ * unlayered; unlayered rules always beat layered ones.
+ */
+
+.prose.prose-djust {
+    --tw-prose-body:          var(--color-brand-text);
+    --tw-prose-headings:      var(--color-brand-text);
+    --tw-prose-lead:          var(--color-brand-text);
+    --tw-prose-links:         var(--color-brand-rust);
+    --tw-prose-bold:          var(--color-brand-text);
+    --tw-prose-counters:      var(--color-brand-text);
+    --tw-prose-bullets:       var(--color-brand-text);
+    --tw-prose-hr:            var(--color-brand-border, hsl(var(--border)));
+    --tw-prose-quotes:        var(--color-brand-text);
+    --tw-prose-quote-borders: var(--color-brand-rust);
+    --tw-prose-captions:      var(--color-brand-text);
+    --tw-prose-kbd:           var(--color-brand-text);
+    --tw-prose-kbd-shadows:   var(--color-brand-text);
+    --tw-prose-code:          var(--color-brand-text);
+    --tw-prose-pre-code:      var(--color-brand-text);
+    --tw-prose-pre-bg:        var(--color-brand-bg);
+    --tw-prose-th-borders:    var(--color-brand-border, hsl(var(--border)));
+    --tw-prose-td-borders:    var(--color-brand-border, hsl(var(--border)));
+
+    /* Dark-mode invert variables — the typography plugin reads these
+       inside `.dark .prose` ancestors. Each one falls back to its
+       light-mode counterpart so packs that don't emit a separate dark
+       palette still work. */
+    --tw-prose-invert-body:          var(--color-brand-text);
+    --tw-prose-invert-headings:      var(--color-brand-text);
+    --tw-prose-invert-lead:          var(--color-brand-text);
+    --tw-prose-invert-links:         var(--color-brand-rust);
+    --tw-prose-invert-bold:          var(--color-brand-text);
+    --tw-prose-invert-counters:      var(--color-brand-text);
+    --tw-prose-invert-bullets:       var(--color-brand-text);
+    --tw-prose-invert-hr:            var(--color-brand-border, hsl(var(--border)));
+    --tw-prose-invert-quotes:        var(--color-brand-text);
+    --tw-prose-invert-quote-borders: var(--color-brand-rust);
+    --tw-prose-invert-captions:      var(--color-brand-text);
+    --tw-prose-invert-kbd:           var(--color-brand-text);
+    --tw-prose-invert-kbd-shadows:   var(--color-brand-text);
+    --tw-prose-invert-code:          var(--color-brand-text);
+    --tw-prose-invert-pre-code:      var(--color-brand-text);
+    --tw-prose-invert-pre-bg:        var(--color-brand-bg);
+    --tw-prose-invert-th-borders:    var(--color-brand-border, hsl(var(--border)));
+    --tw-prose-invert-td-borders:    var(--color-brand-border, hsl(var(--border)));
+}
+
+/* Inline code receives a translucent token-aware background so it pops
+   without re-introducing the typography plugin's hardcoded grey. */
+.prose.prose-djust :where(code):not(:where([class~="not-prose"] *))::before,
+.prose.prose-djust :where(code):not(:where([class~="not-prose"] *))::after {
+    content: "";
+}
+.prose.prose-djust :where(code):not(:where([class~="not-prose"] *)) {
+    background-color: color-mix(in srgb, var(--color-brand-rust) 12%, transparent);
+    padding: 0.15em 0.35em;
+    border-radius: 0.25em;
+}
+
+/* Code blocks lose the inline padding (the <pre> already provides it)
+   and pick up the pack background. */
+.prose.prose-djust :where(pre code):not(:where([class~="not-prose"] *)) {
+    background-color: transparent;
+    padding: 0;
+}

--- a/python/djust/theming/templatetags/theme_tags.py
+++ b/python/djust/theming/templatetags/theme_tags.py
@@ -165,6 +165,58 @@ def theme_css(context):
 
 
 @register.simple_tag(takes_context=True)
+def theme_css_link(context):
+    """
+    Render a ``<link>`` to ``/_theming/theme.css`` with cache-busting URL params.
+
+    Chrome's ``Vary: Cookie`` handling is unreliable for per-cookie dynamic
+    content: after a pack switch, the browser often serves the prior pack's
+    CSS from its own HTTP cache and the page renders with the stale palette
+    until manual cache clear. The fix is to make different pack/mode produce
+    a different URL — the browser then can't re-use the cached body. (#1012)
+
+    Usage::
+
+        <link rel="stylesheet" href="{% theme_css_link %}">
+
+    Or directly drop the tag where you'd put the URL — it returns the URL
+    string when used inside an ``href=""``. The tag reads the same
+    ``ThemeManager.get_state()`` the view itself reads, so the link URL and
+    the served body stay in lockstep.
+    """
+    from django.urls import NoReverseMatch, reverse
+
+    request = context.get("request")
+    manager = get_theme_manager(request)
+    state = manager.get_state()
+
+    try:
+        base_url = reverse("djust_theming:theme_css")
+    except NoReverseMatch:
+        # URL not mounted (e.g. test environment that doesn't include
+        # djust_theming.urls). Fall back to a stable path so templates
+        # that include the tag don't crash.
+        base_url = "/_theming/theme.css"
+
+    # ThemeState is a dataclass, not a dict — use attribute access.
+    pack = (getattr(state, "pack", None) or "").strip()
+    mode = (getattr(state, "resolved_mode", None) or getattr(state, "mode", None) or "").strip()
+    preset = (getattr(state, "preset", None) or "").strip()
+
+    parts = []
+    if pack:
+        parts.append(f"p={pack}")
+    if mode:
+        parts.append(f"m={mode}")
+    if preset:
+        parts.append(f"r={preset}")
+
+    qs = "&".join(parts)
+    full = f"{base_url}?{qs}" if qs else base_url
+    return mark_safe(full)
+
+
+@register.simple_tag(takes_context=True)
 def theme_framework_overrides(context):
     """
     Render theme-aware CSS overrides for the active CSS framework.


### PR DESCRIPTION
## Summary

v0.8.2 drain — Group T (4 theming/CSS issues bundled). All 4 surfaced by docs.djust.org's testing.

- **Closes #1011** (bug, P1) — \`.card\` / \`.alert\` in components.css now set \`overflow: hidden\` so child borders stay inside the rounded corners. Affects every theme pack.
- **Closes #1012** (bug, P1) — new \`{% theme_css_link %}\` simple_tag in theme_tags.py. Emits \`<link href=\"/_theming/theme.css?p=<pack>&m=<mode>&r=<preset>\">\`. Different pack/mode = different URL = guaranteed fresh fetch even when Chrome ignores \`Vary: Cookie\`.
- **Closes #1009** (enhancement, P2) — new \`djust_theming/static/djust_theming/css/prose.css\` (91 lines). Pack-aware overrides for \`@tailwindcss/typography\` plugin's \`--tw-prose-*\` variables. Opt-in via \`prose-djust\` class alongside \`prose\`.
- **Closes #1013** (enhancement, P2) — \`ThemeManager.get_state()\` now respects \`LIVEVIEW_CONFIG['theme']['enable_client_override']\` (default \`True\` for back-compat). Set \`False\` to ignore \`djust_theme_*\` cookies — prevents localhost cross-project bleed.

CHANGELOG.md: 3 \"Added\" entries + 1 \"Fixed\" entry.

## Test plan

- [x] **7 new tests** in \`python/djust/tests/test_theming_v082_drain.py\` — covers all 4 issues with both source-level (CSS file content checks) and behavior-level (template render, ThemeManager.get_state()) assertions.
- [x] Broader theming suite: **1780 passed**, 1 skipped, 0 failures.
- [x] Pre-commit hooks ran clean (after one auto-format pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>