### PR TITLE
docs: fix 4 stale .md refs in RUST_COMPONENTS.md (closes #1010)

### DIFF
--- a/docs/components/RUST_COMPONENTS.md
+++ b/docs/components/RUST_COMPONENTS.md
@@ -1673,7 +1673,7 @@ To contribute new components:
 
 ## See Also
 
-- [LiveView Documentation](LIVEVIEW.md)
-- [Template Engine](TEMPLATES.md)
-- [VDOM System](VDOM_PATCHING_ISSUE.md)
-- [Forms Integration](PYTHONIC_FORMS_IMPLEMENTATION.md)
+- [LiveView API Reference](../website/api-reference/liveview.md) — class structure, lifecycle, and patterns
+- [Template Cheatsheet](../website/guides/template-cheatsheet.md) — djust template tags + filters
+- [VDOM Patching](../vdom/VDOM_PATCHING_ISSUE.md) — diff/patch implementation notes
+- [Forms Guide](../website/guides/forms.md) — FormMixin + real-time validation


### PR DESCRIPTION
## Summary

v0.8.2 drain — solo PR for #1010. Fixes the 4 broken "See Also" links in \`docs/components/RUST_COMPONENTS.md\` surfaced by docs.djust.org's \`link_check.py\` crawl.

| Old (broken) | New |
|---|---|
| \`LIVEVIEW.md\` | \`../website/api-reference/liveview.md\` |
| \`TEMPLATES.md\` | \`../website/guides/template-cheatsheet.md\` |
| \`VDOM_PATCHING_ISSUE.md\` | \`../vdom/VDOM_PATCHING_ISSUE.md\` (relative-path fix) |
| \`PYTHONIC_FORMS_IMPLEMENTATION.md\` | \`../website/guides/forms.md\` |

All 4 new targets verified to exist before commit.

## Out-of-scope (filed as follow-up #1075)

The investigation found a broader pattern — ~50 more broken .md refs across 17 files. Most are wrong relative paths (e.g. \`docs/state-management/STATE_MANAGEMENT_*.md\` references \`MARKETING.md\` etc. that live under \`docs/marketing/\`), not nonexistent targets. Filed as separate tech-debt issue with a proposed \`make docs-lint\` Makefile target to prevent regression.

## Test plan

- [x] DOCS_ONLY change. No code or tests modified.
- [x] All 4 new target paths verified to exist via filesystem check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>