### PR TITLE
feat(mixins): self.defer(callback) — Phoenix-style post-render scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Exception isolation: a failing deferred callback is logged at WARN
   with full traceback and execution continues to the next callback in the
   queue — a deferred callback's failure must not break the WebSocket
-  connection or the user's interactive flow. 14 regression cases in
+  connection or the user's interactive flow. 19 regression cases in
   `python/djust/tests/test_defer.py` cover queue mechanics
   (append/drain/clear), arg/kwarg passing, ordering, sync+async mix,
-  exception isolation, and edge cases (no `view_instance`, view without
-  `AsyncWorkMixin`).
+  exception isolation, edge cases (no `view_instance`, view without
+  `AsyncWorkMixin`), drain-reentry contract (a callback that calls
+  `defer(other)` enqueues `other` for the **next** drain — Phoenix-style,
+  prevents unbounded loops), and SSE transport integration (mirror flush
+  via `_flush_deferred_to_sse()` in `python/djust/sse.py`).
 
   Example::
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`self.defer(callback, *args, **kwargs)` — Phoenix-style post-render
+  callback scheduling** — new method on `AsyncWorkMixin` (and therefore on
+  every `LiveView`) that schedules a callback to run **once, after the
+  current render+patch cycle completes**. Phoenix `send(self(), :foo)` /
+  React `useEffect` (post-render) parity. Fires synchronously in the same
+  WebSocket message cycle (after `_send_update` returns) — so deferred
+  callbacks observe the post-patch state. Use cases: telemetry emission
+  after the user sees the change, post-render cleanup of temporary state,
+  scheduling follow-up side effects without re-rendering.
+
+  Differs from `start_async`: `defer` does NOT trigger a re-render after
+  the callback returns (the caller would use `start_async` for that), and
+  runs synchronously in the same WS frame rather than spawning a
+  background thread. Append-only queue: every `defer()` call adds to a
+  per-view list that is drained and cleared by
+  `LiveViewConsumer._flush_deferred()` after every `_send_update()` call
+  (10 sites in `python/djust/websocket.py`, mirroring the existing
+  `_flush_push_events` / `_flush_flash` / `_flush_page_metadata` /
+  `_flush_pending_layout` post-render-flush pattern).
+
+  Async callbacks (`async def` or coroutine-returning) are awaited inline.
+  Exception isolation: a failing deferred callback is logged at WARN
+  with full traceback and execution continues to the next callback in the
+  queue — a deferred callback's failure must not break the WebSocket
+  connection or the user's interactive flow. 14 regression cases in
+  `python/djust/tests/test_defer.py` cover queue mechanics
+  (append/drain/clear), arg/kwarg passing, ordering, sync+async mix,
+  exception isolation, and edge cases (no `view_instance`, view without
+  `AsyncWorkMixin`).
+
+  Example::
+
+      class CounterView(LiveView):
+          @event_handler
+          def increment(self, **kwargs):
+              self.count += 1
+              self.defer(self._record_metric, action="increment")
+
+          def _record_metric(self, action: str):
+              # Fires AFTER the patch reaches the client.
+              metrics.increment(f"liveview.{action}", count=self.count)
+
+  Phoenix LiveView Parity Tracker entry `self.defer()` (post-render) marked
+  shipped in `ROADMAP.md`.
+
+### Fixed
+
+- **`scripts/check-changelog-test-counts.py` regex missed `async def test_*`** —
+  the test-counter pre-push hook's `PY_TEST_FN_RE` matched only `def test_*`,
+  silently undercounting pytest-asyncio test files (any module-level
+  `async def test_*` was invisible). Updated the pattern to
+  `^[ \t]*(?:async\s+)?def\s+test_\w+\s*\(` so async tests are counted
+  alongside sync tests. Surfaced via `tests/test_defer.py` (7 sync class-method
+  tests + 7 module-level async tests = 14 total; pre-fix the hook reported 7
+  and the CHANGELOG claim of "14 regression cases" tripped a false drift
+  warning). Mechanical fix; no behavior change for files that don't use
+  `async def test_*`.
+
 ## [0.8.4rc1] - 2026-04-26
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1297,7 +1297,7 @@ Open questions that inform future direction:
 | ~~**Colocated JS hooks + namespacing**~~ ✅ | `ColocatedHook` | — | **Shipped v0.5.0** | v0.5.0 |
 | ~~**`UploadWriter` (stream upload)**~~ | ~~**`UploadWriter`**~~ | — | ✅ **Shipped in v0.5.0** | v0.5.0 |
 | ~~**Keyed for-loop change tracking**~~ | ~~**Auto in comprehensions**~~ | — | ✅ **Shipped** — `crates/djust_vdom/src/parser.rs` per-item change detection in `{% for %}` loops (via `dj-key`) | **v0.5.0** |
-| **`self.defer()` (post-render)** | **`send(self(), ...)`** | `useEffect` (post-render) | **Not started** *(verified: no `def defer` / `self.defer` / `post_render` / `after_render` in `live_view.py` or mixins as of v0.8.3rc1)* | **v0.5.0** |
+| ~~**`self.defer()` (post-render)**~~ | ~~**`send(self(), ...)`**~~ | ~~`useEffect` (post-render)~~ | ✅ **Shipped (v0.8.5)** — `python/djust/mixins/async_work.py` `defer()` + `_drain_deferred()` + `LiveViewConsumer._flush_deferred()` (10 post-render-flush sites in `websocket.py`) — Phoenix-parity post-render callback scheduling | **v0.5.0** |
 | **Testing utilities** | **`LiveViewTest`** | **Testing Library** | **Basic** (`LiveViewTestClient`) | **v0.5.1** |
 | **Error overlay (dev)** | Error page | **Next.js overlay** | ✅ Shipped (v0.5.1) | v0.5.1 |
 | Computed/derived state | — | `useMemo` | ✅ Shipped (v0.5.1) | v0.5.1 |
@@ -1385,7 +1385,7 @@ High-impact areas for contributions:
 14. ~~**`dj-scroll-into-view`**~~ ✅
 
 #### Medium Effort (1-3 days)
-14. **`self.defer(callback)`** — Post-render work scheduling, ~40 lines Python *(genuinely pending — verified no `def defer` / `self.defer` / `post_render` in `live_view.py` or mixins as of v0.8.3rc1)*
+14. ~~**`self.defer(callback)`**~~ ✅ **Shipped (v0.8.5)** — `mixins/async_work.py` `defer()` + `_drain_deferred()` (Phoenix-parity post-render scheduling)
 15. ~~**`dj-shortcut`**~~ ✅
 15. ~~**`dj-debounce`/`dj-throttle` HTML attributes**~~ ✅
 16. ~~**`on_mount` hooks**~~ ✅ Shipped — `python/djust/hooks.py` + `live_view.py` integration

--- a/python/djust/mixins/async_work.py
+++ b/python/djust/mixins/async_work.py
@@ -143,6 +143,19 @@ class AsyncWorkMixin:
         :meth:`~djust.mixins.async_work.AsyncWorkMixin.start_async`
         async-detection pattern.
 
+        Reentry semantics (calling ``defer()`` from a deferred callback):
+
+            A callback that itself calls ``self.defer(other_cb)`` queues
+            ``other_cb`` for the **next** render+patch cycle, NOT the
+            current drain. This matches Phoenix ``send(self(), :foo)``
+            semantics — the message is processed after the current handler
+            returns. Implementation: :meth:`_drain_deferred` clears
+            ``self._deferred_callbacks`` BEFORE iterating the snapshot, so
+            re-entry into ``defer()`` writes to a fresh empty queue. This
+            avoids unbounded loops (a callback that re-defers itself does
+            NOT spin within a single drain) and gives users a predictable
+            "next tick" mental model.
+
         Args:
             callback: Callable (typically a method on this view).
             *args: Positional arguments passed to the callback.

--- a/python/djust/mixins/async_work.py
+++ b/python/djust/mixins/async_work.py
@@ -118,6 +118,70 @@ class AsyncWorkMixin:
             self._async_cancelled = set()
         self._async_cancelled.add(name)
 
+    def defer(self, callback: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        """
+        Schedule a callback to run **once, after the current render+patch
+        cycle** completes. Phoenix-style ``send(self(), :foo)`` semantics —
+        useful for telemetry, post-render cleanup, or follow-up side
+        effects that should fire after the user sees the change.
+
+        Unlike :meth:`start_async`, ``defer``:
+
+        * Runs synchronously in the same WebSocket message cycle (not in a
+          background thread).
+        * Does NOT trigger a re-render after the callback returns.
+        * Is fire-once — every call appends to a queue that is drained and
+          cleared after each ``_send_update`` returns.
+
+        If the callback raises, the exception is logged at WARN with full
+        traceback and execution continues to the next deferred callback —
+        a deferred callback's failure must not break the WebSocket
+        connection or the user's interactive flow.
+
+        Async callbacks (``async def`` or coroutine-returning) are
+        awaited inline, mirroring the existing
+        :meth:`~djust.mixins.async_work.AsyncWorkMixin.start_async`
+        async-detection pattern.
+
+        Args:
+            callback: Callable (typically a method on this view).
+            *args: Positional arguments passed to the callback.
+            **kwargs: Keyword arguments passed to the callback.
+
+        Example::
+
+            @event_handler
+            def increment(self, **kwargs):
+                self.count += 1
+                self.defer(self._record_metric, action="increment")
+
+            def _record_metric(self, action: str):
+                # Fires after the patch reaches the client.
+                metrics.increment(f"liveview.{action}", count=self.count)
+        """
+        if not hasattr(self, "_deferred_callbacks"):
+            self._deferred_callbacks = []
+        self._deferred_callbacks.append((callback, args, kwargs))
+
+    def _drain_deferred(self) -> list:
+        """Pop and return the queued deferred callbacks; reset the queue.
+
+        Called by :class:`~djust.websocket.LiveViewConsumer` immediately
+        after each ``_send_update``. The drain is exception-isolated per
+        callback — see :meth:`defer` for semantics.
+
+        Returns the list of ``(callback, args, kwargs)`` tuples; consumers
+        invoke each one. Returning the list (rather than invoking inline)
+        keeps the mixin transport-agnostic — the HTTP path could call
+        :meth:`_drain_deferred` after :meth:`render` if we ever want
+        deferred-callback support there too.
+        """
+        callbacks = getattr(self, "_deferred_callbacks", None)
+        if not callbacks:
+            return []
+        self._deferred_callbacks = []
+        return callbacks
+
     def assign_async(
         self,
         name: str,

--- a/python/djust/sse.py
+++ b/python/djust/sse.py
@@ -43,6 +43,7 @@ same worker process (e.g., nginx ``ip_hash`` or a sticky load-balancer).
 """
 
 import asyncio
+import inspect
 import json
 import logging
 import time
@@ -506,9 +507,10 @@ async def _sse_handle_event(session: SSESession, event_name: str, params: Dict[s
             update_msg["async_pending"] = True
         session.push(update_msg)
 
-    # Flush push_events and navigation commands
+    # Flush push_events, navigation commands, and deferred callbacks
     _flush_push_events_to_queue(session, view_instance)
     _flush_navigation_to_queue(session, view_instance)
+    await _flush_deferred_to_sse(view_instance)
 
     if has_async:
         asyncio.ensure_future(_sse_run_async_work(session, event_name))
@@ -534,6 +536,44 @@ def _flush_navigation_to_queue(session: SSESession, view_instance) -> None:
         return
     for cmd in view_instance._drain_navigation():
         session.push({**cmd, "type": "navigation", "action": cmd["type"]})
+
+
+async def _flush_deferred_to_sse(view_instance) -> None:
+    """Drain ``self.defer(...)`` callbacks from the view and execute them.
+
+    Mirrors :meth:`LiveViewConsumer._flush_deferred` for the SSE transport.
+    Without this, ``defer()`` calls on a view served over SSE would
+    accumulate in ``_deferred_callbacks`` indefinitely (slow leak +
+    contract violation — Phoenix-parity says "after each render+patch").
+
+    Sync callbacks run directly; async callbacks (``async def`` or
+    coroutine-returning) are awaited inline. A failing callback logs at
+    WARN with traceback and execution continues to the next callback —
+    a deferred callback's failure must not break the SSE stream or the
+    user's interactive flow.
+    """
+    if not view_instance:
+        return
+    if not hasattr(view_instance, "_drain_deferred"):
+        return
+    callbacks = view_instance._drain_deferred()
+    # Defensive: same shape as ``LiveViewConsumer._flush_deferred`` —
+    # guard against test mocks (Mock view returns Mock, not list) and
+    # any legacy view that overrode ``_drain_deferred`` to return non-list.
+    if not isinstance(callbacks, list) or not callbacks:
+        return
+    for callback, args, kwargs in callbacks:
+        try:
+            result = callback(*args, **kwargs)
+            if inspect.iscoroutine(result):
+                await result
+        except Exception:
+            logger.warning(
+                "[djust SSE] Deferred callback %s on %s raised; continuing to next",
+                getattr(callback, "__qualname__", repr(callback)),
+                view_instance.__class__.__name__,
+                exc_info=True,
+            )
 
 
 async def _sse_run_async_work(session: SSESession, event_name: Optional[str]) -> None:
@@ -612,6 +652,7 @@ async def _sse_execute_async_task(
 
         session.push(msg)
         _flush_push_events_to_queue(session, view_instance)
+        await _flush_deferred_to_sse(view_instance)
 
     except Exception as exc:
         logger.exception(

--- a/python/djust/tests/test_defer.py
+++ b/python/djust/tests/test_defer.py
@@ -1,0 +1,271 @@
+"""Tests for ``LiveView.defer(callback, *args, **kwargs)`` — Phoenix-style
+post-render callback scheduling.
+
+Mixin-level behavior (queue + drain + exception isolation) is tested
+directly against ``AsyncWorkMixin``. Integration with the WebSocket
+flush pipeline (``LiveViewConsumer._flush_deferred``) is verified by
+calling the consumer method against a fake view in async tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from djust.mixins.async_work import AsyncWorkMixin
+
+
+class FakeView(AsyncWorkMixin):
+    """Minimal view-like class for direct mixin testing."""
+
+    pass
+
+
+# ---------------------------------------------------------------------------
+# defer() queue mechanics
+# ---------------------------------------------------------------------------
+
+
+class TestDeferQueue:
+    def test_defer_appends_to_queue(self):
+        view = FakeView()
+        cb = MagicMock()
+        view.defer(cb)
+
+        assert hasattr(view, "_deferred_callbacks")
+        assert len(view._deferred_callbacks) == 1
+        stored_cb, args, kwargs = view._deferred_callbacks[0]
+        assert stored_cb is cb
+        assert args == ()
+        assert kwargs == {}
+
+    def test_defer_preserves_args_and_kwargs(self):
+        view = FakeView()
+        cb = MagicMock()
+        view.defer(cb, "a", "b", key="value", flag=True)
+
+        stored_cb, args, kwargs = view._deferred_callbacks[0]
+        assert stored_cb is cb
+        assert args == ("a", "b")
+        assert kwargs == {"key": "value", "flag": True}
+
+    def test_defer_multiple_times_appends_all(self):
+        """Order of registration is the order of execution."""
+        view = FakeView()
+        cb1, cb2, cb3 = MagicMock(), MagicMock(), MagicMock()
+        view.defer(cb1)
+        view.defer(cb2, "x")
+        view.defer(cb3, key="y")
+
+        assert len(view._deferred_callbacks) == 3
+        assert view._deferred_callbacks[0][0] is cb1
+        assert view._deferred_callbacks[1][0] is cb2
+        assert view._deferred_callbacks[1][1] == ("x",)
+        assert view._deferred_callbacks[2][0] is cb3
+        assert view._deferred_callbacks[2][2] == {"key": "y"}
+
+
+class TestDrainDeferred:
+    def test_drain_empty_queue_returns_empty_list(self):
+        view = FakeView()
+        # Queue never created → returns []
+        assert view._drain_deferred() == []
+        # Queue created-but-empty also returns []
+        view._deferred_callbacks = []
+        assert view._drain_deferred() == []
+
+    def test_drain_returns_callbacks_then_clears(self):
+        view = FakeView()
+        cb = MagicMock()
+        view.defer(cb, "arg1", key="val")
+
+        callbacks = view._drain_deferred()
+        assert len(callbacks) == 1
+        assert callbacks[0][0] is cb
+        assert callbacks[0][1] == ("arg1",)
+        assert callbacks[0][2] == {"key": "val"}
+
+        # Queue is now empty — second drain returns empty.
+        assert view._drain_deferred() == []
+
+    def test_drain_isolates_subsequent_renders(self):
+        """A render+drain cycle must not affect callbacks queued during
+        the next handler. Previously-drained callbacks must NOT re-fire."""
+        view = FakeView()
+        cb1, cb2 = MagicMock(), MagicMock()
+
+        view.defer(cb1)
+        first_drain = view._drain_deferred()
+        assert len(first_drain) == 1
+        assert first_drain[0][0] is cb1
+
+        # Simulate next handler queuing a different callback
+        view.defer(cb2)
+        second_drain = view._drain_deferred()
+        assert len(second_drain) == 1
+        assert second_drain[0][0] is cb2  # NOT cb1 — first drain already consumed
+
+    def test_defer_returns_none_not_self(self):
+        """``defer()`` is a queue-append, not a builder. Don't accidentally
+        chain it like ``view.defer(cb).defer(cb2)`` and silently drop the
+        second registration."""
+        view = FakeView()
+        result = view.defer(MagicMock())
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# WebSocket flush integration — async exception isolation + async-callback
+# await semantics. Tests the consumer's _flush_deferred directly against a
+# fake view to avoid spinning a real Channels consumer.
+# ---------------------------------------------------------------------------
+
+
+class _FakeConsumer:
+    """Minimal stand-in for LiveViewConsumer that exposes _flush_deferred."""
+
+    def __init__(self, view_instance):
+        self.view_instance = view_instance
+
+    # Pull the implementation off the real consumer class to exercise
+    # the actual flush logic, not a re-implementation. Importing at
+    # method definition time keeps test discovery fast.
+    async def _flush_deferred(self):
+        from djust.websocket import LiveViewConsumer
+
+        return await LiveViewConsumer._flush_deferred(self)
+
+
+@pytest.mark.asyncio
+async def test_flush_deferred_runs_sync_callback_in_order():
+    view = FakeView()
+    order: list[int] = []
+    view.defer(lambda: order.append(1))
+    view.defer(lambda: order.append(2))
+    view.defer(lambda: order.append(3))
+
+    await _FakeConsumer(view)._flush_deferred()
+    assert order == [1, 2, 3]
+    # Queue cleared
+    assert view._drain_deferred() == []
+
+
+@pytest.mark.asyncio
+async def test_flush_deferred_awaits_async_callback():
+    view = FakeView()
+    order: list[str] = []
+
+    async def async_cb():
+        order.append("async")
+
+    def sync_cb():
+        order.append("sync")
+
+    view.defer(async_cb)
+    view.defer(sync_cb)
+
+    await _FakeConsumer(view)._flush_deferred()
+    assert order == ["async", "sync"]
+
+
+@pytest.mark.asyncio
+async def test_flush_deferred_passes_args_and_kwargs():
+    view = FakeView()
+    captured = {}
+
+    def cb(arg1, arg2, key=None, flag=False):
+        captured["args"] = (arg1, arg2)
+        captured["key"] = key
+        captured["flag"] = flag
+
+    view.defer(cb, "x", "y", key="z", flag=True)
+    await _FakeConsumer(view)._flush_deferred()
+
+    assert captured == {"args": ("x", "y"), "key": "z", "flag": True}
+
+
+@pytest.mark.asyncio
+async def test_flush_deferred_logs_and_continues_on_exception(caplog):
+    """A failing deferred callback must not break the connection or stop
+    later callbacks from running. Failure is logged at WARN."""
+    import logging
+
+    view = FakeView()
+    later_ran = []
+
+    def failing_cb():
+        raise RuntimeError("boom")
+
+    def later_cb():
+        later_ran.append(True)
+
+    view.defer(failing_cb)
+    view.defer(later_cb)
+
+    with caplog.at_level(logging.WARNING, logger="djust.websocket"):
+        await _FakeConsumer(view)._flush_deferred()
+
+    # Later callback ran despite the earlier one failing.
+    assert later_ran == [True]
+
+    # WARN log produced with traceback context.
+    matches = [r for r in caplog.records if "Deferred callback" in r.message]
+    assert len(matches) == 1
+    assert "raised; continuing" in matches[0].message
+
+
+@pytest.mark.asyncio
+async def test_flush_deferred_handles_no_view_instance():
+    """Edge case: consumer with view_instance=None must not raise."""
+
+    class _NullConsumer:
+        view_instance = None
+
+        async def _flush_deferred(self):
+            from djust.websocket import LiveViewConsumer
+
+            return await LiveViewConsumer._flush_deferred(self)
+
+    # Should be a no-op, not raise
+    result = await _NullConsumer()._flush_deferred()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_flush_deferred_handles_view_without_drain_method():
+    """Edge case: view that doesn't subclass AsyncWorkMixin (no
+    ``_drain_deferred``) is silently skipped — defensive against legacy
+    or third-party view classes."""
+
+    class _LegacyView:
+        pass  # No _drain_deferred attribute
+
+    # Should be a no-op, not raise
+    await _FakeConsumer(_LegacyView())._flush_deferred()
+
+
+@pytest.mark.asyncio
+async def test_flush_deferred_async_exception_isolated(caplog):
+    """Async-callback failure must isolate the same way sync-callback
+    failure does."""
+    import logging
+
+    view = FakeView()
+    later_ran = []
+
+    async def failing_async_cb():
+        raise ValueError("async boom")
+
+    def later_cb():
+        later_ran.append(True)
+
+    view.defer(failing_async_cb)
+    view.defer(later_cb)
+
+    with caplog.at_level(logging.WARNING, logger="djust.websocket"):
+        await _FakeConsumer(view)._flush_deferred()
+
+    assert later_ran == [True]
+    matches = [r for r in caplog.records if "Deferred callback" in r.message]
+    assert len(matches) == 1

--- a/python/djust/tests/test_defer.py
+++ b/python/djust/tests/test_defer.py
@@ -269,3 +269,142 @@ async def test_flush_deferred_async_exception_isolated(caplog):
     assert later_ran == [True]
     matches = [r for r in caplog.records if "Deferred callback" in r.message]
     assert len(matches) == 1
+
+
+# ---------------------------------------------------------------------------
+# Drain-reentry semantics — Stage 11 must-fix from PR #1091.
+#
+# A callback that calls ``self.defer(other_cb)`` queues ``other_cb`` for the
+# NEXT drain, not the current one. This matches Phoenix ``send(self(), :foo)``
+# semantics and avoids unbounded loops (a callback that re-defers itself does
+# NOT spin within a single drain). Implementation: ``_drain_deferred`` clears
+# the queue BEFORE iterating its snapshot, so re-entry into ``defer()`` writes
+# to a fresh empty queue.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flush_deferred_callback_that_calls_defer_enqueues_for_next_drain():
+    """A callback that calls ``view.defer(other_cb)`` queues ``other_cb``
+    for the NEXT drain, NOT the current one."""
+    view = FakeView()
+    order: list[str] = []
+
+    def second_cb():
+        order.append("second")
+
+    def first_cb():
+        order.append("first")
+        # Re-enter defer — this should NOT fire in the current drain.
+        view.defer(second_cb)
+
+    view.defer(first_cb)
+
+    # First drain: only first_cb fires.
+    await _FakeConsumer(view)._flush_deferred()
+    assert order == ["first"]
+    # second_cb is now queued — confirm by inspecting the queue state.
+    assert len(view._deferred_callbacks) == 1
+    assert view._deferred_callbacks[0][0] is second_cb
+
+    # Second drain: second_cb fires, queue empty.
+    await _FakeConsumer(view)._flush_deferred()
+    assert order == ["first", "second"]
+    assert view._drain_deferred() == []
+
+
+@pytest.mark.asyncio
+async def test_flush_deferred_self_redefer_does_not_loop():
+    """A callback that re-defers itself must NOT spin in the current drain.
+
+    Locks the contract that drain-reentry is always 'next tick' — even when
+    a callback queues itself, the current drain completes after one
+    invocation and the self-re-deferred copy waits for the next drain.
+    """
+    view = FakeView()
+    fire_count = []
+
+    def self_redeferring_cb():
+        fire_count.append(True)
+        view.defer(self_redeferring_cb)
+
+    view.defer(self_redeferring_cb)
+
+    # First drain: callback fires exactly once, even though it re-defers itself.
+    await _FakeConsumer(view)._flush_deferred()
+    assert len(fire_count) == 1
+    assert len(view._deferred_callbacks) == 1  # the self-re-defer
+
+    # Second drain: callback fires once more, re-defers itself again.
+    await _FakeConsumer(view)._flush_deferred()
+    assert len(fire_count) == 2
+    assert len(view._deferred_callbacks) == 1
+
+
+# ---------------------------------------------------------------------------
+# SSE transport integration — Stage 11 must-fix from PR #1091.
+#
+# Without this wire-in, SSE-served views that call ``self.defer(...)`` would
+# accumulate callbacks indefinitely (slow leak + Phoenix-parity contract
+# violation: 'after each render+patch').
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sse_flush_deferred_drains_and_runs_callbacks():
+    """``_flush_deferred_to_sse`` mirrors the WS flush — drains queue,
+    runs each callback (sync or async), exception-isolates per callback."""
+    from djust.sse import _flush_deferred_to_sse
+
+    view = FakeView()
+    order: list[str] = []
+
+    def sync_cb():
+        order.append("sync")
+
+    async def async_cb():
+        order.append("async")
+
+    view.defer(sync_cb)
+    view.defer(async_cb)
+
+    await _flush_deferred_to_sse(view)
+    assert order == ["sync", "async"]
+    assert view._drain_deferred() == []  # queue cleared
+
+
+@pytest.mark.asyncio
+async def test_sse_flush_deferred_handles_no_view_instance():
+    """``_flush_deferred_to_sse(None)`` is a no-op, mirroring the WS guard."""
+    from djust.sse import _flush_deferred_to_sse
+
+    # Should not raise
+    await _flush_deferred_to_sse(None)
+
+
+@pytest.mark.asyncio
+async def test_sse_flush_deferred_isolates_callback_exceptions(caplog):
+    """SSE-side exception isolation must match WS-side: failed callback
+    logs at WARN and execution continues."""
+    import logging
+
+    from djust.sse import _flush_deferred_to_sse
+
+    view = FakeView()
+    later_ran = []
+
+    def failing_cb():
+        raise RuntimeError("sse boom")
+
+    def later_cb():
+        later_ran.append(True)
+
+    view.defer(failing_cb)
+    view.defer(later_cb)
+
+    with caplog.at_level(logging.WARNING, logger="djust.sse"):
+        await _flush_deferred_to_sse(view)
+
+    assert later_ran == [True]
+    matches = [r for r in caplog.records if "Deferred callback" in r.message]
+    assert len(matches) == 1

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -512,6 +512,18 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
     async def _flush_deferred(self) -> None:
         """Drain and execute callbacks queued via :meth:`LiveView.defer`.
 
+        Wire-in pattern: this method is called from two locations —
+        (a) inside :meth:`_send_update` itself (alongside the other
+        ``_flush_*`` methods), and (b) at every per-handler post-render
+        site that already calls ``_flush_pending_layout`` (10 sites).
+        The (b) sites are technically redundant when (a) preceded — the
+        drain is idempotent on an empty queue — but they preserve
+        symmetry with the existing ``_flush_*`` family which has the same
+        redundancy. Removing only ``_flush_deferred``'s (b) wiring would
+        create asymmetry that future contributors would re-introduce.
+        See post-merge follow-up Action #163 for a milestone-level
+        cleanup that drops all redundant ``_flush_*`` calls together.
+
         Runs **after** every other post-render flush (push events, flash,
         page metadata, layout) so deferred callbacks observe the
         post-patch state. Phoenix-style ``send(self(), :foo)`` semantics —

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -509,6 +509,52 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             }
         )
 
+    async def _flush_deferred(self) -> None:
+        """Drain and execute callbacks queued via :meth:`LiveView.defer`.
+
+        Runs **after** every other post-render flush (push events, flash,
+        page metadata, layout) so deferred callbacks observe the
+        post-patch state. Phoenix-style ``send(self(), :foo)`` semantics —
+        useful for telemetry, post-render cleanup, or follow-up side
+        effects that should fire after the user sees the change.
+
+        Each callback is invoked in a try/except. Sync callbacks run
+        directly; async callbacks (``async def`` or coroutine-returning)
+        are awaited inline. A failing deferred callback logs at WARN with
+        full traceback and continues to the next — a deferred callback's
+        failure must not break the WebSocket connection or the user's
+        interactive flow.
+
+        Does NOT trigger a re-render after callbacks complete; if a
+        callback needs to re-render, the caller should use
+        :meth:`AsyncWorkMixin.start_async` instead.
+        """
+        if not self.view_instance:
+            return
+        if not hasattr(self.view_instance, "_drain_deferred"):
+            return
+        callbacks = self.view_instance._drain_deferred()
+        # Defensive: same shape as ``_flush_flash`` — guard against test
+        # mocks (a ``Mock`` ``view_instance`` returns a ``Mock``, not a
+        # list) and any legacy view that overrode ``_drain_deferred`` to
+        # return non-list.
+        if not isinstance(callbacks, list) or not callbacks:
+            return
+        for callback, args, kwargs in callbacks:
+            try:
+                result = callback(*args, **kwargs)
+                # Async callbacks: await inline. Mirrors the inspect-based
+                # detection used elsewhere (e.g. async event handlers).
+                if inspect.iscoroutine(result):
+                    await result
+            except Exception:
+                logger.warning(
+                    "[djust] Deferred callback %s on %s raised; continuing to next",
+                    getattr(callback, "__qualname__", repr(callback)),
+                    self.view_instance.__class__.__name__,
+                    exc_info=True,
+                )
+
     async def _send_noop(self, async_pending: bool = False, ref: Optional[int] = None) -> None:
         """
         Send a lightweight noop acknowledgment to the client.
@@ -857,6 +903,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             await self._flush_flash()
             await self._flush_page_metadata()
             await self._flush_pending_layout()
+            await self._flush_deferred()
 
         except Exception as e:
             error = e
@@ -1017,6 +1064,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 await self._flush_flash()
                 await self._flush_page_metadata()
                 await self._flush_pending_layout()
+                await self._flush_deferred()
                 await self._flush_navigation()
                 await self._flush_accessibility()
                 await self._flush_i18n()
@@ -1044,6 +1092,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             await self._flush_flash()
             await self._flush_page_metadata()
             await self._flush_pending_layout()
+            await self._flush_deferred()
             await self._flush_navigation()
             await self._flush_accessibility()
             await self._flush_i18n()
@@ -1144,6 +1193,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             await self._flush_flash()
             await self._flush_page_metadata()
             await self._flush_pending_layout()
+            await self._flush_deferred()
             await self._send_noop(async_pending=has_async, ref=event_ref)
             if has_async:
                 await self._dispatch_async_work()
@@ -2956,6 +3006,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                             await self._flush_flash()
                             await self._flush_page_metadata()
                             await self._flush_pending_layout()
+                            await self._flush_deferred()
                             await self._send_noop(async_pending=has_async, ref=event_ref)
                             if has_async:
                                 await self._dispatch_async_work()
@@ -3082,6 +3133,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                     await self._flush_flash()
                     await self._flush_page_metadata()
                     await self._flush_pending_layout()
+                    await self._flush_deferred()
                     await self._flush_navigation()
                     await self._flush_i18n()
                 else:
@@ -4317,6 +4369,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                     await self._flush_flash()
                     await self._flush_page_metadata()
                     await self._flush_pending_layout()
+                    await self._flush_deferred()
                     await self._send_noop()
                     return
 
@@ -4342,6 +4395,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                     await self._flush_flash()
                     await self._flush_page_metadata()
                     await self._flush_pending_layout()
+                    await self._flush_deferred()
             finally:
                 self._render_lock.release()
 
@@ -4434,6 +4488,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                     await self._flush_flash()
                     await self._flush_page_metadata()
                     await self._flush_pending_layout()
+                    await self._flush_deferred()
                     await self._send_noop()
                     return
 
@@ -4456,6 +4511,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                     await self._flush_flash()
                     await self._flush_page_metadata()
                     await self._flush_pending_layout()
+                    await self._flush_deferred()
 
                 # v0.7.0 — If handle_info flipped an activity to visible,
                 # drain its queue in the same round-trip. The flush is

--- a/scripts/check-changelog-test-counts.py
+++ b/scripts/check-changelog-test-counts.py
@@ -54,8 +54,9 @@ PY_TEST_PATH_RE = re.compile(
 )
 JS_TEST_PATH_RE = re.compile(r"`(tests/js/[^\s`]+?\.test\.js)`")
 
-# Count test functions inside Python files. Matches top-level and class-level.
-PY_TEST_FN_RE = re.compile(r"^[ \t]*def\s+test_\w+\s*\(", re.MULTILINE)
+# Count test functions inside Python files. Matches top-level and class-level,
+# both `def test_*` and `async def test_*` (pytest-asyncio).
+PY_TEST_FN_RE = re.compile(r"^[ \t]*(?:async\s+)?def\s+test_\w+\s*\(", re.MULTILINE)
 # Python pytest.mark.parametrize adds a case per tuple; count via rough sum
 # of ``parametrize(...)`` argument list lengths is out of scope here — a
 # ``test_*`` function is counted as ONE test, which mirrors ``pytest --collect-only -q``


### PR DESCRIPTION
## Summary

- New `self.defer(callback, *args, **kwargs)` method on `AsyncWorkMixin` (and therefore on every `LiveView`).
- Schedules callback to run **once, after the current render+patch cycle completes**. Phoenix `send(self(), :foo)` / React `useEffect` (post-render) parity.
- Closes Quick Win #14 from `ROADMAP.md` (Phoenix LV Parity Tracker `self.defer()` row).
- Bundled fix: `scripts/check-changelog-test-counts.py` regex extended to count `async def test_*` (was silently undercounting pytest-asyncio test files).

## API

```python
class CounterView(LiveView):
    @event_handler
    def increment(self, **kwargs):
        self.count += 1
        self.defer(self._record_metric, action="increment")

    def _record_metric(self, action: str):
        # Fires AFTER the patch reaches the client.
        metrics.increment(f"liveview.{action}", count=self.count)
```

## Semantics

| Aspect | Behavior |
| --- | --- |
| Timing | Synchronously, in the same WS message cycle, **after `_send_update` returns** |
| Re-render | Does NOT trigger a re-render (use `start_async` for that) |
| Queue | Append-only; drained + cleared after every `_send_update()` call |
| Async callbacks | Awaited inline (`async def` or coroutine-returning) |
| Exception isolation | Failing callback logs at WARN with traceback; next callbacks still run |
| Args | Positional + keyword args passed through verbatim |

## Implementation

**`python/djust/mixins/async_work.py`** — adds:
- `defer(callback, *args, **kwargs)` — appends to `_deferred_callbacks`
- `_drain_deferred()` — pops + clears the queue, returns list

**`python/djust/websocket.py`** — adds:
- `_flush_deferred()` async method (drains queue, runs each callback, awaits coroutines, isolates exceptions, defensive `isinstance(callbacks, list)` guard for Mock view_instance in tests)
- Wired in at all **10 post-render-flush sites** (right after each `_flush_pending_layout()` call), mirroring the existing `_flush_push_events` / `_flush_flash` / `_flush_page_metadata` / `_flush_pending_layout` pattern

## Tests

**14 cases** in `python/djust/tests/test_defer.py`:

Queue mechanics:
- `test_defer_appends_to_queue`
- `test_defer_preserves_args_and_kwargs`
- `test_defer_multiple_times_appends_all` (ordering)
- `test_drain_empty_queue_returns_empty_list`
- `test_drain_returns_callbacks_then_clears`
- `test_drain_isolates_subsequent_renders`
- `test_defer_returns_none_not_self`

WS flush integration:
- `test_flush_deferred_runs_sync_callback_in_order`
- `test_flush_deferred_awaits_async_callback`
- `test_flush_deferred_passes_args_and_kwargs`
- `test_flush_deferred_logs_and_continues_on_exception`
- `test_flush_deferred_handles_no_view_instance`
- `test_flush_deferred_handles_view_without_drain_method`
- `test_flush_deferred_async_exception_isolated`

## Bundled fix — `scripts/check-changelog-test-counts.py`

Pre-existing regex `^[ \t]*def\s+test_\w+\s*\(` matched only sync tests; pytest-asyncio's `async def test_*` was silently invisible. Surfaced when this PR's CHANGELOG claimed "14 regression cases" but the hook reported 7. Extended to `^[ \t]*(?:async\s+)?def\s+test_\w+\s*\(`. Mechanical regex-only change; no behavior change for files without async tests.

## ROADMAP

- Phoenix LV Parity Tracker `self.defer()` (post-render) row → ✅ Shipped
- Quick Win #14 → ✅ Shipped

## Test plan

- [x] `pytest python/djust/tests/test_defer.py -v` — 14 passed
- [x] `pytest python/djust/tests/test_async_work.py python/djust/tests/test_async_integration.py python/djust/tests/test_defer.py -q` — 43 passed
- [x] `pytest python/tests/test_hotreload.py -q` — 18 passed (regression check; defensive `isinstance` guard added after initial implementation broke 6 hotreload tests that mock `view_instance`)
- [x] Pre-commit hooks (ruff, ruff-format, bandit, secrets, CHANGELOG-test-counts with the bundled fix) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)