### PR TITLE
fix(checks): T012 partial-template marker + global suppress wiring (closes #1096)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`djust.T012` false positive on `{% include %}` partial templates (closes
+  #1096)** — `T012` (template uses `dj-*` event directives but missing
+  `dj-view`) fired unconditionally for any template containing `dj-click`,
+  `dj-input`, etc., even when the file was an intentional fragment included
+  from a parent LiveView root. Wizards with 15+ step partials produced a
+  noisy 15-warning wall in `manage.py check`.
+
+  Two opt-out paths now silence T012 for legitimate fragments:
+
+  1. **Per-template marker**: add `{# djust:partial #}` (case-insensitive,
+     whitespace flexible) anywhere in the template. The marker is the right
+     choice when most fragments in a project don't need the check but a few
+     full-page templates do.
+  2. **Global suppression**: `DJUST_CONFIG = {"suppress_checks": ["T012"]}`
+     in `settings.py`. Right when the project never uses T012's intended
+     diagnostic (e.g. component-only architectures).
+
+  T012's hint now mentions both options. Component templates (`dj-component`
+  present) continue to bypass T012 as before — pre-existing behavior
+  unchanged.
+
+  Files: `python/djust/checks.py` (new `_DJ_PARTIAL_MARKER_RE`, T012 guard
+  reads partial marker AND `_is_check_suppressed("djust.T012")` —
+  previously the global suppression infrastructure existed but T012 wasn't
+  wired in). New cases added to `TestT012EventDirectivesWithoutView` in
+  `python/tests/test_checks.py` cover: partial marker silences T012;
+  case-insensitive matching; global suppression via short ID (`"T012"`)
+  and qualified ID (`"djust.T012"`); hint text mentions both opt-out
+  paths.
+
 - **`scripts/check-changelog-test-counts.py` regex missed `async def test_*`** —
   the test-counter pre-push hook's `PY_TEST_FN_RE` matched only `def test_*`,
   silently undercounting pytest-asyncio test files (any module-level

--- a/python/djust/checks.py
+++ b/python/djust/checks.py
@@ -1975,6 +1975,11 @@ _DJ_EVENT_DIRECTIVES_RE = re.compile(
     r"dj-(click|input|change|submit|blur|focus|keydown|keyup|mouseenter|mouseleave|window-\w+|document-\w+|click-away|shortcut)="
 )
 _DJ_COMPONENT_RE = re.compile(r"dj-component")
+# #1096 — opt-out marker for fragment templates that are intentionally
+# {% include %}d from a parent LiveView root. Fragment authors annotate
+# the file with `{# djust:partial #}` (case-insensitive, optional surrounding
+# whitespace) to silence T012 without introducing a global suppression.
+_DJ_PARTIAL_MARKER_RE = re.compile(r"\{#\s*djust\s*:\s*partial\s*#\}", re.IGNORECASE)
 _DEPRECATED_DATA_DJ_ID_RE = re.compile(r"""data-dj-id\s*=\s*["'][^"']*["']""")
 # A090 — scanner for {% djust_markdown %} (v0.7.0). Fires info-level once
 # per project when the tag is detected, confirming the Rust-side safe
@@ -2160,21 +2165,32 @@ def check_templates(app_configs, **kwargs):
         _check_unsupported_tags(content, relpath, filepath, errors)
 
         # T012 -- template uses dj-* event directives but missing dj-view
-        if _DJ_EVENT_DIRECTIVES_RE.search(content) and not _DJ_VIEW_RE.search(content):
-            # Only fire if this isn't a component template (components don't need dj-view)
-            if not _DJ_COMPONENT_RE.search(content):
-                errors.append(
-                    DjustWarning(
-                        "%s -- template uses dj-* event directives but has no dj-view attribute."
-                        % relpath,
-                        hint=(
-                            'Add dj-view="yourapp.views.YourView" to the root element, '
-                            "or this template won't be connected to a LiveView."
-                        ),
-                        id="djust.T012",
-                        file_path=filepath,
-                    )
+        if (
+            _DJ_EVENT_DIRECTIVES_RE.search(content)
+            and not _DJ_VIEW_RE.search(content)
+            # Component templates (dj-component) don't need dj-view
+            and not _DJ_COMPONENT_RE.search(content)
+            # #1096: partial-template opt-out marker
+            and not _DJ_PARTIAL_MARKER_RE.search(content)
+            # Global suppression via DJUST_CONFIG['suppress_checks']
+            and not _is_check_suppressed("djust.T012")
+        ):
+            errors.append(
+                DjustWarning(
+                    "%s -- template uses dj-* event directives but has no dj-view attribute."
+                    % relpath,
+                    hint=(
+                        'Add dj-view="yourapp.views.YourView" to the root element, '
+                        "or this template won't be connected to a LiveView. "
+                        "If this template is an intentional fragment included from "
+                        "a parent LiveView root, add a `{# djust:partial #}` "
+                        "comment to silence this check, or suppress globally "
+                        "with DJUST_CONFIG = {'suppress_checks': ['T012']}."
+                    ),
+                    id="djust.T012",
+                    file_path=filepath,
                 )
+            )
 
         # T013 -- dj-view with empty or invalid value
         for match in re.finditer(r'dj-view="([^"]*)"', content):

--- a/python/tests/test_checks.py
+++ b/python/tests/test_checks.py
@@ -3138,6 +3138,123 @@ class TestT012EventDirectivesWithoutView:
         t012 = [e for e in errors if e.id == "djust.T012"]
         assert len(t012) == 0
 
+    def test_t012_passes_with_partial_marker(self, tmp_path, settings):
+        """#1096: T012 should not fire when {# djust:partial #} marker is present.
+
+        Templates included via {% include %} from a parent LiveView root are
+        intentional fragments — the parent owns dj-view. The partial marker
+        opts the file out of T012 without introducing a global suppression.
+        """
+        tpl_dir = tmp_path / "templates"
+        tpl_dir.mkdir()
+        (tpl_dir / "step_partial.html").write_text(
+            textwrap.dedent(
+                """\
+                {# djust:partial #}
+                <fieldset>
+                    <input dj-input="validate_field" name="vin" />
+                    <button dj-click="next_step">Next</button>
+                </fieldset>
+                """
+            )
+        )
+        settings.TEMPLATES = [
+            {
+                "DIRS": [str(tpl_dir)],
+                "BACKEND": "django.template.backends.django.DjangoTemplateBackend",
+            }
+        ]
+
+        from djust.checks import check_templates
+
+        errors = check_templates(None)
+        t012 = [e for e in errors if e.id == "djust.T012"]
+        assert len(t012) == 0
+
+    def test_t012_partial_marker_case_insensitive(self, tmp_path, settings):
+        """The partial marker should be matched case-insensitively."""
+        tpl_dir = tmp_path / "templates"
+        tpl_dir.mkdir()
+        (tpl_dir / "step.html").write_text(
+            textwrap.dedent(
+                """\
+                {# Djust: Partial #}
+                <button dj-click="next">Next</button>
+                """
+            )
+        )
+        settings.TEMPLATES = [
+            {
+                "DIRS": [str(tpl_dir)],
+                "BACKEND": "django.template.backends.django.DjangoTemplateBackend",
+            }
+        ]
+
+        from djust.checks import check_templates
+
+        errors = check_templates(None)
+        t012 = [e for e in errors if e.id == "djust.T012"]
+        assert len(t012) == 0
+
+    def test_t012_global_suppress_via_djust_config(self, tmp_path, settings):
+        """#1096: T012 honours DJUST_CONFIG['suppress_checks']=['T012']."""
+        tpl_dir = tmp_path / "templates"
+        tpl_dir.mkdir()
+        (tpl_dir / "no_view.html").write_text('<button dj-click="next">Next</button>')
+        settings.TEMPLATES = [
+            {
+                "DIRS": [str(tpl_dir)],
+                "BACKEND": "django.template.backends.django.DjangoTemplateBackend",
+            }
+        ]
+        settings.DJUST_CONFIG = {"suppress_checks": ["T012"]}
+
+        from djust.checks import check_templates
+
+        errors = check_templates(None)
+        t012 = [e for e in errors if e.id == "djust.T012"]
+        assert len(t012) == 0
+
+    def test_t012_global_suppress_accepts_qualified_id(self, tmp_path, settings):
+        """Qualified id 'djust.T012' should also be accepted."""
+        tpl_dir = tmp_path / "templates"
+        tpl_dir.mkdir()
+        (tpl_dir / "no_view.html").write_text('<button dj-click="next">Next</button>')
+        settings.TEMPLATES = [
+            {
+                "DIRS": [str(tpl_dir)],
+                "BACKEND": "django.template.backends.django.DjangoTemplateBackend",
+            }
+        ]
+        settings.DJUST_CONFIG = {"suppress_checks": ["djust.T012"]}
+
+        from djust.checks import check_templates
+
+        errors = check_templates(None)
+        t012 = [e for e in errors if e.id == "djust.T012"]
+        assert len(t012) == 0
+
+    def test_t012_hint_mentions_partial_and_global_suppress(self, tmp_path, settings):
+        """The fired warning's hint should describe both opt-out paths."""
+        tpl_dir = tmp_path / "templates"
+        tpl_dir.mkdir()
+        (tpl_dir / "no_view.html").write_text('<button dj-click="next">Next</button>')
+        settings.TEMPLATES = [
+            {
+                "DIRS": [str(tpl_dir)],
+                "BACKEND": "django.template.backends.django.DjangoTemplateBackend",
+            }
+        ]
+
+        from djust.checks import check_templates
+
+        errors = check_templates(None)
+        t012 = [e for e in errors if e.id == "djust.T012"]
+        assert len(t012) == 1
+        hint = t012[0].hint
+        assert "djust:partial" in hint
+        assert "suppress_checks" in hint
+
 
 class TestT013InvalidViewPath:
     """T013 -- dj-view with empty or invalid value."""


### PR DESCRIPTION
## Summary

Closes #1096. `djust.T012` (template uses `dj-*` event directives but missing `dj-view`) fired unconditionally on fragment templates intentionally `{% include %}`d from a parent LiveView root. Wizards with 15+ step partials produced a 15-warning wall on every `manage.py check`.

## Two opt-out paths

**Per-template marker** — case-insensitive, whitespace-flexible:
```html
{# djust:partial #}
<fieldset>
    <input dj-input="validate_field" name="vin" />
</fieldset>
```

**Global suppression** via `DJUST_CONFIG` (infrastructure existed; T012 just wasn't wired to it):
```python
DJUST_CONFIG = {"suppress_checks": ["T012"]}  # short or qualified id
```

T012's hint now mentions both opt-out paths.

## Implementation

- `python/djust/checks.py` — new `_DJ_PARTIAL_MARKER_RE`; T012 guard now reads partial marker AND `_is_check_suppressed("djust.T012")`. Component templates (`dj-component`) continue to bypass T012 — pre-existing behavior preserved.
- `python/tests/test_checks.py` — 5 new cases in `TestT012EventDirectivesWithoutView`.

## Test plan

- [x] 5 new test cases in `TestT012EventDirectivesWithoutView` cover partial marker (default + case-insensitive), global suppress (short id + qualified id), and hint text mentions both paths
- [x] Existing 3 T012 cases still pass — no regression in detect/with-view/component-template behavior
- [x] Full `test_checks.py` (180 cases) passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)