### PR TITLE
perf(wizard): wizard_rendered_fields opt-in skips field_html for unused fields (closes #1097)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`WizardMixin.wizard_rendered_fields` opt-in skips `field_html` rendering
+  for fields not in the list (closes #1097)** — `WizardMixin.get_context_data()`
+  unconditionally pre-rendered `field_html` for **every** field on the
+  current step's form, regardless of whether the template referenced that
+  field. Wizards with conditional fields (e.g. owner-info hidden behind
+  `is_vehicle_owner == "no"`) paid the rendering cost on every event for
+  fields nobody ever sees. Reported impact on the nyc-claims VPD wizard:
+  115ms template render (threshold: 50ms), 47 VDOM patches per autofill —
+  most for invisible inputs.
+
+  New API (default behavior unchanged — `None` renders all):
+
+  - **Class-level**: `wizard_rendered_fields = ["first_name", "vin", ...]`
+    on the wizard view limits `field_html` to that subset across every step.
+  - **Per-step override**: a step dict can include
+    `{"name": "...", "form_class": ..., "rendered_fields": [...]}` to scope
+    the filter to that step. Wins over the class-level default.
+
+  `form_data`, `form_required`, and `form_choices` are NOT filtered — all
+  fields remain part of validation/state. Only the (expensive) HTML rendering
+  is opt-in skipped. Excluded field names produce no `field_html[fname]`
+  entry; templates that reference them via `{{ field_html.unused|safe }}`
+  render empty (the dict-key absence is intentional and visible).
+
+  Files: `python/djust/wizard.py` (class attribute, per-step lookup +
+  filter in `get_context_data()`); `python/tests/test_wizard_rendered_fields.py`
+  with 8 cases in `DefaultRendersAllFieldsTest`,
+  `ClassAttributeFiltersTest`, `PerStepOverrideTest`.
+
+  Future direction: a smarter automatic template-scan (similar to the JIT
+  serializer's used-field detection) could drive this without explicit
+  developer wiring. This PR ships the explicit escape hatch first.
+
 - **`WizardMixin.wizard_input_event` class attribute + `dom_event` kwarg on
   `as_live_field()` — configurable DOM event for live-field validation
   binding (closes #1095)** — `WizardMixin.as_live_field()` previously emitted

--- a/python/djust/wizard.py
+++ b/python/djust/wizard.py
@@ -91,6 +91,15 @@ class WizardMixin:
     #: pre-filled and submitted without an intermediate blur. Closes #1095.
     wizard_input_event: str = "dj-change"
 
+    #: Optional opt-in to skip ``field_html`` rendering for fields not in this
+    #: list. Default ``None`` renders ALL fields in the current step's form
+    #: (pre-#1097 behavior). Set to a list of field names to render only those
+    #: — useful when a step's form has many fields but the template only
+    #: references a subset (e.g. conditional owner-info fields hidden behind
+    #: ``is_vehicle_owner == "no"``). Per-step overrides via the step dict's
+    #: ``"rendered_fields"`` key. Closes #1097.
+    wizard_rendered_fields: list | None = None
+
     @property
     def _steps(self) -> list:
         """Read wizard_steps from the CLASS definition, not the instance.
@@ -225,6 +234,9 @@ class WizardMixin:
             form_instance = (
                 form_class(data=current_step_data) if current_step_data else form_class()
             )
+            # #1097: opt-in field_html filter. Per-step "rendered_fields" wins
+            # over the class-level default. None = render all (legacy behavior).
+            rendered_filter = current_step.get("rendered_fields", self.wizard_rendered_fields)
             for fname, field in form_instance.fields.items():
                 val = current_step_data.get(fname, field.initial or "")
                 form_data[fname] = val if val is not None else ""
@@ -233,7 +245,8 @@ class WizardMixin:
                     form_choices[fname] = [
                         {"value": str(k), "label": str(v)} for k, v in field.choices if str(k)
                     ]
-                field_html[fname] = self.as_live_field(fname, event_name="validate_field")
+                if rendered_filter is None or fname in rendered_filter:
+                    field_html[fname] = self.as_live_field(fname, event_name="validate_field")
 
         # Expose choices as flat top-level vars too (e.g. borough_choices)
         # so templates can use either form_choices.borough or borough_choices.

--- a/python/djust/wizard.py
+++ b/python/djust/wizard.py
@@ -92,13 +92,18 @@ class WizardMixin:
     wizard_input_event: str = "dj-change"
 
     #: Optional opt-in to skip ``field_html`` rendering for fields not in this
-    #: list. Default ``None`` renders ALL fields in the current step's form
-    #: (pre-#1097 behavior). Set to a list of field names to render only those
-    #: — useful when a step's form has many fields but the template only
-    #: references a subset (e.g. conditional owner-info fields hidden behind
-    #: ``is_vehicle_owner == "no"``). Per-step overrides via the step dict's
-    #: ``"rendered_fields"`` key. Closes #1097.
-    wizard_rendered_fields: list | None = None
+    #: collection. Default ``None`` renders ALL fields in the current step's
+    #: form (pre-#1097 behavior). Set to any iterable of field names (list,
+    #: tuple, set, frozenset — anything that supports ``in`` membership) to
+    #: render only those — useful when a step's form has many fields but the
+    #: template only references a subset (e.g. conditional owner-info fields
+    #: hidden behind ``is_vehicle_owner == "no"``). Per-step overrides via
+    #: the step dict's ``"rendered_fields"`` key — explicit ``None`` at the
+    #: step level reverts that step to render-all. Excluded field names
+    #: produce no ``field_html[fname]`` entry; templates that reference them
+    #: via ``{{ field_html.unused|safe }}`` render empty (intentional — the
+    #: opt-out is a contract between view and template). Closes #1097.
+    wizard_rendered_fields = None
 
     @property
     def _steps(self) -> list:

--- a/python/tests/test_wizard_rendered_fields.py
+++ b/python/tests/test_wizard_rendered_fields.py
@@ -42,32 +42,44 @@ class _StubLiveView:
         return dict(kwargs)
 
 
-class _W(WizardMixin, _StubLiveView):
-    wizard_steps = [
-        {"name": "details", "form_class": _BigForm, "title": "Details"},
-    ]
+_SENTINEL = object()
 
-    def __init__(self, rendered=None, per_step_rendered=None):
-        if rendered is not None:
-            self.wizard_rendered_fields = rendered
-        # Optional per-step override
-        if per_step_rendered is not None:
-            type(self).wizard_steps = [
-                {
-                    "name": "details",
-                    "form_class": _BigForm,
-                    "title": "Details",
-                    "rendered_fields": per_step_rendered,
-                },
-            ]
-        else:
-            type(self).wizard_steps = [
-                {"name": "details", "form_class": _BigForm, "title": "Details"},
-            ]
-        self.wizard_step_index = 0
-        self.wizard_step_data = {}
-        self.wizard_step_errors = {}
-        self.wizard_completed_steps = []
+
+def _make_view(rendered=None, per_step_rendered=_SENTINEL):
+    """Build a fresh WizardMixin subclass per call.
+
+    Each call dynamically creates a NEW subclass with its own class-level
+    ``wizard_steps``, avoiding cross-test mutation of a shared class
+    attribute. ``per_step_rendered=_SENTINEL`` means the step dict has no
+    ``rendered_fields`` key at all (fall through to class attr); pass
+    ``None`` explicitly to put ``"rendered_fields": None`` in the step dict.
+    """
+    if per_step_rendered is _SENTINEL:
+        steps = [{"name": "details", "form_class": _BigForm, "title": "Details"}]
+    else:
+        steps = [
+            {
+                "name": "details",
+                "form_class": _BigForm,
+                "title": "Details",
+                "rendered_fields": per_step_rendered,
+            }
+        ]
+
+    cls = type("_TestWizardView", (WizardMixin, _StubLiveView), {"wizard_steps": steps})
+    view = cls()
+    if rendered is not None:
+        view.wizard_rendered_fields = rendered
+    view.wizard_step_index = 0
+    view.wizard_step_data = {}
+    view.wizard_step_errors = {}
+    view.wizard_completed_steps = []
+    return view
+
+
+# Backwards-compat shim so the existing tests below work unchanged.
+def _W(rendered=None, per_step_rendered=_SENTINEL):
+    return _make_view(rendered=rendered, per_step_rendered=per_step_rendered)
 
 
 class DefaultRendersAllFieldsTest(TestCase):
@@ -144,3 +156,46 @@ class PerStepOverrideTest(TestCase):
         view = _W(per_step_rendered=["first_name", "last_name"])
         ctx = view.get_context_data()
         self.assertEqual(set(ctx["field_html"].keys()), {"first_name", "last_name"})
+
+    def test_per_step_empty_list_renders_no_fields(self):
+        # Per-step "rendered_fields": [] means: render NO fields for this
+        # step, even if the class attr says otherwise.
+        view = _W(rendered=["first_name", "last_name"], per_step_rendered=[])
+        ctx = view.get_context_data()
+        self.assertEqual(ctx["field_html"], {})
+
+    def test_per_step_explicit_none_renders_all(self):
+        # Step dict with `"rendered_fields": None` (explicitly None, NOT
+        # missing): dict.get returns None; the None-filter branch in
+        # get_context_data treats that as "no filter" and renders ALL
+        # fields. Documented semantic: explicit None at step level is the
+        # opt-out from any class-level filter for that specific step.
+        view = _W(rendered=["first_name"], per_step_rendered=None)
+        ctx = view.get_context_data()
+        # All fields render — class attr's filter is overridden by step's None
+        self.assertEqual(
+            set(ctx["field_html"].keys()),
+            {
+                "first_name",
+                "last_name",
+                "email",
+                "phone",
+                "is_vehicle_owner",
+                "owner_first_name",
+                "owner_last_name",
+            },
+        )
+
+
+class FilterIterableShapeTest(TestCase):
+    """The filter accepts any iterable supporting `in` membership checks."""
+
+    def test_tuple_filter(self):
+        view = _W(rendered=("first_name", "last_name"))  # tuple, not list
+        ctx = view.get_context_data()
+        self.assertEqual(set(ctx["field_html"].keys()), {"first_name", "last_name"})
+
+    def test_set_filter(self):
+        view = _W(rendered={"first_name", "email"})  # set
+        ctx = view.get_context_data()
+        self.assertEqual(set(ctx["field_html"].keys()), {"first_name", "email"})

--- a/python/tests/test_wizard_rendered_fields.py
+++ b/python/tests/test_wizard_rendered_fields.py
@@ -1,0 +1,146 @@
+"""Regression tests for #1097: WizardMixin.wizard_rendered_fields opt-in.
+
+When a step's form has many fields but the template only references a subset
+(e.g. conditional fields hidden behind a flag), `wizard_rendered_fields` lets
+the wizard author skip `field_html` generation for the unused fields. Default
+(`None`) preserves existing behavior — render all.
+"""
+
+import django
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        INSTALLED_APPS=["django.contrib.contenttypes", "django.contrib.auth"],
+        DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}},
+    )
+    django.setup()
+
+from django import forms
+from django.test import TestCase
+
+from djust.wizard import WizardMixin
+
+
+class _BigForm(forms.Form):
+    """Form with several fields — only some are 'visible' in template."""
+
+    first_name = forms.CharField(max_length=100)
+    last_name = forms.CharField(max_length=100)
+    email = forms.EmailField()
+    phone = forms.CharField(max_length=20, required=False)
+    is_vehicle_owner = forms.ChoiceField(choices=[("yes", "Yes"), ("no", "No")])
+    # Conditional fields only shown when is_vehicle_owner == "no"
+    owner_first_name = forms.CharField(max_length=100, required=False)
+    owner_last_name = forms.CharField(max_length=100, required=False)
+
+
+class _StubLiveView:
+    """Minimal stub providing get_context_data for WizardMixin to super() into."""
+
+    def get_context_data(self, **kwargs):
+        return dict(kwargs)
+
+
+class _W(WizardMixin, _StubLiveView):
+    wizard_steps = [
+        {"name": "details", "form_class": _BigForm, "title": "Details"},
+    ]
+
+    def __init__(self, rendered=None, per_step_rendered=None):
+        if rendered is not None:
+            self.wizard_rendered_fields = rendered
+        # Optional per-step override
+        if per_step_rendered is not None:
+            type(self).wizard_steps = [
+                {
+                    "name": "details",
+                    "form_class": _BigForm,
+                    "title": "Details",
+                    "rendered_fields": per_step_rendered,
+                },
+            ]
+        else:
+            type(self).wizard_steps = [
+                {"name": "details", "form_class": _BigForm, "title": "Details"},
+            ]
+        self.wizard_step_index = 0
+        self.wizard_step_data = {}
+        self.wizard_step_errors = {}
+        self.wizard_completed_steps = []
+
+
+class DefaultRendersAllFieldsTest(TestCase):
+    """Without `wizard_rendered_fields`, legacy behavior renders every field."""
+
+    def test_field_html_keys_match_form_fields(self):
+        view = _W()
+        ctx = view.get_context_data()
+        self.assertEqual(
+            set(ctx["field_html"].keys()),
+            {
+                "first_name",
+                "last_name",
+                "email",
+                "phone",
+                "is_vehicle_owner",
+                "owner_first_name",
+                "owner_last_name",
+            },
+        )
+
+    def test_default_class_attribute_is_none(self):
+        self.assertIsNone(WizardMixin.wizard_rendered_fields)
+
+
+class ClassAttributeFiltersTest(TestCase):
+    """A class-level list filters `field_html` to that subset."""
+
+    def test_only_listed_fields_render(self):
+        view = _W(rendered=["first_name", "last_name", "email"])
+        ctx = view.get_context_data()
+        self.assertEqual(
+            set(ctx["field_html"].keys()),
+            {"first_name", "last_name", "email"},
+        )
+        # Excluded fields should NOT have field_html entries
+        self.assertNotIn("phone", ctx["field_html"])
+        self.assertNotIn("owner_first_name", ctx["field_html"])
+
+    def test_form_data_still_contains_all_fields(self):
+        # form_data, form_required, form_choices are NOT filtered — only
+        # field_html (which is the expensive HTML rendering). Non-rendered
+        # fields are still part of validation/state.
+        view = _W(rendered=["first_name"])
+        ctx = view.get_context_data()
+        self.assertIn("first_name", ctx["form_data"])
+        self.assertIn("last_name", ctx["form_data"])  # all fields tracked
+        self.assertIn("phone", ctx["form_data"])
+
+    def test_empty_list_renders_no_fields(self):
+        view = _W(rendered=[])
+        ctx = view.get_context_data()
+        self.assertEqual(ctx["field_html"], {})
+
+    def test_unknown_field_in_list_silently_ignored(self):
+        # If the developer lists a name that's not in the form, just no-op.
+        view = _W(rendered=["first_name", "nonexistent_field"])
+        ctx = view.get_context_data()
+        self.assertIn("first_name", ctx["field_html"])
+        self.assertNotIn("nonexistent_field", ctx["field_html"])
+
+
+class PerStepOverrideTest(TestCase):
+    """A step's `"rendered_fields"` key overrides the class-level default."""
+
+    def test_per_step_overrides_class_attr(self):
+        # Class attr says render only first_name, but step dict says
+        # render only email — step-level wins.
+        view = _W(rendered=["first_name"], per_step_rendered=["email"])
+        ctx = view.get_context_data()
+        self.assertEqual(set(ctx["field_html"].keys()), {"email"})
+
+    def test_per_step_with_no_class_attr(self):
+        view = _W(per_step_rendered=["first_name", "last_name"])
+        ctx = view.get_context_data()
+        self.assertEqual(set(ctx["field_html"].keys()), {"first_name", "last_name"})


### PR DESCRIPTION
## Summary

Closes #1097. `WizardMixin.get_context_data()` unconditionally pre-rendered `field_html` for **every** field on the current step's form, regardless of whether the template referenced that field. Wizards with conditional fields (e.g. owner-info hidden behind `is_vehicle_owner == \"no\"`) paid the rendering cost on every event for fields nobody ever sees.

Reported impact (nyc-claims VPD wizard):
- Template render: **115ms** (threshold: 50ms)
- **47 VDOM patches** on autofill, most for invisible inputs

## API (default behavior unchanged)

**Class-level**:
```python
class VPDVehicleInfoView(WizardMixin, LiveView):
    wizard_rendered_fields = [\"first_name\", \"last_name\", \"vehicle_vin\"]
```

**Per-step override** (wins over class-level):
```python
wizard_steps = [
    {\"name\": \"vpd\", \"form_class\": VPDVehicleInfoForm,
     \"rendered_fields\": [\"first_name\", \"vehicle_vin\"]},
]
```

`None` (default) renders all fields — pre-#1097 behavior preserved.

## Important: only `field_html` is filtered

`form_data`, `form_required`, and `form_choices` are NOT filtered — all fields remain part of validation state. Only the (expensive) HTML rendering is opt-in skipped. Excluded field names produce no `field_html[fname]` entry; templates that reference them via `{{ field_html.unused|safe }}` render empty.

## Implementation

- `python/djust/wizard.py` — `wizard_rendered_fields` class attribute; `get_context_data()` reads `current_step.get(\"rendered_fields\", self.wizard_rendered_fields)` and only calls `as_live_field()` when the field passes the filter
- `python/tests/test_wizard_rendered_fields.py` — 8 new cases across 3 classes

## Future direction

A template-scan-driven version (similar to the JIT serializer's used-field detection) is the next iteration. This PR ships the explicit escape hatch first per the issue's \"intermediate fix\" request.

## Test plan

- [x] 8 new cases cover default-None renders all; class-attr filters; empty list renders nothing; unknown names silently ignored; per-step override; per-step wins over class-attr; form_data/required/choices still contain ALL fields
- [x] `test_wizard_input_event.py` (the #1095 sibling) still passes — no regression
- [x] Full Python suite: 2076 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)