### PR TITLE
fix(framework-gaps): 4-issue v0.8.6 P2 drain (closes #1088, #1089, #1090, #1093)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false  # Continue building other platforms if one fails
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         exclude:
           # Windows builds are slower; only build latest Python versions
           # Users on older Python can use Linux/macOS wheels or build from source
@@ -73,11 +73,19 @@ jobs:
             python-version: '3.11'
           - os: macos-15-intel
             python-version: '3.12'
+          - os: macos-15-intel
+            python-version: '3.13'
+          - os: macos-15-intel
+            python-version: '3.14'
           # macOS ARM - latest (macos-15)
           - os: macos-15
             python-version: '3.11'
           - os: macos-15
             python-version: '3.12'
+          - os: macos-15
+            python-version: '3.13'
+          - os: macos-15
+            python-version: '3.14'
 
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`djust.C013` system check — stale collectstatic copy of `client.min.js`
+  (closes #1088)** — anyone with `STATIC_ROOT` configured (typical
+  production deployment behind WhiteNoise / nginx / a CDN) can ship a
+  stale `client.min.js` after a djust wheel upgrade if they forget
+  `collectstatic --clear`. The server runs new code; the browser loads
+  old client.js → wire-protocol skew → mysterious VDOM patch failures.
+  #1081 was reopened twice before the reporter root-caused this
+  structurally-recurring trap.
+
+  C013 compares the SHA-256 of `STATIC_ROOT/djust/client.min.js`
+  against the wheel-bundled copy at `python/djust/static/djust/client.min.js`.
+  When they diverge, emits a Django system warning at startup with the
+  exact fix command. No-op when `STATIC_ROOT` is unset, when the
+  collected file is absent (pre-collectstatic), or when content matches.
+  Honors `DJUST_CONFIG = {"suppress_checks": ["C013"]}` for users who
+  serve `client.min.js` from a CDN or custom build.
+
+  Files: `python/djust/checks.py` (new `_check_stale_collected_client`,
+  wired into `check_configuration`); 5 cases in `TestC013StaleCollectstatic`
+  in `python/tests/test_checks.py` cover no-STATIC_ROOT skip,
+  no-collected-file skip, matching-content quiet, diverged-content
+  warning, suppress-via-DJUST_CONFIG silence.
+
+### Fixed
+
+- **`|date` and `|time` filters now debug-log on parse failure (closes
+  #1090)** — both filters previously fell through silently to the
+  original value when chrono failed to parse the input string. The
+  #1081 4-round-reopen investigation would have collapsed to a
+  5-minute diagnosis if a single line had been logged at parse-failure
+  time. Now the failure is surfaced via `tracing::debug!` against
+  target `djust.templates.filters` with the offending value, format
+  string, and chrono error message.
+
+  Enable via Python `LOGGING['loggers']['djust.templates.filters'] =
+  {'level': 'DEBUG'}` or set `RUST_LOG=djust.templates.filters=debug`
+  for the Rust-side `tracing` consumer. Behavior unchanged when the
+  log target is disabled — just no longer a silent void.
+
+  Files: `crates/djust_templates/Cargo.toml` (added `tracing`
+  workspace dep), `crates/djust_templates/src/filters.rs` (`|date`
+  arm at line ~248, `|time` arm at line ~284 — replaced
+  `Err(_) => Ok(value.clone())` with `Err(e) => { tracing::debug!(...);
+  Ok(value.clone()) }`).
+
+- **`_flush_deferred_to_sse` legacy-view guard now has a regression
+  test (closes #1093)** — Stage 13 review of PR #1091 flagged that the
+  WS-side `hasattr` guard had a parallel test
+  (`test_flush_deferred_handles_view_without_drain_method`) but the
+  SSE-side did not. New `test_sse_flush_deferred_handles_view_without_drain_method`
+  in `python/djust/tests/test_defer.py` mirrors the WS shape — a
+  legacy view class without `_drain_deferred` must short-circuit
+  cleanly without `AttributeError`.
+
+- **Release wheel matrix expanded to cp313 + cp314 (closes #1089)** —
+  `.github/workflows/release.yml` previously built only cp310/cp311/cp312
+  wheels. Users on Python 3.13 or 3.14 fell back to source-compiling
+  the sdist at `pip install` time, producing untested binaries whose
+  runtime behavior could diverge from CI-tested cp312 (this was the
+  root cause of #1081's first reopen — reporter on 3.14 hit a source-
+  compiled `_rust.cpython-314-darwin.so`). Matrix now ships tested
+  wheels for cp310–cp314 across Linux x86_64, macOS Intel + ARM, and
+  Windows x86_64 (Windows still excludes 3.10 per the existing
+  policy).
+
 - **View Transitions API integration in `applyPatches` (PR-B / ADR-013)** —
   Opt-in via `<body dj-view-transitions>`. When the browser supports
   `document.startViewTransition()` AND the body attribute is present

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "0.8.4-rc.1"
+version = "0.8.5-rc.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "0.8.4-rc.1"
+version = "0.8.5-rc.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "0.8.4-rc.1"
+version = "0.8.5-rc.1"
 dependencies = [
  "bincode",
  "criterion",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "0.8.4-rc.1"
+version = "0.8.5-rc.1"
 dependencies = [
  "ahash",
  "chrono",
@@ -365,11 +365,12 @@ dependencies = [
  "smallvec",
  "tempfile",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "djust_vdom"
-version = "0.8.4-rc.1"
+version = "0.8.5-rc.1"
 dependencies = [
  "ahash",
  "criterion",

--- a/crates/djust_templates/Cargo.toml
+++ b/crates/djust_templates/Cargo.toml
@@ -18,6 +18,7 @@ regex.workspace = true
 once_cell.workspace = true
 thiserror.workspace = true
 chrono.workspace = true
+tracing = { workspace = true }
 pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
 djust_core = { path = "../djust_core" }
 djust_components = { path = "../djust_components" }

--- a/crates/djust_templates/src/filters.rs
+++ b/crates/djust_templates/src/filters.rs
@@ -247,7 +247,21 @@ pub fn apply_filter_with_context(
             let datetime_str = value.to_string();
             match format_date(&datetime_str, format_str) {
                 Ok(formatted) => Ok(Value::String(formatted)),
-                Err(_) => Ok(value.clone()), // If parsing fails, return original value
+                Err(e) => {
+                    // #1090: surface silent parse failures so template authors
+                    // can diagnose without instrumentation. Common cause:
+                    // upstream JSON-encoding of datetime objects produces
+                    // strings with embedded literal `\"` chars that don't
+                    // round-trip through chrono's parsers.
+                    tracing::debug!(
+                        target: "djust.templates.filters",
+                        value = %datetime_str,
+                        format = %format_str,
+                        error = %e,
+                        "|date filter parse failed; returning original value unchanged",
+                    );
+                    Ok(value.clone()) // If parsing fails, return original value
+                }
             }
         }
         "time" => {
@@ -269,7 +283,18 @@ pub fn apply_filter_with_context(
             let datetime_str = value.to_string();
             match format_time(&datetime_str, format_str) {
                 Ok(formatted) => Ok(Value::String(formatted)),
-                Err(_) => Ok(value.clone()),
+                Err(e) => {
+                    // #1090: see |date filter — same parse-failure surface,
+                    // same diagnostic value when log target is enabled.
+                    tracing::debug!(
+                        target: "djust.templates.filters",
+                        value = %datetime_str,
+                        format = %format_str,
+                        error = %e,
+                        "|time filter parse failed; returning original value unchanged",
+                    );
+                    Ok(value.clone())
+                }
             }
         }
         "dictsort" => {

--- a/python/djust/checks.py
+++ b/python/djust/checks.py
@@ -285,6 +285,83 @@ def _check_missing_compiled_css(errors):
                 )
 
 
+def _check_stale_collected_client(errors):
+    """C013 — STATIC_ROOT/djust/client.min.js is older than the wheel-bundled
+    copy at python/djust/static/djust/client.min.js (closes #1088).
+
+    The trap: anyone with STATIC_ROOT configured (typical production setup
+    behind WhiteNoise / nginx / a CDN) can ship a stale client.min.js after
+    a djust wheel upgrade if they forget `collectstatic --clear`. The
+    server runs new code; the browser loads old client.js → wire-protocol
+    skew → mysterious VDOM patch failures. #1081 was reopened twice
+    before the reporter root-caused this.
+
+    Honors DJUST_CONFIG['suppress_checks'] = ['C013'] for users who
+    deliberately serve client.min.js from elsewhere (CDN, custom build).
+    """
+    import hashlib
+    from pathlib import Path
+
+    from django.conf import settings
+
+    if _is_check_suppressed("djust.C013"):
+        return
+
+    static_root = getattr(settings, "STATIC_ROOT", None)
+    if not static_root:
+        # No STATIC_ROOT means collectstatic isn't part of the deploy story
+        return
+
+    collected = Path(static_root) / "djust" / "client.min.js"
+    if not collected.exists():
+        # Either collectstatic hasn't run or the user serves client.min.js
+        # from a different path. Either way, not our problem to flag here —
+        # C011 (missing compiled CSS) and C012 (manual client.js) cover the
+        # related symptoms.
+        return
+
+    # Find the wheel-bundled copy. djust.__file__ resolves to the installed
+    # package path; static/djust/client.min.js is right alongside.
+    try:
+        from djust import __file__ as djust_init_path
+    except ImportError:
+        return
+    wheel_bundled = Path(djust_init_path).parent / "static" / "djust" / "client.min.js"
+    if not wheel_bundled.exists():
+        return
+
+    # Compare by content hash — mtime is unreliable across pip-install,
+    # tar extraction, file-system mounts.
+    def _sha256(p: Path) -> str:
+        h = hashlib.sha256()
+        with open(p, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                h.update(chunk)
+        return h.hexdigest()
+
+    try:
+        if _sha256(collected) == _sha256(wheel_bundled):
+            return  # Up-to-date — quiet
+    except OSError:
+        return  # Permission / IO error — don't fail the check at startup
+
+    errors.append(
+        DjustWarning(
+            f"Stale collectstatic copy of client.min.js detected at "
+            f"{collected}. The wheel-bundled copy is different — your browser "
+            f"will load outdated client code.",
+            hint=(
+                "Run `python manage.py collectstatic --clear --noinput` to refresh, "
+                "then hard-reload the browser (Cmd+Shift+R / Ctrl+Shift+R). "
+                "Suppress this check with DJUST_CONFIG = {'suppress_checks': ['C013']} "
+                "if you serve client.min.js from a CDN or custom build."
+            ),
+            id="djust.C013",
+            fix_hint=("Run: python manage.py collectstatic --clear --noinput"),
+        )
+    )
+
+
 def _check_manual_client_js(errors):
     """Detect manual client.js loading in base templates (causes double-loading)."""
     template_dirs = _get_template_dirs()
@@ -531,6 +608,9 @@ def check_configuration(app_configs, **kwargs):
 
     # C012 -- Manual client.js in base templates
     _check_manual_client_js(errors)
+
+    # C013 -- Stale collectstatic copy of client.min.js (closes #1088)
+    _check_stale_collected_client(errors)
 
     # C005 -- WebSocket routes missing AuthMiddlewareStack
     # A001 -- WebSocket routes missing AllowedHostsOriginValidator (#659)

--- a/python/djust/tests/test_defer.py
+++ b/python/djust/tests/test_defer.py
@@ -383,6 +383,24 @@ async def test_sse_flush_deferred_handles_no_view_instance():
 
 
 @pytest.mark.asyncio
+async def test_sse_flush_deferred_handles_view_without_drain_method():
+    """Closes #1093: SSE-side parallel of the WS-side legacy-view guard test.
+
+    A view that doesn't subclass ``AsyncWorkMixin`` lacks ``_drain_deferred``;
+    the ``hasattr`` guard at ``python/djust/sse.py`` must short-circuit
+    cleanly without ``AttributeError``. Defensive against legacy or
+    third-party view classes that don't inherit ``LiveView``'s mixin chain.
+    """
+    from djust.sse import _flush_deferred_to_sse
+
+    class _LegacyView:
+        pass  # No _drain_deferred attribute
+
+    # Should be a no-op, not raise
+    await _flush_deferred_to_sse(_LegacyView())
+
+
+@pytest.mark.asyncio
 async def test_sse_flush_deferred_isolates_callback_exceptions(caplog):
     """SSE-side exception isolation must match WS-side: failed callback
     logs at WARN and execution continues."""

--- a/python/tests/test_checks.py
+++ b/python/tests/test_checks.py
@@ -679,6 +679,97 @@ def _force_gc():
     gc.collect()
 
 
+class TestC013StaleCollectstatic:
+    """C013 — stale collectstatic copy of client.min.js (closes #1088)."""
+
+    def _baseline_settings(self, settings):
+        settings.ASGI_APPLICATION = "myproject.asgi.application"
+        settings.CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+        settings.INSTALLED_APPS = ["daphne", "django.contrib.staticfiles", "djust"]
+
+    def test_c013_no_static_root_skips(self, tmp_path, settings):
+        """No STATIC_ROOT configured → check is a no-op."""
+        self._baseline_settings(settings)
+        settings.STATIC_ROOT = None
+
+        from djust.checks import check_configuration
+
+        errors = check_configuration(None)
+        c013 = [e for e in errors if e.id == "djust.C013"]
+        assert len(c013) == 0
+
+    def test_c013_no_collected_file_skips(self, tmp_path, settings):
+        """STATIC_ROOT exists but no djust/client.min.js inside → no-op."""
+        self._baseline_settings(settings)
+        settings.STATIC_ROOT = str(tmp_path)
+
+        from djust.checks import check_configuration
+
+        errors = check_configuration(None)
+        c013 = [e for e in errors if e.id == "djust.C013"]
+        assert len(c013) == 0
+
+    def test_c013_matching_content_quiet(self, tmp_path, settings):
+        """Collected copy hashes-equal to wheel-bundled → no warning."""
+        self._baseline_settings(settings)
+        settings.STATIC_ROOT = str(tmp_path)
+
+        # Mirror the wheel's client.min.js exactly into STATIC_ROOT
+        from djust import __file__ as djust_init
+        from pathlib import Path
+        import shutil
+
+        wheel_path = Path(djust_init).parent / "static" / "djust" / "client.min.js"
+        if not wheel_path.exists():
+            import pytest
+
+            pytest.skip("wheel-bundled client.min.js not present in this dev tree")
+
+        target_dir = tmp_path / "djust"
+        target_dir.mkdir()
+        shutil.copyfile(wheel_path, target_dir / "client.min.js")
+
+        from djust.checks import check_configuration
+
+        errors = check_configuration(None)
+        c013 = [e for e in errors if e.id == "djust.C013"]
+        assert len(c013) == 0
+
+    def test_c013_diverged_content_warns(self, tmp_path, settings):
+        """Collected copy diverges from wheel-bundled → warning."""
+        self._baseline_settings(settings)
+        settings.STATIC_ROOT = str(tmp_path)
+
+        target_dir = tmp_path / "djust"
+        target_dir.mkdir()
+        # Plant intentionally-stale content
+        (target_dir / "client.min.js").write_bytes(b"// stale 0.5.5rc1-era client\n")
+
+        from djust.checks import check_configuration
+
+        errors = check_configuration(None)
+        c013 = [e for e in errors if e.id == "djust.C013"]
+        assert len(c013) == 1
+        assert "Stale collectstatic" in c013[0].msg
+        assert "collectstatic --clear" in c013[0].hint
+
+    def test_c013_suppressed_via_djust_config(self, tmp_path, settings):
+        """DJUST_CONFIG['suppress_checks'] = ['C013'] silences the check."""
+        self._baseline_settings(settings)
+        settings.STATIC_ROOT = str(tmp_path)
+        settings.DJUST_CONFIG = {"suppress_checks": ["C013"]}
+
+        target_dir = tmp_path / "djust"
+        target_dir.mkdir()
+        (target_dir / "client.min.js").write_bytes(b"// stale content\n")
+
+        from djust.checks import check_configuration
+
+        errors = check_configuration(None)
+        c013 = [e for e in errors if e.id == "djust.C013"]
+        assert len(c013) == 0
+
+
 class TestV001MissingTemplateName:
     """V001 -- missing template_name on LiveView subclass."""
 


### PR DESCRIPTION
## Summary

Single batch PR for 4 unrelated framework gaps surfaced by the v0.8.5 arc retros and Stage 13 review of PR #1091.

## Issues closed

### #1093 — SSE-side `_flush_deferred_to_sse` legacy-view guard test (test-only)
Stage 13 review of PR #1091 flagged that the WS-side has a parallel test (`test_flush_deferred_handles_view_without_drain_method`) but the SSE-side only covered `view_instance=None`. Added `test_sse_flush_deferred_handles_view_without_drain_method` — mirrors WS shape.

### #1090 — debug-log on `|date` / `|time` filter parse failure
Both filters previously fell through silently to the original value when chrono parse failed. The #1081 4-round-reopen investigation would have collapsed to a 5-minute diagnosis with this log. Added `tracing::debug!` against target `djust.templates.filters` with offending value, format string, and chrono error. New `tracing` workspace dep in `djust_templates`; enable via `RUST_LOG=djust.templates.filters=debug` or Python LOGGING config.

### #1088 — `djust.C013` system check for stale `collectstatic` `client.min.js`
Anyone with `STATIC_ROOT` configured can ship a stale `client.min.js` after a wheel upgrade if they forget `collectstatic --clear`. Server runs new code; browser loads old client.js → wire-protocol skew. C013 compares SHA-256 of `STATIC_ROOT/djust/client.min.js` to the wheel-bundled copy at startup. Honors `DJUST_CONFIG['suppress_checks']=['C013']` for users who serve `client.min.js` from a CDN or custom build.

### #1089 — release wheel matrix expanded to cp313 + cp314
`.github/workflows/release.yml` previously built only cp310/cp311/cp312. Users on 3.13/3.14 fell back to source-compiling the sdist at `pip install` time → untested binaries (root cause of #1081's first reopen). Matrix now ships tested wheels for cp310–cp314 across Linux x86_64, macOS Intel + ARM, Windows x86_64.

## Test plan

- [x] `TestC013StaleCollectstatic` (5 cases): no-STATIC_ROOT skip, no-collected-file skip, matching-content quiet, diverged-content warning, suppress-via-DJUST_CONFIG silence
- [x] `test_sse_flush_deferred_handles_view_without_drain_method` mirrors the WS-side shape
- [x] 4745 Python pass; 1414 JS pass
- [x] Rust crate builds clean with new `tracing` dep
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)