### PR TITLE
fix(components): DataTableMixin LiveView compat — pre-mount guard + @event_handler decoration (closes #1114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`DataTableMixin` LiveView compatibility — pre-mount guard +
+  `@event_handler()` decoration on all `on_table_*` methods (closes
+  #1114)** — using `DataTableMixin` in a `LiveView` (rather than a
+  `Component`) caused a blank/empty table on every page load even
+  when `refresh_table_server()` correctly populated `self.table_rows`
+  in `mount()`. Three compounding root causes:
+
+  1. **BUG-06 pre-mount lifecycle**: djust's WebSocket consumer calls
+     `get_context_data()` (which often calls `get_table_context()`)
+     BEFORE `mount()` runs, to build the initial Rust VDOM snapshot.
+     `init_table_state()` hadn't run yet, so `self.table_rows` didn't
+     exist and `get_table_context()` raised `AttributeError`. djust
+     caught it silently → empty initial VDOM → all subsequent VDOM
+     patches diff against empty content → wrong renders.
+  2. **Missing `@event_handler()` decoration**: `on_table_sort`,
+     `on_table_search`, and 19 other handlers were plain methods.
+     djust's default `event_security="strict"` rejected them — every
+     consumer had to write wrapper boilerplate.
+  3. **Documentation gap**: the API boundary between Component and
+     LiveView use cases wasn't called out anywhere in the mixin's
+     docstring.
+
+  Fix: `get_table_context()` now guards on `hasattr(self, "table_rows")`
+  and returns `_PRE_MOUNT_TABLE_CONTEXT` (a module-level minimal
+  default with every key the `{% data_table %}` template tag reads —
+  ~80 keys covering all 5 phases). All 21 `on_table_*` handlers now
+  carry `@event_handler()` decoration. Mixin docstring expanded with a
+  "LiveView vs Component lifecycle" note + recommended pattern for
+  large datasets (pass queryset directly via `get_context_data()`,
+  define `@event_handler()` methods on the view).
+
+  Downstream impact: nyc-claims PR #189 attempted migration and hit
+  this; PR #191 reverted to native handlers. With this fix,
+  `DataTableMixin` is usable from `LiveView` subclasses without
+  per-handler boilerplate.
+
+  8 regression cases in
+  `python/tests/test_data_table_mixin_liveview.py` cover: pre-mount
+  call doesn't raise; pre-mount returns the default; post-mount
+  returns real state; pre-mount key set is a superset of post-mount
+  (catches future post-mount additions that forgot to update the
+  default); all 21 expected handlers have `_djust_decorators`
+  metadata; handler count matches expected (catches future additions
+  that forgot decoration); docstring mentions LiveView lifecycle and
+  `@event_handler()` decoration (catches doc-rot).
+
 - **`handleMessage` interleaving across `await` boundaries (closes #1098)** —
   PR-A (v0.8.5rc1) made `LiveViewWebSocket.handleMessage` and
   `LiveViewSSE.handleMessage` async without serializing the inbound

--- a/python/djust/components/mixins/data_table.py
+++ b/python/djust/components/mixins/data_table.py
@@ -34,6 +34,7 @@ import math
 import re
 
 from djust.components.utils import format_cell, interpolate_color_gradient
+from djust.decorators import event_handler
 
 __all__ = ["DataTableMixin"]
 
@@ -183,8 +184,139 @@ def _safe_eval_arithmetic(expression, namespace):
     return parser.parse()
 
 
+# Minimal context returned by ``DataTableMixin.get_table_context()`` when
+# ``init_table_state()`` hasn't been called yet (e.g. during the pre-mount
+# ``get_context_data()`` build of the initial Rust VDOM snapshot — see
+# #1114). The ``{% data_table %}`` template tag must render this as an
+# empty table without raising.
+_PRE_MOUNT_TABLE_CONTEXT = {
+    "rows": [],
+    "columns": [],
+    "sort_by": "",
+    "sort_desc": False,
+    "sort_event": "table_sort",
+    "selectable": False,
+    "selected_rows": [],
+    "select_event": "table_select",
+    "row_key": "id",
+    "search": False,
+    "search_query": "",
+    "search_event": "table_search",
+    "search_debounce": 300,
+    "filters": {},
+    "filter_event": "table_filter",
+    "loading": False,
+    "empty_title": "No data",
+    "empty_description": "",
+    "empty_icon": "",
+    "paginate": False,
+    "page": 1,
+    "total_pages": 1,
+    "page_event": "table_page",
+    "striped": False,
+    "compact": False,
+    # Phase 2-5 keys default to falsy/empty so the template tag's
+    # ``{% if %}`` guards short-circuit and no event handlers wire up.
+    "editable_columns": [],
+    "edit_event": "table_cell_edit",
+    "resizable": False,
+    "reorderable": False,
+    "reorder_event": "table_reorder",
+    "frozen_left": 0,
+    "frozen_right": 0,
+    "column_visibility": False,
+    "visibility_event": "table_visibility",
+    "density": "comfortable",
+    "density_toggle": False,
+    "density_event": "table_density",
+    "responsive_cards": False,
+    "editable_rows": False,
+    "edit_row_event": "table_row_edit",
+    "save_row_event": "table_row_save",
+    "cancel_row_event": "table_row_cancel",
+    "editing_rows": [],
+    "expandable": False,
+    "expand_event": "table_expand",
+    "expanded_rows": [],
+    "bulk_actions": [],
+    "bulk_action_event": "table_bulk_action",
+    "exportable": False,
+    "export_event": "table_export",
+    "export_formats": ["csv", "json"],
+    "group_by": "",
+    "group_event": "table_group",
+    "group_toggle_event": "table_group_toggle",
+    "collapsible_groups": True,
+    "collapsed_groups": [],
+    "keyboard_nav": False,
+    "virtual_scroll": False,
+    "virtual_row_height": 40,
+    "virtual_buffer": 5,
+    "server_mode": False,
+    "facets": False,
+    "facet_counts": {},
+    "persist_key": "",
+    "printable": False,
+    "show_stats": False,
+    "column_stats": {},
+    "footer_aggregations": {},
+    "row_class_map": {},
+    "column_groups": [],
+    "row_drag": False,
+    "row_drag_event": "table_row_drag",
+    "copyable": False,
+    "copy_event": "table_copy",
+    "copy_format": "csv",
+    "importable": False,
+    "import_event": "table_import",
+    "import_formats": ["csv", "json"],
+    "import_preview": True,
+    "import_preview_data": [],
+    "import_errors": [],
+    "import_pending": False,
+    "computed_columns": [],
+    "cell_merge_key": "_merge",
+    "column_expressions": {},
+    "expression_event": "table_expression",
+    "active_expressions": {},
+    "conditional_formatting": [],
+    "row_order": [],
+    "current_group_by": "",
+    "column_order": [],
+    "visible_columns": [],
+    "current_density": "comfortable",
+}
+
+
 class DataTableMixin:
-    """Mixin for LiveViews that provides automatic data table event handlers."""
+    """Mixin for LiveViews that provides automatic data table event handlers.
+
+    .. note::
+       **LiveView vs Component lifecycle (#1114)**
+
+       This mixin was originally designed for the ``Component`` API, where
+       ``get_template_context()`` runs only after ``__init__()`` has
+       completed. When used with ``LiveView`` (i.e. a class that mixes in
+       ``DataTableMixin`` AND ``LiveView``), djust's WebSocket consumer
+       calls ``get_context_data()`` BEFORE ``mount()`` runs, to build the
+       initial Rust VDOM snapshot. ``init_table_state()`` (typically called
+       from ``mount()``) hasn't run yet, so instance attributes like
+       ``self.table_rows`` don't exist.
+
+       The mixin handles this automatically via a pre-mount guard in
+       ``get_table_context()`` — the first call returns an empty-table
+       default; subsequent calls (after ``mount()``) return real state.
+
+       **All ``on_table_*`` event handlers below are decorated with
+       ``@event_handler()``** so they work under the default
+       ``event_security="strict"`` mode without per-view boilerplate.
+
+       For LiveView use cases that need FK traversal or large datasets,
+       prefer passing the queryset directly via ``get_context_data()`` and
+       defining ``@event_handler()``-decorated methods on your view —
+       djust's JIT serialization handles ORM objects natively without the
+       JSON-round-trip cost of ``self.table_rows``.
+    """
 
     # ── Class-level configuration ──
     # Note: mutable defaults (lists/dicts) are set to None here to avoid
@@ -329,6 +461,7 @@ class DataTableMixin:
 
     # ── Event Handlers ──
 
+    @event_handler()
     def on_table_sort(self, value, **kwargs):
         """Handle sort event: toggle direction or switch column."""
         column = str(value)
@@ -338,11 +471,13 @@ class DataTableMixin:
             self.table_sort_by = column
             self.table_sort_desc = False
 
+    @event_handler()
     def on_table_search(self, value, **kwargs):
         """Handle search event: update query, reset to page 1."""
         self.table_search_query = str(value)
         self.table_page = 1
 
+    @event_handler()
     def on_table_filter(self, value, column=None, **kwargs):
         """Handle filter event: set or clear per-column filter, reset to page 1."""
         if column is None:
@@ -355,6 +490,7 @@ class DataTableMixin:
             self.table_filters.pop(column, None)
         self.table_page = 1
 
+    @event_handler()
     def on_table_select(self, value, **kwargs):
         """Handle selection event: toggle row or select/deselect all."""
         value = str(value)
@@ -372,6 +508,7 @@ class DataTableMixin:
             else:
                 self.table_selected_rows.append(value)
 
+    @event_handler()
     def on_table_page(self, value, **kwargs):
         """Handle page event: navigate to page number."""
         try:
@@ -382,6 +519,7 @@ class DataTableMixin:
 
     # ── Phase 2 Event Handlers ──
 
+    @event_handler()
     def on_table_cell_edit(self, value, **kwargs):
         """Handle inline cell edit. value is JSON: {row_key, column, value}."""
         try:
@@ -399,29 +537,34 @@ class DataTableMixin:
         """Override this to persist inline cell edits. Called by on_table_cell_edit."""
         pass
 
+    @event_handler()
     def on_table_reorder(self, value, **kwargs):
         """Handle column reorder. value is comma-separated column keys."""
         new_order = [k.strip() for k in str(value).split(",") if k.strip()]
         if new_order:
             self.table_column_order = new_order
 
+    @event_handler()
     def on_table_visibility(self, value, **kwargs):
         """Handle column visibility toggle. value is comma-separated visible keys."""
         visible = [k.strip() for k in str(value).split(",") if k.strip()]
         self.table_visible_columns = visible
 
+    @event_handler()
     def on_table_density(self, value, **kwargs):
         """Handle density toggle. value is 'compact', 'comfortable', or 'spacious'."""
         val = str(value)
         if val in ("compact", "comfortable", "spacious"):
             self.table_current_density = val
 
+    @event_handler()
     def on_table_row_edit(self, value, **kwargs):
         """Handle entering row edit mode."""
         row_id = str(value)
         if row_id not in self.table_editing_rows:
             self.table_editing_rows.append(row_id)
 
+    @event_handler()
     def on_table_row_save(self, value, **kwargs):
         """Handle saving an edited row. Override handle_row_save to persist."""
         row_id = str(value)
@@ -429,6 +572,7 @@ class DataTableMixin:
         if row_id in self.table_editing_rows:
             self.table_editing_rows.remove(row_id)
 
+    @event_handler()
     def on_table_row_cancel(self, value, **kwargs):
         """Handle cancelling row edit."""
         row_id = str(value)
@@ -441,6 +585,7 @@ class DataTableMixin:
 
     # ── Phase 3 Event Handlers ──
 
+    @event_handler()
     def on_table_expand(self, value, **kwargs):
         """Handle row expansion toggle."""
         row_id = str(value)
@@ -449,6 +594,7 @@ class DataTableMixin:
         else:
             self.table_expanded_rows.append(row_id)
 
+    @event_handler()
     def on_table_bulk_action(self, value, **kwargs):
         """Handle bulk action on selected rows."""
         action = str(value)
@@ -458,6 +604,7 @@ class DataTableMixin:
         """Override this to handle bulk actions. Called with action key and selected row IDs."""
         pass
 
+    @event_handler()
     def on_table_export(self, value, **kwargs):
         """Handle export request. value is the format (csv/json)."""
         fmt = str(value)
@@ -489,10 +636,12 @@ class DataTableMixin:
             self.table_export_data = json.dumps(export_rows, default=str)
             self.table_export_format = "json"
 
+    @event_handler()
     def on_table_group(self, value, **kwargs):
         """Handle grouping by column."""
         self.table_current_group_by = str(value)
 
+    @event_handler()
     def on_table_group_toggle(self, value, **kwargs):
         """Handle group collapse/expand toggle."""
         group_key = str(value)
@@ -503,6 +652,7 @@ class DataTableMixin:
 
     # ── Phase 4 Event Handlers ──
 
+    @event_handler()
     def on_table_row_drag(self, value, **kwargs):
         """Handle row drag-and-drop reorder. value is JSON: {old_index, new_index}."""
         try:
@@ -524,6 +674,7 @@ class DataTableMixin:
         """Override this to persist row reorder. Called by on_table_row_drag."""
         pass
 
+    @event_handler()
     def on_table_copy(self, value, **kwargs):
         """Handle copy event. value is JSON list of row keys to copy."""
         try:
@@ -558,6 +709,7 @@ class DataTableMixin:
 
     # ── Phase 5 Event Handlers ──
 
+    @event_handler()
     def on_table_import(self, value, **kwargs):
         """Handle import event. value is JSON: {format, data, confirm}.
 
@@ -637,6 +789,7 @@ class DataTableMixin:
         """Override this to persist imported rows. Default appends to table_rows."""
         self.table_rows.extend(rows)
 
+    @event_handler()
     def on_table_expression(self, value, **kwargs):
         """Handle column expression filter. value is JSON: {column, expression}."""
         try:
@@ -991,7 +1144,27 @@ class DataTableMixin:
     # ── Context Generation ──
 
     def get_table_context(self):
-        """Return a dict suitable for the {% data_table %} template tag."""
+        """Return a dict suitable for the ``{% data_table %}`` template tag.
+
+        **Pre-mount safety (closes #1114)**: djust's WebSocket consumer calls
+        ``get_context_data()`` (which often calls this) BEFORE ``mount()``
+        runs, to build the initial Rust VDOM snapshot. Without ``mount()``,
+        ``init_table_state()`` hasn't run, so instance attributes like
+        ``self.table_rows``, ``self.table_sort_by``, etc. don't exist yet —
+        and a raw attribute read raises ``AttributeError`` (which djust
+        catches silently → empty initial VDOM → all subsequent patches diff
+        against empty content).
+
+        Guard: if ``init_table_state()`` hasn't run, return a minimal
+        pre-mount default that the ``{% data_table %}`` template tag can
+        render as an empty table without errors. The first patch after
+        ``mount()`` resolves to the real state.
+
+        Use a sentinel attribute (``table_rows`` is set as the LAST line
+        of ``init_table_state()``) to detect the pre-mount state cheaply.
+        """
+        if not hasattr(self, "table_rows"):
+            return _PRE_MOUNT_TABLE_CONTEXT
         return {
             "rows": self.table_rows,
             "columns": self.table_columns,

--- a/python/djust/components/mixins/data_table.py
+++ b/python/djust/components/mixins/data_table.py
@@ -1160,8 +1160,11 @@ class DataTableMixin:
         render as an empty table without errors. The first patch after
         ``mount()`` resolves to the real state.
 
-        Use a sentinel attribute (``table_rows`` is set as the LAST line
-        of ``init_table_state()``) to detect the pre-mount state cheaply.
+        Use ``table_rows`` as the sentinel attribute — it's set partway
+        through ``init_table_state()`` and serves as a cheap "init has
+        happened" signal. Any future re-ordering of ``init_table_state()``
+        should keep ``table_rows`` set on the instance before any code
+        path that calls ``get_table_context()`` runs.
         """
         if not hasattr(self, "table_rows"):
             return _PRE_MOUNT_TABLE_CONTEXT

--- a/python/tests/test_data_table_mixin_liveview.py
+++ b/python/tests/test_data_table_mixin_liveview.py
@@ -1,0 +1,165 @@
+"""Regression tests for #1114: DataTableMixin compatibility with LiveView.
+
+Three compounding root causes documented in #1114:
+  1. ``get_context_data()`` runs before ``mount()`` in djust's WS lifecycle,
+     so ``self.table_rows`` doesn't exist → silent ``AttributeError`` →
+     empty initial VDOM → all subsequent patches diff against empty content.
+  2. ``on_table_*`` event handlers aren't ``@event_handler()``-decorated,
+     so they're rejected under default ``event_security="strict"``.
+  3. (Documentation) Mixin authors using LiveView need to know the API
+     boundary differs from the Component case.
+
+This test module covers (1) and (2). (3) is verified by reading the
+docstring (kept in sync as a regression).
+"""
+
+import django
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        INSTALLED_APPS=["django.contrib.contenttypes", "django.contrib.auth"],
+        DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}},
+    )
+    django.setup()
+
+from django.test import TestCase
+
+from djust.components.mixins.data_table import DataTableMixin, _PRE_MOUNT_TABLE_CONTEXT
+
+
+class PreMountGuardTest(TestCase):
+    """get_table_context() must be safe to call before init_table_state()."""
+
+    def test_get_table_context_pre_mount_returns_default(self):
+        """Calling ``get_table_context()`` before ``init_table_state()`` returns
+        the empty-table default rather than raising ``AttributeError``."""
+
+        view = DataTableMixin()
+        # No init_table_state() called — table_rows not set
+        ctx = view.get_table_context()
+
+        # Should be the pre-mount default, not a raised exception
+        self.assertEqual(ctx["rows"], [])
+        self.assertEqual(ctx["columns"], [])
+        self.assertEqual(ctx["page"], 1)
+        self.assertEqual(ctx["sort_by"], "")
+
+    def test_get_table_context_pre_mount_does_not_raise(self):
+        """Pre-mount call must not raise any exception."""
+        view = DataTableMixin()
+        try:
+            view.get_table_context()
+        except Exception as exc:
+            self.fail(f"get_table_context() raised {type(exc).__name__}: {exc}")
+
+    def test_post_mount_returns_real_state(self):
+        """After ``init_table_state()`` runs, real instance state is returned."""
+        view = DataTableMixin()
+        view.table_columns = [{"key": "name", "label": "Name"}]
+        view.init_table_state()
+        view.table_rows = [{"name": "Alice"}, {"name": "Bob"}]
+
+        ctx = view.get_table_context()
+
+        self.assertEqual(len(ctx["rows"]), 2)
+        self.assertEqual(ctx["rows"][0]["name"], "Alice")
+        self.assertEqual(ctx["columns"][0]["key"], "name")
+
+    def test_pre_mount_default_has_required_template_keys(self):
+        """The pre-mount default must contain every key the
+        ``{% data_table %}`` template tag reads — otherwise the template
+        raises VariableDoesNotExist at render time.
+
+        The test asserts the pre-mount dict and the post-mount dict have the
+        same keyset; that way adding a new key to the post-mount path will
+        flag (via this test) that the pre-mount default needs updating too.
+        """
+        view = DataTableMixin()
+        view.table_columns = [{"key": "name"}]
+        view.init_table_state()
+        view.table_rows = []
+        post_mount_keys = set(view.get_table_context().keys())
+        pre_mount_keys = set(_PRE_MOUNT_TABLE_CONTEXT.keys())
+
+        missing = post_mount_keys - pre_mount_keys
+        self.assertFalse(
+            missing,
+            f"Pre-mount default is missing keys present post-mount: {missing}",
+        )
+
+
+class EventHandlerDecorationTest(TestCase):
+    """All on_table_* methods must carry the @event_handler() decorator
+    so they work under default event_security="strict" mode."""
+
+    EXPECTED_HANDLERS = [
+        "on_table_sort",
+        "on_table_search",
+        "on_table_filter",
+        "on_table_select",
+        "on_table_page",
+        "on_table_cell_edit",
+        "on_table_reorder",
+        "on_table_visibility",
+        "on_table_density",
+        "on_table_row_edit",
+        "on_table_row_save",
+        "on_table_row_cancel",
+        "on_table_expand",
+        "on_table_bulk_action",
+        "on_table_export",
+        "on_table_group",
+        "on_table_group_toggle",
+        "on_table_row_drag",
+        "on_table_copy",
+        "on_table_import",
+        "on_table_expression",
+    ]
+
+    def test_all_on_table_methods_decorated(self):
+        """Every documented on_table_* method must have _djust_decorators
+        metadata (the marker @event_handler() leaves)."""
+        missing = []
+        for name in self.EXPECTED_HANDLERS:
+            method = getattr(DataTableMixin, name, None)
+            if method is None:
+                missing.append(f"{name} (not found on DataTableMixin)")
+                continue
+            metadata = getattr(method, "_djust_decorators", None)
+            if not metadata or "event_handler" not in metadata:
+                missing.append(f"{name} (no @event_handler() decoration)")
+
+        self.assertFalse(
+            missing,
+            f"Methods missing @event_handler() decoration: {missing}",
+        )
+
+    def test_handler_count_matches_expected(self):
+        """Sanity: 21 documented handlers; if a future PR adds more, this
+        flags that EXPECTED_HANDLERS needs updating."""
+        actual = [
+            name
+            for name in dir(DataTableMixin)
+            if name.startswith("on_table_") and callable(getattr(DataTableMixin, name))
+        ]
+        self.assertEqual(
+            sorted(actual),
+            sorted(self.EXPECTED_HANDLERS),
+            "EXPECTED_HANDLERS list is out of sync with DataTableMixin",
+        )
+
+
+class DocstringRegressionTest(TestCase):
+    """The mixin docstring must explain the LiveView pre-mount lifecycle
+    (root cause 3 of #1114). Catches doc-rot if a future refactor strips it."""
+
+    def test_docstring_mentions_lifecycle(self):
+        doc = DataTableMixin.__doc__ or ""
+        self.assertIn("LiveView", doc)
+        self.assertIn("mount", doc)
+        self.assertIn("get_context_data", doc)
+
+    def test_docstring_mentions_event_handler_decoration(self):
+        doc = DataTableMixin.__doc__ or ""
+        self.assertIn("event_handler", doc)


### PR DESCRIPTION
## Summary

Closes #1114 (HIGH severity). `DataTableMixin` in a `LiveView` (rather than a `Component`) caused a blank/empty table on every page load. nyc-claims PR #189 hit this and reverted in PR #191.

## Root causes (3 compounding)

1. **BUG-06 pre-mount lifecycle** — djust's WebSocket consumer calls `get_context_data()` (which often calls `get_table_context()`) BEFORE `mount()` runs. `init_table_state()` hadn't run, `self.table_rows` didn't exist, `get_table_context()` raised `AttributeError` silently → empty initial VDOM → all subsequent VDOM patches diff against empty content.
2. **Missing `@event_handler()` decoration** on the 21 `on_table_*` methods. Default `event_security="strict"` rejected them.
3. **Documentation gap** — the LiveView vs Component API boundary wasn't called out anywhere.

## Fixes

| File | Change |
|---|---|
| `python/djust/components/mixins/data_table.py` | New module-level `_PRE_MOUNT_TABLE_CONTEXT` (~80 keys covering Phase 1-5); `get_table_context()` guards on `hasattr(self, 'table_rows')`; all 21 `on_table_*` handlers decorated with `@event_handler()`; mixin docstring expanded with LiveView lifecycle note + recommended pattern |
| `python/tests/test_data_table_mixin_liveview.py` | New 8-case test file |
| `CHANGELOG.md` | `[Unreleased] / Fixed` entry |

## Test plan

| Issue # | File touched | Test class |
|---|---|---|
| #1114 root cause 1 | `data_table.py` pre-mount guard | `PreMountGuardTest` (4 cases) |
| #1114 root cause 2 | `data_table.py` 21 decorators | `EventHandlerDecorationTest` (2 cases) |
| #1114 root cause 3 | `data_table.py` docstring | `DocstringRegressionTest` (2 cases) |

- [x] 8 new cases pass; 4753 Python pass overall
- [x] Pre-mount key set is a superset of post-mount (catches future post-mount additions that forgot to update the default)
- [x] Handler count matches expected (catches future additions that forgot decoration)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)