### PR TITLE
feat(data_table): link column type + row-level navigation (closes #1110, #1111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `table_row_click_value_key`, and `table_row_url` class attributes,
   threaded through `get_table_context()` and `_PRE_MOUNT_TABLE_CONTEXT`.
 
+  **Security note for Option A (`row_url`)**: the URL flows into JS via
+  `onclick="window.location=this.dataset.href"`. Only assign
+  developer-controlled URLs (typically computed from `reverse()`);
+  user-controlled strings could enable `javascript:` URI execution.
+  **CSP note**: Option A requires `'unsafe-inline'` in `script-src`;
+  prefer Option B (LiveView event) when CSP is strict. Option B is
+  CSP-clean — the click is dispatched via the existing djust event
+  pipeline, no inline JS executed.
+
   14 regression cases in `python/tests/test_data_table_link_row_nav.py`
   cover: link-column emits `<a>`; link_class flows through; no-link
   pre-#1110 compat; `row_click_event` adds `dj-click` to every `<tr>`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ROADMAP Phoenix LiveView Parity Tracker `View Transitions API` →
   shipped. Quick Win #23 closed.
 
+### Added
+
+- **`{% data_table %}` link column type (closes #1110)** — column dicts
+  now accept a `link` key naming another row dict key that holds the
+  href, and an optional `link_class` for the `<a>` element's CSS class:
+
+  ```python
+  table_columns = [
+      {"key": "claim_number", "label": "Claim #", "link": "claim_url",
+       "link_class": "claim-link"},
+  ]
+  # row dicts include both keys:
+  {"claim_number": "2026PI000001", "claim_url": "/claims/1/", ...}
+  ```
+
+  Renders as:
+
+  ```html
+  <td><a href="/claims/1/" class="claim-link">2026PI000001</a></td>
+  ```
+
+  Falls through to plain text when `col.link` is unset — strict
+  backwards-compat with pre-#1110 column dicts. Replaces the
+  `_inject_link_column` regex post-process workaround downstream
+  consumers had to maintain (e.g. nyc-claims).
+
+- **`{% data_table %}` row-level navigation: `row_click_event` + `row_url`
+  (closes #1111)** — the entire `<tr>` becomes clickable for navigation.
+  Two API shapes:
+
+  **Option B (preferred — LiveView-idiomatic)**: `row_click_event` fires
+  a djust event with `data-value=row[row_click_value_key]`. Default
+  value key is `"id"`; override per-table for slug-based routing:
+
+  ```python
+  table_row_click_event = "open_claim"
+  table_row_click_value_key = "uuid"
+  ```
+
+  ```python
+  @event_handler()
+  def open_claim(self, value: str = "", **kwargs):
+      self.redirect(reverse("claims:detail", kwargs={"claim_id": value}))
+  ```
+
+  **Option A (static URL fallback)**: `row_url` names a row dict key
+  containing the href; the `<tr>` gets `data-href` + an `onclick` that
+  reads `this.dataset.href` and navigates:
+
+  ```python
+  table_row_url = "claim_url"
+  ```
+
+  Both options also wire `style="cursor:pointer"` on each `<tr>` for
+  the affordance. `row_click_event` takes precedence when both are set.
+  Mirrored in `DataTableMixin` via `table_row_click_event`,
+  `table_row_click_value_key`, and `table_row_url` class attributes,
+  threaded through `get_table_context()` and `_PRE_MOUNT_TABLE_CONTEXT`.
+
+  14 regression cases in `python/tests/test_data_table_link_row_nav.py`
+  cover: link-column emits `<a>`; link_class flows through; no-link
+  pre-#1110 compat; `row_click_event` adds `dj-click` to every `<tr>`;
+  `row_click_value_key` overrides default `id`; absent `row_click_event`
+  → no `<tr>` `dj-click` (compat); `row_url` adds `data-href` + JS;
+  `row_click_event` precedence over `row_url`; mixin class-attr
+  defaults; per-view override; pre-mount default + post-mount context
+  + template-tag function include all 3 new keys.
+
 ### Fixed
 
 - **`DataTableMixin` LiveView compatibility — pre-mount guard +

--- a/python/djust/components/mixins/data_table.py
+++ b/python/djust/components/mixins/data_table.py
@@ -285,6 +285,10 @@ _PRE_MOUNT_TABLE_CONTEXT = {
     "column_order": [],
     "visible_columns": [],
     "current_density": "comfortable",
+    # Phase 6 (#1111: row-level navigation)
+    "row_click_event": "",
+    "row_click_value_key": "id",
+    "row_url": "",
 }
 
 
@@ -400,6 +404,13 @@ class DataTableMixin:
     table_column_expressions = None  # {col_key: expression_string} for advanced filtering
     table_expression_event = "table_expression"
     table_conditional_formatting = None  # list of formatting preset dicts
+
+    # Phase 6 class-level configuration (#1111: row-level navigation)
+    table_row_click_event = (
+        ""  # if set, dj-click fires per row with data-value=row[row_click_value_key]
+    )
+    table_row_click_value_key = "id"  # which row key to send as data-value
+    table_row_url = ""  # if set, row becomes a static link (Option A in #1111)
 
     def init_table_state(self):
         """Initialize instance state. Call from mount()."""
@@ -1260,6 +1271,10 @@ class DataTableMixin:
             "expression_event": self.table_expression_event,
             "active_expressions": self.table_active_expressions,
             "conditional_formatting": self.table_conditional_formatting,
+            # Phase 6 (#1111: row-level navigation)
+            "row_click_event": self.table_row_click_event,
+            "row_click_value_key": self.table_row_click_value_key,
+            "row_url": self.table_row_url,
         }
 
     # ── Queryset Pipeline ──

--- a/python/djust/components/templates/djust_components/table.html
+++ b/python/djust/components/templates/djust_components/table.html
@@ -39,7 +39,10 @@
     </thead>
     <tbody>
       {% for row in rows %}
-      <tr{% if selectable %} aria-selected="{% if row.id|stringformat:'s' in selected_rows %}true{% else %}false{% endif %}"{% endif %}>
+      {# #1111: row-level navigation. row_click_event fires a djust event
+         (LiveView-idiomatic, preferred); row_url is a static fallback that
+         uses dataset+JS to navigate without LiveView routing. #}
+      <tr{% if selectable %} aria-selected="{% if row.id|stringformat:'s' in selected_rows %}true{% else %}false{% endif %}"{% endif %}{% if row_click_event %} dj-click="{{ row_click_event }}" data-value="{{ row|dictsort:row_click_value_key|first }}" style="cursor:pointer"{% elif row_url %} data-href="{{ row|dictsort:row_url|first }}" style="cursor:pointer" onclick="window.location=this.dataset.href"{% endif %}>
         {% if selectable %}
         <td>
           <input type="checkbox" class="data-table-checkbox"
@@ -49,7 +52,11 @@
         </td>
         {% endif %}
         {% for col in columns %}
-        <td>{{ row|dictsort:col.key|first }}</td>
+        {# #1110: link column type. col.link names a key in the same row
+           dict that holds the href; col.link_class is an optional CSS
+           class on the <a>. Falls through to plain text when col.link
+           is unset, preserving pre-#1110 behavior. #}
+        <td>{% if col.link %}<a href="{{ row|dictsort:col.link|first }}"{% if col.link_class %} class="{{ col.link_class }}"{% endif %}>{{ row|dictsort:col.key|first }}</a>{% else %}{{ row|dictsort:col.key|first }}{% endif %}</td>
         {% endfor %}
       </tr>
       {% empty %}

--- a/python/djust/components/templatetags/djust_components.py
+++ b/python/djust/components/templatetags/djust_components.py
@@ -595,6 +595,10 @@ def data_table(
     expression_event="table_expression",
     active_expressions=None,
     conditional_formatting=None,
+    # Phase 6 params (#1111: row-level navigation)
+    row_click_event="",
+    row_click_value_key="id",
+    row_url="",
 ):
     """Render a sortable data table with search, filters, selection, pagination, and editing.
 
@@ -791,6 +795,10 @@ def data_table(
         "expression_event": expression_event,
         "active_expressions": active_expressions or {},
         "conditional_formatting": conditional_formatting or [],
+        # Phase 6 (#1111: row-level navigation)
+        "row_click_event": row_click_event,
+        "row_click_value_key": row_click_value_key,
+        "row_url": row_url,
     }
 
 

--- a/python/djust/components/templatetags/djust_components.py
+++ b/python/djust/components/templatetags/djust_components.py
@@ -700,6 +700,31 @@ def data_table(
         expression_event: column expression filter event name
         active_expressions: dict of active column expression filters
         conditional_formatting: list of formatting preset dicts
+
+    Phase 6 args (#1110, #1111):
+        row_click_event: dj-click event name fired when any <tr> is clicked.
+            Empty string (default) disables row-level click events.
+            LiveView-idiomatic — preferred over row_url for routing inside
+            a LiveView app. CSP-friendly (no inline JS).
+        row_click_value_key: row dict key whose value is sent as data-value
+            on the dj-click. Default "id". Override for slug-based routing
+            (e.g. "uuid", "slug").
+        row_url: row dict key holding a URL. When set, the <tr> gets
+            data-href + an inline onclick that navigates via
+            window.location. **Security**: values flow into JS via
+            ``this.dataset.href`` — only assign developer-controlled URLs
+            (typically computed from ``reverse()``). User-controlled
+            strings could enable ``javascript:`` URI execution.
+            **CSP**: requires ``'unsafe-inline'`` in script-src; prefer
+            row_click_event when CSP is strict. row_click_event takes
+            precedence when both are set.
+
+    Cell-level link column (#1110):
+        column dicts now accept ``link`` (key in row dict holding the
+        href) and ``link_class`` (optional CSS class on the <a>). When
+        ``col.link`` is set the cell renders as
+        ``<a href="{{ row[col.link] }}">{{ row[col.key] }}</a>``;
+        otherwise plain text (pre-#1110 behavior).
     """
     return {
         "rows": rows,

--- a/python/tests/test_data_table_link_row_nav.py
+++ b/python/tests/test_data_table_link_row_nav.py
@@ -1,0 +1,253 @@
+"""Regression tests for #1110 (link column type) and #1111 (row-level
+navigation) in the {% data_table %} template tag.
+
+Tests verify the STRUCTURAL output of `table.html` — presence of `<a>`
+wrappers, `dj-click` / `data-href` attributes — rather than extracted
+cell content. The cell-content render uses `row|dictsort:col.key|first`,
+which depends on the Rust template engine's filter dispatch (Django's
+stock engine doesn't extract dict values via that filter chain). The
+structural conditional logic added by #1110/#1111 is what these tests
+prove; cell-content rendering has separate test coverage.
+"""
+
+from pathlib import Path
+
+from django.template import Context, Engine
+from django.test import TestCase
+
+# Read the template directly — djust.components is intentionally not in
+# demo_project's INSTALLED_APPS, so Django's app-based template loader
+# can't find this file by name.
+_TABLE_HTML_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "python"
+    / "djust"
+    / "components"
+    / "templates"
+    / "djust_components"
+    / "table.html"
+)
+_TABLE_TEMPLATE = Engine().from_string(_TABLE_HTML_PATH.read_text())
+
+
+def render_table(ctx):
+    return _TABLE_TEMPLATE.render(Context(ctx))
+
+
+def _base_ctx(rows, columns, **overrides):
+    base = {
+        "rows": rows,
+        "columns": columns,
+        "sort_by": "",
+        "sort_desc": False,
+        "sort_event": "table_sort",
+        "page": 1,
+        "total_pages": 1,
+        "selectable": False,
+        "selected_rows": [],
+        "select_event": "table_select",
+        "row_key": "id",
+        "search": False,
+        "search_query": "",
+        "search_event": "table_search",
+        "search_debounce": 300,
+        "filters": {},
+        "filter_event": "table_filter",
+        "loading": False,
+        "empty_title": "No data",
+        "empty_description": "",
+        "empty_icon": "",
+        "paginate": False,
+        "page_event": "table_page",
+        "prev_event": "table_prev",
+        "next_event": "table_next",
+        "striped": False,
+        "compact": False,
+        "row_click_event": "",
+        "row_click_value_key": "id",
+        "row_url": "",
+    }
+    base.update(overrides)
+    return base
+
+
+class LinkColumnStructureTest(TestCase):
+    """#1110: column with `link` key wraps the cell in an <a>."""
+
+    def test_link_column_emits_anchor_tag(self):
+        """When col.link is set, the cell contains an <a> element."""
+        rows = [{"claim_number": "C-001", "claim_url": "/claims/1/"}]
+        columns = [{"key": "claim_number", "label": "Claim", "link": "claim_url"}]
+        out = render_table(_base_ctx(rows, columns))
+        # The <a> tag is rendered (the href value is rust-template-rendered
+        # at runtime; we just assert the wrapper structure here).
+        self.assertIn("<a href=", out)
+
+    def test_link_class_attribute_rendered(self):
+        """col.link_class becomes class="..." on the <a>."""
+        rows = [{"name": "Alice", "profile_url": "/u/alice/"}]
+        columns = [
+            {
+                "key": "name",
+                "label": "Name",
+                "link": "profile_url",
+                "link_class": "user-link",
+            },
+        ]
+        out = render_table(_base_ctx(rows, columns))
+        self.assertIn('class="user-link"', out)
+
+    def test_no_link_no_anchor_pre_1110_compat(self):
+        """col without `link` key renders the cell as plain <td> (no <a>)."""
+        rows = [{"name": "Alice"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = render_table(_base_ctx(rows, columns))
+        # Cell is <td>...</td> without an <a> wrap.
+        # Header cells use `dj-click` for sort but those aren't <a>.
+        # Find the row body specifically.
+        body_start = out.find("<tbody>")
+        body_end = out.find("</tbody>")
+        body = out[body_start:body_end]
+        self.assertNotIn("<a href=", body)
+
+
+class RowClickEventStructureTest(TestCase):
+    """#1111 Option B: row_click_event makes <tr> clickable with dj-click."""
+
+    def test_row_click_event_attaches_dj_click_to_tr(self):
+        rows = [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = render_table(_base_ctx(rows, columns, row_click_event="open_user"))
+        self.assertIn('dj-click="open_user"', out)
+        # cursor:pointer style is part of the affordance
+        self.assertIn("cursor:pointer", out)
+
+    def test_row_click_event_appears_on_every_tr(self):
+        """One per row — count occurrences match row count."""
+        rows = [{"id": 1}, {"id": 2}, {"id": 3}]
+        columns = [{"key": "id", "label": "ID"}]
+        out = render_table(_base_ctx(rows, columns, row_click_event="open"))
+        self.assertEqual(out.count('dj-click="open"'), 3)
+
+    def test_no_row_click_event_no_tr_dj_click(self):
+        """Backwards-compat: without row_click_event, no dj-click on <tr>."""
+        rows = [{"id": 1, "name": "Alice"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = render_table(_base_ctx(rows, columns))
+        body_start = out.find("<tbody>")
+        body_end = out.find("</tbody>")
+        body = out[body_start:body_end]
+        # Body should have <tr> tags but none with dj-click
+        self.assertIn("<tr", body)
+        for line in body.split("\n"):
+            if "<tr" in line and not line.strip().startswith("{#"):
+                self.assertNotIn(
+                    "dj-click",
+                    line,
+                    f"<tr> got unexpected dj-click: {line.strip()}",
+                )
+
+
+class RowUrlStructureTest(TestCase):
+    """#1111 Option A: row_url adds data-href + inline JS to <tr>."""
+
+    def test_row_url_attaches_data_href_and_onclick(self):
+        rows = [{"claim_url": "/claims/1/", "name": "Claim 1"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = render_table(_base_ctx(rows, columns, row_url="claim_url"))
+        # data-href attribute is present (value extracted by Rust engine
+        # at runtime; we just assert the wiring is in place).
+        self.assertIn("data-href=", out)
+        self.assertIn("window.location=this.dataset.href", out)
+        self.assertIn("cursor:pointer", out)
+
+    def test_row_click_event_takes_precedence_over_row_url(self):
+        """Both set → dj-click wins, data-href is NOT rendered."""
+        rows = [{"id": 1, "claim_url": "/claims/1/", "name": "Claim 1"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = render_table(
+            _base_ctx(rows, columns, row_click_event="open_claim", row_url="claim_url")
+        )
+        self.assertIn('dj-click="open_claim"', out)
+        # No data-href because the {% if row_click_event %} branch wins
+        body_start = out.find("<tbody>")
+        body_end = out.find("</tbody>")
+        body = out[body_start:body_end]
+        self.assertNotIn("data-href=", body)
+
+
+class MixinDefaultsTest(TestCase):
+    """Verify class-level defaults flow through to context."""
+
+    def test_class_attributes_present(self):
+        from djust.components.mixins.data_table import DataTableMixin
+
+        self.assertEqual(DataTableMixin.table_row_click_event, "")
+        self.assertEqual(DataTableMixin.table_row_click_value_key, "id")
+        self.assertEqual(DataTableMixin.table_row_url, "")
+
+    def test_post_mount_context_includes_new_keys(self):
+        from djust.components.mixins.data_table import DataTableMixin
+
+        view = DataTableMixin()
+        view.init_table_state()
+        view.table_rows = [{"id": 1, "name": "Alice"}]
+        ctx = view.get_table_context()
+
+        self.assertEqual(ctx["row_click_event"], "")
+        self.assertEqual(ctx["row_click_value_key"], "id")
+        self.assertEqual(ctx["row_url"], "")
+
+    def test_pre_mount_default_includes_new_keys(self):
+        from djust.components.mixins.data_table import _PRE_MOUNT_TABLE_CONTEXT
+
+        self.assertIn("row_click_event", _PRE_MOUNT_TABLE_CONTEXT)
+        self.assertIn("row_click_value_key", _PRE_MOUNT_TABLE_CONTEXT)
+        self.assertIn("row_url", _PRE_MOUNT_TABLE_CONTEXT)
+
+    def test_class_attributes_settable_per_view(self):
+        """A view can override the defaults."""
+        from djust.components.mixins.data_table import DataTableMixin
+
+        class _ClickableTable(DataTableMixin):
+            table_row_click_event = "open_claim"
+            table_row_click_value_key = "uuid"
+
+        view = _ClickableTable()
+        view.init_table_state()
+        view.table_rows = []
+        ctx = view.get_table_context()
+
+        self.assertEqual(ctx["row_click_event"], "open_claim")
+        self.assertEqual(ctx["row_click_value_key"], "uuid")
+
+
+class TemplateTagDispatcherTest(TestCase):
+    """The {% data_table %} template-tag function passes the new params
+    through to the inclusion-tag context dict."""
+
+    def test_data_table_function_accepts_new_kwargs(self):
+        """Smoke: calling the underlying function shouldn't TypeError."""
+        from djust.components.templatetags.djust_components import data_table
+
+        ctx = data_table(
+            rows=[{"id": 1, "name": "A"}],
+            columns=[{"key": "name"}],
+            row_click_event="open",
+            row_click_value_key="id",
+            row_url="",
+        )
+        self.assertEqual(ctx["row_click_event"], "open")
+        self.assertEqual(ctx["row_click_value_key"], "id")
+        self.assertEqual(ctx["row_url"], "")
+
+    def test_data_table_defaults_when_omitted(self):
+        from djust.components.templatetags.djust_components import data_table
+
+        ctx = data_table(
+            rows=[],
+            columns=[],
+        )
+        self.assertEqual(ctx["row_click_event"], "")
+        self.assertEqual(ctx["row_click_value_key"], "id")
+        self.assertEqual(ctx["row_url"], "")


### PR DESCRIPTION
## Summary

Closes #1110 + #1111 — two related `{% data_table %}` enhancements requested by nyc-claims for admin/dashboard list views.

## #1110 — link column type

Column dicts now accept `link` (names a row-dict key holding the href) and `link_class` (optional CSS class on the `<a>`):

```python
table_columns = [
    {"key": "claim_number", "label": "Claim #",
     "link": "claim_url", "link_class": "claim-link"},
]
# Row dicts include both keys:
{"claim_number": "2026PI000001", "claim_url": "/claims/1/", ...}
```

Renders as `<td><a href="/claims/1/" class="claim-link">2026PI000001</a></td>`. Falls through to plain text when `col.link` is unset — strict pre-#1110 backwards compat.

## #1111 — row-level navigation

Two API shapes (Option B preferred per issue body):

**Option B — `row_click_event` (LiveView-idiomatic)**:
```python
table_row_click_event = "open_claim"
table_row_click_value_key = "id"  # default
```
Fires `dj-click="open_claim" data-value="<row.id>"` on every `<tr>`.

**Option A — `row_url` (static URL fallback)**:
```python
table_row_url = "claim_url"
```
Adds `data-href` + inline `onclick="window.location=this.dataset.href"` on every `<tr>`.

`row_click_event` takes precedence when both are set. Both add `cursor:pointer`.

## Issue × file × test mapping

| Issue | Modified files | Tests |
|---|---|---|
| #1110 | `templates/djust_components/table.html` (cell `<a>` wrap) | `LinkColumnStructureTest` (3 cases) |
| #1111 | `templatetags/djust_components.py` (data_table tag fn), `templates/djust_components/table.html` (`<tr>` attrs), `mixins/data_table.py` (3 class attrs + `get_table_context()` + `_PRE_MOUNT_TABLE_CONTEXT`) | `RowClickEventStructureTest` (3) + `RowUrlStructureTest` (2) + `MixinDefaultsTest` (4) + `TemplateTagDispatcherTest` (2) |

## Test plan

- [x] 14 new tests in `test_data_table_link_row_nav.py` all pass
- [x] Tests assert STRUCTURAL output (anchor presence, dj-click attribute, data-href attribute) rather than extracted cell content (cell content extraction uses `row|dictsort:col.key|first` which is Rust-template-engine-only)
- [x] Pre-#1110 compat: `col` without `link` → no `<a>` wrap; absent `row_click_event` and `row_url` → no `<tr>` modifications (asserted in negative tests)
- [x] 4767 Python pass overall (was 4753, +14 new)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)