### PR TITLE
feat(theming): docs theme pack + bump 0.8.8rc1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "0.8.6-rc.1"
+version = "0.8.8-rc.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "0.8.6-rc.1"
+version = "0.8.8-rc.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "0.8.6-rc.1"
+version = "0.8.8-rc.1"
 dependencies = [
  "bincode",
  "criterion",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "0.8.6-rc.1"
+version = "0.8.8-rc.1"
 dependencies = [
  "ahash",
  "chrono",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "0.8.6-rc.1"
+version = "0.8.8-rc.1"
 dependencies = [
  "ahash",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.7-rc.1"
+version = "0.8.8-rc.1"
 edition = "2021"
 authors = ["djust contributors"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "djust"
-version = "0.8.7rc1"
+version = "0.8.8rc1"
 description = "Phoenix LiveView-style reactive components for Django with Rust-powered performance. Real-time UI updates over WebSocket, no JavaScript build step required."
 authors = [{name = "djust contributors"}]
 readme = "README.md"

--- a/python/djust/theming/theme_packs.py
+++ b/python/djust/theming/theme_packs.py
@@ -1053,6 +1053,7 @@ def _ensure_theme_imports() -> None:
     from .themes.art_deco import PACK as _PACK_ART_DECO, DESIGN_SYSTEM as _DESIGN_ART_DECO
     from .themes.handcraft import PACK as _PACK_HANDCRAFT, DESIGN_SYSTEM as _DESIGN_HANDCRAFT
     from .themes.terminal import PACK as _PACK_TERMINAL, DESIGN_SYSTEM as _DESIGN_TERMINAL
+    from .themes.docs import PACK as _PACK_DOCS, DESIGN_SYSTEM as _DESIGN_DOCS
     from .themes.magazine import PACK as _PACK_MAGAZINE, DESIGN_SYSTEM as _DESIGN_MAGAZINE
     from .themes.swiss import PACK as _PACK_SWISS, DESIGN_SYSTEM as _DESIGN_SWISS
     from .themes.candy import PACK as _PACK_CANDY, DESIGN_SYSTEM as _DESIGN_CANDY
@@ -1124,6 +1125,7 @@ def _ensure_theme_imports() -> None:
             "art_deco": _PACK_ART_DECO,
             "handcraft": _PACK_HANDCRAFT,
             "terminal": _PACK_TERMINAL,
+            "docs": _PACK_DOCS,
             "magazine": _PACK_MAGAZINE,
             "swiss": _PACK_SWISS,
             "candy": _PACK_CANDY,
@@ -1188,6 +1190,7 @@ def _ensure_theme_imports() -> None:
     DESIGN_SYSTEMS["art_deco"] = _DESIGN_ART_DECO
     DESIGN_SYSTEMS["handcraft"] = _DESIGN_HANDCRAFT
     DESIGN_SYSTEMS["terminal"] = _DESIGN_TERMINAL
+    DESIGN_SYSTEMS["docs"] = _DESIGN_DOCS
     DESIGN_SYSTEMS["magazine"] = _DESIGN_MAGAZINE
     DESIGN_SYSTEMS["swiss"] = _DESIGN_SWISS
     DESIGN_SYSTEMS["candy"] = _DESIGN_CANDY

--- a/python/djust/theming/themes/docs.py
+++ b/python/djust/theming/themes/docs.py
@@ -1,0 +1,230 @@
+"""Docs — Warm editorial dark with rust accent, Geist + JetBrains Mono."""
+
+from ._base import (
+    ColorScale,
+    ThemeTokens,
+    ThemePreset,
+    TypographyStyle,
+    LayoutStyle,
+    SurfaceStyle,
+    IconStyle,
+    AnimationStyle,
+    InteractionStyle,
+    DesignSystem,
+    ThemePack,
+    PATTERN_MINIMAL,
+    ILLUST_LINE,
+)
+
+
+# =============================================================================
+# Color Preset
+# =============================================================================
+# Warm editorial dark — rust orange accent on warm cream foreground over a
+# very dark warm background (#11100d). Inspired by print-magazine running
+# headers and the New York Review of Books palette.
+
+DARK = ThemeTokens(
+    background=ColorScale(40, 30, 7),  # #11100d  warm dark
+    foreground=ColorScale(40, 20, 92),  # #ebe6d8  warm cream
+    card=ColorScale(40, 20, 9),  # #1a1814  slightly lifted
+    card_foreground=ColorScale(40, 20, 92),
+    popover=ColorScale(40, 20, 9),
+    popover_foreground=ColorScale(40, 20, 92),
+    primary=ColorScale(28, 85, 55),  # #f08646  rust orange
+    primary_foreground=ColorScale(30, 25, 8),  # ink for on-rust
+    secondary=ColorScale(40, 20, 12),
+    secondary_foreground=ColorScale(40, 20, 92),
+    muted=ColorScale(40, 15, 15),
+    muted_foreground=ColorScale(40, 15, 50),
+    accent=ColorScale(28, 85, 55),
+    accent_foreground=ColorScale(30, 25, 8),
+    destructive=ColorScale(350, 75, 55),
+    destructive_foreground=ColorScale(0, 0, 100),
+    success=ColorScale(160, 60, 40),
+    success_foreground=ColorScale(0, 0, 100),
+    warning=ColorScale(38, 90, 50),
+    warning_foreground=ColorScale(0, 0, 8),
+    info=ColorScale(210, 60, 55),
+    info_foreground=ColorScale(0, 0, 100),
+    link=ColorScale(28, 85, 55),
+    link_hover=ColorScale(28, 85, 65),
+    code=ColorScale(40, 20, 12),
+    code_foreground=ColorScale(40, 20, 92),
+    selection=ColorScale(28, 80, 55),
+    selection_foreground=ColorScale(30, 25, 8),
+    brand=ColorScale(28, 85, 55),
+    brand_foreground=ColorScale(30, 25, 8),
+    border=ColorScale(0, 0, 16),  # rgba(255,255,255,0.16)
+    input=ColorScale(0, 0, 16),
+    ring=ColorScale(28, 85, 55),
+    surface_1=ColorScale(40, 30, 7),
+    surface_2=ColorScale(40, 20, 9),
+    surface_3=ColorScale(40, 20, 12),
+)
+
+LIGHT = ThemeTokens(
+    background=ColorScale(40, 10, 98),  # warm cream paper
+    foreground=ColorScale(40, 30, 8),  # near-black warm
+    card=ColorScale(40, 10, 96),
+    card_foreground=ColorScale(40, 30, 8),
+    popover=ColorScale(40, 10, 96),
+    popover_foreground=ColorScale(40, 30, 8),
+    primary=ColorScale(28, 85, 50),  # slightly darker rust on light
+    primary_foreground=ColorScale(0, 0, 100),
+    secondary=ColorScale(40, 10, 92),
+    secondary_foreground=ColorScale(40, 30, 8),
+    muted=ColorScale(40, 8, 88),
+    muted_foreground=ColorScale(40, 10, 45),
+    accent=ColorScale(28, 85, 50),
+    accent_foreground=ColorScale(0, 0, 100),
+    destructive=ColorScale(350, 75, 50),
+    destructive_foreground=ColorScale(0, 0, 100),
+    success=ColorScale(160, 60, 35),
+    success_foreground=ColorScale(0, 0, 100),
+    warning=ColorScale(38, 90, 45),
+    warning_foreground=ColorScale(0, 0, 100),
+    info=ColorScale(210, 60, 50),
+    info_foreground=ColorScale(0, 0, 100),
+    link=ColorScale(28, 85, 45),
+    link_hover=ColorScale(28, 85, 35),
+    code=ColorScale(40, 10, 92),
+    code_foreground=ColorScale(40, 30, 8),
+    selection=ColorScale(28, 80, 85),
+    selection_foreground=ColorScale(40, 30, 8),
+    brand=ColorScale(28, 85, 50),
+    brand_foreground=ColorScale(0, 0, 100),
+    border=ColorScale(40, 8, 84),
+    input=ColorScale(40, 8, 84),
+    ring=ColorScale(28, 85, 50),
+    surface_1=ColorScale(40, 10, 98),
+    surface_2=ColorScale(40, 10, 96),
+    surface_3=ColorScale(40, 10, 92),
+)
+
+PRESET = ThemePreset(
+    name="docs",
+    display_name="docs.djust.org",
+    description="Warm editorial dark — rust orange accent, sharp borders, Geist",
+    light=LIGHT,
+    dark=DARK,
+    radius=0.0,  # 0px — sharp editorial edges
+)
+
+
+# =============================================================================
+# Design System
+# =============================================================================
+
+TYPOGRAPHY = TypographyStyle(
+    name="docs",
+    heading_font='"Geist", ui-sans-serif, system-ui, -apple-system, sans-serif',
+    body_font='"Geist", ui-sans-serif, system-ui, -apple-system, sans-serif',
+    base_size="17px",  # comfortable reading size
+    heading_scale=1.35,
+    line_height="1.5",
+    body_line_height="1.65",
+    heading_weight="700",
+    section_heading_weight="700",
+    body_weight="400",
+    letter_spacing="-0.02em",
+    prose_max_width="72ch",
+    badge_radius="0px",
+)
+
+LAYOUT = LayoutStyle(
+    name="docs",
+    space_unit="1rem",
+    space_scale=1.5,
+    border_radius_sm="0px",
+    border_radius_md="0px",
+    border_radius_lg="0px",
+    button_shape="sharp",
+    card_shape="sharp",
+    input_shape="sharp",
+    container_width="1280px",
+    grid_gap="2rem",
+    section_spacing="5rem",
+    hero_padding_top="6rem",
+    hero_padding_bottom="5rem",
+    hero_line_height="0.96",
+    hero_max_width="60rem",
+)
+
+SURFACE = SurfaceStyle(
+    name="docs",
+    shadow_sm="none",  # flat editorial — no shadows
+    shadow_md="none",
+    shadow_lg="none",
+    border_width="1px",
+    border_style="solid",
+    surface_treatment="flat",
+    backdrop_blur="0px",
+    noise_opacity=0.0,
+)
+
+ICON = IconStyle(
+    name="docs",
+    style="outlined",
+    weight="regular",
+    size_scale=1.0,
+    stroke_width="1.5",
+    corner_rounding="0px",
+)
+
+ANIMATION = AnimationStyle(
+    name="docs",
+    entrance_effect="fade",
+    exit_effect="fade",
+    hover_effect="none",
+    hover_scale=1.0,
+    hover_translate_y="0px",
+    click_effect="none",
+    loading_style="spinner",
+    transition_style="smooth",
+    duration_fast="0.15s",
+    duration_normal="0.25s",
+    duration_slow="0.4s",
+    easing="cubic-bezier(0.4, 0, 0.2, 1)",
+)
+
+INTERACTION = InteractionStyle(
+    name="docs",
+    button_hover="color",
+    link_hover="color",
+    card_hover="none",
+    focus_style="ring",
+    focus_ring_width="1px",
+)
+
+DESIGN_SYSTEM = DesignSystem(
+    name="docs",
+    display_name="docs.djust.org",
+    description="Warm editorial dark — sharp borders, rust orange accent, Geist + JetBrains Mono",
+    category="editorial",
+    typography=TYPOGRAPHY,
+    layout=LAYOUT,
+    surface=SURFACE,
+    icons=ICON,
+    animation=ANIMATION,
+    interaction=INTERACTION,
+)
+
+
+# =============================================================================
+# Theme Pack
+# =============================================================================
+
+PACK = ThemePack(
+    name="docs",
+    display_name="docs.djust.org",
+    description="Warm editorial dark — Geist headings, JetBrains Mono labels, rust orange accent",
+    category="editorial",
+    design_theme="docs",
+    color_preset="docs",
+    icon_style=ICON,
+    animation_style=ANIMATION,
+    pattern_style=PATTERN_MINIMAL,
+    interaction_style=INTERACTION,
+    illustration_style=ILLUST_LINE,
+)

--- a/uv.lock
+++ b/uv.lock
@@ -588,7 +588,7 @@ wheels = [
 
 [[package]]
 name = "djust"
-version = "0.8.6rc1"
+version = "0.8.8rc1"
 source = { editable = "." }
 dependencies = [
     { name = "channels", extra = ["daphne"] },


### PR DESCRIPTION
## Summary

- New \`docs\` theme pack — warm editorial dark with rust orange accent (\`#f08646\`), Geist + JetBrains Mono, sharp 0px borders, flat surfaces, 17px reading size. Category \`editorial\`, sits alongside \`magazine\` and \`paper\`.
- Bump to \`0.8.8rc1\` so docs.djust.org can pull it from PyPI.

## Why

docs.djust.org currently sets \`pack: 'docs'\` in settings, but the docs pack only ever existed in a venv site-packages copy from a prior unsynced session. Production falls back to \`default\` and the editorial palette/sharpness/font don't render. Adding the pack to the framework source ships it through the normal PyPI release.

The 480-line editorial structural CSS (\`.docs-hero\`, \`.docs-step\`, \`.docs-ref\`, etc.) lives in \`docs.djust.org/static/css/input.css\`, not in this pack — see the architecture note in \`docs.djust.org/CLAUDE.md\`. This pack only ships colors, typography, layout, and surface tokens; the brand tokens (\`--color-brand-*\`) the editorial CSS references are emitted by the pack via the standard \`/_theming/theme.css\` endpoint.

## Test plan

- [ ] \`from djust.theming.theme_packs import DESIGN_SYSTEMS, THEME_PACKS; _ensure_theme_imports(); 'docs' in DESIGN_SYSTEMS\`
- [ ] \`/_theming/theme.css?p=docs&m=dark\` emits warm dark background (\`hsl 40 30% 7%\`) and rust primary (\`hsl 28 85% 55%\`)
- [ ] Docs pack appears in the theme switcher dropdown alongside magazine/paper
- [ ] \`magazine\` / \`paper\` packs continue to work (no registration regression)
- [ ] \`v0.8.8rc1\` tag publishes successfully via \`publish.yml\` to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)