### PR TITLE
fix(theming): register docs color preset + bump 0.8.8rc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "0.8.8-rc.1"
+version = "0.8.8-rc.2"
 dependencies = [
  "ahash",
  "criterion",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "0.8.8-rc.1"
+version = "0.8.8-rc.2"
 dependencies = [
  "ahash",
  "criterion",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "0.8.8-rc.1"
+version = "0.8.8-rc.2"
 dependencies = [
  "bincode",
  "criterion",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "0.8.8-rc.1"
+version = "0.8.8-rc.2"
 dependencies = [
  "ahash",
  "chrono",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "0.8.8-rc.1"
+version = "0.8.8-rc.2"
 dependencies = [
  "ahash",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.8-rc.1"
+version = "0.8.8-rc.2"
 edition = "2021"
 authors = ["djust contributors"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "djust"
-version = "0.8.8rc1"
+version = "0.8.8rc2"
 description = "Phoenix LiveView-style reactive components for Django with Rust-powered performance. Real-time UI updates over WebSocket, no JavaScript build step required."
 authors = [{name = "djust contributors"}]
 readme = "README.md"

--- a/python/djust/theming/presets.py
+++ b/python/djust/theming/presets.py
@@ -62,6 +62,7 @@ from .themes.art_deco import PRESET as ART_DECO_THEME  # noqa: E402
 from .themes.handcraft import PRESET as HANDCRAFT_THEME  # noqa: E402
 from .themes.terminal import PRESET as TERMINAL_THEME  # noqa: E402
 from .themes.magazine import PRESET as MAGAZINE_THEME  # noqa: E402
+from .themes.docs import PRESET as DOCS_THEME  # noqa: E402
 from .themes.swiss import PRESET as SWISS_THEME  # noqa: E402
 from .themes.candy import PRESET as CANDY_THEME  # noqa: E402
 from .themes.retro_computing import PRESET as RETRO_COMPUTING_THEME  # noqa: E402
@@ -131,6 +132,7 @@ THEME_PRESETS: dict[str, ThemePreset] = {
     "handcraft": HANDCRAFT_THEME,
     "terminal": TERMINAL_THEME,
     "magazine": MAGAZINE_THEME,
+    "docs": DOCS_THEME,
     "swiss": SWISS_THEME,
     "candy": CANDY_THEME,
     "retro_computing": RETRO_COMPUTING_THEME,

--- a/uv.lock
+++ b/uv.lock
@@ -588,7 +588,7 @@ wheels = [
 
 [[package]]
 name = "djust"
-version = "0.8.8rc1"
+version = "0.8.8rc2"
 source = { editable = "." }
 dependencies = [
     { name = "channels", extra = ["daphne"] },


### PR DESCRIPTION
## Summary

Follow-up to #1129. The docs theme pack was registered in \`theme_packs.py\` (THEME_PACKS + DESIGN_SYSTEMS) but the \`PRESET\` (DARK/LIGHT \`ThemeTokens\`) wasn't added to \`THEME_PRESETS\` in \`presets.py\`. Result on docs.djust.org production: the pack metadata header reads \"docs.djust.org\" but the actual color variables fall back to the \`default\` palette (cool dark, gray-primary, rounded corners) because \`THEME_PRESETS["docs"]\` doesn't exist.

This PR adds the missing import + registry entry, and bumps to \`0.8.8rc2\` for the re-publish.

## Test plan

- [ ] \`from djust.theming.presets import THEME_PRESETS; 'docs' in THEME_PRESETS\` → True
- [ ] \`/_theming/theme.css?p=docs&m=dark\` emits \`--background: 40 30% 7%\` and \`--primary: 28 85% 55%\` under \`html[data-theme=\"dark\"]\`
- [ ] \`v0.8.8rc2\` publishes to PyPI; docs.djust.org redeploy resolves rust accent + warm dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)