### PR TITLE
docs(getting-started): polish — Rust note, dev-server warning, tutorial cross-links

### DIFF
--- a/docs/website/getting-started/core-concepts.md
+++ b/docs/website/getting-started/core-concepts.md
@@ -103,10 +103,10 @@ This means complex re-renders that change one row in a 1000-row table only trans
 **Use LiveView for:**
 
 - Forms with real-time validation
-- Search/filter interfaces that update as you type
+- Search/filter interfaces that update as you type — see [search-as-you-type](../guides/tutorial-search-as-you-type.md) and [typeahead with @server_function](../guides/tutorial-typeahead-server-function.md)
 - Live dashboards, counters, feeds
-- Multi-step wizards
-- Collaborative features (presence, cursors)
+- Multi-step wizards — see [build a wizard](../guides/tutorial-multi-step-wizard.md)
+- Collaborative features (presence, cursors) — see [real-time comments](../guides/tutorial-real-time-comments.md)
 - Any UI where you'd otherwise write custom fetch/AJAX code
 
 **Use standard Django views for:**

--- a/docs/website/getting-started/first-liveview.md
+++ b/docs/website/getting-started/first-liveview.md
@@ -142,3 +142,13 @@ def delete_item(self, item_id: int = 0, **kwargs):
 - [Core Concepts](./core-concepts.md) — understand the lifecycle and state model
 - [Forms](../forms/index.md) — real-time form validation
 - [State Management](../state/index.md) — debouncing, loading states, optimistic updates
+
+### Try a real-world walkthrough
+
+Once the counter is working, the four end-to-end tutorials apply the
+same primitives to common shipping patterns:
+
+- [Build a search-as-you-type feature](../guides/tutorial-search-as-you-type.md) — debounced single-input
+- [Build a real-time comment thread](../guides/tutorial-real-time-comments.md) — multi-user broadcast
+- [Build a multi-step form wizard](../guides/tutorial-multi-step-wizard.md) — stateful step cursor
+- [Build a typeahead with @server_function](../guides/tutorial-typeahead-server-function.md) — partial-page server RPC

--- a/docs/website/getting-started/installation.md
+++ b/docs/website/getting-started/installation.md
@@ -7,7 +7,7 @@ Get djust running in your Django project.
 - Python 3.10+
 - Django 4.2+
 - Django Channels 4.0+
-- Rust toolchain (for building from source)
+- Rust toolchain — **only if building from source**. `pip install djust` ships pre-built wheels for Linux / macOS / Windows on Python 3.10–3.14, so most users never need Rust installed.
 
 ## Install
 
@@ -78,12 +78,9 @@ Use `uvicorn` (or `daphne`) instead of `manage.py runserver` — the standard Dj
 uvicorn myproject.asgi:application --reload
 ```
 
-Or add a Makefile target:
-
-```makefile
-start:
-    uvicorn myproject.asgi:application --reload
-```
+> Avoid `python manage.py runserver` for djust development — it accepts
+> WebSocket connections on some Django versions but does not actually
+> serve them, leading to silently broken real-time updates.
 
 ## Building from Source
 


### PR DESCRIPTION
## Summary

Three small clarity fixes across the three \`docs/website/getting-started/\` pages:

| File | Change |
|---|---|
| installation.md | Rust toolchain note clarified (only needed for source builds; pip wheels cover most users). Replaced misleading Makefile snippet (4-space indent vs Makefile tab requirement) with a callout warning against \`manage.py runserver\` for djust development. |
| first-liveview.md | Added \"Try a real-world walkthrough\" subsection cross-linking to the four end-to-end tutorials. |
| core-concepts.md | Inline cross-links from the \"Use LiveView for:\" bullets to the tutorial that demos each pattern. |

## Merge order

The cross-links assume the four tutorial PRs are already on \`main\`:

1. #1131 — tutorial-search-as-you-type
2. #1132 — tutorial-real-time-comments
3. #1133 — tutorial-multi-step-wizard
4. #1136 — tutorial-typeahead-server-function
5. **this PR**

If the polish PR lands before any of those, the corresponding link will 404 in production until the missing tutorial merges.

## Test plan

- [ ] Markdown renders cleanly
- [ ] All linked tutorial paths resolve (after the four PRs above merge)
- [ ] No regressions to existing in-page links

🤖 Generated with [Claude Code](https://claude.com/claude-code)