### PR TITLE
feat(streaming): asyncio.as_completed parallel lazy render (v0.9.0 PR-C, closes #1043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Parallel lazy render via `asyncio.as_completed` (v0.9.0 PR-C, closes #1043)** —
+  closes the v0.9.0 streaming arc. PR-B shipped sequential thunk
+  invocation in `arender_chunks` Phase 5 (one thunk runs to
+  completion before the next starts; total wall-clock time =
+  sum of thunk durations). PR-C swaps the for-loop for
+  `asyncio.as_completed` over the thunk-task set. All thunks start
+  concurrently; chunks emerge in completion order rather than
+  registration order. Total wall-clock time = max(thunk_durations).
+
+  Client-side reconciliation is keyed by slot id (`data-target` on
+  `<template id="djl-fill-X">`), so out-of-order chunk arrival is
+  correct by construction — no client changes needed.
+
+  Cancellation: when the emitter is cancelled mid-stream (client
+  disconnect), all pending thunk tasks are cancelled via
+  `task.cancel()`. Already-completed tasks whose results were not yet
+  iterated are GC'd. Tasks already running through `sync_to_async` to
+  a synchronous render function will complete (asyncio cancellation
+  doesn't propagate into sync DB work) — the documented contract per
+  ADR-015 §"Cancellation contract".
+
+  Files: `python/djust/mixins/template.py` (~50 LoC swap from
+  for-loop to `asyncio.as_completed`). 3 new wall-clock-sensitive
+  tests in `tests/integration/test_chunks_overlap.py`:
+  - Three thunks (100ms, 50ms, 25ms) registered in that order →
+    chunks arrive in completion order (slot-c, slot-b, slot-a).
+  - Three 50ms-each thunks → wall clock under 100ms (sequential
+    baseline 150ms).
+  - One thunk raises → others still emit their fills (no stall).
+
+  Closes #1043. v0.9.0 streaming arc complete: PR-A (foundation) →
+  PR-B (`lazy=True` user API + `as_view` dispatch) → PR-C (parallel
+  render).
+
 - **`{% live_render lazy=True %}` capability + `as_view` dispatch wiring (v0.9.0 PR-B, ADR-015)** —
   ships the user-facing API on top of PR-A's async render foundation.
   Three forms: `lazy=True` (parent-flush trigger, default), `lazy="visible"`

--- a/docs/adr/015-phase-2-streaming.md
+++ b/docs/adr/015-phase-2-streaming.md
@@ -67,9 +67,12 @@ Per-task timeout. Sentinel-based cancellation propagates via
 `request_token` from the emitter on ASGI scope `disconnected`.
 
 Files:
-- `python/djust/http_streaming.py` — `as_completed()` refactor. ~80 LoC.
-- `python/djust/decorators.py` — `cancel_async` reason field. ~30 LoC.
-- `tests/integration/test_chunks_overlap.py` — slow vs fast child timing assertions. ~200 LoC.
+- `python/djust/mixins/template.py` — `as_completed()` refactor in
+  `arender_chunks` Phase 5. ~80 LoC. (Originally planned for
+  `http_streaming.py` but the loop lives where it consumes thunks.)
+- `tests/integration/test_chunks_overlap.py` — slow vs fast child
+  timing assertions + mid-stream cancellation propagation
+  (T-PRC-4). ~200 LoC.
 
 ## Total estimate
 

--- a/python/djust/mixins/template.py
+++ b/python/djust/mixins/template.py
@@ -418,28 +418,62 @@ Object.assign(window.handlerMetadata, {json.dumps(metadata)});
             logger.debug("arender_chunks: cancelled mid-stream")
             return
 
-        # 5. Lazy thunks (PR-B, ADR-015). The body of the page has
-        # already flushed; lazy ``<template id="djl-fill-X">`` chunks
-        # are appended after </html>. Browsers tolerate post-</html>
-        # content per the HTML5 parser tree-construction spec — the
-        # template element + its inline <script> activator move into
-        # the implicit body and execute in order. Sequential in PR-B;
-        # PR-C ships parallelism via ``asyncio.as_completed``.
+        # 5. Lazy thunks (PR-B + PR-C, ADR-015). The body of the page
+        # has already flushed; lazy ``<template id="djl-fill-X">``
+        # chunks are appended after </html>. Browsers tolerate
+        # post-</html> content per the HTML5 parser tree-construction
+        # spec — the template element + its inline <script> activator
+        # move into the implicit body and execute in order.
+        #
+        # PR-C: parallel render via ``asyncio.as_completed``. All
+        # thunks start concurrently; chunks emerge in completion order
+        # rather than registration order. Total wall-clock time =
+        # max(thunk_durations) instead of sum(thunk_durations). Client-
+        # side reconciliation is keyed by slot id (``data-target``) so
+        # out-of-order arrival is correct by construction.
         if not emitter.thunks:
             return
+
+        # Schedule every thunk concurrently. ``asyncio.ensure_future``
+        # wraps coroutines into tasks so ``as_completed`` can iterate.
+        thunk_tasks = [
+            (view_id, asyncio.ensure_future(thunk_fn())) for view_id, thunk_fn in emitter.thunks
+        ]
+        # Build a reverse lookup so we can recover the view_id when a
+        # task surfaces from ``as_completed``.
+        task_to_id = {task: view_id for view_id, task in thunk_tasks}
+
         try:
-            for view_id, thunk_fn in emitter.thunks:
+            for completed in asyncio.as_completed([task for _, task in thunk_tasks]):
                 if emitter.cancelled:
+                    # Cancel any still-pending thunks so they don't
+                    # leak past the response. Already-completed tasks
+                    # whose results we haven't iterated yet are GC'd.
+                    for _vid, task in thunk_tasks:
+                        if not task.done():
+                            task.cancel()
                     return
                 try:
-                    chunk_bytes = await thunk_fn()
+                    chunk_bytes = await completed
                 except ChunkEmitterCancelled:
                     raise
+                except asyncio.CancelledError:
+                    # Cooperative cancel — emitter was cancelled while
+                    # this thunk was in-flight. The outer ``cancelled``
+                    # check on the next iteration will exit cleanly.
+                    continue
                 except Exception:  # noqa: BLE001 — thunk owns its own envelope
+                    # Recover view_id from the originating task so the
+                    # log message is actionable.
+                    failed_task = next(
+                        (t for t in task_to_id if t.done() and t.exception() is not None),
+                        None,
+                    )
+                    failed_id = task_to_id.get(failed_task, "<unknown>")
                     logger.exception(
                         "arender_chunks: lazy thunk raised for view_id=%s; "
                         "thunks should catch + emit error envelope themselves",
-                        view_id,
+                        failed_id,
                     )
                     continue
                 if chunk_bytes is None:
@@ -448,9 +482,14 @@ Object.assign(window.handlerMetadata, {json.dumps(metadata)});
                     chunk_bytes = chunk_bytes.encode("utf-8")
                 await emitter.emit(chunk_bytes)
                 # Yield between fills so each chunk has a chance to
-                # leave the wire before the next thunk's render starts.
+                # leave the wire before the next completed task is
+                # picked up.
                 await asyncio.sleep(0)
         except ChunkEmitterCancelled:
+            # Cancel any still-running tasks on the way out.
+            for _vid, task in thunk_tasks:
+                if not task.done():
+                    task.cancel()
             logger.debug("arender_chunks: cancelled during lazy phase")
             return
 

--- a/python/djust/mixins/template.py
+++ b/python/djust/mixins/template.py
@@ -434,46 +434,60 @@ Object.assign(window.handlerMetadata, {json.dumps(metadata)});
         if not emitter.thunks:
             return
 
-        # Schedule every thunk concurrently. ``asyncio.ensure_future``
-        # wraps coroutines into tasks so ``as_completed`` can iterate.
+        # Per-thunk wrapper returns ``(view_id, result, exc)`` so the
+        # surfacing task is unambiguously identified at completion
+        # time. A naive ``next(t for t in task_to_id if t.done() and
+        # t.exception() ...)`` recovery returns the FIRST done-with-
+        # exception task — on multi-failure that attributes the wrong
+        # view_id. Wrapping packages the identity at thunk-start time.
+        async def _wrap(view_id, thunk_fn):
+            try:
+                result = await thunk_fn()
+            except asyncio.CancelledError:
+                # Re-raise so as_completed sees the cancellation
+                # propagate; otherwise the wrapped task swallows the
+                # cancel signal and the caller can't tell.
+                raise
+            except ChunkEmitterCancelled:
+                raise
+            except Exception as exc:  # noqa: BLE001 — captured for logging
+                return (view_id, None, exc)
+            return (view_id, result, None)
+
         thunk_tasks = [
-            (view_id, asyncio.ensure_future(thunk_fn())) for view_id, thunk_fn in emitter.thunks
+            asyncio.ensure_future(_wrap(view_id, thunk_fn)) for view_id, thunk_fn in emitter.thunks
         ]
-        # Build a reverse lookup so we can recover the view_id when a
-        # task surfaces from ``as_completed``.
-        task_to_id = {task: view_id for view_id, task in thunk_tasks}
+
+        def _cancel_pending():
+            for task in thunk_tasks:
+                if not task.done():
+                    task.cancel()
 
         try:
-            for completed in asyncio.as_completed([task for _, task in thunk_tasks]):
+            for completed in asyncio.as_completed(thunk_tasks):
                 if emitter.cancelled:
-                    # Cancel any still-pending thunks so they don't
-                    # leak past the response. Already-completed tasks
-                    # whose results we haven't iterated yet are GC'd.
-                    for _vid, task in thunk_tasks:
-                        if not task.done():
-                            task.cancel()
+                    _cancel_pending()
                     return
                 try:
-                    chunk_bytes = await completed
+                    view_id, chunk_bytes, exc = await completed
                 except ChunkEmitterCancelled:
                     raise
                 except asyncio.CancelledError:
-                    # Cooperative cancel — emitter was cancelled while
-                    # this thunk was in-flight. The outer ``cancelled``
-                    # check on the next iteration will exit cleanly.
+                    # Suppressing CancelledError is safe HERE because
+                    # this is an INNER thunk task being cancelled by
+                    # ``_cancel_pending`` (in response to the outer
+                    # emitter cancel). The outer ``arender_chunks``
+                    # coroutine's own cancellation propagates via the
+                    # next iteration's ``emitter.cancelled`` check and
+                    # then the outer ``except ChunkEmitterCancelled``
+                    # branch. Re-raising here would short-circuit that.
                     continue
-                except Exception:  # noqa: BLE001 — thunk owns its own envelope
-                    # Recover view_id from the originating task so the
-                    # log message is actionable.
-                    failed_task = next(
-                        (t for t in task_to_id if t.done() and t.exception() is not None),
-                        None,
-                    )
-                    failed_id = task_to_id.get(failed_task, "<unknown>")
+                if exc is not None:
                     logger.exception(
                         "arender_chunks: lazy thunk raised for view_id=%s; "
                         "thunks should catch + emit error envelope themselves",
-                        failed_id,
+                        view_id,
+                        exc_info=exc,
                     )
                     continue
                 if chunk_bytes is None:
@@ -486,12 +500,14 @@ Object.assign(window.handlerMetadata, {json.dumps(metadata)});
                 # picked up.
                 await asyncio.sleep(0)
         except ChunkEmitterCancelled:
-            # Cancel any still-running tasks on the way out.
-            for _vid, task in thunk_tasks:
-                if not task.done():
-                    task.cancel()
+            _cancel_pending()
             logger.debug("arender_chunks: cancelled during lazy phase")
             return
+        finally:
+            # Defensive — drain any remaining pending tasks so we don't
+            # leak ``coroutine '_AsCompletedIterator._wait_for_one'
+            # was never awaited`` warnings on early-return paths.
+            _cancel_pending()
 
     def _split_for_streaming(self, full_html: str) -> tuple:
         """Split rendered HTML into ``(shell_open, main_content, shell_close)``.

--- a/tests/integration/test_chunks_overlap.py
+++ b/tests/integration/test_chunks_overlap.py
@@ -145,7 +145,16 @@ class TestParallelRender:
     @pytest.mark.asyncio
     async def test_parallel_thunk_failure_does_not_stall_others(self, rf, make_parent):
         """If one thunk raises, the others still emit their fills.
-        Failure is logged + skipped per ADR §"Error propagation"."""
+        Failure is logged + skipped per ADR §"Error propagation".
+
+        Note: ``_failing`` here is a bare ``async def`` that raises —
+        NOT how production thunks behave. The PR-B tag closure catches
+        its own exceptions and emits a ``data-status="error"``
+        envelope. This test exercises the OUTER (defensive) phase-5
+        error handler that catches anything the closure missed; the
+        log message uses the per-thunk wrapper's ``view_id`` capture
+        so multi-failure attribution is correct.
+        """
         parent = make_parent()
         parent.request = rf.get("/")
         emitter = ChunkEmitter(parent.request)
@@ -173,3 +182,45 @@ class TestParallelRender:
         # outer phase-5 handler logs and skips). Production thunks do
         # catch + emit error envelopes.
         assert b'id="djl-fill-slot-bad"' not in body
+
+    @pytest.mark.asyncio
+    async def test_cancel_mid_stream_aborts_pending_thunks(self, rf, make_parent):
+        """T-PRC-4 from ADR §"Test contract": when the emitter is
+        cancelled while thunks are still running, ``arender_chunks``
+        cancels every pending task via ``task.cancel()`` and returns
+        cleanly. Tests the cancellation propagation path that the basic
+        ``test_aget_cancels_emitter_on_disconnect`` does not exercise
+        (which has no thunks registered).
+        """
+        parent = make_parent()
+        parent.request = rf.get("/")
+        emitter = ChunkEmitter(parent.request)
+
+        # Slow thunks so the cancel fires while they're pending.
+        for vid in ("slot-slow-1", "slot-slow-2", "slot-slow-3"):
+            emitter.register_thunk(vid, _make_sleeping_thunk(vid, 1.0))
+
+        async def _drain():
+            return [c async for c in emitter]
+
+        consumer = asyncio.create_task(_drain())
+        # Run arender_chunks in the background; cancel the emitter
+        # mid-stream so the phase-5 loop hits the cancellation branch.
+        render_task = asyncio.create_task(parent.arender_chunks(parent.template, emitter))
+
+        # Yield once so render_task starts; then cancel.
+        await asyncio.sleep(0.05)
+        await emitter.cancel("test-disconnect")
+
+        # arender_chunks returns cleanly within a short window —
+        # without ``_cancel_pending`` it would block on the slow
+        # thunks for 1 second.
+        await asyncio.wait_for(render_task, timeout=0.5)
+        await emitter.close()
+        chunks = await consumer
+
+        # No fills should have completed before cancellation.
+        body = b"".join(chunks)
+        assert b'id="djl-fill-slot-slow-1"' not in body
+        assert b'id="djl-fill-slot-slow-2"' not in body
+        assert b'id="djl-fill-slot-slow-3"' not in body

--- a/tests/integration/test_chunks_overlap.py
+++ b/tests/integration/test_chunks_overlap.py
@@ -1,0 +1,175 @@
+"""Integration tests for v0.9.0 PR-C: asyncio.as_completed parallel
+lazy render (ADR-015).
+
+PR-B shipped the sequential thunk loop in ``arender_chunks`` Phase 5.
+PR-C swaps to ``asyncio.as_completed`` so lazy children render in
+parallel. Total wall-clock time = max(thunk_durations) instead of
+sum(thunk_durations); chunks emerge in completion order rather than
+registration order.
+
+These tests are wall-clock-sensitive but use generous tolerances
+(50ms) to stay non-flaky on shared CI workers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import List
+
+import pytest
+
+from djust.http_streaming import ChunkEmitter
+
+
+# ---------------------------------------------------------------------------
+# Thunk factory — produces a thunk that sleeps for the requested duration
+# then emits a tag chunk identifying itself.
+# ---------------------------------------------------------------------------
+
+
+def _make_sleeping_thunk(view_id: str, sleep_s: float):
+    async def _thunk():
+        await asyncio.sleep(sleep_s)
+        return (
+            f'<template id="djl-fill-{view_id}" data-target="{view_id}" '
+            f'data-status="ok"><span>{view_id}</span></template>'
+            f'<script>window.djust.lazyFill("{view_id}")</script>'
+        ).encode("utf-8")
+
+    return _thunk
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class _ParentStub:
+    """Bare-minimum stand-in for a LiveView — supplies arender_chunks via
+    inheritance from TemplateMixin."""
+
+    template = "<!DOCTYPE html><html><body><div dj-root></div></body></html>"
+
+
+@pytest.fixture
+def make_parent():
+    """Construct a real LiveView so we get arender_chunks via the mixin
+    chain."""
+    from djust import LiveView
+
+    class _ParallelTestParent(LiveView):
+        template = "<!DOCTYPE html><html><body><div dj-root></div></body></html>"
+
+        def mount(self, request, **kwargs):
+            pass
+
+    return _ParallelTestParent
+
+
+class TestParallelRender:
+    @pytest.mark.asyncio
+    async def test_fills_arrive_in_completion_order_not_registration_order(self, rf, make_parent):
+        """Three thunks with sleeps 100ms, 50ms, 25ms registered in that
+        order. With sequential render, fills arrive 100ms / 150ms /
+        175ms. With parallel render via as_completed, fills arrive in
+        completion order: 25ms (slot-c), 50ms (slot-b), 100ms (slot-a).
+
+        We assert the order of fill ids in the chunk stream matches
+        completion order, NOT registration order.
+        """
+        parent = make_parent()
+        parent.request = rf.get("/")
+        emitter = ChunkEmitter(parent.request)
+
+        emitter.register_thunk("slot-a", _make_sleeping_thunk("slot-a", 0.10))
+        emitter.register_thunk("slot-b", _make_sleeping_thunk("slot-b", 0.05))
+        emitter.register_thunk("slot-c", _make_sleeping_thunk("slot-c", 0.025))
+
+        async def _drain():
+            return [c async for c in emitter]
+
+        consumer = asyncio.create_task(_drain())
+        # ``arender_chunks`` runs Phase 1-4 (instant for this minimal
+        # template) then Phase 5 (parallel thunks).
+        await parent.arender_chunks(parent.template, emitter)
+        await emitter.close()
+        chunks = await consumer
+
+        body = b"".join(chunks)
+        # Find the position of each fill template — order of arrival.
+        positions = sorted(
+            [
+                (body.find(f'id="djl-fill-{vid}"'.encode("utf-8")), vid)
+                for vid in ("slot-a", "slot-b", "slot-c")
+            ]
+        )
+        ordered_ids = [vid for _pos, vid in positions]
+
+        # Completion order: c (25ms) → b (50ms) → a (100ms).
+        assert ordered_ids == ["slot-c", "slot-b", "slot-a"], (
+            f"expected completion order [c,b,a], got {ordered_ids}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_total_wall_clock_is_max_not_sum(self, rf, make_parent):
+        """Three thunks with 50ms sleep each. Sequential render takes
+        ≥ 150ms; parallel takes ≈ 50ms. Generous 100ms tolerance — the
+        invariant we're checking is "well below the sequential
+        baseline", not exact wall-clock."""
+        parent = make_parent()
+        parent.request = rf.get("/")
+        emitter = ChunkEmitter(parent.request)
+
+        for vid in ("slot-x", "slot-y", "slot-z"):
+            emitter.register_thunk(vid, _make_sleeping_thunk(vid, 0.05))
+
+        async def _drain():
+            chunks: List[bytes] = []
+            async for c in emitter:
+                chunks.append(c)
+            return chunks
+
+        consumer = asyncio.create_task(_drain())
+        t0 = time.perf_counter()
+        await parent.arender_chunks(parent.template, emitter)
+        await emitter.close()
+        await consumer
+        elapsed = time.perf_counter() - t0
+
+        # 3 × 50ms sequential = 150ms baseline. Parallel: ~50ms +
+        # overhead. 100ms ceiling proves parallel even on slow
+        # workers.
+        assert elapsed < 0.10, f"expected parallel render under 100ms, took {elapsed * 1000:.1f}ms"
+
+    @pytest.mark.asyncio
+    async def test_parallel_thunk_failure_does_not_stall_others(self, rf, make_parent):
+        """If one thunk raises, the others still emit their fills.
+        Failure is logged + skipped per ADR §"Error propagation"."""
+        parent = make_parent()
+        parent.request = rf.get("/")
+        emitter = ChunkEmitter(parent.request)
+
+        async def _failing():
+            raise ValueError("intentional failure mid-render")
+
+        emitter.register_thunk("slot-good-1", _make_sleeping_thunk("slot-good-1", 0.01))
+        emitter.register_thunk("slot-bad", _failing)
+        emitter.register_thunk("slot-good-2", _make_sleeping_thunk("slot-good-2", 0.02))
+
+        async def _drain():
+            return [c async for c in emitter]
+
+        consumer = asyncio.create_task(_drain())
+        await parent.arender_chunks(parent.template, emitter)
+        await emitter.close()
+        chunks = await consumer
+
+        body = b"".join(chunks)
+        # Both healthy thunks emit.
+        assert b'id="djl-fill-slot-good-1"' in body
+        assert b'id="djl-fill-slot-good-2"' in body
+        # Failed thunk does NOT emit (its closure didn't catch + wrap;
+        # outer phase-5 handler logs and skips). Production thunks do
+        # catch + emit error envelopes.
+        assert b'id="djl-fill-slot-bad"' not in body


### PR DESCRIPTION
## Summary

Final PR of the v0.9.0 streaming arc. Closes #1043. Replaces the sequential thunk loop in `arender_chunks` Phase 5 with `asyncio.as_completed` so lazy children render in parallel.

| | |
|---|---|
| Foundation | PR #1135 (PR-A) — `aget` + `ChunkEmitter` + `arender_chunks` |
| API + dispatch | PR #1138 (PR-B) — `{% live_render lazy=True %}` + `as_view` wiring |
| **This PR** (PR-C) | `asyncio.as_completed` parallel render |

## What changes

| Before (PR-B) | After (PR-C) |
|---|---|
| Sequential `for` loop over thunks | `asyncio.ensure_future` per thunk; iterate over `asyncio.as_completed` |
| Wall clock = sum(thunk durations) | Wall clock = max(thunk durations) |
| Chunks emerge in registration order | Chunks emerge in completion order |

Client-side reconciliation is keyed by slot id (`data-target` on `<template id="djl-fill-X">`), so out-of-order arrival is correct by construction. **Zero client changes needed.**

## Cancellation

Mid-stream client disconnect cancels all pending thunk tasks via `task.cancel()`. Already-completed tasks whose results were not yet iterated are GC'd. Tasks already running through `sync_to_async` to synchronous render code complete normally — asyncio cancellation doesn't propagate into sync DB work, the documented contract per ADR-015 §"Cancellation contract".

## Tests

3 new wall-clock-sensitive integration tests in `tests/integration/test_chunks_overlap.py`:
1. **Order**: thunks (100ms, 50ms, 25ms) registered a→b→c → fills arrive c→b→a (completion order, NOT registration order).
2. **Wall clock**: 3 × 50ms thunks → total < 100ms (sequential baseline 150ms; 100ms tolerance keeps non-flaky on shared CI).
3. **Failure isolation**: one thunk raises → others still emit fills (no stall).

## Test plan

- [x] `pytest tests/integration/test_chunks_overlap.py` → 3/3 pass
- [x] `pytest tests/integration/test_lazy_streaming_flow.py tests/unit/test_async_render_path.py tests/unit/test_live_render_lazy.py tests/integration/test_streaming_flow.py` → 40/40 pass (no regression)
- [x] Pre-commit + pre-push hooks green

## Closes #1043

v0.9.0 streaming arc complete after PR-C merges:
- ✅ Async render foundation (PR-A)
- ✅ `lazy=True` user API + dispatch wiring (PR-B)
- ✅ Parallel render via `asyncio.as_completed` (PR-C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)