### PR TITLE
feat(theming): namespace cookie names per project (closes #1158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Theming cookie namespace for per-project isolation on shared
+  domains (closes #1158)** — adds opt-in
+  `LIVEVIEW_CONFIG['theme']['cookie_namespace']` setting so multiple
+  djust projects on `localhost:80xx` (or any shared domain) don't
+  overwrite each other's theme preferences. Browsers scope cookies by
+  domain only — not by port — so the four `djust_theme*` cookies bleed
+  across projects without this. PR #1013 already shipped
+  `enable_client_override: False` as a workaround, but that breaks
+  sites with a user-facing theme switcher; this is the missing piece
+  for those sites. When `cookie_namespace="djust_org"` is set, the
+  cookies become `djust_org_djust_theme`, `djust_org_djust_theme_preset`,
+  `djust_org_djust_theme_pack`, `djust_org_djust_theme_layout`.
+  Read path tries namespaced first, falls back to unprefixed once on
+  upgrade so users keep their existing theme. Write path (`theme.js`)
+  reads `window.__djust_theme_cookie_prefix` injected by
+  `theme_head.html` and writes only the namespaced name when set. When
+  unset (default), the legacy unprefixed names are used — existing
+  deployments unaffected. 8 new regression cases in
+  `tests/unit/test_theming_cookie_namespace_1158.py` cover namespaced
+  precedence, unprefixed fallback, default back-compat, two-namespace
+  isolation, all four cookies honour the namespace, and the
+  `theme_head.html` + `theme.js` write-side wiring.
 - **Rust template engine `{% live_render %}` lazy=True parity (closes
   #1145)** — the Rust template engine now ships a registered handler
   for `{% live_render %}`, closing the v0.9.0 PR-B (#1138) gap. Before

--- a/docs/website/guides/components.md
+++ b/docs/website/guides/components.md
@@ -818,6 +818,44 @@ Then use theme colors in Tailwind classes:
 </button>
 ```
 
+### Cross-project cookie isolation (`cookie_namespace`)
+
+If you run two or more djust projects on the same domain (e.g.
+`localhost:8001`, `localhost:8002`, etc.), browsers scope cookies by domain
+only — *not* by port. Without isolation, the four theming cookies
+(`djust_theme`, `djust_theme_preset`, `djust_theme_pack`,
+`djust_theme_layout`) leak across projects, so picking the "Cyberpunk" pack
+in project A pins it for project B too.
+
+For sites without a user-facing theme switcher, the simpler fix is
+`enable_client_override: False` (introduced in v0.8.2 / #1013), which makes
+the server ignore client cookies entirely.
+
+For sites *with* a user-facing switcher — where cookie writes must stay on —
+set a per-project namespace:
+
+```python
+LIVEVIEW_CONFIG = {
+    "theme": {
+        "cookie_namespace": "djust_org",   # any unique-per-project string
+    },
+}
+```
+
+When set, theming cookies are read and written under
+`<ns>_djust_theme`, `<ns>_djust_theme_preset`, `<ns>_djust_theme_pack`, and
+`<ns>_djust_theme_layout`, so each project gets its own slot in the shared
+cookie jar.
+
+The read path tries the namespaced cookie first and falls back to the legacy
+unprefixed cookie once on the first request after upgrade — users keep their
+existing theme choice. After the user clicks the switcher (or any other path
+that calls `setPreset` / `setPack` / `setTheme` / `setLayout`), only the
+namespaced cookie is written.
+
+When `cookie_namespace` is unset (default), the unprefixed names are used —
+existing deployments don't lose their theme on upgrade.
+
 ## Choosing a Styling Approach
 
 | Approach                                 | When to Use                                                                                                                           |

--- a/python/djust/theming/manager.py
+++ b/python/djust/theming/manager.py
@@ -283,18 +283,42 @@ class ThemeManager:
         # answering on localhost shares a cookie jar — `djust_theme_pack` set
         # by project A pins the palette for project B). Default ``True`` for
         # back-compat: sites with a user-facing switcher keep working.
+        #
+        # #1158 — sites WITH a user-facing switcher (so cookies must stay on)
+        # can opt into a per-project cookie namespace via
+        # ``LIVEVIEW_CONFIG['theme']['cookie_namespace']: '<ns>'``. When set,
+        # the four theming cookies become ``<ns>_djust_theme``,
+        # ``<ns>_djust_theme_preset``, ``<ns>_djust_theme_pack``,
+        # ``<ns>_djust_theme_layout``. Read-side falls back to the unprefixed
+        # name for one-time migration; write-side (theme.js) writes only the
+        # namespaced name when the prefix is set.
         theme = None
         preset = None
         pack = None
         layout = ""
         enable_client_override = bool(self.config.get("enable_client_override", True))
         if self.request and enable_client_override:
-            theme = self.request.COOKIES.get("djust_theme")
-            preset = self.request.COOKIES.get("djust_theme_preset")
-            pack = self.request.COOKIES.get("djust_theme_pack")
-            layout = self.request.COOKIES.get("djust_theme_layout", "")
+            cookies = self.request.COOKIES
+            ns = (self.config.get("cookie_namespace") or "").strip()
+            prefix = f"{ns}_" if ns else ""
+
+            # Read namespaced first; fall back to unprefixed (migration window).
+            def _read(name: str, default: str = "") -> str:
+                if prefix:
+                    return cookies.get(f"{prefix}{name}", cookies.get(name, default))
+                return cookies.get(name, default)
+
+            theme = _read("djust_theme") or None
+            preset = _read("djust_theme_preset") or None
+            pack = _read("djust_theme_pack") or None
+            layout = _read("djust_theme_layout", "")
             logger.debug(
-                "Cookies: theme=%s, preset=%s, pack=%s, layout=%s", theme, preset, pack, layout
+                "Cookies (ns=%r): theme=%s, preset=%s, pack=%s, layout=%s",
+                ns,
+                theme,
+                preset,
+                pack,
+                layout,
             )
         elif self.request:
             logger.debug("Cookies skipped — LIVEVIEW_CONFIG.theme.enable_client_override=False")

--- a/python/djust/theming/static/djust_theming/js/theme.js
+++ b/python/djust/theming/static/djust_theming/js/theme.js
@@ -18,10 +18,19 @@
     const STORAGE_KEY_PACK = 'djust-theme-pack';
     const STORAGE_KEY_LAYOUT = 'djust-theme-layout';
 
-    const COOKIE_KEY_PRESET = 'djust_theme_preset';
-    const COOKIE_KEY_THEME = 'djust_theme';
-    const COOKIE_KEY_PACK = 'djust_theme_pack';
-    const COOKIE_KEY_LAYOUT = 'djust_theme_layout';
+    // #1158 — Per-project cookie namespace. The server emits
+    // `window.__djust_theme_cookie_prefix` from `theme_head.html` based on
+    // `LIVEVIEW_CONFIG['theme']['cookie_namespace']`. Empty string means the
+    // legacy unprefixed cookie names (back-compat). When set, every theming
+    // cookie this script writes is prefixed so two djust projects on the
+    // same localhost domain don't overwrite each other's theme preferences.
+    const COOKIE_PREFIX = (typeof window !== 'undefined' && typeof window.__djust_theme_cookie_prefix === 'string')
+        ? window.__djust_theme_cookie_prefix
+        : '';
+    const COOKIE_KEY_PRESET = COOKIE_PREFIX + 'djust_theme_preset';
+    const COOKIE_KEY_THEME = COOKIE_PREFIX + 'djust_theme';
+    const COOKIE_KEY_PACK = COOKIE_PREFIX + 'djust_theme_pack';
+    const COOKIE_KEY_LAYOUT = COOKIE_PREFIX + 'djust_theme_layout';
 
     class DjustThemeManager {
         constructor() {

--- a/python/djust/theming/templates/djust_theming/theme_head.html
+++ b/python/djust/theming/templates/djust_theming/theme_head.html
@@ -1,10 +1,12 @@
 {# Theme head block: anti-FOUC script, CSS, and optional JS include #}
 {# Safety: autoescape off is safe here — all variables (css_block, direction, etc.) #}
 {# are framework-generated in theme_tags.py, not user input. #}
+{# cookie_prefix_js is a JSON-encoded string ("" or "<ns>_"), framework-generated. #}
 {% load static %}
 {% autoescape off %}
 <script>
 (function() {
+    window.__djust_theme_cookie_prefix = {{ cookie_prefix_js }};
     {% if loading_class %}document.documentElement.classList.add('loading');
     {% endif %}var storageKey = 'djust-theme-mode';
     var storedMode = localStorage.getItem(storageKey);

--- a/python/djust/theming/templatetags/theme_tags.py
+++ b/python/djust/theming/templatetags/theme_tags.py
@@ -17,6 +17,8 @@ Usage:
     {% theme_preset_selector layout="dropdown" %}
 """
 
+import json
+
 from django import template
 from django.template.loader import render_to_string
 from django.urls import reverse, NoReverseMatch
@@ -129,6 +131,13 @@ def theme_head(context, include_js: bool = True, link_css: bool = False):
     # Resolve text direction
     direction = get_direction()
 
+    # #1158 — namespace prefix for theming cookies (cross-project isolation
+    # on shared domains like localhost). JSON-encoded for safe inlining in a
+    # <script> context (json.dumps gives a valid JS string literal).
+    ns = (config.get("cookie_namespace") or "").strip()
+    cookie_prefix = f"{ns}_" if ns else ""
+    cookie_prefix_js = json.dumps(cookie_prefix)
+
     # Render via shared template
     html = render_to_string(
         "djust_theming/theme_head.html",
@@ -140,6 +149,7 @@ def theme_head(context, include_js: bool = True, link_css: bool = False):
             "include_component_link": include_component_link,
             "include_js": include_js,
             "direction": direction,
+            "cookie_prefix_js": cookie_prefix_js,
         },
     )
     return mark_safe(html)

--- a/tests/unit/test_theming_cookie_namespace_1158.py
+++ b/tests/unit/test_theming_cookie_namespace_1158.py
@@ -1,0 +1,230 @@
+"""Regression tests for #1158 — per-project cookie namespace for theming.
+
+Background
+----------
+On localhost, cookies are scoped by domain only (not port). Multiple djust
+projects on `localhost:80xx` share the `djust_theme*` cookie jar and overwrite
+each other. PR #1013 added `enable_client_override: False` as a workaround,
+but sites with a user-facing theme switcher need cookie writes ON, so the
+bleed persists for them.
+
+Fix
+---
+`LIVEVIEW_CONFIG['theme']['cookie_namespace']: '<ns>'` causes the four
+theming cookies to be read/written as `<ns>_djust_theme`,
+`<ns>_djust_theme_preset`, `<ns>_djust_theme_pack`, `<ns>_djust_theme_layout`.
+
+Read order: namespaced first, fall back to unprefixed for one-time migration.
+Write order: only namespaced (handled by `theme.js` reading
+`window.__djust_theme_cookie_prefix` injected by `theme_head.html`).
+
+These tests cover the read side (Python) and the write-side wiring (the
+template emits the right `__djust_theme_cookie_prefix` value, and the JS
+file's cookie-key constants resolve from that global).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from django.template import Context, Template
+from django.test import RequestFactory
+
+
+# ---------------------------------------------------------------------------
+# Read side — ThemeManager.get_state()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_namespaced_cookie_wins_when_namespace_set():
+    """When `cookie_namespace` is set, the namespaced cookie is read."""
+    from djust.theming.manager import ThemeManager
+
+    rf = RequestFactory()
+    req = rf.get("/")
+    req.COOKIES["djust_org_djust_theme_pack"] = "nyc_core"
+    # Stale unprefixed cookie from another project on the same domain — must NOT win.
+    req.COOKIES["djust_theme_pack"] = "djust"
+    req.session = {}
+
+    mgr = ThemeManager(request=req)
+    mgr.config = dict(mgr.config, cookie_namespace="djust_org", enable_client_override=True)
+    state = mgr.get_state()
+    assert state.pack == "nyc_core", (
+        f"namespaced cookie must win over stale unprefixed cookie; got pack={state.pack!r}"
+    )
+
+
+@pytest.mark.django_db
+def test_namespace_set_falls_back_to_unprefixed_when_namespaced_missing():
+    """Migration window: when the namespaced cookie hasn't been written yet
+    (first request after upgrade), fall back to the unprefixed cookie so
+    users don't lose their existing theme on upgrade."""
+    from djust.theming.manager import ThemeManager
+
+    rf = RequestFactory()
+    req = rf.get("/")
+    # Only the legacy unprefixed cookie is present.
+    req.COOKIES["djust_theme_pack"] = "nyc_core"
+    req.session = {}
+
+    mgr = ThemeManager(request=req)
+    mgr.config = dict(mgr.config, cookie_namespace="djust_org", enable_client_override=True)
+    state = mgr.get_state()
+    assert state.pack == "nyc_core", (
+        f"unprefixed fallback must apply when namespaced cookie missing; got pack={state.pack!r}"
+    )
+
+
+@pytest.mark.django_db
+def test_no_namespace_reads_unprefixed_default_back_compat():
+    """Default behaviour (no namespace configured): read the legacy unprefixed
+    cookie. Existing deployments must keep working unchanged."""
+    from djust.theming.manager import ThemeManager
+
+    rf = RequestFactory()
+    req = rf.get("/")
+    req.COOKIES["djust_theme_pack"] = "nyc_core"
+    req.session = {}
+
+    mgr = ThemeManager(request=req)
+    # cookie_namespace not set in config (default).
+    mgr.config = dict(mgr.config, enable_client_override=True)
+    mgr.config.pop("cookie_namespace", None)
+    state = mgr.get_state()
+    assert state.pack == "nyc_core"
+
+
+@pytest.mark.django_db
+def test_two_namespace_isolation():
+    """Project A (namespace='a') only sees its own namespaced cookie even when
+    project B's namespaced cookie is also present in the cookie jar (which
+    happens on a shared localhost domain)."""
+    from djust.theming.manager import ThemeManager
+
+    rf = RequestFactory()
+    req = rf.get("/")
+    # Both projects' cookies present in the shared jar.
+    req.COOKIES["a_djust_theme_pack"] = "pack_a"
+    req.COOKIES["b_djust_theme_pack"] = "pack_b"
+    req.session = {}
+
+    mgr_a = ThemeManager(request=req)
+    mgr_a.config = dict(mgr_a.config, cookie_namespace="a", enable_client_override=True)
+    state_a = mgr_a.get_state()
+    assert state_a.pack == "pack_a", f"namespace 'a' must read 'a_*' cookies; got {state_a.pack!r}"
+
+    # Same request, different ThemeManager configured for namespace 'b'.
+    req2 = rf.get("/")
+    req2.COOKIES["a_djust_theme_pack"] = "pack_a"
+    req2.COOKIES["b_djust_theme_pack"] = "pack_b"
+    req2.session = {}
+    mgr_b = ThemeManager(request=req2)
+    mgr_b.config = dict(mgr_b.config, cookie_namespace="b", enable_client_override=True)
+    state_b = mgr_b.get_state()
+    assert state_b.pack == "pack_b", f"namespace 'b' must read 'b_*' cookies; got {state_b.pack!r}"
+
+
+@pytest.mark.django_db
+def test_namespace_applies_to_all_four_cookies():
+    """All four theming cookies (theme, preset, pack, layout) honour the
+    namespace, not just `pack`."""
+    from djust.theming.manager import ThemeManager
+
+    rf = RequestFactory()
+    req = rf.get("/")
+    req.COOKIES["proj_djust_theme"] = "ios"
+    req.COOKIES["proj_djust_theme_preset"] = "rose"
+    req.COOKIES["proj_djust_theme_pack"] = "nyc_core"
+    req.COOKIES["proj_djust_theme_layout"] = "sidebar"
+    # Stale unprefixed cookies from another project — must NOT bleed in.
+    req.COOKIES["djust_theme"] = "material"
+    req.COOKIES["djust_theme_preset"] = "default"
+    req.COOKIES["djust_theme_pack"] = "djust"
+    req.COOKIES["djust_theme_layout"] = ""
+    req.session = {}
+
+    mgr = ThemeManager(request=req)
+    mgr.config = dict(mgr.config, cookie_namespace="proj", enable_client_override=True)
+    state = mgr.get_state()
+    # Pack overrides theme + preset (existing behaviour) — assert pack wins.
+    assert state.pack == "nyc_core"
+    assert state.layout == "sidebar"
+
+
+# ---------------------------------------------------------------------------
+# Write side — theme_head.html template emits __djust_theme_cookie_prefix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_theme_head_emits_empty_prefix_when_no_namespace(settings):
+    """When no namespace is configured, the inline anti-FOUC script sets
+    `window.__djust_theme_cookie_prefix = ""`. That keeps `theme.js` writing
+    the legacy unprefixed cookie names — back-compat default."""
+    settings.LIVEVIEW_CONFIG = {"theme": {}}
+
+    rf = RequestFactory()
+    req = rf.get("/")
+    req.COOKIES = {}
+    req.session = {}
+
+    rendered = Template("{% load theme_tags %}{% theme_head %}").render(Context({"request": req}))
+    assert 'window.__djust_theme_cookie_prefix = ""' in rendered, (
+        f"expected empty-prefix global; got snippet:\n{rendered[:600]}"
+    )
+
+
+@pytest.mark.django_db
+def test_theme_head_emits_namespaced_prefix_when_configured(settings):
+    """When `cookie_namespace='djust_org'`, the inline script emits
+    `window.__djust_theme_cookie_prefix = "djust_org_"`. `theme.js` reads
+    that global to build prefixed cookie keys before writing."""
+    settings.LIVEVIEW_CONFIG = {"theme": {"cookie_namespace": "djust_org"}}
+
+    rf = RequestFactory()
+    req = rf.get("/")
+    req.COOKIES = {}
+    req.session = {}
+
+    rendered = Template("{% load theme_tags %}{% theme_head %}").render(Context({"request": req}))
+    assert 'window.__djust_theme_cookie_prefix = "djust_org_"' in rendered, (
+        f"expected 'djust_org_' prefix global; got snippet:\n{rendered[:600]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# theme.js: cookie-key constants resolve from window.__djust_theme_cookie_prefix
+# ---------------------------------------------------------------------------
+
+
+def test_theme_js_reads_cookie_prefix_from_window_global():
+    """The shipped `theme.js` must read `window.__djust_theme_cookie_prefix`
+    when computing cookie keys. Without this, no namespacing reaches the
+    write path."""
+    theme_js = (
+        Path(__file__).resolve().parent.parent.parent
+        / "python"
+        / "djust"
+        / "theming"
+        / "static"
+        / "djust_theming"
+        / "js"
+        / "theme.js"
+    )
+    text = theme_js.read_text()
+    # The prefix is read from window.
+    assert "window.__djust_theme_cookie_prefix" in text, (
+        "theme.js must consult window.__djust_theme_cookie_prefix"
+    )
+    # Cookie keys are built by concatenation, not as static literals.
+    # Match e.g. `COOKIE_KEY_THEME = COOKIE_PREFIX + 'djust_theme'`
+    assert re.search(r"COOKIE_KEY_THEME\s*=\s*COOKIE_PREFIX\s*\+\s*['\"]djust_theme['\"]", text), (
+        "COOKIE_KEY_THEME must be derived from COOKIE_PREFIX, not a static literal"
+    )
+    assert re.search(
+        r"COOKIE_KEY_PACK\s*=\s*COOKIE_PREFIX\s*\+\s*['\"]djust_theme_pack['\"]", text
+    ), "COOKIE_KEY_PACK must be derived from COOKIE_PREFIX"


### PR DESCRIPTION
## Summary

Closes #1158. Adds opt-in `LIVEVIEW_CONFIG['theme']['cookie_namespace']` so multiple djust projects on the same domain (e.g. `localhost:80xx`) don't overwrite each other's theme preferences. Browsers scope cookies by domain only — not by port — so the four `djust_theme*` cookies bleed across projects without this. PR #1013 already shipped `enable_client_override: False` as a workaround, but that breaks sites with a user-facing theme switcher; this is the missing piece for those sites.

```python
LIVEVIEW_CONFIG = {
    "theme": {"cookie_namespace": "djust_org"},
}
```

## Design choice

- **Read side (`ThemeManager.get_state`)**: read namespaced first, fall back to legacy unprefixed name once on upgrade so users keep their existing theme.
- **Write side**: only the namespaced name is written. The shipped `theme.js` derives `COOKIE_KEY_*` from `window.__djust_theme_cookie_prefix`, which `theme_head.html` injects from `LIVEVIEW_CONFIG['theme']['cookie_namespace']`. No regeneration of static JS needed.
- **Default**: when `cookie_namespace` is unset, the legacy unprefixed names are used — existing deployments unaffected.

## Behavior matrix

| `cookie_namespace` | Namespaced cookie present | Unprefixed cookie present | Result |
|---|---|---|---|
| unset | — | yes | reads unprefixed (legacy) |
| unset | — | no  | falls back to session/config |
| `"ns"` | yes | (any)  | reads namespaced (wins over unprefixed) |
| `"ns"` | no  | yes | reads unprefixed (one-time migration fallback) |
| `"ns"` | no  | no  | falls back to session/config |

## Back-compat

When `cookie_namespace` is unset (default), behavior is byte-for-byte identical to v0.9.0:
- Cookies read/written under the unprefixed names.
- The new `window.__djust_theme_cookie_prefix` global is set to `""`, which makes `theme.js`'s `COOKIE_PREFIX + 'djust_theme'` evaluate to the legacy literal `'djust_theme'`.

When `cookie_namespace` is set (opt-in):
- First request after upgrade: server reads the legacy unprefixed cookie (fallback) so the theme is preserved across the cutover.
- Next user click on the theme switcher: `theme.js` writes the namespaced cookie.
- Subsequent requests: server reads the namespaced cookie.

## Test count

- 8 new regression cases in `tests/unit/test_theming_cookie_namespace_1158.py`.
- Full suite: 4583 passed, 14 skipped (unchanged baseline).
- Targeted theming subset: 643 passed.

## Files touched

- `python/djust/theming/manager.py` — read-side namespace logic in `ThemeManager.get_state`.
- `python/djust/theming/static/djust_theming/js/theme.js` — `COOKIE_KEY_*` constants derived from `window.__djust_theme_cookie_prefix`.
- `python/djust/theming/templates/djust_theming/theme_head.html` — emits the prefix global before the existing anti-FOUC script.
- `python/djust/theming/templatetags/theme_tags.py` — computes `cookie_prefix_js` (JSON-encoded for safe inline injection).
- `tests/unit/test_theming_cookie_namespace_1158.py` (new) — 8 regression cases.
- `docs/website/guides/components.md` — "Cross-project cookie isolation (`cookie_namespace`)" subsection in the djust-theming guide.
- `CHANGELOG.md` — `[Unreleased] / Added` entry.

## Test plan

- [x] `pytest tests/unit/test_theming_cookie_namespace_1158.py` — 8/8 pass
- [x] `pytest python/djust/ tests/` — 4583 pass, no regressions
- [x] `pre-push` hook (full suite + checks) — passed on push
- [ ] Manual: configure `cookie_namespace="djust_org"` in `djust.org`, reload, click switcher, inspect Cookies tab — verify only `djust_org_djust_theme*` cookies are written
- [ ] Manual: spin up two djust projects on `localhost:8001` and `localhost:8002` with different namespaces, switch theme on one, verify the other is unaffected

## Stage 11 self-review notes

- 🟡 **`build_themes.py` not modified.** The task brief mentioned updating its JS template; on inspection that file generates `djust-theme-switcher.js` which is **localStorage-only** (no cookie writes). LocalStorage is origin-scoped (port-aware), so there's no cross-project bleed in the bug class for that path. The actual cookie writes live in `static/djust_theming/js/theme.js`, which this PR does update.
- 🟡 The implementation deliberately does NOT touch session keys (`session_key="djust_theme"` in `DEFAULT_CONFIG`). Sessions are server-scoped per Django's settings and don't suffer the cross-project cookie-jar problem. Out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)