### PR TITLE
feat(data_table): row-level navigation accessibility + CSP-strict layer (closes #1111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`{% data_table %}` row-level navigation: accessibility, keyboard,
+  and CSP-strict layer (closes #1111)** — layers v0.9.1 quality
+  additions onto the prior #1111 row-navigation scaffolding (which
+  shipped `row_click_event` / `row_url` template-tag args, mixin
+  defaults, and structural wiring). What's added:
+  - **Accessibility**: every row-clickable `<tr>` now renders
+    `role="button"`, `tabindex="0"`, and `cursor:pointer`. Screen
+    readers announce the row as a button; keyboard users get focus.
+  - **Keyboard activation**: Enter and Space on a focused row fire
+    the configured action. Guarded by `document.activeElement === tr`
+    so Space inside a nested input doesn't hijack the keystroke.
+  - **Nested-control guard**: clicks inside `<a>`, `<button>`,
+    `<input>`, `<label>`, `<select>`, `<textarea>` are short-circuited
+    via capture-phase `stopImmediatePropagation`, so the row-level
+    action never fires for those clicks. This is the integration
+    point with `selectable=True` (per-row checkbox) and the
+    cell-level link column (#1110).
+  - **CSP-strict friendly**: the row_url path's previous inline
+    `onclick="window.location=this.dataset.href"` is replaced by a
+    new component JS module
+    (`python/djust/components/static/djust_components/data-table-row-click.js`).
+    No inline event handlers, no nonce plumbing — works under
+    `script-src 'self'` out of the box.
+  - **Defense-in-depth**: `data-href` values are regex-validated
+    against `/^(https?:|\/|\.)/` before `window.location.assign`,
+    so a hostile `javascript:` URI cannot execute even if it sneaks
+    into the row dict.
+  - **Multi-line template comments fixed**: the pre-existing
+    `{# ... #}` row-nav and link-column doc comments were rendering
+    as literal text in output because Django's `{# %}` is
+    single-line-only. Converted to `{% comment %}...{% endcomment %}`.
+
+  New cases in `TestRowClickAccessibility`,
+  `TestRowClickableMarkerClass`, `TestRowClickAffordance`,
+  `TestCSPInlineHandler`, `TestSelectableComposition`, `TestCSPNonce`
+  (`tests/unit/test_data_table_row_navigation_1111.py`, 14 Python
+  cases) plus 11 JS cases in `tests/js/data_table_row_click.test.js`
+  cover: role + tabindex presence, marker class on/off, no-inline-
+  onclick (CSP), checkbox cell composition, click navigation, nested
+  `<a>`/`<input>` guard, Enter/Space activation, `activeElement`
+  guard, javascript: URI rejection, dj-click composition (capture-phase
+  stop), and bindRow idempotence. One pre-existing structural test
+  in `python/tests/test_data_table_link_row_nav.py` was rewritten to
+  assert the new `data-table-row-clickable` marker class instead of
+  the removed inline `onclick`.
+
 - **Theming cookie namespace for per-project isolation on shared
   domains (closes #1158)** — adds opt-in
   `LIVEVIEW_CONFIG['theme']['cookie_namespace']` setting so multiple

--- a/docs/website/guides/components.md
+++ b/docs/website/guides/components.md
@@ -680,6 +680,95 @@ INSTALLED_APPS = [
 | `{% pagination %}`                         | Page navigation                      |
 | `{% avatar %}`                             | User avatar with initials fallback   |
 
+### `{% data_table %}` row-level navigation (#1111)
+
+Two ways to make whole rows clickable for navigation. Both render
+`role="button"`, `tabindex="0"`, and `cursor:pointer` on every row, and
+both respect Enter / Space for keyboard activation. Clicks inside
+nested interactive descendants (`<a>`, `<button>`, `<input>`,
+`<label>`, `<select>`, `<textarea>`) are short-circuited so they
+**never** trigger row navigation.
+
+**Option B — `row_click_event` (preferred, LiveView-idiomatic)**: each
+`<tr>` fires a djust event with `data-value=row[row_click_value_key]`.
+Your `@event_handler` receives the row's value via `**kwargs` and can
+`self.redirect(...)` (or do anything else):
+
+```python
+from djust import LiveView
+from djust.decorators import event_handler
+from django.urls import reverse
+
+class ClaimsListView(LiveView):
+    template_name = "claims/list.html"
+
+    def mount(self, request, **kwargs):
+        self.rows = list(Claim.objects.values("id", "claim_number", "status"))
+        self.columns = [
+            {"key": "claim_number", "label": "Claim #"},
+            {"key": "status", "label": "Status"},
+        ]
+
+    @event_handler()
+    def open_claim(self, value: str = "", **kwargs):
+        self.redirect(reverse("claims:detail", kwargs={"claim_id": value}))
+```
+
+```django
+{% data_table rows=rows columns=columns
+              row_click_event="open_claim"
+              row_click_value_key="id" %}
+```
+
+`row_click_value_key` defaults to `"id"`; override for slug-based
+routing (e.g. `"uuid"`, `"slug"`).
+
+**Option A — `row_url` (static-URL fallback)**: each `<tr>` gets
+`data-href` from a row dict key; the component JS module navigates via
+`window.location.assign(href)` on click / Enter / Space. Use when the
+target URL is computed once in the view and doesn't need a server
+round-trip:
+
+```python
+def get_context_data(self, **kwargs):
+    ctx = super().get_context_data(**kwargs)
+    ctx["rows"] = [
+        {"claim_number": "C-001", "claim_url": reverse("claims:detail", args=[1])},
+    ]
+    ctx["columns"] = [{"key": "claim_number", "label": "Claim #"}]
+    return ctx
+```
+
+```django
+{% data_table rows=rows columns=columns row_url="claim_url" %}
+```
+
+`row_click_event` takes precedence when both are set.
+
+**Accessibility**: row-clickable `<tr>`s are focusable (`tabindex="0"`),
+announce as buttons (`role="button"`), and activate on Enter or Space.
+Screen reader users get the same affordance as mouse / touch users.
+
+**CSP-strict friendly**: no inline event handlers, no `eval`, no nonce
+plumbing required. Both options work under
+`Content-Security-Policy: script-src 'self'` once the component JS
+module is served as a static asset (no `'unsafe-inline'`).
+
+**Composition with `selectable=True`**: per-row checkbox cells are
+`<input>` elements, which are in the nested-control guard's protected
+list. Clicking the checkbox fires the existing `select_event` and does
+**not** also fire row navigation.
+
+**Composition with cell-level link columns (#1110)**: cell `<a>` tags
+also "win" — clicking a cell link follows the link without firing the
+row event.
+
+**Static-URL safety**: Option A's `data-href` value is regex-validated
+(`/^(https?:|\/|\.)/`) before navigation, so a hostile `javascript:`
+URI cannot execute even if it sneaks into the row dict. Always prefer
+URLs computed from `reverse()` in your view; never assign
+user-controlled strings to `row_url` data.
+
 ### Customization
 
 All components use CSS custom properties. Override them to match any theme:

--- a/python/djust/components/static/djust_components/data-table-row-click.js
+++ b/python/djust/components/static/djust_components/data-table-row-click.js
@@ -50,11 +50,14 @@
     // Static-URL path: navigate via dataset.href.
     var href = tr.dataset && tr.dataset.href;
     if (href) {
-      // Only allow http(s) and relative-path URLs to defend against a
-      // hostile data-href value sneaking in (e.g. javascript: URIs).
+      // Only allow http(s) and SAME-ORIGIN relative-path URLs to defend
+      // against a hostile data-href value sneaking in (e.g. javascript:
+      // URIs or protocol-relative `//evil.com/...` cross-origin redirects).
       // Developer-controlled values from `reverse()` are always either
       // absolute or relative paths, never `javascript:` schemes.
-      if (/^(https?:|\/|\.)/.test(href)) {
+      // The `(?!\/)` lookahead on the leading `/` rejects `//host` while
+      // still allowing single-leading-slash absolute paths.
+      if (/^(https?:\/\/|\/(?!\/)|\.)/.test(href)) {
         // Tests override window.__djustRowClickNavigate to capture the
         // target URL since JSDOM's window.location.assign is
         // non-configurable. Production code path is the default arm.

--- a/python/djust/components/static/djust_components/data-table-row-click.js
+++ b/python/djust/components/static/djust_components/data-table-row-click.js
@@ -1,0 +1,161 @@
+/**
+ * djust-components Data Table — Row-level navigation handler (#1111).
+ *
+ * Adds keyboard accessibility (Enter / Space activate a focused row) and
+ * a nested-control guard (clicks inside an interactive descendant
+ * <a>/<button>/<input>/<label>/<select> do NOT trigger row navigation)
+ * to data_table rows that opt in via the `data-table-row-clickable`
+ * marker class.
+ *
+ * The template tag emits one of two row shapes when row navigation is
+ * enabled:
+ *   1. `dj-click="<event>" data-value="<row_key>"` (Option B, preferred):
+ *      djust's existing event binder fires the LiveView event on
+ *      bubble-phase click. This module's job is purely defensive —
+ *      cancel the click in the capture phase when the target is a
+ *      nested control, so the LiveView event handler never fires for
+ *      those clicks.
+ *   2. `data-href="<url>"` (Option A, static URL): no `dj-click`, so
+ *      this module is responsible for the navigation. On click (and on
+ *      Enter / Space keydown when focused), navigate via
+ *      `window.location.assign(tr.dataset.href)`. Same nested-control
+ *      guard applies.
+ *
+ * Design notes:
+ *   - CSP-strict friendly: no inline event handlers, no eval, no nonce
+ *     plumbing required. The whole feature works under
+ *     `script-src 'self'` once this file is served as a static asset.
+ *   - Composition with selectable=True: the per-row checkbox is an
+ *     <input>, so the nested-control guard automatically suppresses row
+ *     navigation when clicking it. No special-case code required.
+ *   - Composition with the cell-level link column (#1110): the cell
+ *     <a> is also caught by the nested-control guard, so cell links
+ *     "win" over row navigation — clicking the link follows the link
+ *     and does NOT also fire the row event.
+ *   - Auto-init on DOMContentLoaded; re-runs on djust LiveView VDOM
+ *     patches via a MutationObserver, idempotent per-row via a
+ *     `_dtRowClick` instance flag so repeated patches don't double-bind.
+ */
+(function () {
+  "use strict";
+
+  // Selectors for descendants whose clicks should NOT propagate up to
+  // row-level navigation. Matches the Stage 4 brief enumeration plus
+  // textarea (a non-button form control whose accidental row-nav would
+  // be just as user-hostile as the others).
+  var NESTED_CONTROL_SELECTOR =
+    "a, button, input, label, select, textarea";
+
+  function navigateForRow(tr) {
+    // Static-URL path: navigate via dataset.href.
+    var href = tr.dataset && tr.dataset.href;
+    if (href) {
+      // Only allow http(s) and relative-path URLs to defend against a
+      // hostile data-href value sneaking in (e.g. javascript: URIs).
+      // Developer-controlled values from `reverse()` are always either
+      // absolute or relative paths, never `javascript:` schemes.
+      if (/^(https?:|\/|\.)/.test(href)) {
+        // Tests override window.__djustRowClickNavigate to capture the
+        // target URL since JSDOM's window.location.assign is
+        // non-configurable. Production code path is the default arm.
+        var navigate =
+          (typeof window !== "undefined" &&
+            window.__djustRowClickNavigate) ||
+          function (h) {
+            window.location.assign(h);
+          };
+        navigate(href);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  function bindRow(tr) {
+    if (tr._dtRowClick) return;
+    tr._dtRowClick = true;
+
+    // Capture-phase click on the row: if the click originated inside a
+    // nested control, stopImmediatePropagation prevents the bubble-phase
+    // dj-click handler from firing, AND prevents this module's own
+    // click->navigate logic below.
+    tr.addEventListener(
+      "click",
+      function (e) {
+        if (e.target !== tr && e.target.closest) {
+          var nested = e.target.closest(NESTED_CONTROL_SELECTOR);
+          if (nested && tr.contains(nested)) {
+            // The nested control gets to handle the click natively.
+            // Suppress row-level navigation entirely.
+            e.stopImmediatePropagation();
+            return;
+          }
+        }
+
+        // Static-URL navigation. (For dj-click rows, this is a no-op
+        // because dataset.href isn't set.)
+        navigateForRow(tr);
+      },
+      true /* capture */
+    );
+
+    // Keyboard activation: Enter and Space when the row is focused
+    // synthesise a click. The click then re-enters the handler above
+    // with `e.target === tr`, so the nested-control guard doesn't trip
+    // and the navigation (or dj-click) fires normally.
+    tr.addEventListener("keydown", function (e) {
+      if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+        // Only fire when the row itself is the active element — don't
+        // hijack Space when the user is typing into a nested input.
+        if (document.activeElement !== tr) return;
+        e.preventDefault();
+        tr.click();
+      }
+    });
+  }
+
+  function initWrapper(wrapper) {
+    var rows = wrapper.querySelectorAll("tr.data-table-row-clickable");
+    rows.forEach(bindRow);
+  }
+
+  function initAll() {
+    document.querySelectorAll(".data-table-wrapper").forEach(initWrapper);
+    // Also support tables that aren't wrapped (defensive).
+    document
+      .querySelectorAll("tr.data-table-row-clickable")
+      .forEach(bindRow);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initAll);
+  } else {
+    initAll();
+  }
+
+  // Re-init on djust LiveView patches that insert new rows.
+  if (typeof MutationObserver !== "undefined") {
+    var observer = new MutationObserver(function (mutations) {
+      var shouldInit = false;
+      for (var i = 0; i < mutations.length; i++) {
+        if (mutations[i].addedNodes.length) {
+          shouldInit = true;
+          break;
+        }
+      }
+      if (shouldInit) initAll();
+    });
+    if (document.body) {
+      observer.observe(document.body, { childList: true, subtree: true });
+    }
+  }
+
+  // Expose for tests and for explicit re-init from app code.
+  if (typeof window !== "undefined") {
+    window.djustDataTableRowClick = {
+      initAll: initAll,
+      initWrapper: initWrapper,
+      bindRow: bindRow,
+    };
+  }
+})();

--- a/python/djust/components/templates/djust_components/table.html
+++ b/python/djust/components/templates/djust_components/table.html
@@ -97,4 +97,21 @@
   </div>
   {% endif %}
   {% endif %}
+
+  {% if row_click_event or row_url %}
+  {% comment %}
+    #1111: auto-load the row-click handler when row navigation is enabled.
+
+    Hardcoded /static/ prefix (default STATIC_URL). Works for the default
+    Django configuration without requiring `{% load static %}` (which a
+    bare `Engine()` test renderer can't resolve). Sites with a custom
+    STATIC_URL can override `djust_components/table.html` via Django's
+    standard template-customization mechanism — drop a copy in their
+    own templates dir with their `{% static %}` resolution.
+
+    Defer attribute → loads after parsing; the JS module is idempotent if
+    multiple data_tables on one page each emit this script tag.
+  {% endcomment %}
+  <script src="/static/djust_components/data-table-row-click.js" defer></script>
+  {% endif %}
 </div>

--- a/python/djust/components/templates/djust_components/table.html
+++ b/python/djust/components/templates/djust_components/table.html
@@ -39,10 +39,17 @@
     </thead>
     <tbody>
       {% for row in rows %}
-      {# #1111: row-level navigation. row_click_event fires a djust event
-         (LiveView-idiomatic, preferred); row_url is a static fallback that
-         uses dataset+JS to navigate without LiveView routing. #}
-      <tr{% if selectable %} aria-selected="{% if row.id|stringformat:'s' in selected_rows %}true{% else %}false{% endif %}"{% endif %}{% if row_click_event %} dj-click="{{ row_click_event }}" data-value="{{ row|dictsort:row_click_value_key|first }}" style="cursor:pointer"{% elif row_url %} data-href="{{ row|dictsort:row_url|first }}" style="cursor:pointer" onclick="window.location=this.dataset.href"{% endif %}>
+      {% comment %}
+        #1111: row-level navigation. row_click_event fires a djust event
+        (LiveView-idiomatic, preferred); row_url is a static fallback
+        that uses dataset+JS to navigate without LiveView routing. The
+        data-table-row-clickable marker class wires up keyboard
+        activation (Enter / Space) and a nested-control guard (clicks
+        inside <a>/<button>/<input>/<label>/<select> do NOT trigger row
+        navigation) via the data-table-row-click.js component module —
+        CSP-clean, no inline event handlers.
+      {% endcomment %}
+      <tr{% if selectable %} aria-selected="{% if row.id|stringformat:'s' in selected_rows %}true{% else %}false{% endif %}"{% endif %}{% if row_click_event %} class="data-table-row-clickable" dj-click="{{ row_click_event }}" data-value="{{ row|dictsort:row_click_value_key|first }}" role="button" tabindex="0" style="cursor:pointer"{% elif row_url %} class="data-table-row-clickable" data-href="{{ row|dictsort:row_url|first }}" role="button" tabindex="0" style="cursor:pointer"{% endif %}>
         {% if selectable %}
         <td>
           <input type="checkbox" class="data-table-checkbox"
@@ -52,10 +59,12 @@
         </td>
         {% endif %}
         {% for col in columns %}
-        {# #1110: link column type. col.link names a key in the same row
-           dict that holds the href; col.link_class is an optional CSS
-           class on the <a>. Falls through to plain text when col.link
-           is unset, preserving pre-#1110 behavior. #}
+        {% comment %}
+          #1110: link column type. col.link names a key in the same row
+          dict that holds the href; col.link_class is an optional CSS
+          class on the <a>. Falls through to plain text when col.link
+          is unset, preserving pre-#1110 behavior.
+        {% endcomment %}
         <td>{% if col.link %}<a href="{{ row|dictsort:col.link|first }}"{% if col.link_class %} class="{{ col.link_class }}"{% endif %}>{{ row|dictsort:col.key|first }}</a>{% else %}{{ row|dictsort:col.key|first }}{% endif %}</td>
         {% endfor %}
       </tr>

--- a/python/tests/test_data_table_link_row_nav.py
+++ b/python/tests/test_data_table_link_row_nav.py
@@ -152,13 +152,20 @@ class RowUrlStructureTest(TestCase):
     """#1111 Option A: row_url adds data-href + inline JS to <tr>."""
 
     def test_row_url_attaches_data_href_and_onclick(self):
+        """Pre-#1111-v0.9.1: this asserted an inline ``onclick=""``. The
+        v0.9.1 implementation moved navigation logic into the static JS
+        component module ``data-table-row-click.js`` for CSP-strict
+        compatibility, so the inline handler is gone — the marker class
+        ``data-table-row-clickable`` is the new hook the JS module
+        binds against. ``data-href`` and ``cursor:pointer`` are still
+        emitted on the <tr>."""
         rows = [{"claim_url": "/claims/1/", "name": "Claim 1"}]
         columns = [{"key": "name", "label": "Name"}]
         out = render_table(_base_ctx(rows, columns, row_url="claim_url"))
         # data-href attribute is present (value extracted by Rust engine
         # at runtime; we just assert the wiring is in place).
         self.assertIn("data-href=", out)
-        self.assertIn("window.location=this.dataset.href", out)
+        self.assertIn("data-table-row-clickable", out)
         self.assertIn("cursor:pointer", out)
 
     def test_row_click_event_takes_precedence_over_row_url(self):

--- a/tests/js/data_table_row_click.test.js
+++ b/tests/js/data_table_row_click.test.js
@@ -271,3 +271,59 @@ describe("data-table-row-click — idempotence", () => {
     expect(dom.window.__locationAssignSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("data-table-row-click — URL allowlist (open-redirect defense)", () => {
+  // Stage 11 review of PR #1170 found `/^(https?:|\/|\.)/` allowed
+  // protocol-relative URLs (`//evil.com/path`) — same-origin assumption
+  // fails. Tightened to `/^(https?:\/\/|\/(?!\/)|\.)/` which rejects `//`.
+  it("rejects protocol-relative URL `//evil.com/path` (cross-origin)", () => {
+    const dom = buildDom(`
+      <table><tbody>
+        <tr class="data-table-row-clickable" role="button" tabindex="0"
+            data-href="//evil.com/path">
+          <td>cell</td>
+        </tr>
+      </tbody></table>
+    `);
+    const tr = dom.window.document.querySelector("tr.data-table-row-clickable");
+    dom.window.djustDataTableRowClick.bindRow(tr);
+
+    tr.click();
+
+    expect(dom.window.__locationAssignSpy).not.toHaveBeenCalled();
+  });
+
+  it("accepts single-leading-slash absolute path `/claims/42`", () => {
+    const dom = buildDom(`
+      <table><tbody>
+        <tr class="data-table-row-clickable" role="button" tabindex="0"
+            data-href="/claims/42">
+          <td>cell</td>
+        </tr>
+      </tbody></table>
+    `);
+    const tr = dom.window.document.querySelector("tr.data-table-row-clickable");
+    dom.window.djustDataTableRowClick.bindRow(tr);
+
+    tr.click();
+
+    expect(dom.window.__locationAssignSpy).toHaveBeenCalledWith("/claims/42");
+  });
+
+  it("rejects `javascript:alert(1)` (existing guard, regression)", () => {
+    const dom = buildDom(`
+      <table><tbody>
+        <tr class="data-table-row-clickable" role="button" tabindex="0"
+            data-href="javascript:alert(1)">
+          <td>cell</td>
+        </tr>
+      </tbody></table>
+    `);
+    const tr = dom.window.document.querySelector("tr.data-table-row-clickable");
+    dom.window.djustDataTableRowClick.bindRow(tr);
+
+    tr.click();
+
+    expect(dom.window.__locationAssignSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/js/data_table_row_click.test.js
+++ b/tests/js/data_table_row_click.test.js
@@ -1,0 +1,273 @@
+/**
+ * Tests for #1111 row-level navigation client-side handler
+ * (`python/djust/components/static/djust_components/data-table-row-click.js`).
+ *
+ * Covers:
+ *   - Click on `<tr.data-table-row-clickable>` with `data-href` →
+ *     `window.location.assign(href)` is called.
+ *   - Click on a nested `<a>` inside the row → navigation does NOT fire.
+ *   - Keyboard Enter / Space on a focused row → navigation fires.
+ *   - Click on the selectable checkbox cell → navigation does NOT fire
+ *     (composes with the dj-click case via the same nested-control
+ *     guard since `<input>` is in the protected-descendants list).
+ *
+ * The handler is loaded as a component module (not bundled into
+ * `client.js`), so we eval it directly into a JSDOM and exercise the
+ * exposed `window.djustDataTableRowClick.bindRow()` entry point.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { JSDOM } from "jsdom";
+import { readFileSync } from "fs";
+
+const ROW_CLICK_JS_PATH =
+  "./python/djust/components/static/djust_components/data-table-row-click.js";
+const rowClickCode = readFileSync(ROW_CLICK_JS_PATH, "utf-8");
+
+function buildDom(bodyHtml) {
+  const dom = new JSDOM(
+    `<!DOCTYPE html><html><body>${bodyHtml}</body></html>`,
+    { runScripts: "dangerously", url: "http://localhost/" }
+  );
+  // JSDOM 26+ marks window.location.assign as non-writable +
+  // non-configurable, so we can't intercept it directly. The handler
+  // module honours a test-only hook, window.__djustRowClickNavigate,
+  // when present — used here to capture target URLs without actually
+  // navigating.
+  const assignSpy = vi.fn();
+  dom.window.__djustRowClickNavigate = assignSpy;
+  dom.window.__locationAssignSpy = assignSpy;
+  // Eval the component module into the JSDOM window.
+  dom.window.eval(rowClickCode);
+  // The module hooks DOMContentLoaded when readyState === "loading"
+  // (which is true under JSDOM); fire it explicitly so initAll() runs.
+  dom.window.document.dispatchEvent(
+    new dom.window.Event("DOMContentLoaded")
+  );
+  return dom;
+}
+
+function clickableRowMarkup({
+  href = "/c/1/",
+  withCheckbox = false,
+  withAnchor = false,
+} = {}) {
+  return `
+    <div class="data-table-wrapper">
+      <table class="data-table">
+        <tbody>
+          <tr class="data-table-row-clickable"
+              data-href="${href}"
+              role="button" tabindex="0" style="cursor:pointer">
+            ${
+              withCheckbox
+                ? `<td><input type="checkbox" class="data-table-checkbox" id="cb1"></td>`
+                : ""
+            }
+            <td>
+              ${
+                withAnchor
+                  ? `<a href="/inner/" id="inner-link">inner</a>`
+                  : "Plain cell"
+              }
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  `;
+}
+
+describe("data-table-row-click — Option A (data-href)", () => {
+  it("navigates via window.location.assign on row click", () => {
+    const dom = buildDom(clickableRowMarkup());
+    const tr = dom.window.document.querySelector("tr.data-table-row-clickable");
+    expect(tr).not.toBeNull();
+
+    // Click on the row's plain cell (target === td → bubbles to tr).
+    const td = tr.querySelector("td");
+    td.click();
+
+    expect(dom.window.__locationAssignSpy).toHaveBeenCalledTimes(1);
+    expect(dom.window.__locationAssignSpy).toHaveBeenCalledWith("/c/1/");
+  });
+
+  it("does NOT navigate when click target is a nested <a>", () => {
+    const dom = buildDom(clickableRowMarkup({ withAnchor: true }));
+    const link = dom.window.document.getElementById("inner-link");
+    expect(link).not.toBeNull();
+
+    link.click();
+
+    expect(dom.window.__locationAssignSpy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT navigate when click target is a nested <input> (selectable composition)", () => {
+    const dom = buildDom(clickableRowMarkup({ withCheckbox: true }));
+    const cb = dom.window.document.getElementById("cb1");
+    expect(cb).not.toBeNull();
+
+    cb.click();
+
+    expect(dom.window.__locationAssignSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects javascript: URI in data-href (defense-in-depth)", () => {
+    // Even if a developer accidentally let a hostile value through into
+    // data-href, the handler must not call assign() with a
+    // javascript: URI.
+    const dom = buildDom(
+      clickableRowMarkup({ href: "javascript:alert(1)" })
+    );
+    const tr = dom.window.document.querySelector("tr.data-table-row-clickable");
+    tr.click();
+
+    expect(dom.window.__locationAssignSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("data-table-row-click — keyboard activation", () => {
+  it("Enter on a focused row triggers navigation", () => {
+    const dom = buildDom(clickableRowMarkup());
+    const tr = dom.window.document.querySelector("tr.data-table-row-clickable");
+    tr.focus();
+
+    const enterEvent = new dom.window.KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
+    tr.dispatchEvent(enterEvent);
+
+    expect(dom.window.__locationAssignSpy).toHaveBeenCalledTimes(1);
+    expect(dom.window.__locationAssignSpy).toHaveBeenCalledWith("/c/1/");
+  });
+
+  it("Space on a focused row triggers navigation", () => {
+    const dom = buildDom(clickableRowMarkup());
+    const tr = dom.window.document.querySelector("tr.data-table-row-clickable");
+    tr.focus();
+
+    const spaceEvent = new dom.window.KeyboardEvent("keydown", {
+      key: " ",
+      bubbles: true,
+      cancelable: true,
+    });
+    tr.dispatchEvent(spaceEvent);
+
+    expect(dom.window.__locationAssignSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("Space inside a nested input does NOT hijack the keystroke", () => {
+    // The user is typing in a nested checkbox/text input — Space must
+    // NOT navigate. Implementation guard: only fires when
+    // document.activeElement === tr.
+    const dom = buildDom(clickableRowMarkup({ withCheckbox: true }));
+    const cb = dom.window.document.getElementById("cb1");
+    cb.focus();
+
+    const spaceEvent = new dom.window.KeyboardEvent("keydown", {
+      key: " ",
+      bubbles: true,
+      cancelable: true,
+    });
+    // Space dispatched FROM the checkbox bubbles up; we must not
+    // navigate because document.activeElement is the checkbox, not
+    // the row.
+    cb.dispatchEvent(spaceEvent);
+
+    expect(dom.window.__locationAssignSpy).not.toHaveBeenCalled();
+  });
+
+  it("non-Enter/Space keys do nothing", () => {
+    const dom = buildDom(clickableRowMarkup());
+    const tr = dom.window.document.querySelector("tr.data-table-row-clickable");
+    tr.focus();
+
+    ["Tab", "Escape", "ArrowDown", "a"].forEach((key) => {
+      tr.dispatchEvent(
+        new dom.window.KeyboardEvent("keydown", {
+          key,
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    });
+
+    expect(dom.window.__locationAssignSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("data-table-row-click — Option B (dj-click composition)", () => {
+  /**
+   * Verifies that for the dj-click row shape, the handler:
+   *   - Does NOT call window.location.assign (no data-href).
+   *   - DOES call stopImmediatePropagation when target is a nested
+   *     control (so the bubble-phase dj-click handler never fires).
+   *   - Does NOT cancel the click for plain row clicks (so dj-click
+   *     fires normally on bubble).
+   */
+  it("plain row click does not preventDefault or stopPropagation", () => {
+    const dom = buildDom(`
+      <table class="data-table"><tbody>
+        <tr class="data-table-row-clickable"
+            dj-click="open_user" data-value="42"
+            role="button" tabindex="0">
+          <td id="cell">Alice</td>
+        </tr>
+      </tbody></table>
+    `);
+    const tr = dom.window.document.querySelector("tr.data-table-row-clickable");
+    let bubbledTarget = null;
+    // Mimic djust's bubble-phase dj-click binding via a document-level
+    // capture-false listener. If our capture-phase handler stops
+    // propagation, this listener won't fire.
+    dom.window.document.addEventListener("click", function (e) {
+      if (e.target.closest && e.target.closest("[dj-click]")) {
+        bubbledTarget = e.target.closest("[dj-click]");
+      }
+    });
+
+    dom.window.document.getElementById("cell").click();
+
+    expect(bubbledTarget).toBe(tr); // bubble reached document
+    expect(dom.window.__locationAssignSpy).not.toHaveBeenCalled();
+  });
+
+  it("nested <a> click stops propagation so dj-click does not fire", () => {
+    const dom = buildDom(`
+      <table class="data-table"><tbody>
+        <tr class="data-table-row-clickable"
+            dj-click="open_user" data-value="42"
+            role="button" tabindex="0">
+          <td><a href="/inner/" id="inner-link">link</a></td>
+        </tr>
+      </tbody></table>
+    `);
+    let djClickFired = false;
+    dom.window.document.addEventListener("click", function (e) {
+      if (e.target.closest && e.target.closest("[dj-click]")) {
+        djClickFired = true;
+      }
+    });
+
+    dom.window.document.getElementById("inner-link").click();
+
+    expect(djClickFired).toBe(false);
+  });
+});
+
+describe("data-table-row-click — idempotence", () => {
+  it("bindRow() is safe to call multiple times on the same <tr>", () => {
+    const dom = buildDom(clickableRowMarkup());
+    const tr = dom.window.document.querySelector("tr.data-table-row-clickable");
+    // Manually re-bind a few times.
+    dom.window.djustDataTableRowClick.bindRow(tr);
+    dom.window.djustDataTableRowClick.bindRow(tr);
+    dom.window.djustDataTableRowClick.bindRow(tr);
+
+    tr.click();
+
+    expect(dom.window.__locationAssignSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/test_data_table_row_navigation_1111.py
+++ b/tests/unit/test_data_table_row_navigation_1111.py
@@ -1,0 +1,304 @@
+"""Regression tests for #1111 row-level navigation accessibility +
+nested-control + CSP additions on top of the prior #1110/#1111
+scaffolding.
+
+The earlier ``python/tests/test_data_table_link_row_nav.py`` already
+covers the structural template wiring (``dj-click`` / ``data-href`` on
+each ``<tr>``, mixin defaults, template-tag dispatcher). This file
+covers the v0.9.1 additions called out in the issue brief:
+
+  * ``role="button"`` and ``tabindex="0"`` on row-clickable ``<tr>``
+  * ``data-table-row-clickable`` marker class (drives the JS module)
+  * No inline ``onclick=""`` (CSP-strict friendly)
+  * Selectable composition — checkbox cell does NOT inherit
+    ``dj-click`` from the row, and the row-level ``dj-click`` is NOT
+    accidentally placed on the checkbox.
+  * CSP nonce propagation — the template tag accepts a nonce-aware
+    request without raising; the row-click feature is implemented as a
+    static JS module (CSP-clean), so no inline-script nonce thread is
+    required.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import django
+from django.conf import settings
+from django.template import Context, Engine
+from django.test import SimpleTestCase
+
+# Tests in tests/unit/ run under demo_project's settings module. Lazy
+# Django setup for the bare-template render path.
+if not settings.configured:
+    import os
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "demo_project.settings")
+    django.setup()
+
+
+_TABLE_HTML_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "python"
+    / "djust"
+    / "components"
+    / "templates"
+    / "djust_components"
+    / "table.html"
+)
+_TABLE_TEMPLATE = Engine().from_string(_TABLE_HTML_PATH.read_text())
+
+
+def _base_ctx(rows, columns, **overrides):
+    base = {
+        "rows": rows,
+        "columns": columns,
+        "sort_by": "",
+        "sort_desc": False,
+        "sort_event": "table_sort",
+        "page": 1,
+        "total_pages": 1,
+        "selectable": False,
+        "selected_rows": [],
+        "select_event": "table_select",
+        "row_key": "id",
+        "search": False,
+        "search_query": "",
+        "search_event": "table_search",
+        "search_debounce": 300,
+        "filters": {},
+        "filter_event": "table_filter",
+        "loading": False,
+        "empty_title": "No data",
+        "empty_description": "",
+        "empty_icon": "",
+        "paginate": False,
+        "page_event": "table_page",
+        "prev_event": "table_prev",
+        "next_event": "table_next",
+        "striped": False,
+        "compact": False,
+        "row_click_event": "",
+        "row_click_value_key": "id",
+        "row_url": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _render(ctx):
+    return _TABLE_TEMPLATE.render(Context(ctx))
+
+
+def _tbody(html: str) -> str:
+    start = html.find("<tbody>")
+    end = html.find("</tbody>")
+    return html[start:end] if start != -1 and end != -1 else ""
+
+
+# ---------------------------------------------------------------------------
+# Accessibility: role="button" + tabindex="0" on clickable rows
+# ---------------------------------------------------------------------------
+
+
+class RowClickAccessibilityTest(SimpleTestCase):
+    """When row navigation is enabled, the <tr> must be reachable +
+    activatable via keyboard. role="button" announces the affordance to
+    assistive tech; tabindex="0" puts the row in the focus order."""
+
+    def test_row_click_event_sets_role_button_and_tabindex(self):
+        rows = [{"id": 1, "name": "Alice"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = _render(_base_ctx(rows, columns, row_click_event="open_user"))
+        body = _tbody(out)
+        self.assertIn('role="button"', body)
+        self.assertIn('tabindex="0"', body)
+
+    def test_row_url_sets_role_button_and_tabindex(self):
+        rows = [{"claim_url": "/claims/1/", "name": "Claim 1"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = _render(_base_ctx(rows, columns, row_url="claim_url"))
+        body = _tbody(out)
+        self.assertIn('role="button"', body)
+        self.assertIn('tabindex="0"', body)
+
+    def test_no_row_navigation_no_role_button(self):
+        """Backwards-compat: without row_click_event or row_url,
+        the rendered <tr> must NOT advertise as role=button (it's just a
+        plain row)."""
+        rows = [{"id": 1, "name": "Alice"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = _render(_base_ctx(rows, columns))
+        body = _tbody(out)
+        self.assertNotIn("role=", body)
+        self.assertNotIn("tabindex=", body)
+
+    def test_role_and_tabindex_render_per_row(self):
+        rows = [{"id": 1}, {"id": 2}, {"id": 3}]
+        columns = [{"key": "id", "label": "ID"}]
+        out = _render(_base_ctx(rows, columns, row_click_event="open"))
+        # 3 rows → 3 each
+        self.assertEqual(out.count('role="button"'), 3)
+        self.assertEqual(out.count('tabindex="0"'), 3)
+
+
+# ---------------------------------------------------------------------------
+# Marker class: data-table-row-clickable (drives the JS module)
+# ---------------------------------------------------------------------------
+
+
+class RowClickableMarkerClassTest(SimpleTestCase):
+    """The data-table-row-clickable marker class is what the JS
+    component module hooks onto for keyboard activation + nested-control
+    guard. Both row_click_event and row_url paths must emit it."""
+
+    def test_row_click_event_sets_marker_class(self):
+        rows = [{"id": 1, "name": "Alice"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = _render(_base_ctx(rows, columns, row_click_event="open"))
+        body = _tbody(out)
+        self.assertIn('class="data-table-row-clickable"', body)
+
+    def test_row_url_sets_marker_class(self):
+        rows = [{"claim_url": "/c/1/", "name": "C1"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = _render(_base_ctx(rows, columns, row_url="claim_url"))
+        body = _tbody(out)
+        self.assertIn('class="data-table-row-clickable"', body)
+
+    def test_no_marker_class_when_no_row_navigation(self):
+        rows = [{"id": 1, "name": "Alice"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = _render(_base_ctx(rows, columns))
+        body = _tbody(out)
+        self.assertNotIn("data-table-row-clickable", body)
+
+
+# ---------------------------------------------------------------------------
+# Cursor pointer affordance (already shipped, regression-locked here)
+# ---------------------------------------------------------------------------
+
+
+class RowClickAffordanceTest(SimpleTestCase):
+    def test_cursor_pointer_present_for_event_path(self):
+        rows = [{"id": 1, "name": "A"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = _render(_base_ctx(rows, columns, row_click_event="open"))
+        self.assertIn("cursor:pointer", out)
+
+    def test_cursor_pointer_present_for_url_path(self):
+        rows = [{"claim_url": "/c/1/", "name": "C"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = _render(_base_ctx(rows, columns, row_url="claim_url"))
+        self.assertIn("cursor:pointer", out)
+
+
+# ---------------------------------------------------------------------------
+# CSP-strict friendliness: no inline onclick on the row
+# ---------------------------------------------------------------------------
+
+
+class CSPInlineHandlerTest(SimpleTestCase):
+    """The pre-#1111 row_url path used inline ``onclick=""`` which
+    requires ``script-src 'unsafe-inline'``. The v0.9.1 implementation
+    moves the navigation logic into the static JS component module
+    (``data-table-row-click.js``), so neither path emits inline JS.
+    Locks in the CSP-strict-compatible architecture against accidental
+    regression."""
+
+    def test_row_url_path_emits_no_inline_onclick(self):
+        rows = [{"claim_url": "/claims/1/", "name": "Claim"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = _render(_base_ctx(rows, columns, row_url="claim_url"))
+        body = _tbody(out)
+        self.assertNotIn("onclick=", body)
+        # Defensive: data-href is still wired up for the JS module to
+        # read.
+        self.assertIn("data-href=", body)
+
+    def test_row_click_event_path_emits_no_inline_onclick(self):
+        rows = [{"id": 1, "name": "Alice"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = _render(_base_ctx(rows, columns, row_click_event="open"))
+        body = _tbody(out)
+        self.assertNotIn("onclick=", body)
+
+
+# ---------------------------------------------------------------------------
+# Selectable + row navigation composition
+# ---------------------------------------------------------------------------
+
+
+class SelectableCompositionTest(SimpleTestCase):
+    """selectable=True adds a <td><input type="checkbox" .../></td>
+    cell. With row_click_event also set, the row-level dj-click must
+    NOT be accidentally placed on the checkbox (the existing select_event
+    is what fires for checkbox clicks). The JS module's nested-control
+    guard handles the runtime side; this test locks in the structural
+    side — the dj-click event count matches the row count, not the
+    row-count + checkbox-count."""
+
+    def test_selectable_does_not_double_dj_click_on_checkboxes(self):
+        rows = [{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = _render(
+            _base_ctx(
+                rows,
+                columns,
+                selectable=True,
+                row_click_event="open_user",
+            )
+        )
+        # Only the 2 <tr>s should have dj-click="open_user"; the
+        # 2 checkboxes have dj-click="{{ select_event }}" (default
+        # "table_select"), not "open_user".
+        self.assertEqual(out.count('dj-click="open_user"'), 2)
+        # And the select_event still wires up the checkboxes.
+        self.assertEqual(out.count('dj-click="table_select"'), 3)  # 2 row + 1 select-all
+
+    def test_selectable_checkbox_is_input_for_nested_guard(self):
+        """The JS-side nested-control guard works because the checkbox
+        is an <input>, which is in the NESTED_CONTROL_SELECTOR list.
+        Lock in that the markup is in fact an <input>."""
+        rows = [{"id": 1, "name": "A"}]
+        columns = [{"key": "name", "label": "Name"}]
+        out = _render(
+            _base_ctx(
+                rows,
+                columns,
+                selectable=True,
+                row_click_event="open_user",
+            )
+        )
+        body = _tbody(out)
+        self.assertIn('<input type="checkbox"', body)
+
+
+# ---------------------------------------------------------------------------
+# CSP nonce propagation (smoke)
+# ---------------------------------------------------------------------------
+
+
+class CSPNonceTest(SimpleTestCase):
+    """The data_table template-tag function and underlying template
+    don't crash when rendered against a Context whose request carries a
+    csp_nonce attribute (django-csp's middleware contract). The static
+    JS module architecture means we never need to inject an inline
+    <script> with the nonce, but the test verifies the render path is
+    nonce-tolerant against future template additions that may need it."""
+
+    def test_template_renders_with_csp_nonce_in_context(self):
+        rows = [{"id": 1, "name": "Alice"}]
+        columns = [{"key": "name", "label": "Name"}]
+        ctx = _base_ctx(rows, columns, row_url="claim_url")
+        # Synthetic Django request with csp_nonce — the template-tag
+        # context has no access to the request directly (inclusion-tag
+        # context is the dict returned by data_table()), but adding a
+        # csp_nonce key must not break rendering.
+        ctx["csp_nonce"] = "test-nonce-value-1234"
+        out = _render(ctx)
+        # Render succeeded and produced row markup.
+        self.assertIn("<tbody>", out)
+        # Sanity: no inline-script tag was emitted (CSP-clean
+        # architecture).
+        self.assertNotIn("<script", _tbody(out))


### PR DESCRIPTION
## Summary

Layers v0.9.1 quality additions onto the prior #1111 row-navigation scaffolding (which already shipped `row_click_event` / `row_url` template-tag args, mixin defaults, and structural template wiring):

- **Accessibility**: every row-clickable `<tr>` renders `role="button"`, `tabindex="0"`, and `cursor:pointer` — screen readers announce as button, keyboard users get focus.
- **Keyboard activation**: Enter and Space on a focused row fire the configured action. `document.activeElement === tr` guard so Space inside a nested input doesn't hijack the keystroke.
- **Nested-control guard**: clicks inside `<a>`, `<button>`, `<input>`, `<label>`, `<select>`, `<textarea>` are short-circuited via capture-phase `stopImmediatePropagation` so the row-level action never fires for those clicks. Composes with `selectable=True` (the per-row `<input type="checkbox">`) and the cell-level link column (#1110).
- **CSP-strict friendly**: the row_url path's previous inline `onclick="window.location=this.dataset.href"` is replaced by a new component JS module (`python/djust/components/static/djust_components/data-table-row-click.js`). No inline event handlers, no nonce plumbing — works under `script-src 'self'` out of the box.
- **Defense-in-depth**: `data-href` values are regex-validated against `/^(https?:|\/|\.)/` before `window.location.assign`, so a hostile `javascript:` URI cannot execute.
- **Multi-line template comments fixed**: pre-existing `{# ... #}` row-nav and link-column doc comments rendered as literal text (Django's `{# %}` is single-line-only). Converted to `{% comment %}…{% endcomment %}`.

## Design choice: both options shipped (architectural)

The earlier #1111 PR shipped both `row_click_event` (Option B, LiveView-idiomatic, dj-click on the `<tr>`) and `row_url` (Option A, static-URL navigate via dataset). This PR layers on the missing accessibility / keyboard / CSP / defense-in-depth bits without changing the public API or template-tag signature.

The brief suggested a CSP-nonce-aware inline `<script>` for `row_url`; the chosen architecture (single static JS module, marker class on the `<tr>`) is **strictly more CSP-friendly**: no inline script, no `unsafe-inline` requirement, no nonce plumbing. The same module also handles keyboard activation and nested-control guarding for both options uniformly.

## Behaviour matrix

| Option | Selectable | CSP-strict | Keyboard (Enter/Space) | Nested-control guard |
|--------|-----------|-----------|------------------------|----------------------|
| `row_click_event` | ✓ (checkbox cell unaffected) | ✓ (no inline JS) | ✓ | ✓ |
| `row_url` | ✓ | ✓ (static module replaces inline `onclick`) | ✓ | ✓ |
| Neither (default) | ✓ | n/a (no row-nav) | n/a | n/a |
| Both set | `row_click_event` wins (existing precedence rule) | ✓ | ✓ | ✓ |

## Test count delta

- Python: **+14** new cases in 6 classes (`tests/unit/test_data_table_row_navigation_1111.py`); 1 pre-existing case rewritten in `python/tests/test_data_table_link_row_nav.py` to match the architectural change (no longer asserting inline `onclick`). 28 cases total in the two data_table-row-nav test files now pass.
- JS: **+11** new cases in `tests/js/data_table_row_click.test.js`.
- Net: **+25 test cases**.

## Issue × file × test mapping

| Issue | Files modified | Test classes / cases |
|-------|---------------|----------------------|
| #1111 (this PR) | `python/djust/components/templates/djust_components/table.html` | `TestRowClickAccessibility` (4), `TestRowClickableMarkerClass` (3), `TestRowClickAffordance` (2), `TestCSPInlineHandler` (2), `TestSelectableComposition` (2), `TestCSPNonce` (1) |
| #1111 (this PR) | `python/djust/components/static/djust_components/data-table-row-click.js` (new) | `data-table-row-click — Option A (data-href)` (4), `keyboard activation` (4), `Option B (dj-click composition)` (2), `idempotence` (1) |
| #1111 (compat with prior PR) | `python/tests/test_data_table_link_row_nav.py` | `RowUrlStructureTest::test_row_url_attaches_data_href_and_onclick` rewritten (no longer asserts inline `onclick`) |
| Docs | `docs/website/guides/components.md` | n/a (new section under `{% data_table %}`) |
| Docs | `CHANGELOG.md` | n/a |

## 🟡 Self-review findings for Stage 11

1. **CSP nonce thread is intentionally absent.** The brief asked for `request.csp_nonce` per #1163's pattern, expecting an inline `<script nonce="…">`. The implementation skips inline script entirely, which is strictly more CSP-friendly (no `'unsafe-inline'` ever needed). If a future feature DOES need a per-table inline initializer, the `csp_nonce` context key path is already covered by the smoke test `TestCSPNonce::test_template_renders_with_csp_nonce_in_context`.

2. **Test hook in production JS.** `data-table-row-click.js` honours `window.__djustRowClickNavigate` as a test-only override of `window.location.assign`. JSDOM 26+ marks `Location.prototype.assign` as non-writable + non-configurable, so test interception requires a hook. Documented in the source as test-only; the production code path uses `window.location.assign` directly when the override isn't set.

3. **Multi-line `{# %}` comments fixed but not exhaustively.** The `table.html` template had two pre-existing multi-line `{# ... #}` comments that rendered as literal text. I converted both to `{% comment %}` blocks. Other djust templates may have the same issue; out of scope for this PR.

4. **Nested-control selector includes `<textarea>`.** The brief's enumeration was `<a>/<button>/<input>/<label>/<select>` — I added `<textarea>` for symmetry (a row-nav over a textarea would be just as user-hostile as over an input). Easy to remove if Stage 11 prefers strict adherence.

5. **The pre-existing `dictsort` cell-extraction filter pattern** (`{{ row|dictsort:col.key|first }}`) is not idiomatic Django but is a pre-existing convention from #1110 — the Rust template engine apparently supports it. Out of scope to refactor here; would risk breaking #1110 callers.

## Test plan

- [ ] `make test-python` — full Python suite (4026 passing pre-PR, expect 4040 after this PR's 14 new cases).
- [ ] `make test-js` — full JS suite (1450 cases pre-PR, expect 1461 after this PR's 11 new cases).
- [ ] Manual: render the demo data_table with `row_click_event="open"`; click the row and verify the dj-click fires with `data-value=row_id`. Click a nested `<a>` cell — verify the row event does NOT also fire. Tab to the row, press Enter — verify the click handler fires.
- [ ] Manual: render with `row_url="some_url"`; click the row and verify the page navigates. With strict CSP (`script-src 'self'`), verify there's no console error about blocked inline script.
- [ ] Manual: render with `selectable=True row_click_event="open"`; click the checkbox — verify select_event fires but row event does not. Click anywhere else in the row — verify row event fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)