### PR TITLE
docs: canonicalize CSP-strict defaults for new client-side framework code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CSP-strict defaults canonicalized for new client-side framework code
+  (closes #1175)** — adds explicit guidance in `CLAUDE.md`,
+  `docs/PULL_REQUEST_CHECKLIST.md`, and `docs/guides/security.md` that
+  any new framework feature emitting HTML must default to: external
+  static JS modules (no inline `<script>` blocks), no inline event
+  handlers (no `onclick=`/`onchange=`/`oninput=`), auto-bind via marker
+  class + delegated listener on `document`/root, CSP nonce propagation
+  only when genuinely required (lazy-fill case from #1147 is the
+  canonical exception). Reference-module shapes documented (PR #1170
+  `data-table-row-click.js`, PR #1138 `50-lazy-fill.js`, existing
+  `39-dj-track-static.js`). v1.0 readiness — positions strict-CSP
+  deployments as a design constraint, not an opt-in.
+
 ### Added
 
 - **`{% data_table %}` row-level navigation: accessibility, keyboard,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,6 +345,52 @@ Five additional rules from the View Transitions arc + nyc-claims data_table arc.
   string (`errors[0][0].toContain('label')`). Decouples the test from
   later parameterization fixes for tainted-format-string warnings.
 
+## Process canonicalizations from v0.9.1 retro arc
+
+Each rule below was a v0.9.1 retro tracker row distilled across the
+7-PR drain (#1159, #1161, #1163, #1164, #1166, #1168, #1170).
+Canonicalized here so the next drain doesn't repeat the failure mode.
+
+- **One implementer agent per checkout** (#180 / #1172, applied to
+  `~/.claude/skills/pipeline-run/SKILL.md`). Two background implementer
+  agents on the same git working tree flip branches via pre-commit
+  stash/restore mid-edit and produce CHANGELOG cross-contamination +
+  duplicate-heading collisions on `[Unreleased]` blocks. Either
+  serialize agent execution OR use the single-script-transformation
+  pattern (each agent writes one Python script that applies all edits
+  in one filesystem pass + commits immediately). Different git
+  worktrees or different repos are safe — the rule is one-checkout =
+  one-agent.
+
+- **Two-commit shape: impl+tests / docs+CHANGELOG** (#181 / #1173,
+  applied to `.pipeline-templates/feature-state.json`,
+  `bugfix-state.json`, `ship-state.json`). Stage 5 (Implementation)
+  forbids CHANGELOG.md edits; Stage 9 (feature/bugfix) or Stage 5
+  (ship-pipelines, since they have no separate Implementation stage)
+  is the canonical CHANGELOG commit boundary. Defends against
+  cross-edit collisions on `[Unreleased]` even under serial execution.
+
+- **3-clean-runs verification gate for pollution-class fixes** (#182 /
+  #1174, applied to `.pipeline-templates/bugfix-state.json` Stage 6).
+  When the bugfix task description matches `/pollution|leak|flak|test
+  isolation/i`, run the full pytest suite three times consecutively;
+  all three must be clean. Single-run pass is insufficient — pollution
+  by definition shows up under specific orderings, and the "second
+  hidden polluter" failure mode is real (PR #1159 caught
+  `sys.modules`-rebind on the third verification run after the
+  primary SQLite leak fix).
+
+- **CSP-strict defaults for new client-side framework code** (#183 /
+  #1175). Any new framework feature that emits HTML must default to:
+  no inline `<script>` blocks, no inline event handlers, auto-bind
+  via marker class + delegated listener on `document`/root. Use a
+  static JS module served from `python/djust/.../static/` that
+  registers itself on `DOMContentLoaded` + a `MutationObserver` for
+  morphdom-managed regions. Inline scripts with `request.csp_nonce`
+  are the rare exception (lazy-fill / #1147 case). The PR-checklist
+  has a CSP-Strict Defaults block at `docs/PULL_REQUEST_CHECKLIST.md`
+  with concrete external-module-shape references.
+
 ## Additional Documentation
 
 - `docs/PULL_REQUEST_CHECKLIST.md` — PR review checklist

--- a/docs/PULL_REQUEST_CHECKLIST.md
+++ b/docs/PULL_REQUEST_CHECKLIST.md
@@ -181,6 +181,35 @@ console.error(error); // ❌ Won't be captured in production
 - [ ] **Privacy considerations** - PII handling follows regulations
 - [ ] **Secure defaults** - New features are secure by default
 
+### CSP-Strict Defaults for New Client-Side Framework Code
+
+Any new framework feature that emits HTML must default to a CSP-strict
+shape so deployments running `script-src 'self'` (no `'unsafe-inline'`,
+no `'unsafe-eval'`) work without configuration. Canonicalized in v0.9.1
+retro / Action Tracker #183 / GitHub #1175.
+
+- [ ] **No inline `<script>` blocks** - new client-side behavior lives in
+  external static JS modules served from `python/djust/...static/`
+- [ ] **No inline event handlers** - no `onclick=`, `onchange=`,
+  `oninput=`, etc. in emitted HTML
+- [ ] **Auto-bind via marker class** - the static JS module attaches a
+  delegated listener on `document` (or root) and dispatches based on a
+  marker class set on the emitted element (e.g. `data-table-row-clickable`,
+  `dj-form`, `dj-track-static`). Compose with `MutationObserver` for
+  morphdom-managed regions.
+- [ ] **CSP nonce only when genuinely required** - inline `<script>` is
+  only acceptable when the activator must run synchronously inline (rare;
+  the lazy-fill case from #1147 is the canonical exception). When that's
+  unavoidable, propagate `request.csp_nonce` per the #1147 pattern.
+- [ ] **External-module shape canonical references**:
+  - `python/djust/components/static/djust_components/data-table-row-click.js`
+    + `tr.data-table-row-clickable` marker class (PR #1170, the cleanest
+    example).
+  - `python/djust/static/djust/src/50-lazy-fill.js` + `<dj-lazy-slot>`
+    custom element (PR #1138).
+  - `python/djust/static/djust/src/39-dj-track-static.js` + Phoenix-style
+    `phx-track-static` parity attribute (existing pattern).
+
 ### Security Hot Spot Changes
 
 If the PR modifies any file listed in [Security Hot Spot Files](SECURITY_GUIDELINES.md#security-hot-spot-files), the following additional requirements apply:

--- a/docs/PULL_REQUEST_CHECKLIST.md
+++ b/docs/PULL_REQUEST_CHECKLIST.md
@@ -192,10 +192,13 @@ retro / Action Tracker #183 / GitHub #1175.
   external static JS modules served from `python/djust/...static/`
 - [ ] **No inline event handlers** - no `onclick=`, `onchange=`,
   `oninput=`, etc. in emitted HTML
-- [ ] **Auto-bind via marker class** - the static JS module attaches a
-  delegated listener on `document` (or root) and dispatches based on a
-  marker class set on the emitted element (e.g. `data-table-row-clickable`,
-  `dj-form`, `dj-track-static`). Compose with `MutationObserver` for
+- [ ] **Auto-bind via marker class or attribute** - the static JS module
+  attaches a delegated listener on `document` (or root) and dispatches
+  based on a marker (CSS class OR HTML attribute) set on the emitted
+  element. Two real patterns: marker CSS class
+  (`tr.data-table-row-clickable` in PR #1170) and marker attribute
+  (`[dj-track-static]` in `39-dj-track-static.js`, `[dj-submit]` on
+  forms in `09-event-binding.js`). Compose with `MutationObserver` for
   morphdom-managed regions.
 - [ ] **CSP nonce only when genuinely required** - inline `<script>` is
   only acceptable when the activator must run synchronously inline (rare;

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -387,6 +387,86 @@ Example output:
       * search(value: str = "")          @debounce(wait=0.3)
 ```
 
+## CSP-Strict Defaults for Framework Code
+
+djust is designed to work under stricter Content Security Policy
+deployments — `script-src 'self'` (no `'unsafe-inline'`, no
+`'unsafe-eval'`) — without configuration. v1.0 readiness positions
+strict-CSP as a design constraint, not an opt-in.
+
+### What this means in practice
+
+Framework code that emits HTML defaults to:
+
+- **External static JS modules** served from
+  `python/djust/static/djust/` or
+  `python/djust/components/static/djust_components/`. Every behavior
+  the framework adds at the client lives in a versioned, addressable
+  module. No `eval`, no `Function(string)`.
+- **No inline event handlers** — no `onclick=`, `onchange=`,
+  `oninput=` in emitted markup. Click/keyboard/input behavior comes
+  from delegated listeners installed by the static modules.
+- **Auto-bind via marker class** — when an element opts into a
+  framework behavior, it carries a marker class (e.g.
+  `data-table-row-clickable`, `dj-form`, `dj-track-static`) plus the
+  data attributes the behavior reads. The static JS module attaches a
+  delegated listener on `document` (or root) and dispatches based on
+  `event.target.closest('.<marker-class>')`. Compose with
+  `MutationObserver` for morphdom-managed regions so the binding
+  survives VDOM patches.
+- **CSP nonce only when genuinely required** — the lazy-fill protocol
+  (`<dj-lazy-slot>` activator scripts) is the canonical exception
+  where an inline `<script>` is needed because the activator must run
+  synchronously inline. When you need an inline script, propagate
+  `request.csp_nonce` per
+  `python/djust/templatetags/live_tags.py:live_render`'s `lazy=True`
+  branch.
+
+### Canonical reference modules
+
+If you're adding a new framework feature that needs client-side
+behavior, the cleanest examples to copy are:
+
+- **`python/djust/components/static/djust_components/data-table-row-click.js`**
+  + the `tr.data-table-row-clickable` marker class (PR #1170). External
+  module + delegated listener + nested-control guard + keyboard
+  activation. The "no inline script, ever" example.
+- **`python/djust/static/djust/src/50-lazy-fill.js`** + the
+  `<dj-lazy-slot>` custom element (PR #1138). The exception case where
+  an inline activator script is unavoidable; demonstrates the
+  `request.csp_nonce` propagation pattern.
+- **`python/djust/static/djust/src/39-dj-track-static.js`** +
+  Phoenix-style `phx-track-static` parity attribute. Existing canonical
+  pattern for attribute-driven behavior dispatch.
+
+### What CSP headers your deployment should set
+
+For djust apps using only the canonical modules:
+
+```
+Content-Security-Policy:
+  default-src 'self';
+  script-src 'self';
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' data:;
+  connect-src 'self' wss://your-host;
+```
+
+For djust apps using the lazy-fill protocol:
+
+```
+Content-Security-Policy:
+  default-src 'self';
+  script-src 'self' 'nonce-<csp_nonce>';
+  ...
+```
+
+Set `request.csp_nonce` via `django-csp` middleware (pip
+`django-csp>=4.0`); djust's lazy-fill template tag reads
+`getattr(request, 'csp_nonce', None)` automatically.
+
+Canonicalized in v0.9.1 retro / Action Tracker #183 / GitHub #1175.
+
 ## Further Reading
 
 - [Security Guidelines for Contributors](../SECURITY_GUIDELINES.md) — banned patterns, code review checklist, security testing

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -406,12 +406,15 @@ Framework code that emits HTML defaults to:
 - **No inline event handlers** — no `onclick=`, `onchange=`,
   `oninput=` in emitted markup. Click/keyboard/input behavior comes
   from delegated listeners installed by the static modules.
-- **Auto-bind via marker class** — when an element opts into a
-  framework behavior, it carries a marker class (e.g.
-  `data-table-row-clickable`, `dj-form`, `dj-track-static`) plus the
-  data attributes the behavior reads. The static JS module attaches a
-  delegated listener on `document` (or root) and dispatches based on
-  `event.target.closest('.<marker-class>')`. Compose with
+- **Auto-bind via marker class or attribute** — when an element opts
+  into a framework behavior, it carries a marker (CSS class OR HTML
+  attribute) plus the data attributes the behavior reads. Two real
+  patterns: CSS class — `tr.data-table-row-clickable` (PR #1170) — and
+  attribute — `[dj-track-static]` (`39-dj-track-static.js`),
+  `[dj-submit]` on forms (`09-event-binding.js`). The static JS module
+  attaches a delegated listener on `document` (or root) and dispatches
+  based on `event.target.closest('.<marker-class>')` or
+  `event.target.closest('[<marker-attr>]')`. Compose with
   `MutationObserver` for morphdom-managed regions so the binding
   survives VDOM patches.
 - **CSP nonce only when genuinely required** — the lazy-fill protocol


### PR DESCRIPTION
## Summary

Documents the strict-CSP design constraint as v1.0 readiness. v0.9.1 retro / Action Tracker #183 surfaced a cross-PR pattern (PR #1163 nonce activator + PR #1170 inline-script-free architecture) — this PR encodes the lesson before we forget it.

Closes #1175

## Why

Two converging pieces of evidence in the v0.9.1 drain showed strict-CSP deployments are first-class:
- **PR #1163** added CSP-nonce-aware activator for `<dj-lazy-slot>` fills.
- **PR #1170** went further — chose to skip inline scripts entirely in favor of an external static JS module that auto-binds on a marker class.

The "external module + auto-bind on marker class" shape is strictly more CSP-friendly than "inline script + nonce attribute" and works under stricter CSP policies. Positioning this as a design constraint (not an opt-in) for v1.0.

## Changes

- `CLAUDE.md` — new "Process canonicalizations from v0.9.1 retro arc" section covering all 4 v0.9.1 retro tracker rows (#180/#181/#182/#183).
- `docs/PULL_REQUEST_CHECKLIST.md` — new "CSP-Strict Defaults for New Client-Side Framework Code" subsection under Security Review with 6 explicit checkbox items + 3 canonical reference modules.
- `docs/guides/security.md` — new "CSP-Strict Defaults for Framework Code" section with what-this-means / canonical-modules / what-CSP-headers-to-set, including pip django-csp integration note.
- `CHANGELOG.md` — `[Unreleased] > Changed` entry.

## Test plan

- [x] No code changes — docs + CHANGELOG only.
- [x] Pre-push hooks green (ruff, bandit, detect-secrets, CHANGELOG test counts).
- [ ] Future PRs cite these as the canonical reference (verified in subsequent v0.9.2 drain PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)