### PR TITLE
chore(v0.9.2): hygiene group — Redis docstring + caplog + descriptor doc + dev-env script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **v0.9.2 hygiene group — Redis perf docstring softened, replay-rejection
+  caplog assertions, descriptor-pattern auto-promotion gap documented,
+  dev-env import regression guard (closes #1160, closes #1165)** — Stage 11
+  follow-ups from the v0.9.1 retro arc, batched as a single chore PR:
+  - **#1160**: rewrite `test_redis_serialization_performance` docstring
+    in `tests/unit/test_state_backend.py` to match what the 100ms bound
+    actually catches (catastrophic ~10× regressions, e.g. accidental
+    JSON/pickle round-trip), not gradual perf drift. Points to
+    `pytest-benchmark`-style median-based assertions for SLA-grade
+    perf checks.
+  - **#1165 (a)**: extend `TestReplayHandlerValidation` rejection-path
+    tests in `tests/unit/test_time_travel.py` to assert via `caplog`
+    that the `logger.warning(...)` record fires with the expected
+    message (`"refused unregistered method"` / `"refused dunder/private
+    event_name"`). Side-effect-only assertions previously stayed green
+    if the warning silently regressed to a no-op.
+  - **#1165 (b)**: document the descriptor-pattern auto-promotion gap
+    in the `LiveComponent` docstring (`python/djust/components/base.py`)
+    and in `docs/website/guides/components.md`. The framework's
+    `_assign_component_ids` walker only inspects instance-level attrs,
+    so descriptor components must be appended to `self._components` in
+    `mount()` until auto-promotion ships. Time-travel snapshots and
+    other walkers silently miss them otherwise.
+  - **#1165 (c)**: add `scripts/check-dev-env-imports.py` and a paired
+    pytest module (`tests/unit/test_dev_env_imports.py`, 2 new
+    parametrized cases) that hard-fail (not skip) if
+    `djust.components.components` or its `.markdown` submodule cannot
+    import. Locks in the #1149 fix where missing `markdown`/`nh3`
+    caused opaque pytest collection failures. Script is standalone for
+    now; a follow-up PR can wire it into pre-commit / Makefile.
 - **CSP-strict defaults canonicalized for new client-side framework code
   (closes #1175)** — adds explicit guidance in `CLAUDE.md`,
   `docs/PULL_REQUEST_CHECKLIST.md`, and `docs/guides/security.md` that

--- a/docs/website/guides/components.md
+++ b/docs/website/guides/components.md
@@ -230,6 +230,35 @@ class DashboardView(LiveView):
 
 The `component_id` is automatically set to the attribute name (`"counter"`) by the framework. No manual ID management needed.
 
+### Descriptor-pattern auto-promotion gap
+
+When LiveComponents are declared as **class-level descriptors** (the preferred
+pattern shown above), the framework's component-id walker (`_assign_component_ids`)
+only inspects instance-level attributes. As a result, **descriptor-pattern
+components are NOT auto-registered in `view._components`** today. Framework
+features that walk `_components` -- including time-travel snapshots, session-based
+component-state save/restore, and other introspection paths -- will silently miss
+descriptor-pattern components unless the view appends them manually during
+`mount()`.
+
+**Workaround** -- register the descriptor's instance in `_components` explicitly:
+
+```python
+class MyView(LiveView):
+    greeting = GreetingWidget.descriptor()  # class-level descriptor
+
+    def mount(self, request, **kwargs):
+        # Required until auto-promotion ships: makes the descriptor's
+        # instance visible to time-travel snapshots and other framework
+        # walkers that iterate self._components.
+        self._components.append(self.greeting)
+```
+
+Auto-promotion is planned future framework work (tracked separately). Until it
+ships, document this gap in any code that mixes descriptor-pattern components
+with time-travel or session restore -- otherwise the component will appear to
+"vanish" from snapshots even though its public state is intact on the view.
+
 ### Lifecycle
 
 ```

--- a/python/djust/components/base.py
+++ b/python/djust/components/base.py
@@ -427,6 +427,34 @@ class LiveComponent(ContextProviderMixin):
         The attribute name becomes the component_id. State is stored in
         ``obj.__dict__["_component_{name}"]`` (underscore prefix excludes it from
         djust's context pipeline; the public attribute via ``__get__`` is included).
+
+    Descriptor-pattern auto-promotion gap (#1165):
+        Currently, descriptor-pattern components are NOT auto-promoted into
+        ``view._components`` by the framework. The
+        :func:`djust.mixins.components.ComponentManagementMixin._assign_component_ids`
+        walker only inspects instance-level (``self.__dict__``) attributes,
+        so a class-level descriptor never lands in ``_components`` unless
+        the view explicitly appends it during ``mount()``.
+
+        Framework features that walk ``_components`` (time-travel snapshots
+        in :mod:`djust.time_travel`, the component-state session save path,
+        etc.) will silently miss descriptor-pattern components otherwise.
+
+        **Workaround** — register manually in ``mount()``::
+
+            class MyView(LiveView):
+                greeting = MyComponent.descriptor()  # class-level descriptor
+
+                def mount(self, request, **kwargs):
+                    # Required until auto-promotion ships: include the
+                    # descriptor's instance in ``self._components`` so
+                    # snapshot machinery and other framework walkers can
+                    # see it.
+                    self._components.append(self.greeting)
+
+        Auto-promotion is tracked separately as future framework work.
+        Until it ships, document the gap so users aren't surprised when
+        time-travel or session-restore appears to "lose" a component.
     """
 
     # Component configuration

--- a/scripts/check-dev-env-imports.py
+++ b/scripts/check-dev-env-imports.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Verify the dev-env can import critical eager-import modules.
+
+Several djust modules eagerly import optional-extra dependencies at
+package init time. The most prominent: ``djust.components.components``
+imports :class:`djust.components.components.markdown.Markdown`, which
+in turn requires both ``markdown`` and ``nh3`` at import time. If a
+dev-env is missing either, ``pytest`` collection fails with an opaque
+``ImportError`` long before the user-facing tests run.
+
+#1149 added ``markdown`` and ``nh3`` to the
+``[project.optional-dependencies.dev]`` block in ``pyproject.toml`` for
+this exact reason. This script is a regression guard: run it after a
+fresh ``uv sync`` (or ``pip install -e .[dev]``) and it asserts every
+module in :data:`CRITICAL_IMPORTS` actually imports cleanly.
+
+Exit codes:
+    0 — all imports succeeded.
+    1 — at least one import failed; the missing-package hint is printed.
+
+Usage::
+
+    python scripts/check-dev-env-imports.py
+
+Could be wired into ``Makefile`` or ``.pre-commit-config.yaml`` later;
+this script ships standalone first so a follow-up PR can pick up
+automation without coupling.
+
+#1165 (sub-item c).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import List, Tuple
+
+# Each entry: (module_path, hint_for_missing_dep).
+#
+# When adding a new entry, prefer (a) modules that eagerly import
+# optional-extra packages at top level, or (b) modules whose silent
+# absence has caused test-collection failures in the past. The hint is
+# printed verbatim when the import fails, so name the install-extra
+# (e.g. ``pip install -e '.[dev]'`` or ``pip install markdown nh3``).
+CRITICAL_IMPORTS: List[Tuple[str, str]] = [
+    (
+        "djust.components.components",
+        "djust.components.components eagerly imports the Markdown component "
+        "(see #1149). Install dev deps: 'uv sync' or 'pip install -e .[dev]' "
+        "(pulls in markdown + nh3).",
+    ),
+    (
+        "djust.components.components.markdown",
+        "Markdown component requires 'markdown' and 'nh3' at import time. "
+        "Install: 'pip install markdown nh3' or 'pip install -e .[dev]'.",
+    ),
+]
+
+
+def main() -> int:
+    failures: List[Tuple[str, str, BaseException]] = []
+    for module_path, hint in CRITICAL_IMPORTS:
+        try:
+            importlib.import_module(module_path)
+        except BaseException as exc:  # noqa: BLE001 — diagnostic script
+            failures.append((module_path, hint, exc))
+
+    if not failures:
+        print("OK: all %d critical dev-env imports succeeded." % len(CRITICAL_IMPORTS))
+        return 0
+
+    print(
+        "FAIL: %d/%d critical dev-env imports failed."
+        % (len(failures), len(CRITICAL_IMPORTS)),
+        file=sys.stderr,
+    )
+    for module_path, hint, exc in failures:
+        print("", file=sys.stderr)
+        print("  module: %s" % module_path, file=sys.stderr)
+        print("  error:  %s: %s" % (type(exc).__name__, exc), file=sys.stderr)
+        print("  hint:   %s" % hint, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_dev_env_imports.py
+++ b/tests/unit/test_dev_env_imports.py
@@ -1,0 +1,62 @@
+"""Regression tests for dev-env critical imports (#1165 sub-item c).
+
+PR #1149 added ``markdown`` and ``nh3`` to
+``[project.optional-dependencies.dev]`` because
+``djust.components.components.__init__`` eagerly imports
+``Markdown`` (which needs both packages). Without those in dev,
+pytest collection fails with an opaque ``ModuleNotFoundError``
+during the very first ``import djust.components`` chain.
+
+This test is a hard fail-fast guard: it runs at module-import time
+in the test process, so a missing dep surfaces during collection
+of THIS test (with a clear traceback) rather than in some random
+unrelated test downstream.
+
+Companion: ``scripts/check-dev-env-imports.py`` runs the same check
+out-of-band (e.g. for pre-commit / Makefile hooks). The script is
+the visible artifact; this test is the automated guard. They share
+the same source of truth (:data:`CRITICAL_IMPORTS_HINTS`).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# Paired list of (module_path, install hint). Mirrors
+# ``scripts/check-dev-env-imports.py`` ``CRITICAL_IMPORTS``.
+# When you add an eager-imported module to djust, add it here AND in
+# the script.
+CRITICAL_IMPORTS_HINTS = [
+    (
+        "djust.components.components",
+        "Run 'uv sync' or 'pip install -e .[dev]' (#1149).",
+    ),
+    (
+        "djust.components.components.markdown",
+        "Install 'markdown' + 'nh3' (transitive deps of the Markdown component).",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "module_path,hint",
+    CRITICAL_IMPORTS_HINTS,
+    ids=[m for m, _ in CRITICAL_IMPORTS_HINTS],
+)
+def test_critical_dev_env_imports(module_path: str, hint: str) -> None:
+    """The dev-env must be able to import every entry in
+    :data:`CRITICAL_IMPORTS_HINTS`. Note: we use a hard ``import``
+    (and ``pytest.fail`` on ImportError) — NOT
+    ``pytest.importorskip`` — because for a dev-env we want a hard
+    fail, not a silent skip. A skip would let CI go green with a
+    broken environment."""
+    try:
+        importlib.import_module(module_path)
+    except ImportError as exc:
+        pytest.fail(
+            "dev-env critical import failed: %s\n"
+            "  error: %s\n"
+            "  hint:  %s" % (module_path, exc, hint)
+        )

--- a/tests/unit/test_state_backend.py
+++ b/tests/unit/test_state_backend.py
@@ -298,15 +298,15 @@ class TestRedisBackend:
         assert html == "<div>Redis</div>"
 
     def test_redis_serialization_performance(self, redis_backend):
-        """Test that Redis uses native serialization (set/get are fast).
-
-        The bound is 100ms (not the ideal microsecond-range a localhost
-        Redis can hit) because this assertion previously hard-coded 10ms
-        and flaked under heavy full-suite load — pytest scheduling jitter
-        + GC pauses + occasional Redis hiccups blow past 10ms even when
-        the codepath is healthy. See #1134. 100ms is still ~10× faster
-        than any "we forgot to use native serialization" regression
-        would produce, so the assertion still has signal.
+        """Smoke test that JSON/pickle round-trip doesn't catastrophically
+        regress. The 100ms bound is INTENTIONALLY GENEROUS — it catches
+        only catastrophic regressions (e.g. ~10× slowdown from accidental
+        double-serialization), not gradual perf drift. For a real perf
+        SLA, use a benchmark suite with median-based assertions over N
+        runs (pytest-benchmark or similar). Wall-clock 10ms was the
+        original bound but flaked under heavy suite load (pytest
+        scheduling jitter + GC pauses + occasional Redis hiccups);
+        see #1134 retro and #1160 for the bound-vs-claim reconciliation.
         """
         view = RustLiveView("<div>{{ data }}</div>")
         view.update_state({"data": "x" * 1000})

--- a/tests/unit/test_time_travel.py
+++ b/tests/unit/test_time_travel.py
@@ -1080,11 +1080,20 @@ class TestReplayHandlerValidation:
         assert replay_snap is not None
         assert replay_snap.state_after == {"count": 3}
 
-    def test_replay_unregistered_method_returns_none(self):
+    def test_replay_unregistered_method_returns_none(self, caplog):
         """A snapshot naming a non-handler method (no
         ``@event_handler`` decorator) is rejected by the guard.
         ``view.some_helper`` exists, is callable, and isn't
-        underscore-prefixed — but it isn't a registered handler."""
+        underscore-prefixed — but it isn't a registered handler.
+
+        Also asserts the rejection emits a ``logger.warning`` record
+        with the expected message text (#1165 sub-item a). Without
+        this, a future regression that silently demotes the
+        ``logger.warning(...)`` call to a no-op (e.g. dropped during
+        a refactor) would leave the side-effect assertion green and
+        the regression invisible to CI."""
+        import logging
+
         view = _CounterView()
         assert callable(view.some_helper)
 
@@ -1095,14 +1104,28 @@ class TestReplayHandlerValidation:
             ts=0.0,
             state_before={"count": 0},
         )
-        result = replay_event(view, snap)
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="djust.time_travel"):
+            result = replay_event(view, snap)
         assert result is None
         assert view.count != -999  # helper body never ran
+        assert any(
+            "refused unregistered method" in record.getMessage()
+            and "some_helper" in record.getMessage()
+            for record in caplog.records
+        ), "expected a 'refused unregistered method' warning; got: " + repr(
+            [r.getMessage() for r in caplog.records]
+        )
 
-    def test_replay_dunder_still_rejected(self):
+    def test_replay_dunder_still_rejected(self, caplog):
         """Regression for the existing underscore-prefix guard: even
         with the new ``is_event_handler`` check, dunder/private
-        names are rejected by the earlier short-circuit."""
+        names are rejected by the earlier short-circuit.
+
+        Also asserts the rejection emits a ``logger.warning`` record
+        with the expected message text (#1165 sub-item a)."""
+        import logging
+
         view = _CounterView()
         snap = EventSnapshot(
             event_name="__init__",
@@ -1111,8 +1134,17 @@ class TestReplayHandlerValidation:
             ts=0.0,
             state_before={"count": 0},
         )
-        result = replay_event(view, snap)
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="djust.time_travel"):
+            result = replay_event(view, snap)
         assert result is None
+        assert any(
+            "refused dunder/private event_name" in record.getMessage()
+            and "__init__" in record.getMessage()
+            for record in caplog.records
+        ), "expected a 'refused dunder/private event_name' warning; got: " + repr(
+            [r.getMessage() for r in caplog.records]
+        )
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Stage 11 follow-ups from the v0.9.1 retro arc, batched as a single chore PR. Four small surface-area changes; all guard against future-regression failure modes that the side-effect-only tests would have missed.

- **#1160**: rewrite `test_redis_serialization_performance` docstring to match what the 100ms bound actually catches (catastrophic ~10× regressions, not gradual perf drift). Points users to `pytest-benchmark`-style median-based assertions for SLA-grade perf checks.
- **#1165 (a)**: extend `TestReplayHandlerValidation` rejection-path tests to assert via `caplog` that the `logger.warning(...)` record fires with the expected message text. Without this, a future regression that silently demotes the warning to a no-op would leave the side-effect assertion green.
- **#1165 (b)**: document the descriptor-pattern auto-promotion gap in the `LiveComponent` docstring (`python/djust/components/base.py`) and in `docs/website/guides/components.md`. The framework's `_assign_component_ids` walker only inspects instance-level attrs, so descriptor components must be appended to `self._components` in `mount()` until auto-promotion ships.
- **#1165 (c)**: add `scripts/check-dev-env-imports.py` and a paired pytest module (`tests/unit/test_dev_env_imports.py`, 2 parametrized cases) that hard-fail (not skip) if `djust.components.components` or its `.markdown` submodule can't import. Locks in the #1149 fix.

## Files changed

| Item | Files |
|------|-------|
| #1160 docstring | `tests/unit/test_state_backend.py` |
| #1165 (a) caplog | `tests/unit/test_time_travel.py` |
| #1165 (b) docs | `python/djust/components/base.py`, `docs/website/guides/components.md` |
| #1165 (c) dev-env | `scripts/check-dev-env-imports.py`, `tests/unit/test_dev_env_imports.py` |
| CHANGELOG | `CHANGELOG.md` |

## Test plan

- [x] `uv run pytest tests/unit/test_state_backend.py tests/unit/test_time_travel.py tests/unit/test_dev_env_imports.py -q` — 90 passed, 2 skipped
- [x] Full suite: `uv run pytest python/djust/ tests/ -q` — 4601 passed, 14 skipped
- [x] `python scripts/check-dev-env-imports.py` — exits 0 with "OK: all 2 critical dev-env imports succeeded"
- [x] Pre-push hooks pass (ruff, ruff-format, bandit, detect-secrets, pytest, check-changelog-test-counts, cargo-checks-skip)

## Test count delta

+2 (the new `test_critical_dev_env_imports` parametrized cases). The caplog additions modify existing tests in-place — no new test methods.

## Two-commit shape

Per v0.9.1 retro / #1173: implementation + tests in commit 1, docs + CHANGELOG in commit 2.

Closes #1160
Closes #1165

🤖 Generated with [Claude Code](https://claude.com/claude-code)