### PR TITLE
fix(rust): tag-registry test isolation + sidecar bridge extension (closes #1167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Tag-registry test isolation + sidecar bridge extension to block /
+  assign tags (closes #1167)** — two Stage 11 follow-ups from PR #1166
+  (which wired the raw-Python sidecar into ``Node::CustomTag``):
+  - **Test isolation**: ``tests/unit/test_tag_registry.py`` previously
+    used per-class ``setup_registry`` fixtures that re-registered the
+    Python built-in handlers on teardown but did NOT clear the global
+    Rust ``TAG_HANDLERS`` registry first. Transient handlers from the
+    file (notably ``BrokenHandler`` registered for the ``broken`` tag
+    in ``test_handler_exception_returns_error``) leaked into
+    subsequent test files. ``test_assign_tag.py`` running after this
+    file would see ``handler_exists("broken")`` == True; the parser
+    dispatches ``handler_exists`` before ``assign_handler_exists``
+    so ``{% broken %}`` was routed to the leaked CustomTag handler
+    and ``test_non_dict_return_is_empty_merge`` failed with the leaked
+    handler's exception. Fix: replace the per-class fixtures with one
+    function-scoped autouse fixture that clears all three Rust
+    registries (tag / block-tag / assign-tag) before AND after every
+    test, then re-registers the built-ins from
+    ``djust.template_tags._registered_handlers``. The file is now
+    self-contained.
+  - **Sidecar parity**: PR #1166's
+    ``call_handler_with_py_sidecar`` only fired for ``Node::CustomTag``.
+    Block tags (``Node::BlockCustomTag``) and assign tags
+    (``Node::AssignTag``) didn't receive the ``request`` / ``view``
+    sidecar, so a custom block or assign handler couldn't reach the
+    parent view. Added ``call_block_handler_with_py_sidecar`` and
+    ``call_assign_handler_with_py_sidecar`` mirroring the PR #1166
+    pattern; the existing variants are kept as back-compat shims that
+    delegate with ``None``. All five renderer call sites (1× block,
+    4× assign — single-node, sibling-aware, collecting, and
+    partial-render paths) forward ``context.raw_py_objects()``.
+
+  New cases in ``TestBlockTagSidecar`` and ``TestAssignTagSidecar``
+  (``tests/unit/test_tag_sidecar_parity_1167.py``, 6 Python cases)
+  cover sidecar receipt of ``request`` and ``view`` per node type
+  plus a back-compat regression per node type confirming legacy
+  handlers that ignore the sidecar continue to work unchanged.
+
 - **Custom filter bridge polish — 6 sub-items deferred from #1161
   (closes #1162)** — Stage 11 review of PR #1161 (which closed #1121
   by adding the eager Rust filter registry) flagged six follow-ups.

--- a/crates/djust_templates/src/registry.rs
+++ b/crates/djust_templates/src/registry.rs
@@ -251,11 +251,36 @@ pub fn block_handler_exists(name: &str) -> Option<String> {
 ///
 /// The handler's `render(args, content, context)` method is called and the
 /// returned string is inserted into the rendered output.
+///
+/// Back-compat shim around [`call_block_handler_with_py_sidecar`] —
+/// equivalent to passing `None` for the raw Python sidecar.
 pub fn call_block_handler(
     name: &str,
     args: &[String],
     content: &str,
     context: &HashMap<String, djust_core::Value>,
+) -> Result<String, String> {
+    call_block_handler_with_py_sidecar(name, args, content, context, None)
+}
+
+/// Variant of [`call_block_handler`] that additionally injects raw
+/// Python objects from the [`Context::raw_py_objects`] sidecar into
+/// the handler's ``context`` dict.
+///
+/// Mirrors [`call_handler_with_py_sidecar`] (extended in PR #1166)
+/// for `Node::CustomTag`. Block handlers (``modal``, ``card`` …)
+/// that need access to Python-only objects in the parent's render
+/// context (notably ``request`` / ``view``) can read those keys from
+/// the dict directly. Sidecar values overwrite same-named JSON keys
+/// so a Python model instance wins over a normalized dict snapshot.
+///
+/// Existing block handlers that ignore the extra keys are unaffected.
+pub fn call_block_handler_with_py_sidecar(
+    name: &str,
+    args: &[String],
+    content: &str,
+    context: &HashMap<String, djust_core::Value>,
+    raw_py_objects: Option<&HashMap<String, pyo3::PyObject>>,
 ) -> Result<String, String> {
     let handler = {
         let registry = BLOCK_TAG_HANDLERS
@@ -288,6 +313,18 @@ pub fn call_block_handler(
             py_context
                 .set_item(key, py_value)
                 .map_err(|e| format!("Failed to set context key '{key}': {e}"))?;
+        }
+
+        // Inject raw Python sidecar objects (e.g. ``request``, ``view``)
+        // so block handlers needing full Python context can reach them.
+        // Overwrites same-named JSON entries — the Python object is the
+        // source of truth.
+        if let Some(raw) = raw_py_objects {
+            for (key, obj) in raw {
+                py_context
+                    .set_item(key, obj.bind(py))
+                    .map_err(|e| format!("Failed to set raw context key '{key}': {e}"))?;
+            }
         }
 
         let handler_ref = handler.bind(py);
@@ -520,10 +557,34 @@ pub fn assign_handler_exists(name: &str) -> bool {
 /// Returns a map of context updates to merge into the surrounding
 /// render context. Error strings bubble up through
 /// [`crate::renderer`] as `DjangoRustError::TemplateError`.
+///
+/// Back-compat shim around [`call_assign_handler_with_py_sidecar`] —
+/// equivalent to passing `None` for the raw Python sidecar.
 pub fn call_assign_handler(
     name: &str,
     args: &[String],
     context: &HashMap<String, djust_core::Value>,
+) -> Result<HashMap<String, djust_core::Value>, String> {
+    call_assign_handler_with_py_sidecar(name, args, context, None)
+}
+
+/// Variant of [`call_assign_handler`] that additionally injects raw
+/// Python objects from the [`Context::raw_py_objects`] sidecar into
+/// the handler's ``context`` dict.
+///
+/// Mirrors [`call_handler_with_py_sidecar`] (extended in PR #1166)
+/// for `Node::CustomTag`. Assign handlers needing access to
+/// Python-only context (e.g. ``request`` / ``view``) can read those
+/// keys from the dict directly. Sidecar values overwrite same-named
+/// JSON keys.
+///
+/// Existing assign handlers that ignore the extra keys are
+/// unaffected.
+pub fn call_assign_handler_with_py_sidecar(
+    name: &str,
+    args: &[String],
+    context: &HashMap<String, djust_core::Value>,
+    raw_py_objects: Option<&HashMap<String, pyo3::PyObject>>,
 ) -> Result<HashMap<String, djust_core::Value>, String> {
     let handler = {
         let registry = ASSIGN_TAG_HANDLERS
@@ -550,6 +611,17 @@ pub fn call_assign_handler(
             py_context
                 .set_item(key, py_value)
                 .map_err(|e| format!("Failed to set context key '{key}': {e}"))?;
+        }
+
+        // Inject raw Python sidecar objects (e.g. ``request``, ``view``)
+        // so assign handlers needing full Python context can reach them.
+        // Overwrites same-named JSON entries.
+        if let Some(raw) = raw_py_objects {
+            for (key, obj) in raw {
+                py_context
+                    .set_item(key, obj.bind(py))
+                    .map_err(|e| format!("Failed to set raw context key '{key}': {e}"))?;
+            }
         }
 
         let handler_ref = handler.bind(py);

--- a/crates/djust_templates/src/renderer.rs
+++ b/crates/djust_templates/src/renderer.rs
@@ -61,13 +61,19 @@ pub fn render_nodes_with_loader<L: TemplateLoader>(
                     .collect();
 
                 let context_map = active_ctx.to_hashmap();
-                let updates =
-                    crate::registry::call_assign_handler(name, &resolved_args, &context_map)
-                        .map_err(|e| {
-                            DjangoRustError::TemplateError(format!(
-                                "Assign tag '{name}' error: {e}"
-                            ))
-                        })?;
+                // Forward the raw-Python sidecar so assign handlers
+                // can reach Python-only context (request, view) the
+                // same way `Node::CustomTag` handlers do (#1167).
+                let raw_py = active_ctx.raw_py_objects();
+                let updates = crate::registry::call_assign_handler_with_py_sidecar(
+                    name,
+                    &resolved_args,
+                    &context_map,
+                    raw_py,
+                )
+                .map_err(|e| {
+                    DjangoRustError::TemplateError(format!("Assign tag '{name}' error: {e}"))
+                })?;
 
                 // Promote to owned context if we haven't already, then
                 // merge the handler's returned dict.
@@ -150,13 +156,17 @@ pub fn render_nodes_collecting<L: TemplateLoader>(
                     .map(|arg| resolve_tag_arg(arg, active_ctx))
                     .collect();
                 let context_map = active_ctx.to_hashmap();
-                let updates =
-                    crate::registry::call_assign_handler(name, &resolved_args, &context_map)
-                        .map_err(|e| {
-                            DjangoRustError::TemplateError(format!(
-                                "Assign tag '{name}' error: {e}"
-                            ))
-                        })?;
+                // Forward raw-Python sidecar (#1167).
+                let raw_py = active_ctx.raw_py_objects();
+                let updates = crate::registry::call_assign_handler_with_py_sidecar(
+                    name,
+                    &resolved_args,
+                    &context_map,
+                    raw_py,
+                )
+                .map_err(|e| {
+                    DjangoRustError::TemplateError(format!("Assign tag '{name}' error: {e}"))
+                })?;
                 if mutated.is_none() {
                     mutated = Some(active_ctx.clone());
                 }
@@ -217,13 +227,17 @@ pub fn render_nodes_partial<L: TemplateLoader>(
                         .map(|arg| resolve_tag_arg(arg, active_ctx))
                         .collect();
                     let context_map = active_ctx.to_hashmap();
-                    let updates =
-                        crate::registry::call_assign_handler(name, &resolved_args, &context_map)
-                            .map_err(|e| {
-                                DjangoRustError::TemplateError(format!(
-                                    "Assign tag '{name}' error: {e}"
-                                ))
-                            })?;
+                    // Forward raw-Python sidecar (#1167).
+                    let raw_py = active_ctx.raw_py_objects();
+                    let updates = crate::registry::call_assign_handler_with_py_sidecar(
+                        name,
+                        &resolved_args,
+                        &context_map,
+                        raw_py,
+                    )
+                    .map_err(|e| {
+                        DjangoRustError::TemplateError(format!("Assign tag '{name}' error: {e}"))
+                    })?;
                     if mutated.is_none() {
                         mutated = Some(active_ctx.clone());
                     }
@@ -828,10 +842,20 @@ pub fn render_node_with_loader<L: TemplateLoader>(
 
             let context_map = context.to_hashmap();
 
-            crate::registry::call_block_handler(name, &resolved_args, &content, &context_map)
-                .map_err(|e| {
-                    DjangoRustError::TemplateError(format!("Block tag '{}' error: {}", name, e))
-                })
+            // Forward raw-Python sidecar so block handlers can reach
+            // Python-only context (request, view) the same way
+            // ``Node::CustomTag`` handlers do (#1167).
+            let raw_py = context.raw_py_objects();
+            crate::registry::call_block_handler_with_py_sidecar(
+                name,
+                &resolved_args,
+                &content,
+                &context_map,
+                raw_py,
+            )
+            .map_err(|e| {
+                DjangoRustError::TemplateError(format!("Block tag '{}' error: {}", name, e))
+            })
         }
 
         Node::AssignTag { name, args } => {
@@ -845,9 +869,17 @@ pub fn render_node_with_loader<L: TemplateLoader>(
                 .map(|arg| resolve_tag_arg(arg, context))
                 .collect();
             let context_map = context.to_hashmap();
-            crate::registry::call_assign_handler(name, &resolved_args, &context_map).map_err(
-                |e| DjangoRustError::TemplateError(format!("Assign tag '{name}' error: {e}")),
-            )?;
+            // Forward raw-Python sidecar (#1167).
+            let raw_py = context.raw_py_objects();
+            crate::registry::call_assign_handler_with_py_sidecar(
+                name,
+                &resolved_args,
+                &context_map,
+                raw_py,
+            )
+            .map_err(|e| {
+                DjangoRustError::TemplateError(format!("Assign tag '{name}' error: {e}"))
+            })?;
             Ok(String::new())
         }
 

--- a/tests/unit/test_tag_registry.py
+++ b/tests/unit/test_tag_registry.py
@@ -2,10 +2,64 @@
 Tests for the Tag Handler Registry.
 
 Tests the Rust registry, Python handlers, and integration between them.
+
+Test isolation (#1167)
+----------------------
+Some tests in this file register transient handlers (e.g.
+``BrokenHandler`` for the ``broken`` tag) into the Rust-side
+``TAG_HANDLERS`` registry. The previous per-class ``setup_registry``
+fixture only re-registered the *built-in* Python handlers on
+teardown and did NOT clear the registry first, so transient test
+handlers leaked into subsequent test files. ``test_assign_tag.py``
+running after this file would then see ``handler_exists("broken")``
+== True and the parser would dispatch ``{% broken %}`` as a
+``CustomTag`` instead of an ``AssignTag`` — flake.
+
+The module-scoped ``_isolate_tag_registries`` fixture below clears
+ALL three registries (tag, block-tag, assign-tag) at module setup
+and after every test, then re-registers the built-ins from the
+Python ``_registered_handlers`` snapshot. This makes the file
+self-contained: no test in this module can leak any handler into
+the rest of the suite.
 """
 
 import pytest
 from unittest.mock import patch
+
+
+@pytest.fixture(autouse=True)
+def _isolate_tag_registries():
+    """Hard-isolate all three Rust tag registries per test (#1167).
+
+    Clears tag / block-tag / assign-tag registries before and after every
+    test in this module, then restores the built-in tag handlers from the
+    Python ``_registered_handlers`` snapshot. Any transient handler a
+    test registers (e.g. ``BrokenHandler`` from
+    ``test_handler_exception_returns_error``) is wiped on teardown — it
+    cannot leak into ``test_assign_tag.py`` or other downstream files.
+    """
+    try:
+        from djust._rust import (
+            clear_tag_handlers,
+            clear_block_tag_handlers,
+            clear_assign_tag_handlers,
+            register_tag_handler,
+        )
+        from djust.template_tags import _registered_handlers
+    except ImportError:
+        pytest.skip("Rust extension not available")
+        return
+
+    def _reset() -> None:
+        clear_tag_handlers()
+        clear_block_tag_handlers()
+        clear_assign_tag_handlers()
+        for name, handler in _registered_handlers.items():
+            register_tag_handler(name, handler)
+
+    _reset()
+    yield
+    _reset()
 
 
 class TestTagHandlerBase:
@@ -183,27 +237,11 @@ class TestStaticTagHandler:
 
 
 class TestRegistryIntegration:
-    """Integration tests for the registry system."""
+    """Integration tests for the registry system.
 
-    @pytest.fixture(autouse=True)
-    def setup_registry(self):
-        """Clear registry before each test, restore built-in handlers after."""
-        try:
-            from djust._rust import clear_tag_handlers
-
-            clear_tag_handlers()
-        except ImportError:
-            pytest.skip("Rust extension not available")
-        yield
-        # Restore built-in handlers to prevent test pollution
-        try:
-            from djust._rust import register_tag_handler
-            from djust.template_tags import _registered_handlers
-
-            for name, handler in _registered_handlers.items():
-                register_tag_handler(name, handler)
-        except ImportError:
-            pass  # Rust extension not available; nothing to restore
+    The module-scoped ``_isolate_tag_registries`` autouse fixture
+    handles cleanup; this class no longer needs its own setup_registry.
+    """
 
     def test_register_and_check(self):
         """Handler can be registered and checked."""
@@ -286,27 +324,11 @@ class TestRegistryIntegration:
 
 
 class TestRenderIntegration:
-    """Tests for rendering templates with custom tags."""
+    """Tests for rendering templates with custom tags.
 
-    @pytest.fixture(autouse=True)
-    def setup_registry(self):
-        """Clear registry before each test, restore built-in handlers after."""
-        try:
-            from djust._rust import clear_tag_handlers
-
-            clear_tag_handlers()
-        except ImportError:
-            pytest.skip("Rust extension not available")
-        yield
-        # Restore built-in handlers to prevent test pollution
-        try:
-            from djust._rust import register_tag_handler
-            from djust.template_tags import _registered_handlers
-
-            for name, handler in _registered_handlers.items():
-                register_tag_handler(name, handler)
-        except ImportError:
-            pass  # Rust extension not available; nothing to restore
+    The module-scoped ``_isolate_tag_registries`` autouse fixture
+    handles cleanup; this class no longer needs its own setup_registry.
+    """
 
     def test_render_custom_tag(self):
         """Custom tag is rendered via Python handler."""

--- a/tests/unit/test_tag_sidecar_parity_1167.py
+++ b/tests/unit/test_tag_sidecar_parity_1167.py
@@ -1,0 +1,201 @@
+"""Sidecar bridge parity for block-tag and assign-tag handlers (#1167).
+
+PR #1166 wired the raw-Python sidecar (``request`` / ``view`` / …)
+into ``Node::CustomTag`` handlers so the ``live_render`` lazy-true
+path could reach the parent view from the Rust template engine.
+This file extends parity to the other two custom-tag node types:
+
+* ``Node::BlockCustomTag`` — block tags such as ``{% modal %}…{% endmodal %}``.
+* ``Node::AssignTag`` — context-mutating tags such as ``{% assign_slot %}``.
+
+Each test exercises sidecar receipt by registering a handler that
+inspects its ``context`` dict for the sidecar key, plus a back-compat
+test confirming a handler that ignores the sidecar still works
+unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from djust._rust import (
+    RustLiveView,
+    clear_assign_tag_handlers,
+    clear_block_tag_handlers,
+    register_assign_tag_handler,
+    register_block_tag_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sentinel objects we can identity-compare in handler render() calls
+# ---------------------------------------------------------------------------
+
+
+class _RequestSentinel:
+    """Stand-in for a Django HttpRequest in the sidecar."""
+
+    def __init__(self) -> None:
+        self.method = "GET"
+
+
+class _ViewSentinel:
+    """Stand-in for a LiveView instance in the sidecar."""
+
+    def __init__(self) -> None:
+        self.flag = "view-sentinel"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_registries():
+    """Hard-reset block + assign registries around every test."""
+    clear_block_tag_handlers()
+    clear_assign_tag_handlers()
+    yield
+    clear_block_tag_handlers()
+    clear_assign_tag_handlers()
+
+
+def _make_view(template: str, *, request, view) -> RustLiveView:
+    rv = RustLiveView(template)
+    rv.set_raw_py_values({"request": request, "view": view})
+    return rv
+
+
+# ---------------------------------------------------------------------------
+# Block-tag sidecar tests
+# ---------------------------------------------------------------------------
+
+
+class TestBlockTagSidecar:
+    def test_block_handler_receives_request_from_sidecar(self):
+        """A custom block tag can read ``request`` out of its context dict."""
+        seen: dict[str, object] = {}
+
+        class _CaptureBlock:
+            def render(self, args, content, context):  # noqa: ARG002 — fixture stub
+                seen["request"] = context.get("request")
+                return f"<wrap>{content}</wrap>"
+
+        register_block_tag_handler("capture_blk", "endcapture_blk", _CaptureBlock())
+
+        request = _RequestSentinel()
+        view = _ViewSentinel()
+        rv = _make_view("{% capture_blk %}body{% endcapture_blk %}", request=request, view=view)
+        html = rv.render()
+
+        assert html == "<wrap>body</wrap>"
+        assert seen["request"] is request, (
+            "Block-tag handler must receive the raw `request` object from "
+            "the sidecar, not a JSON projection or None."
+        )
+
+    def test_block_handler_receives_view_from_sidecar(self):
+        """A custom block tag can read ``view`` (LiveView) from its context dict."""
+        seen: dict[str, object] = {}
+
+        class _CaptureViewBlock:
+            def render(self, args, content, context):  # noqa: ARG002
+                seen["view"] = context.get("view")
+                return content
+
+        register_block_tag_handler("capture_view_blk", "endcapture_view_blk", _CaptureViewBlock())
+
+        request = _RequestSentinel()
+        view = _ViewSentinel()
+        rv = _make_view(
+            "{% capture_view_blk %}x{% endcapture_view_blk %}",
+            request=request,
+            view=view,
+        )
+        rv.render()
+
+        assert seen["view"] is view
+        # And isinstance check — the actual Python object is exposed,
+        # not a JSON snapshot.
+        assert isinstance(seen["view"], _ViewSentinel)
+
+    def test_block_handler_back_compat_without_sidecar(self):
+        """Existing block handlers that ignore the sidecar are unaffected."""
+
+        class _LegacyBlock:
+            def render(self, args, content, context):  # noqa: ARG002
+                # Legacy handler: only looks at content, never touches
+                # request/view. This is the dominant case (modal, card,
+                # slot, dj_suspense).
+                return f"[legacy:{content}]"
+
+        register_block_tag_handler("legacy_blk", "endlegacy_blk", _LegacyBlock())
+
+        # No set_raw_py_values call — sidecar is None.
+        rv = RustLiveView("{% legacy_blk %}hi{% endlegacy_blk %}")
+        html = rv.render()
+        assert html == "[legacy:hi]"
+
+
+# ---------------------------------------------------------------------------
+# Assign-tag sidecar tests
+# ---------------------------------------------------------------------------
+
+
+class TestAssignTagSidecar:
+    def test_assign_handler_receives_view_from_sidecar(self):
+        """A custom assign tag can read ``view`` from its context dict."""
+        seen: dict[str, object] = {}
+
+        class _CaptureViewAssign:
+            def render(self, args, context):  # noqa: ARG002
+                seen["view"] = context.get("view")
+                # Emit a context update keyed off a sidecar attr so we
+                # can confirm both arms (sidecar visible AND merge
+                # still works) in a single render.
+                v = context.get("view")
+                return {"flag_seen": getattr(v, "flag", None)}
+
+        register_assign_tag_handler("capture_view_assign", _CaptureViewAssign())
+
+        request = _RequestSentinel()
+        view = _ViewSentinel()
+        rv = _make_view("{% capture_view_assign %}val={{ flag_seen }}", request=request, view=view)
+        html = rv.render()
+
+        assert seen["view"] is view
+        assert isinstance(seen["view"], _ViewSentinel)
+        assert html == "val=view-sentinel"
+
+    def test_assign_handler_receives_request_from_sidecar(self):
+        """A custom assign tag can read ``request`` from its context dict."""
+        seen: dict[str, object] = {}
+
+        class _CaptureReqAssign:
+            def render(self, args, context):  # noqa: ARG002
+                seen["request"] = context.get("request")
+                return {}
+
+        register_assign_tag_handler("capture_req_assign", _CaptureReqAssign())
+
+        request = _RequestSentinel()
+        view = _ViewSentinel()
+        rv = _make_view("{% capture_req_assign %}", request=request, view=view)
+        rv.render()
+
+        assert seen["request"] is request
+
+    def test_assign_handler_back_compat_without_sidecar(self):
+        """Existing assign handlers that ignore the sidecar are unaffected."""
+
+        class _LegacyAssign:
+            def render(self, args, context):  # noqa: ARG002
+                return {"legacy_key": "legacy_value"}
+
+        register_assign_tag_handler("legacy_assign", _LegacyAssign())
+
+        # No set_raw_py_values call — sidecar is None.
+        rv = RustLiveView("{% legacy_assign %}{{ legacy_key }}")
+        html = rv.render()
+        assert html == "legacy_value"


### PR DESCRIPTION
## Summary

Two Stage 11 follow-ups from PR #1166 (which wired the raw-Python sidecar into `Node::CustomTag`).

- **Sub-item 1: tag-registry test isolation.** `tests/unit/test_tag_registry.py` previously used per-class `setup_registry` fixtures that only re-registered Python built-in handlers on teardown — they never *cleared* the global Rust `TAG_HANDLERS` registry. Transient handlers from the file (notably `BrokenHandler` registered for the `broken` tag in `test_handler_exception_returns_error`) leaked into subsequent test files. `test_assign_tag.py` running after this file would see `handler_exists("broken") == True`; the parser checks `handler_exists` before `assign_handler_exists`, so `{% broken %}` was routed to the leaked `CustomTag` handler and `test_non_dict_return_is_empty_merge` failed with the leaked handler's exception. Replaced the per-class fixtures with one function-scoped autouse fixture that clears all three Rust registries (tag / block-tag / assign-tag) before AND after every test, then re-registers the built-ins.

- **Sub-item 2: sidecar parity for block + assign tags.** PR #1166's `call_handler_with_py_sidecar` only fired for `Node::CustomTag`. Block tags (`Node::BlockCustomTag`) and assign tags (`Node::AssignTag`) didn't receive the `request` / `view` sidecar. Added `call_block_handler_with_py_sidecar` and `call_assign_handler_with_py_sidecar` mirroring the PR #1166 pattern; existing `call_block_handler` / `call_assign_handler` are kept as back-compat shims that delegate with `None`. All five renderer call sites (1× block, 4× assign — single-node, sibling-aware, collecting, and partial-render paths) forward `context.raw_py_objects()`.

## Issue × file × test mapping

| Issue / Sub-item | Files modified | Tests covering it |
|---|---|---|
| #1167 sub-item 1 (test isolation) | `tests/unit/test_tag_registry.py` (new module-scoped autouse `_isolate_tag_registries`; per-class `setup_registry` fixtures removed) | `pytest tests/unit/test_tag_registry.py tests/unit/test_assign_tag.py -v` now passes (was failing on `test_non_dict_return_is_empty_merge` before) |
| #1167 sub-item 2 (block-tag sidecar) | `crates/djust_templates/src/registry.rs` (added `call_block_handler_with_py_sidecar`); `crates/djust_templates/src/renderer.rs` (`Node::BlockCustomTag` arm) | `TestBlockTagSidecar::test_block_handler_receives_request_from_sidecar`, `..._receives_view_from_sidecar`, `..._back_compat_without_sidecar` (`tests/unit/test_tag_sidecar_parity_1167.py`) |
| #1167 sub-item 2 (assign-tag sidecar) | `crates/djust_templates/src/registry.rs` (added `call_assign_handler_with_py_sidecar`); `crates/djust_templates/src/renderer.rs` (4 `Node::AssignTag` arms) | `TestAssignTagSidecar::test_assign_handler_receives_view_from_sidecar`, `..._receives_request_from_sidecar`, `..._back_compat_without_sidecar` (`tests/unit/test_tag_sidecar_parity_1167.py`) |

## Design choice

Mirrored the PR #1166 pattern exactly: added `_with_py_sidecar` variants alongside the existing `call_block_handler` / `call_assign_handler`, with the existing functions as back-compat shims that delegate with `None`. This keeps the bridge surface uniform across all three node types and means any future external Rust caller that doesn't have a sidecar handy doesn't need to plumb one through.

## Test plan

- [x] `uv run pytest tests/unit/test_tag_registry.py tests/unit/test_assign_tag.py -v` — both files pass in this order (was 1 failure before)
- [x] `uv run pytest tests/unit/test_tag_sidecar_parity_1167.py -v` — 6/6 new tests pass
- [x] `uv run pytest python/djust/ tests/ -q` — 4607 passed, 14 skipped (clean)
- [x] `make test-rust` — all Rust crates pass (104 + 14 + 278 + 24 + 66 + 99 + 6 + 20 + 42 + doc tests)
- [x] `cargo clippy -p djust_templates --all-targets` — clean
- [x] `make dev-build` — maturin rebuild green
- [x] Pre-commit + pre-push hooks — all passed (ruff, cargo fmt, clippy, bandit, detect-secrets, pytest, cargo test, cargo audit)

Closes #1167

🤖 Generated with [Claude Code](https://claude.com/claude-code)