### PR TITLE
fix(theming): cookie namespace polish — 4 sub-items (closes #1169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Theming cookie namespace polish — 4 sub-items (closes #1169)** —
+  Stage 11 follow-ups from PR #1168 (the original cookie-namespace work
+  for #1158):
+  - **(a) Empty namespaced cookie no longer falls back to legacy.**
+    `ThemeManager.get_state()` previously evaluated the namespaced
+    cookie via `_read('<ns>_name') or None`, so an empty-string value
+    (`""`) silently fell through to the unprefixed legacy cookie —
+    re-opening the cross-project bleed path #1158 closed. The read
+    now distinguishes `None` (cookie not in jar) from `""` (cookie set
+    to empty), and only falls back in the former case.
+  - **(b) `cookie_namespace` validated at config-load.** The value is
+    interpolated directly into cookie names; whitespace, `=`, `;`, and
+    non-ASCII characters previously produced malformed Set-Cookie
+    headers (browsers reject or split such cookies).
+    `_validate_cookie_namespace()` now raises `ImproperlyConfigured`
+    at startup for any value outside `[A-Za-z0-9_-]+`.
+  - **(c) JSDOM tests for the cookie WRITE side.** The 8 #1158
+    Python tests only asserted on `theme.js` source-text patterns; new
+    `tests/js/theming_cookie_namespace_write.test.js` loads the file
+    in JSDOM, sets `window.__djust_theme_cookie_prefix`, fires
+    `setPack`/`setPreset`/`setLayout`, and inspects `document.cookie`.
+  - **(d) Legacy-cookie cleanup on first namespaced write.** When
+    `cookie_namespace` is set, every theming-cookie write in
+    `theme.js` now also emits `Max-Age=0` for the unprefixed legacy
+    name. Stale legacy cookies left over from before namespace was
+    configured no longer sit in the jar forever and bleed back if the
+    namespace is later removed. Cleanup is inert when no prefix is
+    configured (back-compat).
+
+  3 new regression cases in `tests/unit/test_theming_cookie_namespace_1158.py`
+  (1 for sub-item (a), 2 for sub-item (b)) plus 7 new JS cases in
+  `tests/js/theming_cookie_namespace_write.test.js` (4 for sub-item (c),
+  3 for sub-item (d)).
+
 - **Tag-registry test isolation + sidecar bridge extension to block /
   assign tags (closes #1167)** — two Stage 11 follow-ups from PR #1166
   (which wired the raw-Python sidecar into ``Node::CustomTag``):

--- a/python/djust/theming/manager.py
+++ b/python/djust/theming/manager.py
@@ -4,13 +4,24 @@ Theme state management for djust.
 Manages theme preset and mode preferences, with session persistence.
 """
 
+import re
 from dataclasses import dataclass
 from typing import Literal
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
 
 from .presets import ThemePreset, get_preset
+
+# #1169(b) — cookie_namespace is interpolated directly into cookie names. RFC
+# 6265 forbids whitespace, control chars, '=' and ';' inside cookie names;
+# non-ASCII is implementation-defined and unsafe in practice. Restrict to
+# ASCII alphanumerics + underscore + hyphen (a strict subset of RFC 6265
+# token chars) so misconfiguration fails loudly at config-load instead of
+# silently emitting malformed Set-Cookie headers that browsers reject or
+# split into multiple cookies.
+COOKIE_NAMESPACE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 ThemeMode = Literal["light", "dark", "system"]
 
@@ -48,11 +59,42 @@ DEFAULT_CONFIG = {
 }
 
 
+def _validate_cookie_namespace(value):
+    """Validate ``LIVEVIEW_CONFIG['theme']['cookie_namespace']`` (#1169(b)).
+
+    The value is interpolated directly into cookie names; characters
+    illegal in cookie names (whitespace, ``=``, ``;``, non-ASCII)
+    silently produce malformed Set-Cookie headers. Validate at
+    config-load so the failure mode is a loud
+    :class:`~django.core.exceptions.ImproperlyConfigured` at startup
+    instead of broken cookies in production.
+
+    ``None`` and empty string are accepted as "no namespace configured".
+    """
+    if value is None or value == "":
+        return value
+    if not isinstance(value, str) or not COOKIE_NAMESPACE_RE.match(value):
+        raise ImproperlyConfigured(
+            f"LIVEVIEW_CONFIG['theme']['cookie_namespace']={value!r} contains "
+            f"characters illegal in cookie names. Use only ASCII letters, "
+            f"digits, underscores, and hyphens."
+        )
+    return value
+
+
 def get_theme_config() -> dict:
-    """Get theme configuration from Django settings."""
+    """Get theme configuration from Django settings.
+
+    Raises:
+        ImproperlyConfigured: if ``cookie_namespace`` contains characters
+            illegal in cookie names (#1169(b)).
+    """
     liveview_config = getattr(settings, "LIVEVIEW_CONFIG", {})
     theme_config = liveview_config.get("theme", {})
-    return {**DEFAULT_CONFIG, **theme_config}
+    merged = {**DEFAULT_CONFIG, **theme_config}
+    # Validate cookie_namespace at config-load (#1169(b)).
+    _validate_cookie_namespace(merged.get("cookie_namespace"))
+    return merged
 
 
 @dataclass
@@ -303,14 +345,29 @@ class ThemeManager:
             prefix = f"{ns}_" if ns else ""
 
             # Read namespaced first; fall back to unprefixed (migration window).
+            #
+            # #1169(a) — distinguish "namespaced cookie not set" from
+            # "namespaced cookie set to empty string". An empty string is a
+            # deliberate value (e.g. user cleared a layout); falling through
+            # to the legacy unprefixed cookie in that case re-introduces
+            # cross-project bleed via the same path #1158 closed.
             def _read(name: str, default: str = "") -> str:
                 if prefix:
-                    return cookies.get(f"{prefix}{name}", cookies.get(name, default))
+                    namespaced = cookies.get(f"{prefix}{name}")
+                    if namespaced is not None:
+                        return namespaced
+                    return cookies.get(name, default)
                 return cookies.get(name, default)
 
-            theme = _read("djust_theme") or None
-            preset = _read("djust_theme_preset") or None
-            pack = _read("djust_theme_pack") or None
+            # _read returns "" when the cookie is set to empty; preserve that
+            # rather than coercing to None via `or None` (which would re-trigger
+            # the bleed-through path the namespaced read just closed).
+            raw_theme = _read("djust_theme")
+            raw_preset = _read("djust_theme_preset")
+            raw_pack = _read("djust_theme_pack")
+            theme = raw_theme if raw_theme else None
+            preset = raw_preset if raw_preset else None
+            pack = raw_pack if raw_pack else None
             layout = _read("djust_theme_layout", "")
             logger.debug(
                 "Cookies (ns=%r): theme=%s, preset=%s, pack=%s, layout=%s",

--- a/python/djust/theming/static/djust_theming/js/theme.js
+++ b/python/djust/theming/static/djust_theming/js/theme.js
@@ -32,6 +32,25 @@
     const COOKIE_KEY_PACK = COOKIE_PREFIX + 'djust_theme_pack';
     const COOKIE_KEY_LAYOUT = COOKIE_PREFIX + 'djust_theme_layout';
 
+    /**
+     * #1169(d) — Delete the legacy unprefixed cookie when writing a
+     * namespaced theming cookie. After a user changes their theme on a
+     * namespaced site, the legacy `djust_theme*` cookies otherwise sit in
+     * the jar forever and can bleed back in if the namespace is ever
+     * removed (or read by another project on the same localhost domain).
+     *
+     * Only fires when COOKIE_PREFIX is non-empty. With no prefix, the
+     * "namespaced" name and the legacy name are identical and deleting it
+     * would clobber the value we just wrote.
+     *
+     * @param {string} legacyName — the unprefixed cookie name to delete
+     *   (e.g. 'djust_theme_pack').
+     */
+    function _deleteLegacyCookie(legacyName) {
+        if (!COOKIE_PREFIX) return;
+        document.cookie = legacyName + '=; path=/; max-age=0; SameSite=Lax';
+    }
+
     class DjustThemeManager {
         constructor() {
             this.pendingUpdate = null;
@@ -186,6 +205,7 @@
 
             // Also set a cookie so the server can read it
             document.cookie = `${COOKIE_KEY_PRESET}=${preset};path=/;max-age=31536000;SameSite=Lax`;
+            _deleteLegacyCookie('djust_theme_preset');
 
             // Clear pack if setting preset manually
             this.clearPack();
@@ -207,6 +227,7 @@
 
             // Set cookie for server
             document.cookie = `${COOKIE_KEY_THEME}=${theme};path=/;max-age=31536000;SameSite=Lax`;
+            _deleteLegacyCookie('djust_theme');
 
             // Clear pack if setting theme manually
             this.clearPack();
@@ -223,6 +244,7 @@
 
             // Set cookie for server
             document.cookie = `${COOKIE_KEY_PACK}=${pack};path=/;max-age=31536000;SameSite=Lax`;
+            _deleteLegacyCookie('djust_theme_pack');
 
             // Reload to apply
             window.location.reload();
@@ -234,6 +256,7 @@
         clearPack() {
             localStorage.removeItem(STORAGE_KEY_PACK);
             document.cookie = `${COOKIE_KEY_PACK}=;path=/;expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+            _deleteLegacyCookie('djust_theme_pack');
         }
 
         /**
@@ -242,6 +265,7 @@
         setLayout(layout) {
             localStorage.setItem(STORAGE_KEY_LAYOUT, layout);
             document.cookie = `${COOKIE_KEY_LAYOUT}=${layout};path=/;max-age=31536000;SameSite=Lax`;
+            _deleteLegacyCookie('djust_theme_layout');
 
             // Apply layout class immediately (CSS-only switching)
             const wrapper = document.querySelector('[data-layout]');
@@ -342,6 +366,7 @@
 
                 // Set cookie for server-side rendering
                 document.cookie = `${COOKIE_KEY_PRESET}=${preset};path=/;max-age=31536000;SameSite=Lax`;
+                _deleteLegacyCookie('djust_theme_preset');
 
                 // Update the CSS dynamically
                 const styleElement = document.querySelector('#djust-theme-css');

--- a/tests/js/theming_cookie_namespace_write.test.js
+++ b/tests/js/theming_cookie_namespace_write.test.js
@@ -1,0 +1,180 @@
+/**
+ * Regression tests for #1169 sub-items (c) and (d) — namespaced cookie
+ * WRITE-side semantics in `python/djust/theming/static/djust_theming/js/theme.js`.
+ *
+ * Background
+ * ----------
+ * #1158 added per-project cookie namespacing for theming cookies. The Python
+ * tests in `tests/unit/test_theming_cookie_namespace_1158.py` cover the
+ * server-side READ. Sub-item (c) of #1169 was that the WRITE side was only
+ * verified via string-source assertions ("the source contains
+ * `COOKIE_PREFIX + 'djust_theme'`"), not by actually executing the JS in a
+ * DOM and inspecting `document.cookie`.
+ *
+ * These tests load `theme.js` inside a JSDOM, set
+ * `window.__djust_theme_cookie_prefix` (the global the inline anti-FOUC
+ * script populates from `LIVEVIEW_CONFIG['theme']['cookie_namespace']`),
+ * trigger each write entry-point, and assert the cookie jar contains the
+ * namespaced name and NOT the unprefixed legacy name.
+ *
+ * Sub-item (d): the write path also fires `Max-Age=0` on the legacy
+ * unprefixed cookie name when a namespace is configured, so old cookies
+ * left over from before the namespace was set don't sit in the jar
+ * forever.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import fs from 'fs';
+import path from 'path';
+
+const THEME_JS_PATH = './python/djust/theming/static/djust_theming/js/theme.js';
+
+// Cache the source so we don't re-read on every test.
+let _themeJsCache = null;
+function getThemeJs() {
+    if (_themeJsCache == null) {
+        _themeJsCache = fs.readFileSync(THEME_JS_PATH, 'utf-8');
+    }
+    return _themeJsCache;
+}
+
+/**
+ * Build a JSDOM with theme.js loaded.
+ *
+ * @param {string|null} cookiePrefix — value of `window.__djust_theme_cookie_prefix`
+ *   to set BEFORE evaluating theme.js. Pass `null` to leave the global unset
+ *   (back-compat path: COOKIE_PREFIX defaults to empty string).
+ */
+function createThemingDom(cookiePrefix) {
+    const dom = new JSDOM(
+        `<!DOCTYPE html><html><head></head><body></body></html>`,
+        { runScripts: 'outside-only', url: 'http://localhost/', pretendToBeVisual: true }
+    );
+    if (cookiePrefix !== null) {
+        dom.window.__djust_theme_cookie_prefix = cookiePrefix;
+    }
+    // matchMedia stub — theme.js calls it during init.
+    dom.window.matchMedia = () => ({
+        matches: false,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+    });
+    // requestAnimationFrame is provided by JSDOM but we want it synchronous
+    // for predictable test ordering.
+    dom.window.requestAnimationFrame = (cb) => { cb(0); return 1; };
+    dom.window.cancelAnimationFrame = () => {};
+    // Stub reload so setPreset/setTheme/setPack don't throw on
+    // window.location.reload() (JSDOM disallows navigation by default).
+    // The location object is non-configurable, so we patch reload directly.
+    try {
+        dom.window.location.reload = () => {};
+    } catch (_) {
+        // If JSDOM tightens this in future, fall back to a Proxy-style override.
+    }
+    dom.window.eval(getThemeJs());
+    return dom;
+}
+
+/**
+ * Parse `document.cookie` into a `{name: value}` map. The browser's cookie
+ * jar joins cookies with `'; '`; deleted cookies (Max-Age=0) are simply
+ * absent from the resulting string.
+ */
+function parseCookies(cookieStr) {
+    const out = {};
+    if (!cookieStr) return out;
+    cookieStr.split(';').forEach((pair) => {
+        const idx = pair.indexOf('=');
+        if (idx < 0) return;
+        const name = pair.slice(0, idx).trim();
+        const value = pair.slice(idx + 1).trim();
+        if (name) out[name] = value;
+    });
+    return out;
+}
+
+describe('#1169(c) — namespaced cookie WRITE side', () => {
+    it('setPack writes the namespaced cookie name when prefix is set', () => {
+        const dom = createThemingDom('myapp_');
+        const tm = dom.window.djustTheme;
+        tm.setPack('nyc_core');
+        const jar = parseCookies(dom.window.document.cookie);
+        expect(jar['myapp_djust_theme_pack']).toBe('nyc_core');
+        // Legacy unprefixed name must NOT carry the value (sub-item d ensures
+        // it's deleted, not overwritten with the new value).
+        expect(jar['djust_theme_pack']).toBeUndefined();
+    });
+
+    it('setPreset writes the namespaced cookie name when prefix is set', () => {
+        const dom = createThemingDom('myapp_');
+        const tm = dom.window.djustTheme;
+        tm.setPreset('rose');
+        const jar = parseCookies(dom.window.document.cookie);
+        expect(jar['myapp_djust_theme_preset']).toBe('rose');
+        expect(jar['djust_theme_preset']).toBeUndefined();
+    });
+
+    it('setLayout writes the namespaced cookie name when prefix is set', () => {
+        const dom = createThemingDom('myapp_');
+        const tm = dom.window.djustTheme;
+        tm.setLayout('sidebar');
+        const jar = parseCookies(dom.window.document.cookie);
+        expect(jar['myapp_djust_theme_layout']).toBe('sidebar');
+        expect(jar['djust_theme_layout']).toBeUndefined();
+    });
+
+    it('back-compat: empty prefix writes the legacy unprefixed cookie name', () => {
+        // window.__djust_theme_cookie_prefix unset (default), or set to "".
+        const dom = createThemingDom(null);
+        const tm = dom.window.djustTheme;
+        tm.setPack('nyc_core');
+        const jar = parseCookies(dom.window.document.cookie);
+        expect(jar['djust_theme_pack']).toBe('nyc_core');
+    });
+});
+
+describe('#1169(d) — legacy unprefixed cookie cleanup on namespaced write', () => {
+    it('setPack deletes the legacy djust_theme_pack cookie when prefix is set', () => {
+        const dom = createThemingDom('myapp_');
+        // Pre-seed the legacy cookie (simulating a stale value left from
+        // before the namespace config was added).
+        dom.window.document.cookie = 'djust_theme_pack=old_legacy_value; path=/';
+        // Sanity check the seed.
+        expect(parseCookies(dom.window.document.cookie)['djust_theme_pack']).toBe('old_legacy_value');
+
+        const tm = dom.window.djustTheme;
+        tm.setPack('nyc_core');
+
+        const jar = parseCookies(dom.window.document.cookie);
+        expect(jar['myapp_djust_theme_pack']).toBe('nyc_core');
+        // Legacy cookie deleted via Max-Age=0 — must NOT be in the jar.
+        expect(jar['djust_theme_pack']).toBeUndefined();
+    });
+
+    it('setPreset deletes the legacy djust_theme_preset cookie when prefix is set', () => {
+        const dom = createThemingDom('myapp_');
+        dom.window.document.cookie = 'djust_theme_preset=stale_legacy; path=/';
+        expect(parseCookies(dom.window.document.cookie)['djust_theme_preset']).toBe('stale_legacy');
+
+        const tm = dom.window.djustTheme;
+        tm.setPreset('rose');
+
+        const jar = parseCookies(dom.window.document.cookie);
+        expect(jar['myapp_djust_theme_preset']).toBe('rose');
+        expect(jar['djust_theme_preset']).toBeUndefined();
+    });
+
+    it('legacy cleanup does NOT fire when prefix is empty (back-compat)', () => {
+        // With no namespace, the "namespaced" name and the "legacy" name
+        // are identical. The cleanup must be inert in this configuration —
+        // otherwise it would Max-Age=0 the cookie we just wrote.
+        const dom = createThemingDom('');
+        const tm = dom.window.djustTheme;
+        tm.setPack('nyc_core');
+
+        const jar = parseCookies(dom.window.document.cookie);
+        // The single (unprefixed) cookie must still hold the value.
+        expect(jar['djust_theme_pack']).toBe('nyc_core');
+    });
+});

--- a/tests/unit/test_theming_cookie_namespace_1158.py
+++ b/tests/unit/test_theming_cookie_namespace_1158.py
@@ -156,6 +156,92 @@ def test_namespace_applies_to_all_four_cookies():
 
 
 # ---------------------------------------------------------------------------
+# #1169(a) — empty namespaced cookie must NOT fall through to legacy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_empty_namespaced_cookie_does_not_fall_back_to_legacy():
+    """#1169(a): when the namespaced cookie is SET but empty (e.g. user
+    cleared their layout), the read must NOT fall through to the legacy
+    unprefixed cookie. Empty != not-set. Falling back re-opens the
+    cross-project bleed path #1158 closed.
+
+    This regresses against the `_read('<ns>_name') or None` pattern,
+    which evaluated empty string as falsy and triggered the unprefixed
+    fallback.
+    """
+    from djust.theming.manager import ThemeManager
+
+    rf = RequestFactory()
+    req = rf.get("/")
+    # Namespaced cookie present but empty — the user's deliberate "no value".
+    req.COOKIES["proj_djust_theme_layout"] = ""
+    # Stale unprefixed cookie from another project — must NOT win, even
+    # though the namespaced cookie is empty.
+    req.COOKIES["djust_theme_layout"] = "sidebar"
+    req.session = {}
+
+    mgr = ThemeManager(request=req)
+    mgr.config = dict(mgr.config, cookie_namespace="proj", enable_client_override=True)
+    state = mgr.get_state()
+    assert state.layout == "", (
+        "empty namespaced cookie must NOT fall back to legacy unprefixed cookie; "
+        f"got layout={state.layout!r} (likely the bleed bug — see PR #1169 sub-item a)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1169(b) — cookie_namespace validation at config-load
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_cookie_namespace_validator_accepts_valid_values(settings):
+    """#1169(b): valid namespace strings (letters, digits, underscores,
+    hyphens) pass validation and round-trip through `get_theme_config()`."""
+    from djust.theming.manager import get_theme_config
+
+    for value in ("djust_org", "Project-A", "abc123", "x", "_", "-"):
+        settings.LIVEVIEW_CONFIG = {"theme": {"cookie_namespace": value}}
+        config = get_theme_config()
+        assert config["cookie_namespace"] == value, (
+            f"valid namespace {value!r} must round-trip; got {config.get('cookie_namespace')!r}"
+        )
+
+    # Empty string and missing key are both accepted as "no namespace".
+    settings.LIVEVIEW_CONFIG = {"theme": {"cookie_namespace": ""}}
+    assert get_theme_config().get("cookie_namespace") == ""
+
+    settings.LIVEVIEW_CONFIG = {"theme": {}}
+    assert get_theme_config().get("cookie_namespace") is None
+
+
+@pytest.mark.django_db
+def test_cookie_namespace_validator_rejects_illegal_characters(settings):
+    """#1169(b): values containing whitespace, '=', ';', or non-ASCII raise
+    `ImproperlyConfigured` at config-load — silent malformed cookies were the
+    bug."""
+    from django.core.exceptions import ImproperlyConfigured
+    from djust.theming.manager import get_theme_config
+
+    illegal = (
+        "has space",  # whitespace
+        "has=equals",  # '='
+        "has;semi",  # ';'
+        "café",  # non-ASCII
+        "tab\there",  # tab whitespace
+        "new\nline",  # newline
+        "has,comma",  # ','
+        "(parens)",  # parens
+    )
+    for value in illegal:
+        settings.LIVEVIEW_CONFIG = {"theme": {"cookie_namespace": value}}
+        with pytest.raises(ImproperlyConfigured, match="cookie_namespace"):
+            get_theme_config()
+
+
+# ---------------------------------------------------------------------------
 # Write side — theme_head.html template emits __djust_theme_cookie_prefix
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Four follow-ups from the PR #1168 Stage 11 review of the per-project
cookie namespacing introduced in #1158:

- **(a)** Empty namespaced cookie no longer falls back to legacy unprefixed.
  The previous `_read('<ns>_name') or None` evaluated `""` as falsy and
  fell through to the unprefixed name, re-opening the cross-project
  cookie bleed path #1158 closed. Now distinguishes `None` (cookie not in
  jar) from `""` (cookie set to empty), and only falls back in the former
  case.
- **(b)** `LIVEVIEW_CONFIG['theme']['cookie_namespace']` now validates at
  config-load via `_validate_cookie_namespace()`. Whitespace, `=`, `;`,
  and non-ASCII characters now raise `ImproperlyConfigured` at startup
  instead of silently producing malformed Set-Cookie headers (browsers
  reject or split such cookies). Allowed charset: `[A-Za-z0-9_-]+`.
- **(c)** New JSDOM tests in `tests/js/theming_cookie_namespace_write.test.js`
  cover the JS-side cookie WRITE path — the 8 #1158 Python tests only
  asserted on the source string of `theme.js`. The JSDOM tests load the
  file in a DOM, set `window.__djust_theme_cookie_prefix`, fire
  `setPack`/`setPreset`/`setLayout`, and inspect `document.cookie`.
- **(d)** Legacy-cookie cleanup: when writing a namespaced theming
  cookie, `theme.js` now also emits `Max-Age=0` for the unprefixed cookie
  of the same logical name. Otherwise stale legacy cookies left over from
  before namespace was configured persist in the browser jar forever and
  bleed back if namespace is later removed. Cleanup is inert when no
  prefix is configured (back-compat).

## Issue × file × test mapping

| Sub-item | Issue | Implementation file | Covering tests |
|---|---|---|---|
| (a) Empty cookie fallback fix | #1169(a) | `python/djust/theming/manager.py` (`_read` / `get_state`) | `tests/unit/test_theming_cookie_namespace_1158.py::test_empty_namespaced_cookie_does_not_fall_back_to_legacy` |
| (b) `cookie_namespace` validation | #1169(b) | `python/djust/theming/manager.py` (`_validate_cookie_namespace`, `get_theme_config`) | `tests/unit/test_theming_cookie_namespace_1158.py::test_cookie_namespace_validator_accepts_valid_values`, `::test_cookie_namespace_validator_rejects_illegal_characters` |
| (c) JSDOM write-side test | #1169(c) | (test-only) | `tests/js/theming_cookie_namespace_write.test.js` (4 cases under `#1169(c)` describe block) |
| (d) Legacy cookie cleanup | #1169(d) | `python/djust/theming/static/djust_theming/js/theme.js` (`_deleteLegacyCookie` + 5 callsites) | `tests/js/theming_cookie_namespace_write.test.js` (3 cases under `#1169(d)` describe block) |

## Test count delta

- Python: +3 new cases (1 for (a), 2 for (b)) in `tests/unit/test_theming_cookie_namespace_1158.py` (8 → 11 total).
- JS: +7 new cases in new file `tests/js/theming_cookie_namespace_write.test.js` (4 for (c), 3 for (d)).

## Two-commit shape

Commit 1: implementation + tests (no CHANGELOG, per v0.9.1 retro / #1173).
Commit 2: CHANGELOG `[Unreleased] > Fixed` entry only.

## Test plan

- [x] `uv run pytest tests/unit/test_theming_cookie_namespace_1158.py -v` — 11/11 pass
- [x] `npx vitest run tests/js/theming_cookie_namespace_write.test.js` — 7/7 pass
- [x] `uv run pytest python/djust/tests/ tests/unit/` — 4386 pass, 6 skip (no regressions)
- [x] `npx vitest run` — 1460/1460 pass (full JS suite)
- [x] Pre-commit hooks pass on both commits
- [x] Pre-push hooks pass (full pytest + cargo + linters)

Closes #1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)