### PR TITLE
fix(data_table): row navigation polish — 3 sub-items (closes #1171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`{% data_table %}` row navigation polish — 3 sub-items from PR #1170
+  Stage 11 review (closes #1171)** — final v0.9.2 drain item; tightens
+  the row-navigation client module that shipped in #1170:
+  - **(a) Nested-control selector — add `<details>`/`<summary>`/`<option>`
+    (R3).** `NESTED_CONTROL_SELECTOR` was 6 tags
+    (`a, button, input, label, select, textarea`); missed three common
+    interactive elements. Disclosure widgets (`<details>`) and `<select>`
+    children (`<option>`) now suppress row navigation when the user
+    toggles or selects them. Pure additive selector change, no
+    behaviour change for existing markup.
+  - **(b) Test-hook namespace refactor — drop `window.__djustRowClickNavigate`
+    (R4).** Production code now dispatches through
+    `window.djustDataTableRowClick.navigate`, which is also the property
+    tests stub via direct assignment (vi.fn). The underscored magic
+    global is gone — cleaner contract; the namespace was already
+    exported for `bindRow` / `initAll` in #1170.
+  - **(c) Server-side contract test for URL allowlist (R5).** New
+    `tests/unit/test_data_table_url_allowlist_1171.py` parametrizes 6
+    URL shapes (3 allowed, 3 hostile — `//evil.com`, `javascript:...`,
+    `data:...`) and locks in the "render-doesn't-crash, wiring-is-stable"
+    contract that the JS guard depends on. The actual open-redirect
+    defense remains the regex in `data-table-row-click.js`; this Python
+    test documents the server-side half of the boundary.
+  - Test count delta: `tests/js/data_table_row_click.test.js` 14 → 17
+    (+3); new `test_data_table_url_allowlist_1171.py` 7 cases.
+
 ### Changed
 
 - **v0.9.2 hygiene group — Redis perf docstring softened, replay-rejection

--- a/python/djust/components/static/djust_components/data-table-row-click.js
+++ b/python/djust/components/static/djust_components/data-table-row-click.js
@@ -3,9 +3,9 @@
  *
  * Adds keyboard accessibility (Enter / Space activate a focused row) and
  * a nested-control guard (clicks inside an interactive descendant
- * <a>/<button>/<input>/<label>/<select> do NOT trigger row navigation)
- * to data_table rows that opt in via the `data-table-row-clickable`
- * marker class.
+ * <a>/<button>/<input>/<label>/<select>/<textarea>/<details>/<summary>/<option>
+ * do NOT trigger row navigation) to data_table rows that opt in via
+ * the `data-table-row-clickable` marker class.
  *
  * The template tag emits one of two row shapes when row navigation is
  * enabled:
@@ -42,9 +42,25 @@
   // Selectors for descendants whose clicks should NOT propagate up to
   // row-level navigation. Matches the Stage 4 brief enumeration plus
   // textarea (a non-button form control whose accidental row-nav would
-  // be just as user-hostile as the others).
+  // be just as user-hostile as the others), plus details/summary/option
+  // — disclosure widgets and select children that the user expects to
+  // toggle/select without triggering row navigation (#1171 R3).
   var NESTED_CONTROL_SELECTOR =
-    "a, button, input, label, select, textarea";
+    "a, button, input, label, select, textarea, details, summary, option";
+
+  // Expose navigate via the public namespace so tests can spy on it
+  // (vi.spyOn) without needing a magic underscored global. JSDOM 26+
+  // marks Location.prototype.assign as non-configurable, so direct
+  // interception isn't possible — going through this namespace lets
+  // tests stub it cleanly. (#1171 R4)
+  if (typeof window !== "undefined") {
+    window.djustDataTableRowClick = window.djustDataTableRowClick || {};
+    if (!window.djustDataTableRowClick.navigate) {
+      window.djustDataTableRowClick.navigate = function (h) {
+        window.location.assign(h);
+      };
+    }
+  }
 
   function navigateForRow(tr) {
     // Static-URL path: navigate via dataset.href.
@@ -58,16 +74,10 @@
       // The `(?!\/)` lookahead on the leading `/` rejects `//host` while
       // still allowing single-leading-slash absolute paths.
       if (/^(https?:\/\/|\/(?!\/)|\.)/.test(href)) {
-        // Tests override window.__djustRowClickNavigate to capture the
-        // target URL since JSDOM's window.location.assign is
-        // non-configurable. Production code path is the default arm.
-        var navigate =
-          (typeof window !== "undefined" &&
-            window.__djustRowClickNavigate) ||
-          function (h) {
-            window.location.assign(h);
-          };
-        navigate(href);
+        // Dispatch through the namespace so tests can vi.spyOn() the
+        // navigate property. Production path is the default function
+        // installed on the namespace above.
+        window.djustDataTableRowClick.navigate(href);
       }
       return true;
     }
@@ -153,12 +163,13 @@
     }
   }
 
-  // Expose for tests and for explicit re-init from app code.
+  // Expose for tests and for explicit re-init from app code. Merge
+  // onto the namespace (the navigate property was already set up at
+  // module top so the closure can call it via the namespace).
   if (typeof window !== "undefined") {
-    window.djustDataTableRowClick = {
-      initAll: initAll,
-      initWrapper: initWrapper,
-      bindRow: bindRow,
-    };
+    window.djustDataTableRowClick = window.djustDataTableRowClick || {};
+    window.djustDataTableRowClick.initAll = initAll;
+    window.djustDataTableRowClick.initWrapper = initWrapper;
+    window.djustDataTableRowClick.bindRow = bindRow;
   }
 })();

--- a/tests/js/data_table_row_click.test.js
+++ b/tests/js/data_table_row_click.test.js
@@ -29,16 +29,15 @@ function buildDom(bodyHtml) {
     `<!DOCTYPE html><html><body>${bodyHtml}</body></html>`,
     { runScripts: "dangerously", url: "http://localhost/" }
   );
-  // JSDOM 26+ marks window.location.assign as non-writable +
-  // non-configurable, so we can't intercept it directly. The handler
-  // module honours a test-only hook, window.__djustRowClickNavigate,
-  // when present — used here to capture target URLs without actually
-  // navigating.
-  const assignSpy = vi.fn();
-  dom.window.__djustRowClickNavigate = assignSpy;
-  dom.window.__locationAssignSpy = assignSpy;
-  // Eval the component module into the JSDOM window.
+  // Eval the component module into the JSDOM window. Module installs
+  // window.djustDataTableRowClick.navigate as the production hook into
+  // window.location.assign; we replace it with a vitest spy so tests
+  // can capture target URLs without JSDOM 26+'s non-configurable
+  // Location.prototype.assign getting in the way (#1171 R4).
   dom.window.eval(rowClickCode);
+  const assignSpy = vi.fn();
+  dom.window.djustDataTableRowClick.navigate = assignSpy;
+  dom.window.__locationAssignSpy = assignSpy;
   // The module hooks DOMContentLoaded when readyState === "loading"
   // (which is true under JSDOM); fire it explicitly so initAll() runs.
   dom.window.document.dispatchEvent(
@@ -269,6 +268,82 @@ describe("data-table-row-click — idempotence", () => {
     tr.click();
 
     expect(dom.window.__locationAssignSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("data-table-row-click — extended nested-control selector (#1171 R3)", () => {
+  // PR #1170 selector covered a/button/input/label/select/textarea (6
+  // tags). #1171 adds details/summary/option so disclosure widgets and
+  // <option>s inside a <select> don't trigger row navigation when the
+  // user toggles them. The <option> case is largely transitive (clicks
+  // bubble via the parent <select>) — we cover it explicitly to lock
+  // the contract in.
+  it("does NOT navigate when click target is a nested <summary> (details disclosure)", () => {
+    const dom = buildDom(`
+      <table class="data-table"><tbody>
+        <tr class="data-table-row-clickable" role="button" tabindex="0"
+            data-href="/c/1/">
+          <td>
+            <details id="row-details">
+              <summary id="row-summary">More info</summary>
+              <p>Body</p>
+            </details>
+          </td>
+        </tr>
+      </tbody></table>
+    `);
+    const summary = dom.window.document.getElementById("row-summary");
+    expect(summary).not.toBeNull();
+
+    summary.click();
+
+    expect(dom.window.__locationAssignSpy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT navigate when click target is a nested <option> (transitive via <select>)", () => {
+    const dom = buildDom(`
+      <table class="data-table"><tbody>
+        <tr class="data-table-row-clickable" role="button" tabindex="0"
+            data-href="/c/1/">
+          <td>
+            <select id="row-select">
+              <option id="row-option-a" value="a">A</option>
+              <option value="b">B</option>
+            </select>
+          </td>
+        </tr>
+      </tbody></table>
+    `);
+    const opt = dom.window.document.getElementById("row-option-a");
+    expect(opt).not.toBeNull();
+
+    opt.click();
+
+    expect(dom.window.__locationAssignSpy).not.toHaveBeenCalled();
+  });
+
+  it("DOES navigate when click is on a row containing <details> but outside the disclosure (happy path regression)", () => {
+    // Regression check: extending the selector did not break the
+    // happy path. Clicking a plain <td> sibling of a <details> still
+    // navigates.
+    const dom = buildDom(`
+      <table class="data-table"><tbody>
+        <tr class="data-table-row-clickable" role="button" tabindex="0"
+            data-href="/c/1/">
+          <td id="plain-cell">Plain cell</td>
+          <td>
+            <details><summary>More</summary><p>Body</p></details>
+          </td>
+        </tr>
+      </tbody></table>
+    `);
+    const cell = dom.window.document.getElementById("plain-cell");
+    expect(cell).not.toBeNull();
+
+    cell.click();
+
+    expect(dom.window.__locationAssignSpy).toHaveBeenCalledTimes(1);
+    expect(dom.window.__locationAssignSpy).toHaveBeenCalledWith("/c/1/");
   });
 });
 

--- a/tests/unit/test_data_table_url_allowlist_1171.py
+++ b/tests/unit/test_data_table_url_allowlist_1171.py
@@ -1,0 +1,152 @@
+"""Server-side contract test for #1171 — URL allowlist on data_table
+``row_url``.
+
+The actual defense against open-redirect via ``data-href`` lives in
+``python/djust/components/static/djust_components/data-table-row-click.js``
+(regex ``/^(https?:\\/\\/|\\/(?!\\/)|\\/.)/``), validated at click-time
+on the client. PR #1170 added 3 JS regression tests for it.
+
+This Python-side test documents the **server-side contract**:
+
+  * The template rendering pipeline does NOT crash when a row dict
+    contains a hostile URL value (``//evil.com/path``,
+    ``javascript:alert(1)``, etc.) under ``row_url``.
+  * The wiring (``data-href=`` attribute, ``data-table-row-clickable``
+    marker class, ``role="button"``, ``tabindex="0"``) is unconditional
+    once ``row_url`` is set — the server intentionally does NOT filter
+    URLs at render time, because legitimate same-origin URLs may take
+    many shapes (``/path``, ``./relative``, ``https://...``) and the
+    server lacks the URL parser context to reject hostile values
+    safely; doing it client-side at click-time both centralises the
+    check and lets the developer pass any URL shape they trust.
+
+The companion JS tests in
+``tests/js/data_table_row_click.test.js`` (under "URL allowlist") verify
+the actual rejection. This file locks in the server-side
+"render-doesn't-crash, wiring-is-stable" contract that the JS layer
+depends on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import django
+import pytest
+from django.conf import settings
+from django.template import Context, Engine
+
+if not settings.configured:
+    import os
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "demo_project.settings")
+    django.setup()
+
+
+_TABLE_HTML_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "python"
+    / "djust"
+    / "components"
+    / "templates"
+    / "djust_components"
+    / "table.html"
+)
+_TABLE_TEMPLATE = Engine().from_string(_TABLE_HTML_PATH.read_text())
+
+
+def _ctx(row_url_value: str) -> dict:
+    """Return a base data_table context with one row whose ``claim_url``
+    cell holds ``row_url_value``."""
+    return {
+        "rows": [{"id": 1, "claim_url": row_url_value, "name": "Row"}],
+        "columns": [{"key": "name", "label": "Name"}],
+        "sort_by": "",
+        "sort_desc": False,
+        "sort_event": "table_sort",
+        "page": 1,
+        "total_pages": 1,
+        "selectable": False,
+        "selected_rows": [],
+        "select_event": "table_select",
+        "row_key": "id",
+        "search": False,
+        "search_query": "",
+        "search_event": "table_search",
+        "search_debounce": 300,
+        "filters": {},
+        "filter_event": "table_filter",
+        "loading": False,
+        "empty_title": "No data",
+        "empty_description": "",
+        "empty_icon": "",
+        "paginate": False,
+        "page_event": "table_page",
+        "prev_event": "table_prev",
+        "next_event": "table_next",
+        "striped": False,
+        "compact": False,
+        "row_click_event": "",
+        "row_click_value_key": "id",
+        "row_url": "claim_url",
+    }
+
+
+def _render(ctx: dict) -> str:
+    return _TABLE_TEMPLATE.render(Context(ctx))
+
+
+# Mix of allowed and hostile URL shapes. The JS regex
+# `/^(https?:\/\/|\/(?!\/)|\.)/` accepts the first three and rejects
+# the last three. Server-side, ALL of them must render without raising
+# and emit the standard `data-href=` wiring — the rejection is
+# client-side.
+_URL_CASES = [
+    pytest.param("/claims/42", id="absolute-path"),
+    pytest.param("./relative", id="relative-path"),
+    pytest.param("https://example.com/x", id="https-absolute"),
+    pytest.param("//evil.com/path", id="protocol-relative-hostile"),
+    pytest.param("javascript:alert(1)", id="javascript-uri-hostile"),
+    pytest.param("data:text/html,<script>1</script>", id="data-uri-hostile"),
+]
+
+
+@pytest.mark.parametrize("url_value", _URL_CASES)
+def test_template_render_does_not_crash_for_url_shape(url_value: str):
+    """Rendering must succeed regardless of URL shape — the JS guard,
+    not the template, is responsible for filtering hostile values at
+    click-time."""
+    out = _render(_ctx(url_value))
+    # Render produced a row body.
+    assert "<tbody>" in out
+    # The data-href wiring is in place (value extracted at runtime by
+    # the Rust template engine; the Django Engine used here for unit
+    # tests doesn't expand `dictsort:row_url|first` to the row value,
+    # but the attribute is unconditionally emitted in the row_url
+    # branch — see python/tests/test_data_table_link_row_nav.py for
+    # the parallel "wiring is in place" assertion).
+    body_start = out.find("<tbody>")
+    body_end = out.find("</tbody>")
+    body = out[body_start:body_end]
+    assert "data-href=" in body
+    # The marker class is on the <tr> so the JS module binds the
+    # nested-control guard + click-time URL-allowlist check.
+    assert "data-table-row-clickable" in body
+    # Keyboard activation affordance.
+    assert 'role="button"' in body
+    assert 'tabindex="0"' in body
+
+
+def test_no_inline_onclick_for_any_url_shape():
+    """Defense-in-depth: even with hostile dict values, the row never
+    emits an inline ``onclick=""`` attribute. The JS module is the
+    only navigation entry point."""
+    for case in _URL_CASES:
+        # Each pytest.param wraps a tuple (values, id, marks); first
+        # element is the actual URL value.
+        url_value = case.values[0]
+        out = _render(_ctx(url_value))
+        body_start = out.find("<tbody>")
+        body_end = out.find("</tbody>")
+        body = out[body_start:body_end]
+        assert "onclick=" not in body, f"Inline onclick leaked for url shape {url_value!r}"


### PR DESCRIPTION
## Summary

Final v0.9.2 drain item. Three follow-ups from PR #1170 Stage 11 review:

- **(a) R3 — Extend `NESTED_CONTROL_SELECTOR`** with `<details>`/`<summary>`/`<option>`. Was 6 tags; missed 3 common interactive elements. Disclosure widgets and `<select>` children now suppress row navigation when the user toggles/selects them.
- **(b) R4 — Drop `window.__djustRowClickNavigate` underscored global.** Production code now dispatches through `window.djustDataTableRowClick.navigate`, which is also the property tests stub via direct assignment (vi.fn). Cleaner contract; the namespace was already exported for `bindRow` / `initAll`.
- **(c) R5 — Server-side contract test for URL allowlist.** New `tests/unit/test_data_table_url_allowlist_1171.py` parametrizes 6 URL shapes (3 allowed, 3 hostile) and locks in the "render-doesn't-crash, wiring-is-stable" contract that the JS guard depends on. Documents that the actual defense lives in `data-table-row-click.js`'s regex.

Closes #1171

## Issue × file × test mapping

| Sub-item | Production file | Test file | Test count delta |
|---|---|---|---|
| (a) R3 nested-control selector | `python/djust/components/static/djust_components/data-table-row-click.js` | `tests/js/data_table_row_click.test.js` (new "extended nested-control selector" describe block) | +3 (14 → 17) |
| (b) R4 namespace refactor | same JS file (above) | same JS file's `buildDom` helper now uses `dom.window.djustDataTableRowClick.navigate = vi.fn()` instead of the underscored global; all 17 tests still pass | 0 net (refactor) |
| (c) R5 Python allowlist contract | (none — server contract test only) | `tests/unit/test_data_table_url_allowlist_1171.py` (new file) | +7 |

## Two-commit shape

Per v0.9.1 retro / v0.9.2 #1173:

1. `a41b4a29` — fix(data_table): implementation + tests
2. `5cb4fb11` — docs(data_table): CHANGELOG entry

## Test plan

- [x] `npx vitest run tests/js/data_table_row_click.test.js` — 17/17 pass
- [x] `uv run pytest tests/unit/test_data_table_row_navigation_1111.py tests/unit/test_data_table_url_allowlist_1171.py python/tests/test_data_table_link_row_nav.py` — 35/35 pass
- [x] Pre-commit hooks pass on both commits (ruff, ruff-format, bandit, detect-secrets, npm test, CHANGELOG count check)
- [x] Pre-push pytest hook passes (full Python suite)

## Self-review notes

🟡 The Python allowlist test asserts `data-href=` is present but does NOT assert the literal hostile value appears as the attribute value, because the Django `Engine` (used by unit tests) doesn't expand `dictsort:row_url|first` to the row's value — only the Rust template engine does at runtime. This matches the existing convention from `python/tests/test_data_table_link_row_nav.py` line 165 ("value extracted by Rust engine at runtime; we just assert the wiring is in place"). Calling out explicitly so a future reviewer doesn't tighten the assertion to something that would break the unit-test rendering path. The test docstring documents this.

🟢 No new dependencies, no new client-JS modules (modification only), no behaviour change for valid URLs. Selector extension is purely additive — markup that didn't have `<details>`/`<summary>`/`<option>` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)