### PR TITLE
feat(hot-reload): auto-enable HVR in DEBUG via DjustConfig.ready()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **HVR auto-enabled in DEBUG (no AppConfig.ready() boilerplate
+  required)** — djust's own `DjustConfig.ready()` now auto-calls
+  `enable_hot_reload()` whenever `DEBUG=True` and `watchdog` is
+  installed. Existing per-consumer `enable_hot_reload()` calls keep
+  working unchanged (idempotent via `hot_reload_server.is_running()`).
+  Opt out via `LIVEVIEW_CONFIG['hot_reload_auto_enable']: False` for
+  projects that orchestrate the file watcher externally. Test runs
+  auto-skip via `PYTEST_CURRENT_TEST` so pytest sessions don't spawn
+  a watchdog thread per test. Files: `python/djust/apps.py` (auto-enable
+  call appended to `ready()`), `python/djust/config.py`
+  (new `hot_reload_auto_enable: True` default),
+  `python/djust/__init__.py` (docstring update). 6 new regression
+  cases in `TestAutoEnableHotReload` (file
+  `python/djust/tests/test_auto_hot_reload.py`). Drops the one-line
+  `enable_hot_reload()` call from
+  `examples/demo_project/demo_app/apps.py`. Closes the friction
+  observed across downstream consumers (docs.djust.org, djust.org,
+  djustlive) that were either rolling their own `watchfiles`
+  process-restart wrappers or silently missing the integration step
+  altogether — the framework's HVR is strictly better than process
+  restart (preserves view state, scroll position, form input across
+  edits) but the consumer-side integration step was easy to skip.
+
 ## [0.9.0rc3] - 2026-04-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a watchdog thread per test. Files: `python/djust/apps.py` (auto-enable
   call appended to `ready()`), `python/djust/config.py`
   (new `hot_reload_auto_enable: True` default),
-  `python/djust/__init__.py` (docstring update). 6 new regression
-  cases in `TestAutoEnableHotReload` (file
+  `python/djust/__init__.py` (docstring update). 6 new cases covering
+  auto-fire, opt-out config, pytest-env skip, idempotency, exception
+  isolation, and other-setup completion (new file
   `python/djust/tests/test_auto_hot_reload.py`). Drops the one-line
   `enable_hot_reload()` call from
   `examples/demo_project/demo_app/apps.py`. Closes the friction

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,17 @@ The Rust template engine supports **all 57 Django built-in filters** in `crates/
 - **Ruff F509**: `%`-format strings containing CSS semicolons trigger false positives. Separate HTML (`%s` substitution) from CSS (static string) and concatenate.
 - **VDOM form values**: Ensure form field values are preserved during updates. See `VDOM_PATCHING_ISSUE.md`.
 - **Pre-commit reformatting**: If commit fails due to ruff auto-format, re-stage and commit again.
+- **Hot reload integration (v0.9.0+)**: djust auto-enables HVR from its
+  own `DjustConfig.ready()` whenever `DEBUG=True` and `watchdog` is
+  installed. Downstream consumers do NOT need to add
+  `enable_hot_reload()` to their own `AppConfig.ready()`. Existing
+  explicit calls keep working (idempotent). Opt out via
+  `LIVEVIEW_CONFIG['hot_reload_auto_enable']: False`. Tests skip the
+  auto-enable via `PYTEST_CURRENT_TEST` so pytest sessions don't spawn
+  a watchdog thread per test. Don't wrap `uvicorn` in
+  `watchfiles` / `--reload` for djust dev servers — that's process
+  restart and drops view state; djust's HVR is strictly better
+  (preserves form input, scroll position, counters).
 
 ## Process canonicalizations from PR retros (2026-04-26 View Transitions arc)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 dependencies = [
  "ahash",
  "criterion",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 dependencies = [
  "ahash",
  "criterion",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 dependencies = [
  "bincode",
  "criterion",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 dependencies = [
  "ahash",
  "chrono",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 dependencies = [
  "ahash",
  "criterion",

--- a/docs/website/guides/hot-view-replacement.md
+++ b/docs/website/guides/hot-view-replacement.md
@@ -17,29 +17,16 @@ Gated on `DEBUG=True` and enabled by default. Zero cost in production.
 
 ## Quick start
 
-Hot View Replacement (HVR) rides on top of the existing
-`enable_hot_reload()` machinery. If you already enabled hot reload, HVR
-is already working — no new config needed.
+**Auto-enabled in DEBUG since v0.9.0.** Add djust to `INSTALLED_APPS`,
+keep `DEBUG=True`, install `watchdog`, and HVR works. No
+`AppConfig.ready()` boilerplate needed.
 
 ```python
-# myapp/apps.py
-from django.apps import AppConfig
-
-class MyAppConfig(AppConfig):
-    name = "myapp"
-
-    def ready(self):
-        from django.conf import settings
-        if settings.DEBUG:
-            from djust import enable_hot_reload
-            enable_hot_reload()
-```
-
-```python
-# settings.py (defaults shown)
+# settings.py (defaults shown — all True out of the box)
 LIVEVIEW_CONFIG = {
-    "hot_reload": True,    # file watcher on
-    "hvr_enabled": True,   # v0.6.1 — state-preserving reload
+    "hot_reload": True,                # file watcher on
+    "hot_reload_auto_enable": True,    # call enable_hot_reload() from DjustConfig.ready()
+    "hvr_enabled": True,               # v0.6.1 — state-preserving reload
 }
 ```
 
@@ -48,6 +35,34 @@ it's missing:
 
 ```bash
 pip install watchdog
+```
+
+### Manual opt-in / advanced control
+
+The auto-enable is on by default. If you orchestrate the file watcher
+externally (e.g. `watchfiles` wrapping `uvicorn`, or a custom dev
+loop), opt out with:
+
+```python
+# settings.py
+LIVEVIEW_CONFIG = {"hot_reload_auto_enable": False}
+```
+
+You can still call `enable_hot_reload()` yourself from any AppConfig.
+The function is idempotent — calling it manually is a safe no-op when
+the server is already running, so explicit calls coexist with the
+auto-enable.
+
+```python
+# myapp/apps.py — only needed if hot_reload_auto_enable is False
+from django.apps import AppConfig
+
+class MyAppConfig(AppConfig):
+    name = "myapp"
+
+    def ready(self):
+        from djust import enable_hot_reload
+        enable_hot_reload()
 ```
 
 ## What gets preserved

--- a/examples/demo_project/demo_app/apps.py
+++ b/examples/demo_project/demo_app/apps.py
@@ -2,10 +2,9 @@ from django.apps import AppConfig
 
 
 class DemoAppConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'demo_app'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "demo_app"
 
-    def ready(self):
-        """Initialize app - enable hot reload in development."""
-        from djust import enable_hot_reload
-        enable_hot_reload()
+    # v0.9.0+ — djust auto-enables hot reload via its own DjustConfig.ready()
+    # whenever DEBUG=True and watchdog is installed. No explicit
+    # enable_hot_reload() call needed here.

--- a/python/djust/__init__.py
+++ b/python/djust/__init__.py
@@ -82,7 +82,19 @@ def enable_hot_reload():
     for changes. When a change is detected, all connected WebSocket clients are sent
     a reload message, triggering an automatic page refresh.
 
-    Usage:
+    Auto-enabled by default (since v0.9.0):
+        djust's own ``DjustConfig.ready()`` auto-calls this whenever
+        ``DEBUG=True`` and the ``watchdog`` package is installed. You no
+        longer need to call it explicitly from your own ``AppConfig.ready()``.
+        The function is idempotent — calling it manually is a safe no-op
+        when the server is already running, so existing per-consumer calls
+        keep working unchanged.
+
+        To opt out (e.g. you orchestrate the file watcher externally), set::
+
+            LIVEVIEW_CONFIG = {"hot_reload_auto_enable": False}
+
+    Manual usage (advanced — only needed if auto-enable is disabled):
         # In your Django app's AppConfig.ready() method:
         from djust import enable_hot_reload
 

--- a/python/djust/apps.py
+++ b/python/djust/apps.py
@@ -35,7 +35,11 @@ class DjustConfig(AppConfig):
         # ``hot_reload_server.is_running()``, so this is safe in production
         # (early-return) and safe alongside an explicit consumer call.
         # Skip during pytest runs to avoid spawning a watchdog thread for
-        # every test session.
+        # every test session — pytest sets ``PYTEST_CURRENT_TEST`` for the
+        # duration of every test invocation. (Tests that need to exercise
+        # the auto-enable path itself temporarily clear this env var; see
+        # ``_no_pytest_env()`` in
+        # ``python/djust/tests/test_auto_hot_reload.py``.)
         import os
 
         if not os.environ.get("PYTEST_CURRENT_TEST"):
@@ -46,7 +50,7 @@ class DjustConfig(AppConfig):
                     from djust import enable_hot_reload
 
                     enable_hot_reload()
-            except Exception as e:  # noqa: BLE001
-                logging.getLogger("djust").warning(
-                    "[HotReload] auto-enable in DjustConfig.ready() failed: %s", e
+            except Exception:  # noqa: BLE001
+                logging.getLogger("djust").exception(
+                    "[HotReload] auto-enable in DjustConfig.ready() failed"
                 )

--- a/python/djust/apps.py
+++ b/python/djust/apps.py
@@ -29,3 +29,24 @@ class DjustConfig(AppConfig):
         except Exception as e:  # noqa: BLE001
             # Observability must never break AppConfig startup.
             logging.getLogger("djust").warning("Observability log handler install failed: %s", e)
+
+        # Auto-enable hot reload in DEBUG. ``enable_hot_reload()`` has its
+        # own DEBUG / watchdog / config gates and is idempotent via
+        # ``hot_reload_server.is_running()``, so this is safe in production
+        # (early-return) and safe alongside an explicit consumer call.
+        # Skip during pytest runs to avoid spawning a watchdog thread for
+        # every test session.
+        import os
+
+        if not os.environ.get("PYTEST_CURRENT_TEST"):
+            try:
+                from djust.config import config
+
+                if config.get("hot_reload_auto_enable", True):
+                    from djust import enable_hot_reload
+
+                    enable_hot_reload()
+            except Exception as e:  # noqa: BLE001
+                logging.getLogger("djust").warning(
+                    "[HotReload] auto-enable in DjustConfig.ready() failed: %s", e
+                )

--- a/python/djust/config.py
+++ b/python/djust/config.py
@@ -80,6 +80,10 @@ class LiveViewConfig:
         "hot_reload": True,  # Enable hot reload in development (requires DEBUG=True)
         "hot_reload_watch_dirs": None,  # Directories to watch (None = auto-detect BASE_DIR)
         "hot_reload_exclude_dirs": None,  # Directories to exclude (None = use defaults)
+        # Auto-call enable_hot_reload() from DjustConfig.ready() in DEBUG.
+        # Set to False if you orchestrate the file watcher externally (e.g.
+        # watchfiles wrapping uvicorn) and want full manual control.
+        "hot_reload_auto_enable": True,
         # Hot View Replacement (v0.6.1) — state-preserving Python code
         # reload in dev. Gated on DEBUG=True AND hot_reload=True.
         "hvr_enabled": True,

--- a/python/djust/tests/test_auto_hot_reload.py
+++ b/python/djust/tests/test_auto_hot_reload.py
@@ -138,33 +138,43 @@ def test_ready_swallows_enable_hot_reload_exceptions(caplog):
 
     The try/except around the auto-enable call mirrors the observability
     setup pattern already in ``ready()`` — dev-mode plumbing must never
-    take down app startup.
+    take down app startup. Uses ``logger.exception()`` so the captured
+    record's ``exc_info`` carries the traceback for debugability.
     """
     app = _make_app_config()
     with (
         _no_pytest_env(),
-        caplog.at_level(logging.WARNING, logger="djust"),
+        caplog.at_level(logging.ERROR, logger="djust"),
         mock.patch("djust.enable_hot_reload", side_effect=RuntimeError("boom")),
     ):
         # Must not raise.
         app.ready()
     assert "auto-enable" in caplog.text
-    assert "boom" in caplog.text
+    # logger.exception() attaches exc_info to the LogRecord; verify that
+    # a record with both the auto-enable message AND a traceback was emitted.
+    matching = [r for r in caplog.records if "auto-enable" in r.message]
+    assert matching, "expected an auto-enable failure log record"
+    assert any(r.exc_info for r in matching), "expected exc_info on the log record"
 
 
 def test_ready_completes_other_setup_even_when_auto_enable_skipped():
     """The auto-enable call is the LAST thing ``ready()`` does; the log-sanitizer
-    filter and observability handler installs must still happen regardless.
+    filter install must still happen regardless of whether auto-enable
+    fires.
 
-    This test asserts that the existing ``ready()`` setup (which the
-    auto-enable call was appended after) still executes during a normal
-    pytest run (where auto-enable is skipped via ``PYTEST_CURRENT_TEST``).
+    Snapshots the filter count BEFORE calling ``ready()`` and asserts the
+    count grew by exactly 1 — proving this test's own ``ready()`` call
+    actually installed a filter. (Asserting ``any(...)`` would pass
+    trivially because prior tests in the file have already populated the
+    logger.)
     """
-    djust_logger = logging.getLogger("djust")
-    # Snapshot existing filters; we'll assert at least one DjustLogSanitizerFilter
-    # is present after ``ready()`` runs.
-    app = _make_app_config()
-    app.ready()
     from djust.security import DjustLogSanitizerFilter
 
-    assert any(isinstance(f, DjustLogSanitizerFilter) for f in djust_logger.filters)
+    djust_logger = logging.getLogger("djust")
+    before = sum(1 for f in djust_logger.filters if isinstance(f, DjustLogSanitizerFilter))
+
+    app = _make_app_config()
+    app.ready()
+
+    after = sum(1 for f in djust_logger.filters if isinstance(f, DjustLogSanitizerFilter))
+    assert after == before + 1

--- a/python/djust/tests/test_auto_hot_reload.py
+++ b/python/djust/tests/test_auto_hot_reload.py
@@ -1,0 +1,170 @@
+"""Auto-enable hot reload (HVR) in DEBUG via ``DjustConfig.ready()``.
+
+As of v0.9.0, djust auto-calls ``enable_hot_reload()`` from its own
+``DjustConfig.ready()`` whenever ``DEBUG=True``. The function itself
+already gates on DEBUG / config / watchdog and is idempotent via
+``hot_reload_server.is_running()``, so the auto-call is safe in
+production (early-return) and safe alongside an explicit consumer call.
+
+These tests pin the behavior:
+
+1. The auto-enable call fires from ``ready()``.
+2. The ``hot_reload_auto_enable`` config knob disables it.
+3. ``PYTEST_CURRENT_TEST`` skips it (so test sessions don't spawn the watcher).
+4. Idempotency: calling ``ready()`` twice doesn't double-start.
+5. Startup-failure isolation: if ``enable_hot_reload`` raises, ``ready()`` still completes.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+from unittest import mock
+
+import pytest
+
+from djust.apps import DjustConfig
+
+
+@pytest.fixture
+def fresh_config():
+    """Reset the djust config singleton so per-test ``set()`` calls don't leak."""
+    from djust.config import config
+
+    snapshot = config.as_dict()
+    yield config
+    config._config = snapshot
+
+
+@contextlib.contextmanager
+def _no_pytest_env():
+    """Context manager that hides ``PYTEST_CURRENT_TEST`` for the duration of the block.
+
+    pytest re-sets this env var between fixture teardown and the test
+    ``call`` phase, so a fixture-based pop doesn't survive into the test
+    body. Use this inside the test body where the env var actually
+    needs to be absent (i.e. wrapping the ``ready()`` call).
+    """
+    saved = os.environ.pop("PYTEST_CURRENT_TEST", None)
+    try:
+        yield
+    finally:
+        if saved is not None:
+            os.environ["PYTEST_CURRENT_TEST"] = saved
+
+
+def _make_app_config():
+    """Construct a ``DjustConfig`` instance without going through Django's app registry.
+
+    ``AppConfig.__init__`` requires ``app_name`` and ``app_module`` args; we
+    don't need a real registered app for unit testing ``ready()`` — we just
+    need an instance whose ``ready()`` method we can call. Pass a minimal
+    stub module.
+    """
+    import djust
+
+    return DjustConfig("djust", djust)
+
+
+def test_ready_auto_calls_enable_hot_reload_when_pytest_env_cleared():
+    """``ready()`` invokes ``enable_hot_reload()`` when ``PYTEST_CURRENT_TEST`` is unset.
+
+    Tests the wiring at the apps.py layer: clearing the pytest env var
+    means the auto-enable branch runs, which dispatches to
+    ``djust.enable_hot_reload``. (The function's own gates — DEBUG,
+    watchdog, etc. — are out of scope here; we patch enable_hot_reload
+    to count calls.)
+    """
+    app = _make_app_config()
+    with _no_pytest_env(), mock.patch("djust.enable_hot_reload") as mock_enable:
+        app.ready()
+    assert mock_enable.call_count == 1
+
+
+def test_ready_skips_when_pytest_env_var_is_set():
+    """The pytest env var (always set during a real pytest run) skips auto-enable.
+
+    This is the test-isolation guard — we don't want every pytest invocation
+    to spawn a watchdog thread.
+    """
+    # PYTEST_CURRENT_TEST is set by pytest for the duration of this test.
+    assert "PYTEST_CURRENT_TEST" in os.environ
+    app = _make_app_config()
+    with mock.patch("djust.enable_hot_reload") as mock_enable:
+        app.ready()
+    assert mock_enable.call_count == 0
+
+
+def test_ready_skips_when_hot_reload_auto_enable_is_false(fresh_config):
+    """``LIVEVIEW_CONFIG['hot_reload_auto_enable'] = False`` opts out of auto-enable."""
+    fresh_config.set("hot_reload_auto_enable", False)
+    app = _make_app_config()
+    with _no_pytest_env(), mock.patch("djust.enable_hot_reload") as mock_enable:
+        app.ready()
+    assert mock_enable.call_count == 0
+
+
+def test_ready_is_idempotent_via_is_running_guard(settings):
+    """Two ``ready()`` calls reach the inner ``hot_reload_server.start()``
+    only once thanks to the ``is_running()`` guard at
+    ``python/djust/__init__.py`` (the existing idempotency check that
+    protects against double-starts when consumers also call
+    ``enable_hot_reload()`` explicitly).
+
+    Uses pytest-django's ``settings`` fixture to set ``DEBUG=True`` so
+    ``enable_hot_reload()`` reaches the ``is_running()`` short-circuit
+    instead of returning early at the DEBUG gate.
+    """
+    from djust.dev_server import hot_reload_server
+
+    settings.DEBUG = True
+    app = _make_app_config()
+    with (
+        _no_pytest_env(),
+        mock.patch.object(hot_reload_server, "is_running", return_value=True) as mock_is_running,
+        mock.patch.object(hot_reload_server, "start") as mock_start,
+    ):
+        app.ready()
+        app.ready()
+    # is_running() short-circuits enable_hot_reload() before start() is called.
+    assert mock_start.call_count == 0
+    # is_running() consulted at least once per ready() call (the idempotency guard).
+    assert mock_is_running.call_count >= 2
+
+
+def test_ready_swallows_enable_hot_reload_exceptions(caplog):
+    """A raise inside ``enable_hot_reload()`` must NOT break Django startup.
+
+    The try/except around the auto-enable call mirrors the observability
+    setup pattern already in ``ready()`` — dev-mode plumbing must never
+    take down app startup.
+    """
+    app = _make_app_config()
+    with (
+        _no_pytest_env(),
+        caplog.at_level(logging.WARNING, logger="djust"),
+        mock.patch("djust.enable_hot_reload", side_effect=RuntimeError("boom")),
+    ):
+        # Must not raise.
+        app.ready()
+    assert "auto-enable" in caplog.text
+    assert "boom" in caplog.text
+
+
+def test_ready_completes_other_setup_even_when_auto_enable_skipped():
+    """The auto-enable call is the LAST thing ``ready()`` does; the log-sanitizer
+    filter and observability handler installs must still happen regardless.
+
+    This test asserts that the existing ``ready()`` setup (which the
+    auto-enable call was appended after) still executes during a normal
+    pytest run (where auto-enable is skipped via ``PYTEST_CURRENT_TEST``).
+    """
+    djust_logger = logging.getLogger("djust")
+    # Snapshot existing filters; we'll assert at least one DjustLogSanitizerFilter
+    # is present after ``ready()`` runs.
+    app = _make_app_config()
+    app.ready()
+    from djust.security import DjustLogSanitizerFilter
+
+    assert any(isinstance(f, DjustLogSanitizerFilter) for f in djust_logger.filters)

--- a/uv.lock
+++ b/uv.lock
@@ -588,7 +588,7 @@ wheels = [
 
 [[package]]
 name = "djust"
-version = "0.9.0rc2"
+version = "0.9.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "channels", extra = ["daphne"] },


### PR DESCRIPTION
## Summary

- djust now auto-calls `enable_hot_reload()` from its own `DjustConfig.ready()` whenever `DEBUG=True` and `watchdog` is installed — drops the AppConfig.ready() boilerplate downstream consumers needed to wire up HVR.
- Existing per-consumer `enable_hot_reload()` calls keep working (idempotent via `hot_reload_server.is_running()`). Opt out via `LIVEVIEW_CONFIG['hot_reload_auto_enable']: False`. Test runs auto-skip via `PYTEST_CURRENT_TEST`.
- Two-commit shape: impl+tests / docs+CHANGELOG.

## Why

The framework's HVR (state-preserving `__class__` swap, shipped v0.6.1) is strictly better than process restart — it preserves form input, scroll position, counters, and active tabs across `.py` edits. But every downstream consumer needed a one-line `enable_hot_reload()` call in their AppConfig.ready() to wire it up, and several silently skipped that step:

- `docs.djust.org` rolled its own dev loop via `watchfiles` wrapping `uvicorn` in its `Makefile` (`make dev` target). That's process restart — drops the WebSocket and kills view state on every save.
- `djust.org`, `djustlive`, and the `djust` framework's own `examples/demo_project` rely on config defaults but only `demo_project` actually called `enable_hot_reload()`.

Drop the integration step. Make HVR the default in DEBUG.

## Gating layers (defense in depth)

`enable_hot_reload()` already short-circuits on:
1. `settings.DEBUG=False` — production safe by construction.
2. `config.get("hot_reload", True) == False` — explicit opt-out.
3. `WATCHDOG_AVAILABLE=False` — production builds don't install watchdog (it's a `[dev]` extra).
4. `hot_reload_server.is_running()` — idempotent.

This PR adds two NEW gates:
5. `config.get("hot_reload_auto_enable", True)` — new opt-out knob, default `True`.
6. `os.environ.get("PYTEST_CURRENT_TEST")` — skip during pytest to avoid spawning a watchdog thread per test.

## Files

- `python/djust/apps.py` — auto-enable call appended to `ready()` with try/except isolation matching the observability-handler pattern already there.
- `python/djust/config.py` — new `hot_reload_auto_enable: True` default.
- `python/djust/__init__.py` — `enable_hot_reload()` docstring updated.
- `examples/demo_project/demo_app/apps.py` — drops the now-unnecessary explicit call.
- `python/djust/tests/test_auto_hot_reload.py` — 6 new cases.
- `CHANGELOG.md`, `CLAUDE.md`, `docs/website/guides/hot-view-replacement.md` — docs.

## Test plan

- [x] `pytest python/djust/tests/test_auto_hot_reload.py -v` — 6 cases green
- [x] `make test` — 4047 Python + 1463 JS passing
- [x] `ruff check` + `ruff format` clean
- [x] Manual: `cd examples/demo_project && make start` — `[HotReload] Hot reload enabled` printed at startup; edits preserve view state
- [ ] Follow-up PR: migrate `docs.djust.org/Makefile` from `watchfiles` wrapping `uvicorn` to plain `uvicorn` after submodule bump to a release containing this change

## Out of scope

- Auto-enable in non-DEBUG production builds (DEBUG gate is non-negotiable for safety).
- `watchfiles` as an alternative file-watcher backend (djust uses `watchdog`).
- Reloading on `settings.py` / `INSTALLED_APPS` changes (HVR is for view code only).
- Removing `enable_hot_reload()` from the public API (kept for explicit-control use cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)