### PR TITLE
feat(time-travel): wire-protocol exposure for branched timelines + per-component scrubbing (PR-A for #1151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Time-travel wire-protocol exposure for branched timelines + per-component
+  scrubbing (PR-A for #1151)** — server-side surface that the v0.9.4 debug
+  panel UI (PR-B, follow-up) consumes. The Python plumbing for per-component
+  time-travel (#1041) and forward-replay through branched timelines (#1042)
+  shipped in v0.9.0; this PR exposes the missing wire fields so the debug
+  panel can drive both.
+  - **`time_travel_state` ack frame**: 3 new additive fields — `branch_id`
+    (defaults `"main"`; new branches allocated as `branch-{N}` on
+    forward-replay from a non-tip cursor), `forward_replay_enabled` (true
+    iff cursor is not at the tip — meaningful replay would produce a
+    branch), `max_events` (the configured ring-buffer cap, so the UI
+    can show "X / max"). Old clients ignore the new keys.
+  - **`time_travel_event` per-event push frame**: 2 new additive fields —
+    `branch_id` and a top-level `components` mirror of
+    `entry.state_after.__components__` so the UI doesn't have to dig into
+    the nested entry.
+  - **New handler `time_travel_component_jump`**: scrubs a SINGLE
+    component's state without touching the parent view or other
+    components. Mirrors the existing `time_travel_jump` validation and
+    re-render path; backed by a new `restore_component_snapshot()`
+    helper in `python/djust/time_travel.py`.
+  - **New handler `forward_replay`**: replays a recorded event with
+    optional `override_params` and allocates a fresh branch id when
+    the cursor is not at the buffer tip. Backed by the existing
+    `replay_event()` (#1042) plus a new `next_branch_id()` allocator.
+  - **Live-view init**: 2 new instance fields on `LiveView.__init__` —
+    `_time_travel_branch_id` (default `"main"`) and
+    `_time_travel_branch_counter` (default `0`). Both are inert when the
+    buffer isn't allocated; zero memory cost for views that don't opt
+    in to time-travel.
+
+  Files: `python/djust/websocket.py` (dispatch arms + 2 handlers + ack
+  builder), `python/djust/time_travel.py` (`restore_component_snapshot`,
+  `next_branch_id`), `python/djust/live_view.py` (branch fields). 9 new
+  cases (5 integration + 4 unit) covering ack-frame shape, replay-enabled
+  semantics, component-only restore isolation, branch-id allocation, and
+  defensive defaults. PR-B (the debug panel UI consuming these fields)
+  is the next v0.9.4 PR.
+
 ### Documentation
 
 - **v0.9.4 process canon (closes #1185, closes #1143, closes #1144)** —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Files: `python/djust/websocket.py` (dispatch arms + 2 handlers + ack
   builder), `python/djust/time_travel.py` (`restore_component_snapshot`,
-  `next_branch_id`), `python/djust/live_view.py` (branch fields). 9 new
-  cases (5 integration + 4 unit) covering ack-frame shape, replay-enabled
-  semantics, component-only restore isolation, branch-id allocation, and
-  defensive defaults. PR-B (the debug panel UI consuming these fields)
-  is the next v0.9.4 PR.
+  `next_branch_id`), `python/djust/live_view.py` (branch fields). 12 new
+  cases (8 integration + 4 unit) covering ack-frame shape, replay-enabled
+  semantics, component-only restore isolation, branch-id allocation,
+  defensive defaults, override-params-at-tip branching, branch-id
+  no-leak on replay failure, and `which="after"` component restore.
+  PR-B (the debug panel UI consuming these fields) is the next v0.9.4 PR.
 
 ### Documentation
 

--- a/python/djust/live_view.py
+++ b/python/djust/live_view.py
@@ -490,6 +490,12 @@ class LiveView(
         # Allocated only when the subclass opts in via the class attr so
         # the 99% of views that don't use it pay zero memory cost.
         self._time_travel_buffer = None
+        # Branched-timeline tracking (#1151, v0.9.4). Default branch is
+        # "main" — the canonical recorded timeline. Forward-replay from
+        # a non-tip cursor allocates a fresh branch id from the counter.
+        # Both fields are inert when the buffer isn't allocated.
+        self._time_travel_branch_id = "main"
+        self._time_travel_branch_counter = 0
         if getattr(self.__class__, "time_travel_enabled", False):
             try:
                 from djust.time_travel import TimeTravelBuffer

--- a/python/djust/time_travel.py
+++ b/python/djust/time_travel.py
@@ -327,6 +327,104 @@ def restore_snapshot(view: Any, snapshot: EventSnapshot, which: str = "before") 
     return ok
 
 
+def restore_component_snapshot(
+    view: Any,
+    snapshot: EventSnapshot,
+    component_id: str,
+    which: str = "before",
+) -> bool:
+    """Restore a SINGLE component's state from a snapshot (#1151, v0.9.4).
+
+    Single-component variant of :func:`restore_snapshot` Phase 3. Touches
+    ONLY ``view._components[component_id]``; never the parent view, never
+    other components. Used by the debug panel's per-component scrubber so
+    the user can rewind component A's history without disturbing component
+    B's current live state.
+
+    Returns ``True`` if every key was applied via :func:`safe_setattr`.
+    Returns ``False`` (and logs at WARN) when:
+
+    * ``component_id`` is not in ``view._components``.
+    * The snapshot's ``state_before`` / ``state_after`` lacks
+      ``"__components__"`` or has no entry for ``component_id``.
+    * Any individual key fails ``safe_setattr`` (dunder / read-only).
+
+    Mirrors the Phase 3 loop in :func:`restore_snapshot` (lines ~298-326)
+    so behaviour stays consistent — same fallback shape, same logging.
+    """
+    if which not in ("before", "after"):
+        raise ValueError("which must be 'before' or 'after', got %r" % (which,))
+    from djust.security import safe_setattr
+
+    state = snapshot.state_before if which == "before" else snapshot.state_after
+    components_state = state.get(_COMPONENTS_SNAPSHOT_KEY, {}) or {}
+    component_snap = components_state.get(component_id)
+    if component_snap is None:
+        logger.warning(
+            "time_travel: restore_component_snapshot — no entry for %r in snapshot",
+            component_id,
+        )
+        return False
+    registry = getattr(view, "_components", None) or {}
+    component = registry.get(component_id)
+    if component is None:
+        logger.warning(
+            "time_travel: restore_component_snapshot — component %r not in registry",
+            component_id,
+        )
+        return False
+    ok = True
+    for key, value in component_snap.items():
+        try:
+            applied = safe_setattr(component, key, value, allow_private=False)
+        except Exception:  # noqa: BLE001 — dev-only, log + degrade
+            logger.exception(
+                "time_travel: component restore failed for id=%s key=%s",
+                component_id,
+                key,
+            )
+            ok = False
+            continue
+        if not applied:
+            logger.warning(
+                "time_travel: component restore blocked for id=%s key=%s",
+                component_id,
+                key,
+            )
+            ok = False
+    return ok
+
+
+def next_branch_id(view: Any) -> str:
+    """Allocate a fresh branch id for forward-replay (#1151, v0.9.4).
+
+    Returns a string of the form ``"branch-{N}"`` where N is the current
+    value of ``view._time_travel_branch_counter``, then increments the
+    counter so the next call yields a fresh id.
+
+    Stable within a single :class:`TimeTravelBuffer` lifetime — the
+    counter lives on the view instance alongside the buffer, so reconnects
+    against the same view get a deterministic sequence (`branch-0`,
+    `branch-1`, …). Resets to zero on view re-mount because the buffer
+    itself is reallocated then. The ids are only meaningful within a
+    single buffer's lifetime; clients should not assume cross-mount
+    stability.
+
+    Defaults to ``"main"`` when the view doesn't have the counter
+    attribute (defensive — pre-v0.9.4 instances or views constructed
+    via test bypasses).
+    """
+    counter = getattr(view, "_time_travel_branch_counter", None)
+    if counter is None:
+        return "main"
+    new_id = "branch-%d" % counter
+    try:
+        view._time_travel_branch_counter = counter + 1
+    except Exception:  # noqa: BLE001 — slot/descriptor readonly
+        logger.exception("time_travel: failed to increment branch counter")
+    return new_id
+
+
 def replay_event(
     view: Any,
     snapshot: EventSnapshot,

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -1591,6 +1591,10 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 self._debug_panel_active = False
             elif msg_type == "time_travel_jump":
                 await self.handle_time_travel_jump(data)
+            elif msg_type == "time_travel_component_jump":
+                await self.handle_time_travel_component_jump(data)
+            elif msg_type == "forward_replay":
+                await self.handle_forward_replay(data)
             else:
                 logger.warning("Unknown message type: %s", msg_type)
                 await self.send_error(f"Unknown message type: {msg_type}")
@@ -4231,15 +4235,67 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                     "_size": len(json.dumps(state_after, default=str)),
                 }
                 entry["_truncated"] = True
+            # Surface __components__ at the top level too (#1151, v0.9.4)
+            # so the client doesn't have to dig into entry.state_after to
+            # find per-component state. Mirrors the existing additive-
+            # field pattern from mount-batch frames.
+            components_mirror = None
+            if not entry.get("_truncated"):
+                state_after = entry.get("state_after") or {}
+                components_mirror = state_after.get("__components__")
             await self.send_json(
                 {
                     "type": "time_travel_event",
                     "entry": entry,
                     "history_len": len(buffer),
+                    "branch_id": getattr(view, "_time_travel_branch_id", "main"),
+                    "components": components_mirror,
                 }
             )
         except Exception:  # noqa: BLE001 — dev-only, degrade silently
             logger.exception("time_travel: failed to push event frame")
+
+    def _build_time_travel_state(
+        self,
+        view: Any,
+        buffer: Any,
+        cursor: int,
+        which: str,
+    ) -> Dict[str, Any]:
+        """Build the ``time_travel_state`` ack frame (#1151, v0.9.4).
+
+        Augments the v0.6.1 ack shape (cursor / which / history_len) with
+        ``branch_id``, ``forward_replay_enabled``, and ``max_events`` so
+        the debug panel UI can render the per-component scrubber, the
+        forward-replay button, and the max-events indicator without a
+        second request.
+
+        ``forward_replay_enabled`` is true iff replaying from the current
+        cursor would produce a meaningful branch — i.e., the cursor is
+        not at the canonical tip of the buffer. Tip semantics depend on
+        ``which``: with ``which="after"`` the tip is the last index;
+        with ``which="before"`` the tip is the index PAST the last (the
+        baseline before any future event would land), so a cursor at
+        ``len-1`` with ``which="before"`` is still pre-tip.
+        """
+        from djust.config import config as _djust_config
+
+        history_len = len(buffer)
+        if which == "after":
+            forward_replay_enabled = cursor < history_len - 1
+        else:  # which == "before"
+            forward_replay_enabled = cursor < history_len
+        return {
+            "type": "time_travel_state",
+            "cursor": cursor,
+            "which": which,
+            "history_len": history_len,
+            "branch_id": getattr(view, "_time_travel_branch_id", "main"),
+            "forward_replay_enabled": forward_replay_enabled,
+            "max_events": getattr(
+                buffer, "max_events", _djust_config.get("time_travel_max_events", 100)
+            ),
+        }
 
     async def handle_time_travel_jump(self, data: Dict[str, Any]):
         """Jump the view to a past :class:`EventSnapshot`.
@@ -4307,12 +4363,161 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             return
 
         await self.send_json(
-            {
-                "type": "time_travel_state",
-                "cursor": index,
-                "which": which,
-                "history_len": len(buffer),
-            }
+            self._build_time_travel_state(self.view_instance, buffer, index, which)
+        )
+
+    async def handle_time_travel_component_jump(self, data: Dict[str, Any]):
+        """Scrub a SINGLE component's state (#1151, v0.9.4).
+
+        Dev-only. Mirrors :meth:`handle_time_travel_jump` but restores
+        only ``view._components[component_id]`` from the snapshot at
+        ``index``, leaving the parent view and other components alone.
+        Used by the debug panel's per-component scrubber.
+
+        Frame: ``{"type": "time_travel_component_jump", "index": N,
+        "component_id": "<id>", "which": "before"|"after"}``.
+        """
+        from django.conf import settings
+
+        if not getattr(settings, "DEBUG", False):
+            await self.send_error("time_travel requires DEBUG=True")
+            return
+        if not self.view_instance:
+            await self.send_error("View not mounted")
+            return
+        buffer = getattr(self.view_instance, "_time_travel_buffer", None)
+        if buffer is None:
+            await self.send_error("time_travel not enabled on this view")
+            return
+
+        index = data.get("index")
+        component_id = data.get("component_id")
+        which = data.get("which", "before")
+        if not isinstance(index, int):
+            await self.send_error("time_travel_component_jump: index must be int")
+            return
+        if not isinstance(component_id, str) or not component_id:
+            await self.send_error(
+                "time_travel_component_jump: component_id must be a non-empty string"
+            )
+            return
+        if which not in ("before", "after"):
+            await self.send_error("time_travel_component_jump: which must be 'before' or 'after'")
+            return
+
+        snapshot = buffer.jump(index)
+        if snapshot is None:
+            await self.send_error("time_travel_component_jump: no snapshot at index %d" % index)
+            return
+
+        from djust.time_travel import restore_component_snapshot
+
+        ok = await sync_to_async(restore_component_snapshot)(
+            self.view_instance, snapshot, component_id, which
+        )
+        if not ok:
+            await self.send_error("time_travel_component_jump: restore failed")
+            return
+
+        try:
+            html, patches, version = await sync_to_async(self.view_instance.render_with_diff)()
+            patch_list = None
+            if patches is not None:
+                patch_list = fast_json_loads(patches) if patches else []
+            await self._send_update(
+                patches=patch_list,
+                html=html,
+                version=version,
+                event_name="__time_travel_component_jump__",
+            )
+        except Exception as exc:  # noqa: BLE001 — dev-only, log + report
+            logger.exception("time_travel_component_jump: re-render failed")
+            await self.send_error("time_travel_component_jump: re-render failed: %s" % exc)
+            return
+
+        await self.send_json(
+            self._build_time_travel_state(self.view_instance, buffer, index, which)
+        )
+
+    async def handle_forward_replay(self, data: Dict[str, Any]):
+        """Forward-replay a recorded event with optional override params (#1151, v0.9.4).
+
+        Dev-only. Restores the view to ``state_before`` of the snapshot at
+        ``from_index`` and re-invokes the recorded event handler with
+        either the original params or caller-supplied ``override_params``.
+        When the cursor is not at the buffer tip, allocates a new
+        ``branch_id`` for the resulting branched timeline.
+
+        Frame: ``{"type": "forward_replay", "from_index": N,
+        "override_params": {...}}`` (override_params is optional).
+        """
+        from django.conf import settings
+
+        if not getattr(settings, "DEBUG", False):
+            await self.send_error("time_travel requires DEBUG=True")
+            return
+        if not self.view_instance:
+            await self.send_error("View not mounted")
+            return
+        buffer = getattr(self.view_instance, "_time_travel_buffer", None)
+        if buffer is None:
+            await self.send_error("time_travel not enabled on this view")
+            return
+
+        from_index = data.get("from_index")
+        override_params = data.get("override_params")
+        if not isinstance(from_index, int):
+            await self.send_error("forward_replay: from_index must be int")
+            return
+        if override_params is not None and not isinstance(override_params, dict):
+            await self.send_error("forward_replay: override_params must be dict or null")
+            return
+
+        snapshot = buffer.jump(from_index)
+        if snapshot is None:
+            await self.send_error("forward_replay: no snapshot at index %d" % from_index)
+            return
+
+        # Allocate a new branch id when forking from a non-tip cursor.
+        # Replay from the tip just appends to the canonical timeline and
+        # keeps branch_id="main".
+        from djust.time_travel import next_branch_id, replay_event
+
+        history_len_before = len(buffer)
+        if from_index < history_len_before - 1:
+            new_branch = next_branch_id(self.view_instance)
+            try:
+                self.view_instance._time_travel_branch_id = new_branch
+            except Exception:  # noqa: BLE001 — slot/descriptor readonly
+                logger.exception("forward_replay: failed to set branch_id")
+
+        replayed = await sync_to_async(replay_event)(
+            self.view_instance, snapshot, override_params, True
+        )
+        if replayed is None:
+            await self.send_error("forward_replay: replay handler missing or refused")
+            return
+
+        try:
+            html, patches, version = await sync_to_async(self.view_instance.render_with_diff)()
+            patch_list = None
+            if patches is not None:
+                patch_list = fast_json_loads(patches) if patches else []
+            await self._send_update(
+                patches=patch_list,
+                html=html,
+                version=version,
+                event_name="__forward_replay__",
+            )
+        except Exception as exc:  # noqa: BLE001 — dev-only, log + report
+            logger.exception("forward_replay: re-render failed")
+            await self.send_error("forward_replay: re-render failed: %s" % exc)
+            return
+
+        # Cursor lands at the new tip after the replay's recorded snapshot.
+        new_cursor = len(buffer) - 1
+        await self.send_json(
+            self._build_time_travel_state(self.view_instance, buffer, new_cursor, "after")
         )
 
     async def presence_event(self, event):

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -4478,18 +4478,23 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             await self.send_error("forward_replay: no snapshot at index %d" % from_index)
             return
 
-        # Allocate a new branch id when forking from a non-tip cursor.
-        # Replay from the tip just appends to the canonical timeline and
-        # keeps branch_id="main".
+        # Decide whether this replay forks the timeline. Two conditions
+        # warrant a new branch_id (either is sufficient):
+        #   1. ``from_index`` is not the buffer tip — replaying a past
+        #      event diverges from the recorded successor.
+        #   2. ``override_params`` is non-None — replay runs with
+        #      different inputs than originally recorded, so it diverges
+        #      even when from the tip. (Caught by Stage 11 review:
+        #      replaying the LAST entry with override_params silently
+        #      merged into "main" before this fix.)
+        # Replay from the tip with no overrides just re-records to
+        # "main". Branch-id is allocated AFTER ``replay_event`` succeeds
+        # — otherwise a missing / un-decorated handler would leak a
+        # counter bump and a stale branch_id with no recorded events.
         from djust.time_travel import next_branch_id, replay_event
 
         history_len_before = len(buffer)
-        if from_index < history_len_before - 1:
-            new_branch = next_branch_id(self.view_instance)
-            try:
-                self.view_instance._time_travel_branch_id = new_branch
-            except Exception:  # noqa: BLE001 — slot/descriptor readonly
-                logger.exception("forward_replay: failed to set branch_id")
+        forks_timeline = from_index < history_len_before - 1 or override_params is not None
 
         replayed = await sync_to_async(replay_event)(
             self.view_instance, snapshot, override_params, True
@@ -4497,6 +4502,14 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
         if replayed is None:
             await self.send_error("forward_replay: replay handler missing or refused")
             return
+
+        # Replay succeeded — commit the branch_id mutation now.
+        if forks_timeline:
+            new_branch = next_branch_id(self.view_instance)
+            try:
+                self.view_instance._time_travel_branch_id = new_branch
+            except Exception:  # noqa: BLE001 — slot/descriptor readonly
+                logger.exception("forward_replay: failed to set branch_id")
 
         try:
             html, patches, version = await sync_to_async(self.view_instance.render_with_diff)()

--- a/tests/integration/test_time_travel_flow.py
+++ b/tests/integration/test_time_travel_flow.py
@@ -308,3 +308,250 @@ async def test_permission_denied_view_handler_records_with_error():
     # State was not mutated — state_before and state_after match.
     assert entries[0]["state_before"]["count"] == 5
     assert entries[0]["state_after"]["count"] == 5
+
+
+# ---------------------------------------------------------------------------
+# #1151, v0.9.4 — wire-protocol exposure for per-component time-travel +
+# forward-replay. Five integration cases against the augmented
+# time_travel_state ack frame and the two new handlers.
+# ---------------------------------------------------------------------------
+
+
+class _TwoComponentView(LiveView):
+    """LiveView with a `_components` registry for component-jump tests."""
+
+    template = "<div>{{ total }}</div>"
+    time_travel_enabled = True
+
+    def mount(self, request=None, **kwargs):
+        self.total = 0
+        self._components = {
+            "comp-a": _CompStub("comp-a"),
+            "comp-b": _CompStub("comp-b"),
+        }
+
+
+class _CompStub:
+    """Minimal component stub — only what restore_component_snapshot needs."""
+
+    def __init__(self, component_id: str):
+        self._component_id = component_id
+        self.value = 0
+
+
+def _make_consumer(view):
+    consumer = LiveViewConsumer()
+    consumer.view_instance = view
+    sent: list = []
+    consumer.send_json = AsyncMock(side_effect=lambda msg: sent.append(msg))
+    consumer.send_error = AsyncMock(
+        side_effect=lambda msg, **kw: sent.append({"type": "error", "error": msg})
+    )
+    consumer._send_update = AsyncMock()
+    return consumer, sent
+
+
+@pytest.mark.asyncio
+async def test_time_travel_state_carries_branch_id_and_max_events_at_tip():
+    """Augmented ack frame: defaults branch_id=main, replay disabled at tip, max_events from buffer."""
+    view = _TTView()
+    view.count = 5
+    consumer, sent = _make_consumer(view)
+    view._time_travel_buffer.append(
+        EventSnapshot(
+            event_name="increment",
+            params={},
+            ref=None,
+            ts=0.0,
+            state_before={"count": 4},
+            state_after={"count": 5},
+        )
+    )
+
+    with override_settings(DEBUG=True):
+        # Jump to the tip (cursor=0, which="after" — i.e., last index, post-event).
+        await consumer.handle_time_travel_jump(
+            {"type": "time_travel_jump", "index": 0, "which": "after"}
+        )
+
+    tt_frames = [m for m in sent if m.get("type") == "time_travel_state"]
+    assert len(tt_frames) == 1
+    frame = tt_frames[0]
+    assert frame["cursor"] == 0
+    assert frame["which"] == "after"
+    assert frame["history_len"] == 1
+    assert frame["branch_id"] == "main"
+    assert frame["forward_replay_enabled"] is False  # at tip — nothing to replay forward
+    assert frame["max_events"] == view._time_travel_buffer.max_events
+
+
+@pytest.mark.asyncio
+async def test_time_travel_state_forward_replay_enabled_when_cursor_not_at_tip():
+    """Cursor before the tip ⇒ forward_replay_enabled=True."""
+    view = _TTView()
+    consumer, sent = _make_consumer(view)
+    buf = view._time_travel_buffer
+    for i in range(3):
+        buf.append(
+            EventSnapshot(
+                event_name="increment",
+                params={"n": i},
+                ref=None,
+                ts=float(i),
+                state_before={"count": i},
+                state_after={"count": i + 1},
+            )
+        )
+
+    with override_settings(DEBUG=True):
+        await consumer.handle_time_travel_jump(
+            {"type": "time_travel_jump", "index": 0, "which": "before"}
+        )
+
+    frame = next(m for m in sent if m.get("type") == "time_travel_state")
+    assert frame["cursor"] == 0
+    assert frame["forward_replay_enabled"] is True
+    assert frame["history_len"] == 3
+
+
+@pytest.mark.asyncio
+async def test_time_travel_event_frame_includes_components_top_level():
+    """Per-event push surfaces __components__ at frame top level (#1151)."""
+    view = _TwoComponentView()
+    view.mount()
+    consumer, sent = _make_consumer(view)
+    snapshot = EventSnapshot(
+        event_name="increment",
+        params={},
+        ref=None,
+        ts=0.0,
+        state_before={"total": 0, "__components__": {"comp-a": {"value": 1}}},
+        state_after={
+            "total": 1,
+            "__components__": {"comp-a": {"value": 2}, "comp-b": {"value": 7}},
+        },
+    )
+    view._time_travel_buffer.append(snapshot)
+
+    with override_settings(DEBUG=True):
+        await consumer._maybe_push_tt_event(view, snapshot)
+
+    event_frames = [m for m in sent if m.get("type") == "time_travel_event"]
+    assert len(event_frames) == 1
+    frame = event_frames[0]
+    assert frame["branch_id"] == "main"
+    # Top-level mirror equals state_after.__components__.
+    assert frame["components"] == {"comp-a": {"value": 2}, "comp-b": {"value": 7}}
+    # And the entry's nested copy is intact (no destructive surfacing).
+    assert frame["entry"]["state_after"]["__components__"]["comp-a"]["value"] == 2
+
+
+@pytest.mark.asyncio
+async def test_handle_time_travel_component_jump_isolates_to_one_component():
+    """Component-only jump scrubs comp-a but leaves comp-b alone."""
+    view = _TwoComponentView()
+    view.mount()
+    consumer, sent = _make_consumer(view)
+    # Snapshot captured at comp-a=5, comp-b=7.
+    view._time_travel_buffer.append(
+        EventSnapshot(
+            event_name="increment",
+            params={},
+            ref=None,
+            ts=0.0,
+            state_before={
+                "total": 0,
+                "__components__": {"comp-a": {"value": 5}, "comp-b": {"value": 7}},
+            },
+            state_after={
+                "total": 12,
+                "__components__": {"comp-a": {"value": 6}, "comp-b": {"value": 8}},
+            },
+        )
+    )
+    # Mutate live state — both components way ahead, parent at 100.
+    view.total = 100
+    view._components["comp-a"].value = 99
+    view._components["comp-b"].value = 88
+
+    with override_settings(DEBUG=True):
+        await consumer.handle_time_travel_component_jump(
+            {
+                "type": "time_travel_component_jump",
+                "index": 0,
+                "component_id": "comp-a",
+                "which": "before",
+            }
+        )
+
+    # comp-a restored to 5 from snapshot.state_before; comp-b untouched at 88.
+    assert view._components["comp-a"].value == 5
+    assert view._components["comp-b"].value == 88
+    # Parent state untouched — component jump doesn't write to the view.
+    assert view.total == 100
+    # Ack frame emitted.
+    frame = next(m for m in sent if m.get("type") == "time_travel_state")
+    assert frame["cursor"] == 0
+    assert frame["which"] == "before"
+
+
+@pytest.mark.asyncio
+async def test_handle_forward_replay_returns_new_branch_id():
+    """Forward-replay from a non-tip cursor allocates a fresh branch_id."""
+    from djust.decorators import event_handler
+
+    class _ReplayView(LiveView):
+        template = "<div>{{ count }}</div>"
+        time_travel_enabled = True
+
+        def mount(self, request=None, **kwargs):
+            self.count = 0
+
+        @event_handler()
+        def increment(self, n: int = 1, **kwargs):
+            self.count += n
+
+    view = _ReplayView()
+    view.mount()
+    consumer, sent = _make_consumer(view)
+    buf = view._time_travel_buffer
+    # Two recorded events: count 0→1, then 1→2.
+    buf.append(
+        EventSnapshot(
+            event_name="increment",
+            params={"n": 1},
+            ref=None,
+            ts=0.0,
+            state_before={"count": 0},
+            state_after={"count": 1},
+        )
+    )
+    buf.append(
+        EventSnapshot(
+            event_name="increment",
+            params={"n": 1},
+            ref=None,
+            ts=1.0,
+            state_before={"count": 1},
+            state_after={"count": 2},
+        )
+    )
+    view.count = 2
+
+    with override_settings(DEBUG=True):
+        await consumer.handle_forward_replay(
+            {"type": "forward_replay", "from_index": 0, "override_params": {"n": 42}}
+        )
+
+    # Branch id allocated; original was "main", new should be "branch-0".
+    assert view._time_travel_branch_id == "branch-0"
+    # Ack frame carries the new branch_id.
+    frame = next(m for m in sent if m.get("type") == "time_travel_state")
+    assert frame["branch_id"] == "branch-0"
+    # History grew by 1 (the replay was recorded).
+    assert frame["history_len"] == 3
+    # The new entry has the override params.
+    new_entry = buf.history()[-1]
+    assert new_entry["params"] == {"n": 42}
+    # And the live view reflects the replayed state.
+    assert view.count == 0 + 42  # restored to state_before (count=0), then handler added 42

--- a/tests/integration/test_time_travel_flow.py
+++ b/tests/integration/test_time_travel_flow.py
@@ -555,3 +555,146 @@ async def test_handle_forward_replay_returns_new_branch_id():
     assert new_entry["params"] == {"n": 42}
     # And the live view reflects the replayed state.
     assert view.count == 0 + 42  # restored to state_before (count=0), then handler added 42
+
+
+@pytest.mark.asyncio
+async def test_handle_forward_replay_branches_on_tip_with_override_params():
+    """Replay from the LAST entry with override_params still allocates a
+    new branch — overrides diverge from the recorded `state_after` even
+    when from_index == tip. Regression for the Stage 11 off-by-one fix.
+    """
+    from djust.decorators import event_handler
+
+    class _ReplayView(LiveView):
+        template = "<div>{{ count }}</div>"
+        time_travel_enabled = True
+
+        def mount(self, request=None, **kwargs):
+            self.count = 0
+
+        @event_handler()
+        def increment(self, n: int = 1, **kwargs):
+            self.count += n
+
+    view = _ReplayView()
+    view.mount()
+    consumer, sent = _make_consumer(view)
+    buf = view._time_travel_buffer
+    # Single entry — replay target is the very last (tip).
+    buf.append(
+        EventSnapshot(
+            event_name="increment",
+            params={"n": 1},
+            ref=None,
+            ts=0.0,
+            state_before={"count": 0},
+            state_after={"count": 1},
+        )
+    )
+    view.count = 1
+
+    with override_settings(DEBUG=True):
+        await consumer.handle_forward_replay(
+            {
+                "type": "forward_replay",
+                "from_index": 0,  # tip
+                "override_params": {"n": 99},  # diverges from recorded n=1
+            }
+        )
+
+    # Override-params at tip ⇒ branch (not "main").
+    assert view._time_travel_branch_id == "branch-0"
+    frame = next(m for m in sent if m.get("type") == "time_travel_state")
+    assert frame["branch_id"] == "branch-0"
+
+
+@pytest.mark.asyncio
+async def test_handle_forward_replay_does_not_leak_branch_id_on_failure():
+    """When replay_event returns None (handler missing / un-decorated),
+    branch_id and the counter MUST stay at their pre-call values.
+    Regression for the Stage 11 finding: branch_id was being mutated
+    BEFORE replay_event was awaited, so a failed replay leaked a stale
+    branch_id with no recorded events.
+    """
+
+    class _ViewWithoutHandler(LiveView):
+        template = "<div>{{ count }}</div>"
+        time_travel_enabled = True
+
+        def mount(self, request=None, **kwargs):
+            self.count = 0
+
+        # No `increment` handler defined — replay_event will return None.
+
+    view = _ViewWithoutHandler()
+    view.mount()
+    consumer, sent = _make_consumer(view)
+    buf = view._time_travel_buffer
+    buf.append(
+        EventSnapshot(
+            event_name="increment",  # not on the view
+            params={"n": 1},
+            ref=None,
+            ts=0.0,
+            state_before={"count": 0},
+            state_after={"count": 1},
+        )
+    )
+    pre_branch_id = view._time_travel_branch_id
+    pre_counter = view._time_travel_branch_counter
+
+    with override_settings(DEBUG=True):
+        await consumer.handle_forward_replay(
+            {
+                "type": "forward_replay",
+                "from_index": 0,
+                "override_params": {"n": 99},
+            }
+        )
+
+    # Branch_id and counter unchanged — no leak.
+    assert view._time_travel_branch_id == pre_branch_id
+    assert view._time_travel_branch_counter == pre_counter
+    # An error frame was emitted, no time_travel_state ack.
+    assert any(m.get("type") == "error" for m in sent)
+    assert not any(m.get("type") == "time_travel_state" for m in sent)
+
+
+@pytest.mark.asyncio
+async def test_handle_time_travel_component_jump_supports_which_after():
+    """Component jump with which="after" restores from state_after."""
+    view = _TwoComponentView()
+    view.mount()
+    consumer, sent = _make_consumer(view)
+    view._time_travel_buffer.append(
+        EventSnapshot(
+            event_name="increment",
+            params={},
+            ref=None,
+            ts=0.0,
+            state_before={
+                "total": 0,
+                "__components__": {"comp-a": {"value": 5}, "comp-b": {"value": 7}},
+            },
+            state_after={
+                "total": 12,
+                "__components__": {"comp-a": {"value": 6}, "comp-b": {"value": 8}},
+            },
+        )
+    )
+    view._components["comp-a"].value = 99
+
+    with override_settings(DEBUG=True):
+        await consumer.handle_time_travel_component_jump(
+            {
+                "type": "time_travel_component_jump",
+                "index": 0,
+                "component_id": "comp-a",
+                "which": "after",
+            }
+        )
+
+    # Restored from state_after (value=6), not state_before (value=5).
+    assert view._components["comp-a"].value == 6
+    frame = next(m for m in sent if m.get("type") == "time_travel_state")
+    assert frame["which"] == "after"

--- a/tests/unit/test_time_travel.py
+++ b/tests/unit/test_time_travel.py
@@ -1281,3 +1281,88 @@ class TestDescriptorPatternComponentTimeTravel:
             assert key not in captured, (
                 "framework-internal attr %r leaked into descriptor component snapshot" % key
             )
+
+
+# ---------------------------------------------------------------------------
+# #1151, v0.9.4 — restore_component_snapshot + next_branch_id unit tests.
+# ---------------------------------------------------------------------------
+
+
+def test_restore_component_snapshot_does_not_touch_parent_state():
+    """Single-component restore writes only to the named component."""
+    from djust.time_travel import restore_component_snapshot
+
+    class _Comp:
+        def __init__(self):
+            self.value = 0
+
+    class _View:
+        def __init__(self):
+            self.total = 100  # parent attr — must be untouched
+            self._components = {"comp-a": _Comp(), "comp-b": _Comp()}
+
+    view = _View()
+    view._components["comp-a"].value = 99
+    view._components["comp-b"].value = 88
+    snap = EventSnapshot(
+        event_name="evt",
+        params={},
+        ref=None,
+        ts=0.0,
+        state_before={
+            "total": 0,
+            "__components__": {"comp-a": {"value": 5}, "comp-b": {"value": 7}},
+        },
+        state_after={
+            "total": 12,
+            "__components__": {"comp-a": {"value": 6}, "comp-b": {"value": 8}},
+        },
+    )
+
+    ok = restore_component_snapshot(view, snap, "comp-a", which="before")
+    assert ok is True
+    assert view._components["comp-a"].value == 5  # restored
+    assert view._components["comp-b"].value == 88  # untouched
+    assert view.total == 100  # parent attr — never written
+
+
+def test_restore_component_snapshot_returns_false_for_missing_component():
+    """Missing component_id ⇒ False, no exception."""
+    from djust.time_travel import restore_component_snapshot
+
+    class _View:
+        _components: dict = {}
+
+    snap = EventSnapshot(
+        event_name="evt",
+        params={},
+        ref=None,
+        ts=0.0,
+        state_before={"__components__": {"comp-a": {"value": 1}}},
+        state_after={"__components__": {"comp-a": {"value": 2}}},
+    )
+    assert restore_component_snapshot(_View(), snap, "comp-missing", which="before") is False
+
+
+def test_next_branch_id_increments_counter():
+    """Branch-id allocator yields branch-0, branch-1, … and bumps the counter."""
+    from djust.time_travel import next_branch_id
+
+    class _View:
+        _time_travel_branch_counter = 0
+
+    view = _View()
+    assert next_branch_id(view) == "branch-0"
+    assert view._time_travel_branch_counter == 1
+    assert next_branch_id(view) == "branch-1"
+    assert view._time_travel_branch_counter == 2
+
+
+def test_next_branch_id_defaults_to_main_when_counter_missing():
+    """Defensive default: views without the counter attr stay on 'main'."""
+    from djust.time_travel import next_branch_id
+
+    class _LegacyView:
+        pass
+
+    assert next_branch_id(_LegacyView()) == "main"


### PR DESCRIPTION
## Summary

Server-side wire-protocol exposure that the v0.9.4 debug panel UI (PR-B, follow-up) will consume. The Python plumbing for per-component time-travel (#1041) and forward-replay through branched timelines (#1042) shipped in v0.9.0; this PR exposes the missing wire fields.

This is **PR-A only** — wire-protocol + handlers + tests. **PR-B** is the debug panel UI built on top.

## What changed

### `time_travel_state` ack frame — 3 new additive fields
- `branch_id`: defaults `"main"`; new branches allocated as `branch-{N}` on forward-replay from a non-tip cursor.
- `forward_replay_enabled`: true iff cursor not at the buffer tip.
- `max_events`: configured ring-buffer cap, surfaced for "X / max" UI.

### `time_travel_event` per-event push — 2 new additive fields
- `branch_id` (mirrors ack-frame field).
- top-level `components` mirror of `entry.state_after.__components__`.

### New handlers
- `time_travel_component_jump(index, component_id, which)` — scrubs SINGLE component without touching parent or other components. Backed by new `restore_component_snapshot()` in `time_travel.py`.
- `forward_replay(from_index, override_params)` — replays recorded event with optional override params. Allocates fresh `branch_id` via new `next_branch_id()` when forking from non-tip cursor. Replay from tip just appends to `"main"`.

### LiveView init
- Two new instance fields when `time_travel_enabled=True`: `_time_travel_branch_id` (default `"main"`), `_time_travel_branch_counter` (default `0`). Inert when buffer not allocated; zero memory cost for views that don't opt in.

## Tests

9 new cases (5 integration + 4 unit) covering ack-frame shape, replay-enabled semantics, component-only restore isolation, branch-id allocation, defensive defaults. Full suite green (4623 Python passed).

## Backwards compat

All new wire fields are additive — old client (`09a-tab-time-travel.js`) reads only `cursor`/`which`/`history_len` from `time_travel_state`. New fields are ignored; no required handshake.

## Critical files

- `python/djust/websocket.py` — dispatch arms, `_build_time_travel_state` helper, `handle_time_travel_component_jump`, `handle_forward_replay`
- `python/djust/time_travel.py` — `restore_component_snapshot`, `next_branch_id`
- `python/djust/live_view.py` — `_time_travel_branch_id` + `_time_travel_branch_counter` init
- `tests/integration/test_time_travel_flow.py` — 5 new integration cases
- `tests/unit/test_time_travel.py` — 4 new unit cases

## Test plan

- [x] `pytest tests/unit/test_time_travel.py tests/integration/test_time_travel_flow.py` — 71 pass (62 existing + 9 new)
- [x] `pytest python/djust/tests/ tests/` — 4623 pass, 14 skipped, no regressions
- [x] `ruff check + format` — clean
- [x] No JS changes (PR-B owns UI work)

Closes #1151 (PR-A — wire protocol). PR-B (debug panel UI) is the next v0.9.4 PR; will reuse the wire fields exposed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)