### PR TITLE
fix(websocket): store _recovery_html after broadcast renders (#1202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`server_push` now stores `_recovery_html` / `_recovery_version` after
+  broadcast renders (#1202)** — push-driven sessions previously left recovery
+  state unset, so a client `request_html` after a failed VDOM patch
+  (e.g. `{% if %}` shifting DOM structure on a broadcast) returned
+  `recoverable=false` and force-reloaded the page. `server_push` now mirrors
+  the `handle_event` pattern of populating `_recovery_html` /
+  `_recovery_version` immediately before dispatching the broadcast patches.
+  Added 3 regression cases in `tests/unit/test_server_push.py`
+  (single-push, multi-push refresh, no-op-push leaves recovery state intact).
+
 ### Security
 
 - **Code-scanning cleanup batch (4 fixes + 15 false-positive dismissals)** —

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -4636,6 +4636,15 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 if patches is not None:
                     if isinstance(patches, str):
                         patches = fast_json_loads(patches)
+                    # Store rendered HTML for on-demand recovery, mirroring
+                    # handle_event. Without this, a VDOM patch failure on a
+                    # broadcast-triggered render (e.g. {% if %} blocks shifting
+                    # DOM structure after a push-driven state change) triggers
+                    # `request_html` with no `_recovery_html` to serve —
+                    # server returns `recoverable=false` and the client
+                    # force-reloads the page. See #1202.
+                    self._recovery_html = html
+                    self._recovery_version = version
                     await self._send_update(
                         patches=patches,
                         version=version,

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -4637,12 +4637,9 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                     if isinstance(patches, str):
                         patches = fast_json_loads(patches)
                     # Store rendered HTML for on-demand recovery, mirroring
-                    # handle_event. Without this, a VDOM patch failure on a
-                    # broadcast-triggered render (e.g. {% if %} blocks shifting
-                    # DOM structure after a push-driven state change) triggers
-                    # `request_html` with no `_recovery_html` to serve —
-                    # server returns `recoverable=false` and the client
-                    # force-reloads the page. See #1202.
+                    # handle_event. Without this, request_html after a failed
+                    # broadcast-triggered patch finds _recovery_html=None and
+                    # forces a page reload. See #1202.
                     self._recovery_html = html
                     self._recovery_version = version
                     await self._send_update(

--- a/tests/unit/test_server_push.py
+++ b/tests/unit/test_server_push.py
@@ -175,6 +175,47 @@ class TestServerPushHandler:
         # Should not raise
         await consumer.server_push({"state": {"x": 1}})
 
+    @pytest.mark.asyncio
+    async def test_stores_recovery_html_after_broadcast(self):
+        """After a broadcast-triggered render, _recovery_html and
+        _recovery_version must be updated so a later `request_html`
+        recovery (triggered by a failed VDOM patch on the client) has
+        fresh HTML to serve. See #1202.
+
+        Regression: previously only handle_event set _recovery_html.
+        If a session received only broadcasts after mount, _recovery_html
+        stayed None, request_html returned `recoverable=false`, and the
+        client force-reloaded the page.
+        """
+        consumer = self._make_consumer()
+        consumer.view_instance.render_with_diff = MagicMock(
+            return_value=("<div>rendered-after-push</div>", '[{"op":"replace"}]', 42)
+        )
+
+        await consumer.server_push({"state": {"x": 1}, "handler": None, "payload": None})
+
+        assert consumer._recovery_html == "<div>rendered-after-push</div>"
+        assert consumer._recovery_version == 42
+
+    @pytest.mark.asyncio
+    async def test_recovery_html_refreshed_across_multiple_pushes(self):
+        """Consecutive pushes must each refresh _recovery_html so a stale
+        render from an earlier broadcast isn't served on a later recovery."""
+        consumer = self._make_consumer()
+        consumer.view_instance.render_with_diff = MagicMock(
+            side_effect=[
+                ("<div>first</div>", '[{"op":"replace","v":"first"}]', 1),
+                ("<div>second</div>", '[{"op":"replace","v":"second"}]', 2),
+                ("<div>third</div>", '[{"op":"replace","v":"third"}]', 3),
+            ]
+        )
+
+        for _ in range(3):
+            await consumer.server_push({"state": {"x": 1}, "handler": None, "payload": None})
+
+        assert consumer._recovery_html == "<div>third</div>"
+        assert consumer._recovery_version == 3
+
 
 # ---------------------------------------------------------------------------
 # Group join / leave

--- a/tests/unit/test_server_push.py
+++ b/tests/unit/test_server_push.py
@@ -216,6 +216,25 @@ class TestServerPushHandler:
         assert consumer._recovery_html == "<div>third</div>"
         assert consumer._recovery_version == 3
 
+    @pytest.mark.asyncio
+    async def test_no_patches_does_not_clobber_recovery_html(self):
+        """A no-op render (patches=None) must NOT overwrite _recovery_html.
+        A previously-good recovery HTML must survive an unchanged broadcast,
+        otherwise we'd lose recovery state on every quiet push."""
+        consumer = self._make_consumer()
+        consumer._recovery_html = "<div>previously-good</div>"
+        consumer._recovery_version = 7
+
+        # Render returns no patches (state didn't change).
+        consumer.view_instance.render_with_diff = MagicMock(
+            return_value=("<div>fresh-but-unused</div>", None, 8)
+        )
+
+        await consumer.server_push({"state": {"x": 1}, "handler": None, "payload": None})
+
+        assert consumer._recovery_html == "<div>previously-good</div>"
+        assert consumer._recovery_version == 7
+
 
 # ---------------------------------------------------------------------------
 # Group join / leave


### PR DESCRIPTION
Fixes #1202.

## Problem

`server_push` in `python/djust/websocket.py` calls `render_with_diff` and sends patches but **never updates `self._recovery_html`**. `handle_event` (the user-initiated event path) does this, but `server_push` was overlooked.

Consequence: when a subsequent `applyPatches` on the client fails (the well-known `{% if %}`-shifts-DOM case), the client sends `request_html` expecting fresh HTML. `handle_request_html` reads `self._recovery_html` — if None, it returns `recoverable: false` and the client triggers `window.location.reload()`.

Sessions that only receive broadcasts after mount (common for real-time apps: an admin watches a dashboard, pushes come from Celery workers) never populate `_recovery_html` via the normal path. Result: intermittent full-page reloads whenever broadcast-driven template changes shift DOM structure.

## Fix

One-location change in `server_push`. Before calling `self._send_update(...)` for the broadcast patches, store the render output as `_recovery_html` / `_recovery_version`. Same pattern as `handle_event` at websocket.py:3271.

## Tests

Added two unit tests in `tests/unit/test_server_push.py`:

- `test_stores_recovery_html_after_broadcast` — single push stores both `_recovery_html` and `_recovery_version`.
- `test_recovery_html_refreshed_across_multiple_pushes` — consecutive pushes each refresh the stored HTML so a stale broadcast isn't served on a later recovery.

Both pass locally. Existing 14 tests in the file remain green.

## Downstream context

Observed in a production prototype where a document upload pushes twice (new row appears as PENDING, then OCR status flips on completion). Without this fix, the second push's patches race recovery-HTML staleness and the user sees:

```
[LiveView] VDOM patches failed. This usually happens when {% if %} blocks…
[LiveView] Server error: Recovery HTML unavailable — the server may have restarted.
[LiveView] Non-recoverable error, reloading page...
```

With this fix applied, the recovery cycle has fresh HTML to morph against and the page doesn't reload.