### PR TITLE
fix: list[Model] in user-overridden get_context_data now triggers VDOM patches (#1205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **JIT serializer silently degrades when context value is `list[Model]`
+  (#1205).** When a view's `get_context_data` override sets
+  `ctx["tasks"] = list(qs)` *after* calling `super().get_context_data()`,
+  the JIT auto-serialization pipeline runs inside `super()` and never sees
+  the user-added value. The raw `list[Model]` then flows through
+  `_sync_state_to_rust`, where change-detection compares list elements via
+  Python `==` — which delegates to `Model.__eq__` (pk-only). In-place field
+  mutations (`is_active` toggle, `completed` flip) don't change `pk`, so
+  the comparison returns equal, the key is never added to the diff-context,
+  Rust never receives the new state, and the rendered HTML is byte-identical
+  on every event despite confirmed DB writes. Symptom from the issue
+  reporter: `patch_count: 0` on every event, `_debug.variables.tasks.value`
+  shows only `__str__` strings. Fix: `_sync_state_to_rust` (in
+  `python/djust/mixins/rust_bridge.py`) now runs a defensive normalize pass
+  over `full_context` immediately after fetching it, converting any
+  `list[Model]` / `Model` / `QuerySet` value to dicts via
+  `normalize_django_value`. After normalization, change-detection compares
+  `list[dict] != list[dict]` element-wise via `dict.__eq__` (structural),
+  correctly catching field mutations. Idempotent on already-serialized
+  values. Also removed dead `_lazy_serialize_context` method from
+  `python/djust/mixins/jit.py` (zero call sites — was misleadingly cited as
+  the bug location in the issue). 7 regression cases in
+  `TestListModelDiff1205` and `TestLazySerializeContextRemoved` lock down
+  the user-override patterns (`list[Model]`, single Model, raw QuerySet)
+  plus idempotency and edge cases (empty list, mixed list).
+
 ## [0.9.0] - 2026-04-29
 
 The "Time Travel" release — the biggest release since 0.3.0, two years of

--- a/python/djust/mixins/jit.py
+++ b/python/djust/mixins/jit.py
@@ -82,7 +82,7 @@ except ImportError:
 
 
 class JITMixin:
-    """JIT serialization: _jit_serialize_queryset, _jit_serialize_model, _lazy_serialize_context, _get_template_content."""
+    """JIT serialization: _jit_serialize_queryset, _jit_serialize_model, _get_template_content."""
 
     def _get_template_content(self) -> Optional[str]:
         """
@@ -324,45 +324,3 @@ class JITMixin:
         except Exception as e:
             logger.debug("JIT serialization failed for %s: %s", variable_name, e)
             return normalize_django_value(obj)
-
-    def _lazy_serialize_context(self, context: dict) -> dict:
-        """
-        Lazy serialization: only serialize values that need conversion.
-        """
-        from ..components.base import Component, LiveComponent
-        from django.db.models import Model
-        from datetime import datetime, date, time
-        from decimal import Decimal
-        from uuid import UUID
-
-        def serialize_value(value):
-            if value is None or isinstance(value, (str, int, float, bool)):
-                return value
-
-            if isinstance(value, (list, tuple)):
-                return [serialize_value(item) for item in value]
-
-            if isinstance(value, dict):
-                return {k: serialize_value(v) for k, v in value.items()}
-
-            if isinstance(value, (Component, LiveComponent)):
-                return {"render": str(value.render())}
-
-            if isinstance(value, Model):
-                return str(value)
-
-            if isinstance(value, (datetime, date)):
-                return value.isoformat()
-
-            if isinstance(value, time):
-                return value.isoformat()
-
-            if isinstance(value, (Decimal, UUID)):
-                return str(value)
-
-            try:
-                return normalize_django_value(value)
-            except (TypeError, ValueError):
-                return str(value)
-
-        return {k: serialize_value(v) for k, v in context.items()}

--- a/python/djust/mixins/rust_bridge.py
+++ b/python/djust/mixins/rust_bridge.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qs, urlencode
 
 from ..security import sanitize_for_log
 from ..serialization import normalize_django_value
-from ..utils import get_template_dirs
+from ..utils import get_template_dirs, is_model_list
 
 logger = logging.getLogger(__name__)
 
@@ -321,10 +321,26 @@ class RustBridgeMixin:
         if self._rust_view:
             from ..components.base import Component, LiveComponent
             from django import forms
+            from django.db.models import Model, QuerySet
 
             full_context = (
                 preloaded_context if preloaded_context is not None else self.get_context_data()
             )
+
+            # Defensive normalize pass for DB values added after super() (#1205).
+            # When a user overrides ``get_context_data`` and sets
+            # ``ctx["tasks"] = list(qs)`` AFTER calling ``super()``, the JIT
+            # pipeline never sees the list[Model] — and downstream change-
+            # detection would compare list[Model] via Model.__eq__ (pk-only),
+            # missing in-place field mutations. Normalize raw DB values to
+            # dicts here so the comparison below sees field-level changes.
+            for _key, _val in list(full_context.items()):
+                if isinstance(_val, Model):
+                    full_context[_key] = normalize_django_value(_val)
+                elif isinstance(_val, QuerySet):
+                    full_context[_key] = [normalize_django_value(_item) for _item in _val]
+                elif is_model_list(_val):
+                    full_context[_key] = [normalize_django_value(_item) for _item in _val]
 
             # Ensure csrf_token is available for {% csrf_token %} tag (#696).
             # Cache it to avoid creating a new string object each call,

--- a/tests/unit/test_list_model_diff_1205.py
+++ b/tests/unit/test_list_model_diff_1205.py
@@ -1,0 +1,251 @@
+"""Regression: ``list[Model]`` in user-overridden ``get_context_data`` must
+produce VDOM patches when model fields mutate (#1205).
+
+The bug
+-------
+
+When a view's ``get_context_data`` override sets ``ctx["tasks"] = list(qs)``
+*after* calling ``super().get_context_data()``, the JIT auto-serialization
+pipeline runs inside ``super()`` and never sees the user-added ``tasks``.
+The list of raw ``Model`` instances flows through ``_sync_state_to_rust``,
+where change-detection compares ``list[Model]`` via Python ``==``. ``==`` on
+lists delegates to per-element ``Model.__eq__``, which only compares by
+``pk``. In-place field mutations (``is_active`` toggling, ``completed``
+flipping, etc.) don't change ``pk``, so the list compares as "unchanged"
+and Rust never receives the new state. Result: zero VDOM patches, template
+renders identically forever.
+
+The fix (in ``rust_bridge.py``) is a defensive normalize pass: any
+``list[Model]`` / ``Model`` / ``QuerySet`` value that snuck past the JIT
+pipeline gets serialized to ``list[dict]`` / ``dict`` via
+``normalize_django_value`` before change-detection runs.
+
+These tests lock down the bug so it can't silently regress.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+
+from djust.decorators import event_handler
+from djust.live_view import LiveView
+from djust.testing import LiveViewTestClient
+
+
+# ---------------------------------------------------------------------------
+# Primary regression: list(qs) in user override propagates field mutations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestListModelDiff1205:
+    def test_user_override_with_list_qs_propagates_field_mutations(self):
+        """``ctx['tasks'] = list(qs)`` after ``super()`` must trigger a real
+        re-render when a model field mutates."""
+
+        class TaskView(LiveView):
+            template = (
+                "<div>"
+                "{% for task in tasks %}"
+                "<li data-pk='{{ task.id }}'>"
+                "{% if task.is_active %}A{% else %}I{% endif %}{{ task.username }}"
+                "</li>"
+                "{% endfor %}"
+                "</div>"
+            )
+
+            def mount(self, request, **kwargs):
+                self._users = [
+                    User(username="alice", pk=1, is_active=True),
+                    User(username="bob", pk=2, is_active=False),
+                ]
+
+            @event_handler
+            def toggle(self, pk: int = 1, **kwargs):
+                for u in self._users:
+                    if u.pk == pk:
+                        u.is_active = not u.is_active
+
+            def get_context_data(self, **kwargs):
+                ctx = super().get_context_data(**kwargs)
+                ctx["tasks"] = list(self._users)  # the bug pattern
+                return ctx
+
+        client = LiveViewTestClient(TaskView).mount()
+        html_before = client.render()
+        assert "Aalice" in html_before, html_before
+        assert "Ibob" in html_before, html_before
+
+        client.send_event("toggle", pk=1)
+        html_after = client.render()
+
+        # The actual bug: html_after used to be byte-identical to html_before
+        # because change-detection missed the in-place field mutation.
+        assert html_before != html_after, (
+            "Re-render after field mutation produced identical HTML — change "
+            "detection missed the list[Model] in-place mutation. See #1205."
+        )
+        assert "Ialice" in html_after, html_after
+        assert "Ibob" in html_after, html_after
+
+    def test_raw_queryset_in_user_override_still_works(self):
+        """Sanity: ``ctx['users'] = qs`` (raw, unmaterialized QuerySet) added in
+        the override must also flow through the normalize pass and propagate
+        DB-level field changes. Locks the QuerySet branch of the fix in
+        (``isinstance(_val, QuerySet)`` arm at rust_bridge.py)."""
+        # Create real users in the test DB so the QuerySet is non-empty.
+        User.objects.create(username="alice", is_active=True)
+        User.objects.create(username="bob", is_active=False)
+
+        class UserListView(LiveView):
+            template = (
+                "<div>"
+                "{% for u in users %}"
+                "<li>{% if u.is_active %}A{% else %}I{% endif %}{{ u.username }}</li>"
+                "{% endfor %}"
+                "</div>"
+            )
+
+            @event_handler
+            def deactivate(self, username: str = "", **kwargs):
+                User.objects.filter(username=username).update(is_active=False)
+
+            def get_context_data(self, **kwargs):
+                ctx = super().get_context_data(**kwargs)
+                # Raw QuerySet (re-evaluated each call). The fix must not break
+                # this path — the normalize pass converts it to list[dict].
+                ctx["users"] = User.objects.order_by("username")
+                return ctx
+
+        client = LiveViewTestClient(UserListView).mount()
+        html_before = client.render()
+        assert "Aalice" in html_before, html_before
+
+        client.send_event("deactivate", username="alice")
+        html_after = client.render()
+        assert html_before != html_after
+        assert "Ialice" in html_after, html_after
+
+    def test_single_model_in_user_override(self):
+        """``ctx['profile'] = single_model`` (Model, not list) added in override
+        must also propagate field mutations."""
+
+        class ProfileView(LiveView):
+            template = (
+                "<div>{% if profile.is_active %}A{% else %}I{% endif %}{{ profile.username }}</div>"
+            )
+
+            def mount(self, request, **kwargs):
+                self._user = User(username="alice", pk=1, is_active=True)
+
+            @event_handler
+            def toggle(self, **kwargs):
+                self._user.is_active = not self._user.is_active
+
+            def get_context_data(self, **kwargs):
+                ctx = super().get_context_data(**kwargs)
+                ctx["profile"] = self._user
+                return ctx
+
+        client = LiveViewTestClient(ProfileView).mount()
+        html_before = client.render()
+        assert "Aalice" in html_before, html_before
+
+        client.send_event("toggle")
+        html_after = client.render()
+        assert html_before != html_after
+        assert "Ialice" in html_after, html_after
+
+    def test_normalize_idempotent_on_already_serialized(self):
+        """If JIT already serialized a value to ``list[dict]``, the normalize
+        pass must NOT double-process. ``is_model_list`` returns False for
+        ``list[dict]`` (first item isn't a Model), and ``isinstance(dict,
+        Model)`` is False — so the pass is a no-op for already-serialized
+        values."""
+
+        class JITView(LiveView):
+            template = "<div>{% for t in tasks %}{{ t.username }}{% endfor %}</div>"
+            tasks = [
+                User(username="alice", pk=1, is_active=True),
+                User(username="bob", pk=2, is_active=False),
+            ]  # class-level list[Model] — JIT WILL process this
+
+            @event_handler
+            def noop(self, **kwargs):
+                pass
+
+        client = LiveViewTestClient(JITView).mount()
+        # First render establishes baseline. Should not throw on the
+        # normalize pass (idempotent on serialized dicts).
+        html = client.render()
+        assert "alice" in html and "bob" in html
+
+        # Second render — context unchanged, no field mutation.
+        client.send_event("noop")
+        html2 = client.render()
+        # No change, but render must succeed (idempotency check).
+        assert "alice" in html2
+
+    def test_empty_list_normalize_safe(self):
+        """An empty list (not list[Model]) must not trip the normalize pass."""
+
+        class EmptyView(LiveView):
+            template = "<div>{% for t in tasks %}{{ t }}{% endfor %}empty</div>"
+
+            def mount(self, request, **kwargs):
+                self._tasks = []
+
+            def get_context_data(self, **kwargs):
+                ctx = super().get_context_data(**kwargs)
+                ctx["tasks"] = list(self._tasks)
+                return ctx
+
+        client = LiveViewTestClient(EmptyView).mount()
+        html = client.render()
+        assert "empty" in html
+
+    def test_mixed_list_with_model_first(self):
+        """``[Model, dict, Model]`` — ``is_model_list`` triggers if first is a
+        Model. The normalize loop must handle each item independently via
+        ``normalize_django_value(item)`` (which is a no-op on plain dicts)."""
+
+        class MixedView(LiveView):
+            template = "<div>{% for t in items %}|{{ t }}{% endfor %}</div>"
+
+            def mount(self, request, **kwargs):
+                self._items = [
+                    User(username="alice", pk=1, is_active=True),
+                    {"name": "plain dict"},
+                ]
+
+            def get_context_data(self, **kwargs):
+                ctx = super().get_context_data(**kwargs)
+                ctx["items"] = list(self._items)
+                return ctx
+
+        client = LiveViewTestClient(MixedView).mount()
+        # Should not crash; rendering the dict via {{ t }} produces its repr/str.
+        html = client.render()
+        assert "alice" in html or "plain dict" in html
+
+
+# ---------------------------------------------------------------------------
+# Dead code: _lazy_serialize_context must be gone
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestLazySerializeContextRemoved:
+    """``_lazy_serialize_context`` was dead code (zero call sites) that the
+    issue reporter mistook for the bug location. It contained a
+    ``str(model_instance)`` fallback that, if ever wired up, would produce
+    exactly the symptom reported. Removing it prevents future confusion."""
+
+    def test_lazy_serialize_context_does_not_exist(self):
+        """The dead method is removed from JITMixin."""
+        from djust.mixins.jit import JITMixin
+
+        assert not hasattr(JITMixin, "_lazy_serialize_context"), (
+            "_lazy_serialize_context should be removed (#1205 retro)"
+        )


### PR DESCRIPTION
## Summary

Closes #1205.

When a view's `get_context_data` override sets `ctx["tasks"] = list(qs)` *after* calling `super().get_context_data()`, the JIT auto-serialization pipeline runs inside `super()` and never sees the user-added value. The raw `list[Model]` then flows through `_sync_state_to_rust`, where change-detection compares list elements via Python `==` — which delegates to `Model.__eq__` (pk-only). In-place field mutations (`is_active` toggle, `completed` flip) don't change `pk`, so the comparison returns equal, the key is never added to the diff-context, Rust never receives the new state, and the rendered HTML is byte-identical on every event despite confirmed DB writes.

Symptom from the issue reporter: `patch_count: 0` on every event, `_debug.variables.tasks.value` shows only `__str__` strings.

## Fix

`_sync_state_to_rust` (in `python/djust/mixins/rust_bridge.py`) now runs a defensive normalize pass over `full_context` immediately after fetching it, converting any `list[Model]` / `Model` / `QuerySet` value to dicts via `normalize_django_value`. After normalization, change-detection compares `list[dict] != list[dict]` element-wise via `dict.__eq__` (structural), correctly catching field mutations. Idempotent on already-serialized values.

Also removed dead `_lazy_serialize_context` method from `python/djust/mixins/jit.py` (zero call sites — was misleadingly cited as the bug location in the issue, the dead `str(model)` fallback inside matched the reported symptom but was never wired up).

## Issue's analysis vs actual root cause

The issue reporter pointed at `_lazy_serialize_context` in `python/djust/mixins/jit.py:328` as the culprit. **That function was dead code** — never called anywhere. The actual bug path is the `_sync_state_to_rust` change-detection comparison described above. The reporter's diagnostic data (`patch_count: 0`, `__str__` strings) was real, but the proposed fix location was wrong. This PR removes the dead code so future investigators don't fall into the same misdirection.

## Files

- `python/djust/mixins/rust_bridge.py` — defensive normalize pass at top of `_sync_state_to_rust`
- `python/djust/mixins/jit.py` — removed dead `_lazy_serialize_context` method + docstring reference
- `tests/unit/test_list_model_diff_1205.py` — 7 regression tests
- `CHANGELOG.md` — `[Unreleased]` entry under `### Fixed`

## Test plan

- [x] Reproducer test (`test_user_override_with_list_qs_propagates_field_mutations`) FAILS on main, PASSES with fix (TDD red→green confirmed)
- [x] Test for raw QuerySet branch (`test_raw_queryset_in_user_override_still_works`) — sanity that existing path doesn't regress
- [x] Test for single Model (`test_single_model_in_user_override`) — covers `isinstance(_val, Model)` arm
- [x] Idempotency test (`test_normalize_idempotent_on_already_serialized`) — JIT-pre-processed values must not double-process
- [x] Edge cases: empty list, mixed list with Model first
- [x] Dead-code removal locked in (`test_lazy_serialize_context_does_not_exist`)
- [x] Full pytest suite: 4660 passed, 14 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)