### PR TITLE
docs: add Bug-report triage section to CLAUDE.md (#1213)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,37 @@ Key features:
 
 The Rust template engine supports **all 57 Django built-in filters** in `crates/djust_templates/src/filters.rs`. HTML-producing filters (`urlize`, `urlizetrunc`, `unordered_list`) handle their own escaping internally and are listed in `safe_output_filters` in `renderer.rs` to prevent double-escaping.
 
+## Bug-report triage
+
+When investigating an issue with a code-location citation:
+
+1. **Trust the symptom, not the cited path.** The reporter's diagnostic data
+   (error messages, patch counts, observable behavior) is the load-bearing
+   evidence. The code location they cite is their hypothesis, which may be
+   wrong — even when the cited code looks like a perfect match for the
+   symptom (e.g., a dead-code fallback that produces the exact bytes the
+   reporter saw).
+
+2. **Trace from observable symptom to actual code path.** Write a reproducer
+   test FIRST (Stage 4 of the bugfix pipeline already requires this).
+   Confirm the reproducer fails. Then trace the data flow from where the
+   symptom appears (output, error, missing patch) BACKWARDS through the
+   framework until you find the offending code. This is symptom-up.
+
+3. **Don't trust path-down hypotheses.** If you start at the reporter-cited
+   location and try to verify the bug from there, you'll burn time when
+   the location is wrong.
+
+4. **Canonical case study**: PR #1206 (#1205 list[Model] VDOM fix). Reporter
+   cited `python/djust/mixins/jit.py:_lazy_serialize_context` — a method
+   with a `str(model)` fallback that exactly matched the reported symptom
+   (`__str__` strings in serialized context). The method had **zero call
+   sites** — dead code. The actual bug was upstream in
+   `python/djust/mixins/rust_bridge.py:_sync_state_to_rust` change-detection
+   comparing `list[Model]` via `Model.__eq__` (pk-only). Reproducer-first
+   TDD surfaced the real path; trying to fix the reporter-cited code would
+   have been a no-op.
+
 ## Common Pitfalls
 
 - **Ruff F509**: `%`-format strings containing CSS semicolons trigger false positives. Separate HTML (`%s` substitution) from CSS (static string) and concatenate.


### PR DESCRIPTION
## Summary

Closes #1213. v0.9.5 retro Action Tracker #194.

Adds a "Bug-report triage" section to project `CLAUDE.md` that generalizes the issue-reporter-analysis ≠ root-cause lesson from PR #1206 (#1205 list[Model] VDOM fix).

The principle: trace from observable symptom to actual code path, not from reporter-cited code path to symptom. **Symptom-up beats path-down.**

## Why now

PR #1206 burned ~10 min in Stage 4 chasing the issue reporter's claimed bug location (`_lazy_serialize_context` in `python/djust/mixins/jit.py`) before writing a `LiveViewTestClient` reproducer that surfaced the actual code path (`_sync_state_to_rust` change-detection comparing `list[Model]` via `Model.__eq__` pk-only). The dead-code fallback method literally contained a `str(model)` call matching the reported symptom — a near-perfect misdirection.

This section makes the discipline structural for next time.

## Section placement

Inserted as `## Bug-report triage` **before `## Common Pitfalls`** in CLAUDE.md, matching the conceptual flow: triage discipline → specific pitfalls → retro canonicalizations.

## Test plan

- [x] CLAUDE.md still renders cleanly (Markdown)
- [x] No code references in the new section are typos (jit.py, rust_bridge.py, _sync_state_to_rust all spelled correctly)
- [x] PR #1206 + #1205 cross-references are accurate
- [x] No CI risk (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)