### PR TITLE
test: strengthen idempotency test with zero-patch assertion + LiveViewTestClient.render_with_patches() (#1208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`LiveViewTestClient.render_with_patches()` — VDOM-diff accessor for tests
+  (#1208).** New public method on `djust.testing.LiveViewTestClient` that
+  wraps `view_instance.render_with_diff()` and returns `(html, patches_list,
+  version)` with the JSON patches parsed into a Python list. Empty list when
+  no patches were produced. Reusable for any test that needs to assert on
+  VDOM-diff invariants (e.g. "this noop event must produce zero patches").
+  First user is the strengthened
+  `test_normalize_idempotent_on_already_serialized` regression test in
+  `tests/unit/test_list_model_diff_1205.py`, which now locks the #1206
+  normalize-pass idempotency contract via an explicit `patches == []`
+  assertion instead of the prior weaker "no exception" check.
+
 ### Fixed
 
 - **JIT serializer silently degrades when context value is `list[Model]`

--- a/python/djust/testing.py
+++ b/python/djust/testing.py
@@ -317,6 +317,45 @@ class LiveViewTestClient:
         template = get_template(template_name)
         return template.render(context)
 
+    def render_with_patches(self) -> tuple:
+        """Render and return ``(html, patches_list, version)`` for VDOM-diff
+        assertions in tests.
+
+        Wraps ``view_instance.render_with_diff()`` and parses the JSON patches
+        into a Python list (empty list when no patches were produced).
+
+        Each call advances the diff baseline — i.e., the second call returns
+        patches relative to the first. The typical pattern for a "noop event
+        produces zero patches" assertion is:
+
+        .. code-block:: python
+
+            client.render_with_patches()              # baseline
+            client.send_event("noop")                  # mutate
+            _, patches, _ = client.render_with_patches()
+            assert patches == []
+
+        Returns:
+            ``(html, patches_list, version)`` where ``patches_list`` is a
+            ``list[dict]`` (empty when no patches), parsed from the Rust
+            view's diff JSON.
+
+        Raises:
+            RuntimeError: If view not mounted.
+        """
+        if not self._mounted or not self.view_instance:
+            raise RuntimeError("View not mounted. Call client.mount() first.")
+
+        request = getattr(self.view_instance, "request", None)
+        html, patches_json, version = self.view_instance.render_with_diff(request)
+        if patches_json:
+            import json as _json
+
+            patches_list = _json.loads(patches_json)
+        else:
+            patches_list = []
+        return (html, patches_list, version)
+
     def assert_state(self, **expected: Any) -> None:
         """
         Assert state variables match expected values.

--- a/tests/unit/test_list_model_diff_1205.py
+++ b/tests/unit/test_list_model_diff_1205.py
@@ -162,7 +162,17 @@ class TestListModelDiff1205:
         pass must NOT double-process. ``is_model_list`` returns False for
         ``list[dict]`` (first item isn't a Model), and ``isinstance(dict,
         Model)`` is False — so the pass is a no-op for already-serialized
-        values."""
+        values.
+
+        Strengthened (#1208): the noop event must produce **zero VDOM
+        patches**. If the normalize pass were ever to double-process
+        already-serialized values (e.g. via a future refactor that broadens
+        ``is_model_list`` to scan the full list), the ``prev_containers``
+        comparison in ``_sync_state_to_rust`` could spuriously mark the key
+        as changed and emit phantom patches. This locks the contract tightly
+        — no exception is necessary; behavioral idempotency is the actual
+        invariant.
+        """
 
         class JITView(LiveView):
             template = "<div>{% for t in tasks %}{{ t.username }}{% endfor %}</div>"
@@ -176,16 +186,25 @@ class TestListModelDiff1205:
                 pass
 
         client = LiveViewTestClient(JITView).mount()
-        # First render establishes baseline. Should not throw on the
-        # normalize pass (idempotent on serialized dicts).
+        # First render establishes baseline.
         html = client.render()
         assert "alice" in html and "bob" in html
 
-        # Second render — context unchanged, no field mutation.
+        # Establish VDOM baseline via render_with_patches so the second call
+        # produces patches relative to the baseline.
+        client.render_with_patches()
+
+        # Send a noop event — no field mutation, no state change.
         client.send_event("noop")
-        html2 = client.render()
-        # No change, but render must succeed (idempotency check).
+
+        # Second render after noop: render must succeed AND produce zero
+        # patches. The zero-patches assertion is the load-bearing invariant.
+        html2, patches, _ = client.render_with_patches()
         assert "alice" in html2
+        assert patches == [], (
+            f"Expected zero patches on noop event (idempotency invariant), "
+            f"got {len(patches)} patches: {patches[:3]!r}"
+        )
 
     def test_empty_list_normalize_safe(self):
         """An empty list (not list[Model]) must not trip the normalize pass."""


### PR DESCRIPTION
## Summary

Closes #1208. v0.9.5 retro Action Tracker #196.

The existing `test_normalize_idempotent_on_already_serialized` (added in PR #1206) asserted `"alice" in html` — a weak assertion that any rendering path passes. **Strengthen with explicit `patches == []`** to lock the behavioral idempotency invariant.

## What changed

1. **New public test API**: `LiveViewTestClient.render_with_patches()` in `python/djust/testing.py`. Thin wrapper around `view_instance.render_with_diff()` returning `(html, patches_list, version)` with JSON patches parsed into a Python list. Reusable for any future VDOM-diff invariant test.
2. **Strengthened test**: `tests/unit/test_list_model_diff_1205.py::test_normalize_idempotent_on_already_serialized` now asserts zero patches on a noop event.

## Why this matters

If a future refactor broadens `is_model_list` to scan the full list (e.g., to fix #1207 heterogeneous shapes), the regression where already-serialized `list[dict]` gets re-processed would surface here as phantom patches in `prev_containers` comparison. The current weak assertion would have missed that.

## Test plan

- [x] All 7 tests in `test_list_model_diff_1205.py` pass
- [x] Full unit suite green: 4431 passed, 6 skipped
- [x] CHANGELOG entry under `### Added` documents the new public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)