### PR TITLE
chore(pipeline): require reproducer/artifact before Stage 4 plan finalization (#1210)

### DIFF
--- a/.pipeline-templates/bugfix-state.json
+++ b/.pipeline-templates/bugfix-state.json
@@ -82,6 +82,11 @@
       "verdict": null,
       "checklist": [
         {
+          "action": "VERIFY ARTIFACT BEFORE PLANNING (#1210, v0.9.5 retro Action Tracker #191): for bug reports, write a failing reproducer test that exhibits the reported symptom; for security alerts, read the actual code at the cited line and confirm the alert's premise. Plan can ONLY lock in fix location AFTER the artifact exists. PR #1206 burned ~10 min on a reporter-cited dead-code path because no reproducer was written first; PR #1201 saved ~2 min by reading the actual cited code lines first.",
+          "done": false,
+          "mandatory": true
+        },
+        {
           "action": "read codebase for current state",
           "done": false
         },

--- a/.pipeline-templates/feature-state.json
+++ b/.pipeline-templates/feature-state.json
@@ -82,6 +82,11 @@
       "verdict": null,
       "checklist": [
         {
+          "action": "VERIFY ARTIFACT BEFORE PLANNING (#1210, v0.9.5 retro Action Tracker #191): for feature work, write a failing test or doc-snippet exercising the desired behavior so the plan reflects what users will observe; for security work, read the actual code at any cited line and confirm the alert's premise. Plan can ONLY lock in design AFTER the artifact exists. The reproducer-first discipline is generalizable from PR #1206 (bugfix) to feature work too — the artifact pins the contract.",
+          "done": false,
+          "mandatory": true
+        },
+        {
           "action": "read codebase for current state",
           "done": false
         },


### PR DESCRIPTION
## Summary

Closes #1210. v0.9.5 retro Action Tracker #191.

Adds a leading mandatory Stage 4 (Planning) checklist item to both `.pipeline-templates/feature-state.json` and `.pipeline-templates/bugfix-state.json` requiring a verified artifact before plan lock-in:

- **For bug reports**: a failing reproducer test exhibiting the reported symptom
- **For security alerts**: a verified read of actual code at the alert-cited line
- **For feature work**: a failing test or doc-snippet exercising desired behavior

The discipline generalizes from two v0.9.5-arc PRs:

- **PR #1206** (#1205 list[Model] fix) burned ~10 min chasing the reporter's cited dead code (`_lazy_serialize_context`) before a reproducer surfaced the actual bug path.
- **PR #1201** (security cleanup) saved ~2 min by reading alert-cited lines BEFORE plan-stage; revealed all 8 `py/log-injection` alerts were FPs.

Same discipline, different surface: trust-but-verify is cheaper than trace-and-rollback. The artifact requirement is now structural — Stage 4 cannot pass without one.

## Test plan

- [x] JSON syntactically valid (`python -c "import json; json.load(open(...))"`)
- [x] No code change to djust framework — process improvement only
- [x] No CHANGELOG entry required (chore: prefix, internal pipeline tooling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)