### PR TITLE
chore(pre-commit): exclude .pxd binary archives from text-fixing hooks (#1215)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,15 +41,21 @@ repos:
     rev: v5.0.0
     hooks:
       - id: trailing-whitespace
-        exclude: '\.min\.js(\.map)?$'
+        exclude: '\.min\.js(\.map)?$|\.pxd$'
       - id: end-of-file-fixer
-        exclude: '\.min\.js(\.map)?$'
+        exclude: '\.min\.js(\.map)?$|\.pxd$'
       - id: check-yaml
       - id: check-added-large-files
         args: [--maxkb=1000]
       - id: check-merge-conflict
       - id: check-toml
+      # `.pxd` excluded: Pixelmator logo files in python/djust/ are
+      # actually binary ZIP archives that `identify` (pre-commit's
+      # text-detection lib) misclassifies as text on the `.pxd`
+      # extension. Without this exclude, the hook auto-"fixes" CR
+      # bytes inside the binary payload and corrupts the asset (#1215).
       - id: mixed-line-ending
+        exclude: '\.pxd$'
 
   # Security - Python security linter
   - repo: https://github.com/PyCQA/bandit


### PR DESCRIPTION
## Summary

Closes #1215. v0.9.5 retro Action Tracker #199 / v0.9.1-6 drain bucket.

Pixelmator logo files at `python/djust/djust{2,3}_logo.pxd` are actually binary ZIP archives — but `identify` (pre-commit-hooks' text-detection library) misclassifies them as text based on the `.pxd` extension. Three hooks were running on them and either bouncing commits or threatening to corrupt the binary payload.

## Fix

Add `\.pxd$` to the `exclude` regex on three hooks in `.pre-commit-config.yaml`:

- `mixed-line-ending` — was flagging CR bytes inside the ZIP container and auto-"fixing" them, which would corrupt the archive on stash-pop. This was the recurring cost flagged in PR #1201's retro: every PR touching the directory bounced its first commit attempt.
- `trailing-whitespace` and `end-of-file-fixer` — same misclassification risk. They had `\.min\.js$` excluded but not `\.pxd$`.

Inline comment added on `mixed-line-ending` explaining the exclude rationale so a future contributor doesn't accidentally remove it.

## Verification

- `pre-commit run mixed-line-ending --files <text-with-CRLF>` → still fixes mixed line endings (hook works on intended target).
- `pre-commit run mixed-line-ending --files <.pxd>` → "(no files to check) Skipped".
- `unzip -t` on both `.pxd` files → "No errors detected in compressed data" (binaries are intact and untouched by this PR).

## Test plan

- [x] YAML config validates
- [x] `.pxd` files confirmed intact (zip-archive-test passes)
- [x] mixed-line-ending hook still fires on real text files with CRLF
- [x] mixed-line-ending hook now skips `.pxd` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)