### PR TITLE
fix: heterogeneous and nested list[Model] shapes in change-detection normalize pass (#1207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Heterogeneous and nested `list[Model]` shapes now propagate field
+  mutations through change-detection (#1207).** Follow-up to PR #1206
+  (#1205 fix). The defensive normalize pass introduced in v0.9.5 covered
+  the homogeneous `list[Model]` shape but two related shapes were NOT
+  covered: heterogeneous `[dict, Model]` (Model not first — `is_model_list`
+  checks only `value[0]`) and nested `list[list[Model]]` (e.g., grouped
+  tasks — the outer list contains lists, not Models). Both reproduced the
+  #1205 bug for those shapes (in-place field mutations escaped
+  change-detection because `Model.__eq__` is pk-only). Fix: refactored the
+  inline normalize loop into a recursive `_normalize_db_values` helper
+  that scans the full list for any-position Model (heterogeneous-safe) and
+  recurses into nested lists with a bounded depth (`_NORMALIZE_DEPTH_LIMIT
+  = 3`). Idempotent on already-serialized values. Two regression cases in
+  `tests/unit/test_list_model_diff_1205.py` lock the new shape coverage in
+  (`test_heterogeneous_list_dict_first_propagates_field_mutations`,
+  `test_nested_list_of_lists_of_models_propagates_field_mutations`).
+
 ### Added
 
 - **`LiveViewTestClient.render_with_patches()` — VDOM-diff accessor for tests

--- a/python/djust/mixins/rust_bridge.py
+++ b/python/djust/mixins/rust_bridge.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qs, urlencode
 
 from ..security import sanitize_for_log
 from ..serialization import normalize_django_value
-from ..utils import get_template_dirs, is_model_list
+from ..utils import get_template_dirs
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +48,72 @@ except ImportError:
 # registry), but the guard skips the walk on every subsequent
 # ``_initialize_rust_view`` call so steady-state cost is one branch.
 _CUSTOM_FILTERS_BRIDGED = False
+
+
+# Maximum recursion depth for ``_normalize_db_values``. Bounded to keep the
+# normalize pass O(N * depth) instead of unbounded for pathological nesting.
+# Three levels is enough for ``list[list[Model]]`` (depth 2) and any
+# ``list[list[list[Model]]]`` (depth 3) shape that's plausible in practice.
+# Beyond depth 3, nested DB content is most likely an unintentional shape
+# that should hit the existing ``_deep_serialize_dict`` path or the user's
+# own override, not the framework's defensive normalize pass.
+_NORMALIZE_DEPTH_LIMIT = 3
+
+
+def _normalize_db_values(value, depth: int = 0):
+    """Recursively normalize raw Django DB values (Model / QuerySet /
+    list[Model] / list[list[Model]]) into JSON-serializable dicts.
+
+    Used by ``_sync_state_to_rust`` to catch DB values that snuck past the
+    JIT pipeline (e.g., user added them via ``get_context_data`` override
+    AFTER ``super()``). After normalization, change-detection compares
+    ``list[dict]`` element-wise via ``dict.__eq__`` (structural) instead of
+    ``Model.__eq__`` (pk-only), correctly catching field mutations.
+
+    Returns the value unchanged if no DB content found. Idempotent on
+    already-serialized values — calling repeatedly is a no-op once the
+    structure is dict-only.
+
+    Shape coverage:
+    - ``Model``            → dict (#1205)
+    - ``QuerySet``         → list[dict] (#1205)
+    - ``list[Model]``      → list[dict] (any-position-Model; heterogeneous
+                             ``[dict, Model]`` is covered, not just
+                             ``[Model, ...]``) (#1207 expansion)
+    - ``list[list[...]]``  → recursive normalize with depth bound (#1207)
+
+    The depth bound (``_NORMALIZE_DEPTH_LIMIT``) prevents pathological
+    recursion on dict-of-list-of-dict-of-list shapes; beyond that depth,
+    the value is returned unchanged (best-effort).
+    """
+    from django.db.models import Model, QuerySet
+
+    if depth >= _NORMALIZE_DEPTH_LIMIT:
+        return value
+
+    if isinstance(value, Model):
+        return normalize_django_value(value)
+
+    if isinstance(value, QuerySet):
+        return [normalize_django_value(item) for item in value]
+
+    if isinstance(value, list) and len(value) > 0:
+        # Heterogeneous-safe: scan the entire list for any Model, not just
+        # value[0]. ``[dict, Model]`` and ``[Model, dict]`` both trigger.
+        if any(isinstance(item, Model) for item in value):
+            return [
+                normalize_django_value(item)
+                if isinstance(item, Model)
+                else _normalize_db_values(item, depth + 1)
+                for item in value
+            ]
+        # Nested-list recursion: ``[[Model, ...], [Model]]`` reaches here
+        # because the outer list has no Model directly; recurse into each
+        # sublist.
+        if isinstance(value[0], list):
+            return [_normalize_db_values(item, depth + 1) for item in value]
+
+    return value
 
 
 def _ensure_custom_filters_bridged() -> None:
@@ -321,26 +387,30 @@ class RustBridgeMixin:
         if self._rust_view:
             from ..components.base import Component, LiveComponent
             from django import forms
-            from django.db.models import Model, QuerySet
 
             full_context = (
                 preloaded_context if preloaded_context is not None else self.get_context_data()
             )
 
-            # Defensive normalize pass for DB values added after super() (#1205).
-            # When a user overrides ``get_context_data`` and sets
-            # ``ctx["tasks"] = list(qs)`` AFTER calling ``super()``, the JIT
-            # pipeline never sees the list[Model] — and downstream change-
-            # detection would compare list[Model] via Model.__eq__ (pk-only),
-            # missing in-place field mutations. Normalize raw DB values to
-            # dicts here so the comparison below sees field-level changes.
+            # Defensive normalize pass for DB values added after super() (#1205, #1207).
+            # When a user overrides ``get_context_data`` and sets a raw DB
+            # value (Model / QuerySet / list[Model]) AFTER calling ``super()``,
+            # the JIT pipeline never sees it — and downstream change-detection
+            # would compare list[Model] via ``Model.__eq__`` (pk-only),
+            # missing in-place field mutations.
+            #
+            # The recursive helper below covers four shapes:
+            #   1. ``Model``                  → dict (full field extraction)
+            #   2. ``QuerySet``               → list[dict]
+            #   3. ``list[Model]`` (any pos)  → list[dict] (heterogeneous-safe;
+            #                                   #1207 — dict-in-position-0 no
+            #                                   longer escapes)
+            #   4. ``list[list[Model]]``      → recurse with depth bound
+            #                                   (#1207 — nested grouping shape)
             for _key, _val in list(full_context.items()):
-                if isinstance(_val, Model):
-                    full_context[_key] = normalize_django_value(_val)
-                elif isinstance(_val, QuerySet):
-                    full_context[_key] = [normalize_django_value(_item) for _item in _val]
-                elif is_model_list(_val):
-                    full_context[_key] = [normalize_django_value(_item) for _item in _val]
+                _normalized = _normalize_db_values(_val)
+                if _normalized is not _val:
+                    full_context[_key] = _normalized
 
             # Ensure csrf_token is available for {% csrf_token %} tag (#696).
             # Cache it to avoid creating a new string object each call,

--- a/tests/unit/test_list_model_diff_1205.py
+++ b/tests/unit/test_list_model_diff_1205.py
@@ -248,6 +248,110 @@ class TestListModelDiff1205:
         html = client.render()
         assert "alice" in html or "plain dict" in html
 
+    # -----------------------------------------------------------------
+    # #1207 follow-up — heterogeneous + nested shapes
+    # -----------------------------------------------------------------
+
+    def test_heterogeneous_list_dict_first_propagates_field_mutations(self):
+        """``ctx["items"] = [dict, Model]`` (Model NOT first) must also
+        propagate field mutations.
+
+        The original PR #1206 normalize pass used ``is_model_list`` which
+        checks ``isinstance(value[0], Model)`` — so a dict in position 0
+        followed by a Model in position 1 fell through unnormalized. The
+        Model in position 1 then escaped change-detection via
+        ``Model.__eq__`` (pk-only), reproducing the #1205 bug for this
+        shape. Locks the #1207 fix in.
+        """
+
+        class HetView(LiveView):
+            template = (
+                "<div>"
+                "{% for t in items %}"
+                "<li>{% if t.is_active %}A{% else %}I{% endif %}{{ t.username }}</li>"
+                "{% endfor %}"
+                "</div>"
+            )
+
+            def mount(self, request, **kwargs):
+                self._user = User(username="alice", pk=1, is_active=True)
+
+            @event_handler
+            def toggle(self, **kwargs):
+                self._user.is_active = not self._user.is_active
+
+            def get_context_data(self, **kwargs):
+                ctx = super().get_context_data(**kwargs)
+                # Header dict in position 0, Model in position 1 — the
+                # ``is_model_list(value[0])`` guard misses this shape.
+                ctx["items"] = [{"is_active": False, "username": "header"}, self._user]
+                return ctx
+
+        client = LiveViewTestClient(HetView).mount()
+        html_before = client.render()
+        assert "Aalice" in html_before, html_before
+
+        client.send_event("toggle")
+        html_after = client.render()
+        assert html_before != html_after, (
+            "Heterogeneous [dict, Model] should propagate field mutation; "
+            "got identical HTML — see #1207."
+        )
+        assert "Ialice" in html_after, html_after
+
+    def test_nested_list_of_lists_of_models_propagates_field_mutations(self):
+        """``ctx["groups"] = [[Model, Model], [Model]]`` (nested
+        list[list[Model]]) must also propagate field mutations.
+
+        The original PR #1206 normalize pass iterated only top-level
+        keys; a nested list[list[Model]] failed ``is_model_list`` because
+        ``value[0]`` was itself a list, not a Model. Field mutations on
+        any nested Model escaped change-detection. Locks the #1207
+        recurse-into-nested-list fix in.
+        """
+
+        class GroupedView(LiveView):
+            template = (
+                "<div>"
+                "{% for group in groups %}"
+                "<ul>{% for t in group %}"
+                "<li>{% if t.is_active %}A{% else %}I{% endif %}{{ t.username }}</li>"
+                "{% endfor %}</ul>"
+                "{% endfor %}"
+                "</div>"
+            )
+
+            def mount(self, request, **kwargs):
+                self._users = [
+                    User(username="alice", pk=1, is_active=True),
+                    User(username="bob", pk=2, is_active=False),
+                ]
+
+            @event_handler
+            def toggle(self, pk: int = 1, **kwargs):
+                for u in self._users:
+                    if u.pk == pk:
+                        u.is_active = not u.is_active
+
+            def get_context_data(self, **kwargs):
+                ctx = super().get_context_data(**kwargs)
+                # Groups: [[alice], [bob]] — top-level list contains lists.
+                ctx["groups"] = [[self._users[0]], [self._users[1]]]
+                return ctx
+
+        client = LiveViewTestClient(GroupedView).mount()
+        html_before = client.render()
+        assert "Aalice" in html_before, html_before
+        assert "Ibob" in html_before, html_before
+
+        client.send_event("toggle", pk=1)
+        html_after = client.render()
+        assert html_before != html_after, (
+            "Nested list[list[Model]] should propagate field mutation; "
+            "got identical HTML — see #1207."
+        )
+        assert "Ialice" in html_after, html_after
+
 
 # ---------------------------------------------------------------------------
 # Dead code: _lazy_serialize_context must be gone


### PR DESCRIPTION
## Summary

Closes #1207. v0.9.5 retro Action Tracker #195 / v0.9.1-6 drain bucket.

Follow-up to PR #1206 (#1205 fix). The defensive normalize pass added to `_sync_state_to_rust` correctly handled the **homogeneous** `list[Model]` shape but two related shapes were NOT covered:

1. **Heterogeneous `[dict, Model]` (Model NOT first)**: `is_model_list` only checks `value[0]`, so `[{"label": "header"}, <Model>]` fell through unnormalized. The Model in position 1 escaped change-detection.
2. **Nested `list[list[Model]]`**: original normalize iterated only top-level keys; nested grouped lists failed `is_model_list` because `value[0]` was a list, not a Model.

## Fix

Refactored the inline normalize loop into a recursive module-level helper `_normalize_db_values`:

- `Model` → dict
- `QuerySet` → list[dict]
- `list[Model]` → list[dict] (any-position-Model; heterogeneous-safe)
- `list[list[...]]` → recursive normalize with depth bound (`_NORMALIZE_DEPTH_LIMIT = 3`)

Bounded recursion handles ``list[list[list[Model]]]`` shapes; deeper nesting is best-effort (returns unchanged).

## Tests

Two regression cases added (both fail without fix, pass with):
- `test_heterogeneous_list_dict_first_propagates_field_mutations`
- `test_nested_list_of_lists_of_models_propagates_field_mutations`

All 9 cases in `test_list_model_diff_1205.py` green. Full unit suite: 4433 passed, 6 skipped.

## Test plan

- [x] Both new tests fail on origin/main (red phase confirmed)
- [x] Both new tests pass on this branch (green phase)
- [x] All 7 existing tests in the file still pass (no regression)
- [x] Full unit suite green
- [x] Idempotency check passes (no double-processing of already-serialized values)
- [x] CHANGELOG entry under `### Fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)