### PR TITLE
fix: PR #1179 follow-ups — CHANGELOG accuracy + test-strength documentation (#1180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -828,12 +828,16 @@ Full migration notes: [`MIGRATION.md`](MIGRATION.md).
      expansion's ``filter_specs.iter().any(...)`` loop, never a Mutex
      acquire. Acquire/Release ordering pairs the load with the store
      in ``register_custom_filter``.
-  2. **Hardcoded ``autoescape=True`` plumbing**: ``apply_custom_filter``
-     now accepts an ``autoescape: bool`` parameter threaded through
-     ``apply_filter_full`` from the renderer call site. Today still
-     always ``true`` (matches prior behaviour) but the call chain is
-     ready for ``{% autoescape %}`` block tracking landing in a future
-     PR without further changes to ``filter_registry.rs``.
+  2. **Hardcoded ``autoescape=True`` plumbing (correction, #1180)**:
+     ``apply_custom_filter`` now accepts an ``autoescape: bool``
+     parameter that's set as a kwarg on the Python callable when the
+     filter declares ``needs_autoescape=True``. The earlier wording
+     here was inaccurate — only ``apply_custom_filter`` was widened;
+     the upstream chain (``apply_filter_full`` in ``filters.rs`` and
+     the renderer's three call sites at ``renderer.rs:287, 349, 1602``)
+     was NOT threaded through. Future ``{% autoescape %}`` block
+     tracking will need to update **~4 sites** to plumb the dynamic
+     value end-to-end, not 1.
   3. **Unknown-filter test tightened**: assert ``RuntimeError`` type
      AND the canonical ``"Unknown filter:"`` message shape, not just
      ``pytest.raises(Exception)`` + substring on filter name only.

--- a/tests/unit/test_rust_custom_filters_1121.py
+++ b/tests/unit/test_rust_custom_filters_1121.py
@@ -189,7 +189,28 @@ def test_is_safe_filter_output_is_not_re_escaped():
 
 def test_needs_autoescape_filter_receives_kwarg():
     """``needs_autoescape=True`` filters must receive ``autoescape``
-    as a kwarg from the renderer."""
+    as a kwarg from the renderer.
+
+    Limitation (#1180 item 2, acknowledged): this test only confirms
+    the **API surface** — the ``autoescape`` kwarg arrives — not the
+    new **dynamic semantics**. The renderer hardcodes ``autoescape=true``
+    at every call site (``renderer.rs:287, 349, 1602`` per the v0.9.2
+    PR #1179 retro), so the filter receives ``True`` regardless of
+    whether the dispatcher's parameterization at ``filter_registry.rs:290``
+    is wired correctly. A test that genuinely exercises the bool would
+    need either:
+
+    - A renderer where the autoescape supply path can vary (i.e., the
+      future ``{% autoescape %}`` block-tracking work; ~4 sites need
+      plumbing per the corrected CHANGELOG entry for #1162).
+    - A Python-exposed ``apply_custom_filter`` shim that lets a test
+      pass an explicit ``autoescape: bool`` (would need a new PyO3
+      binding; the current ``apply_custom_filter`` is internal Rust).
+
+    Both are larger than #1180's scope. The test is left in this weak
+    form intentionally, with this docstring as the audit trail; the
+    deferred strengthening rides on the next ``{% autoescape %}`` work.
+    """
     out = render_template("{{ name|autoescape_aware }}", {"name": "X"})
     # Default autoescape context is True
     assert html.unescape(out) == "AE:X"


### PR DESCRIPTION
## Summary

Closes #1180. Final v0.9.1-8 work unit. Three of the four 🟡 follow-ups from PR #1179's Stage 11 review.

## What changed

### Item 1 — CHANGELOG accuracy

The v0.9.2 entry for #1162 sub-item 2 claimed `apply_custom_filter` widening was "threaded through `apply_filter_full` from the renderer call site." Reality: only `apply_custom_filter` got the param; `apply_filter_full` in `filters.rs` and the renderer's three call sites (`renderer.rs:287, 349, 1602`) are unchanged. Future `{% autoescape %}` block-tracking work needs to plumb ~4 sites, not 1.

### Item 2 — test strengthening (documented limitation)

`test_needs_autoescape_filter_receives_kwarg` is green-on-arrival because the renderer hardcodes `autoescape=true` everywhere; the test confirms API surface, not dynamic semantics. Strengthening genuinely requires either:
- The renderer's autoescape supply path made variable (the future block-tracking work — out of scope for #1180).
- A new PyO3 binding exposing `apply_custom_filter` to Python tests (also out of scope; needs design pass on the public Rust→Python surface).

Test docstring updated with the audit trail; deferred strengthening rides on the next `{% autoescape %}` work. (I attempted a Rust-level test using `pyo3::prepare_freethreaded_python` + direct `apply_custom_filter` invocation; reverted because embedding Python from Rust binaries needs PYTHONHOME/PYTHONPATH tuning that's out of scope.)

### Item 3 — doc nit (acknowledged in commit message)

PR #1179's text claimed PyO3 macros suppress the dead-code warning for the deleted `custom_filter_exists`. Actually `pub fn` visibility itself silences the warning; PyO3 was uninvolved. Acknowledged in this commit's message; no functional change.

### Item 4 — open question (deferred to v0.9.2-1)

The OnceLock-gated short-circuit test in `filter_registry::tests` silently no-ops when prior tests in the same process registered a filter. Adding an isolated `cargo test --test filter_registry` target — or refactoring the gate to a per-test reset — would tighten coverage. Either route is non-trivial test-harness work beyond #1180's scope.

## Test plan

- [x] `tests/unit/test_rust_custom_filters_1121.py`: 12/12 still passing
- [x] CHANGELOG entry corrected
- [x] Test docstring updated with audit trail
- [x] No code changes to production paths
- [x] Cargo-fmt applied

## v0.9.1-8 milestone close

This is the **final v0.9.1-8 work unit** (4th of 4 — after #1177 local skill fix, #1228 comma-list lint, #1229 audit script). Once this merges, the v0.9.1 release window is empty of work — only #1221 (release-cut runbook) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)