### PR TITLE
ci: bump softprops/action-gh-release from v2 to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           prerelease: ${{ steps.prerelease.outputs.is_prerelease }}


### PR DESCRIPTION
## Summary

Refiles dependabot's PR #742 (closed when we deleted the dependabot branch) per user directive to ship before the v0.9.1 release-cut.

## What v3 changes

Per the v3.0.0 release notes:
- **Action runtime**: Node 20 → Node 24
- **Bundle target**: matches Node 24
- **API surface**: unchanged

It's a runtime bump only. The action's `with:` interface is unchanged from v2.6.x.

## Risk assessment

Bounded — if v3 hits an issue we haven't anticipated, revert is the inverse of this 1-line change. Worst case: the v0.9.1 release-cut fails on this step and we revert + retry. GitHub-hosted runners have supported Node 24 for months.

## Test plan

- [x] CI runs cleanly on this branch (the change itself doesn't fire `release.yml`; the workflow only runs on tag push)
- [x] No code changes
- [x] Reversal path is symmetric (1-line `@v3` → `@v2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)