### PR TITLE
docs(roadmap): open v0.9.2-1 milestone for SSE DRY refactor + ADR-016

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # djust Roadmap
 
-> Current version: **0.9.0** — Last roadmap refresh: 2026-04-30 (v0.9.5 drain-bucket complete; milestone-naming convention adopted — see below).
+> Current version: **0.9.1** (released 2026-04-30) — Last roadmap refresh: 2026-04-30 (v0.9.1 cut, v0.9.2-1 drain bucket opened).
 
 This roadmap outlines what has been built, what is actively being worked on, and where djust is headed. Priorities are shaped by real-world usage across [djust.org](https://djust.org) and [djustlive](https://djustlive.com), and by feature parity goals with Phoenix LiveView 1.0 and React 19-level interactivity.
 
@@ -17,11 +17,11 @@ Two name shapes appear in this roadmap, with distinct meanings:
 
 **Historical note**: ROADMAP entries `v0.9.1` through `v0.9.5` (already shipped) were drain buckets under the old naming; they are equivalent to `v0.9.1-1` through `v0.9.1-5` under the new convention. They are NOT being retroactively renamed (would invalidate cross-references in 50+ PRs, retro files, and CHANGELOG entries). The convention applies forward-only.
 
-**Pending release**: 5 drain buckets of work have accumulated since the `v0.9.0` GA tag. The next release-tag should be `v0.9.1`, cut from current `main`. Tracked at [#1221](https://github.com/djust-org/djust/issues/1221).
+**Released**: `v0.9.1` cut 2026-04-30 (tag `v0.9.1`, GitHub Release published, PyPI live). Bundles 8 drain buckets + post-cleanup. Retro: RETRO.md §v0.9.1. Tracker carryovers (#1234, #1235, #1236) and the post-release SSE bug bundle (#1237) move into `v0.9.2-1` below.
 
-## Pending release: v0.9.1
+## Released: v0.9.1 (2026-04-30)
 
-Release `v0.9.1` will package 5 drain buckets shipped between `v0.9.0` GA (2026-04-29) and 2026-04-30. All buckets were shipped under the old naming scheme (`v0.9.1` through `v0.9.5`) and are equivalent to drain buckets `v0.9.1-1` through `v0.9.1-5` under the new convention.
+Release `v0.9.1` packaged 8 drain buckets shipped between `v0.9.0` GA (2026-04-29) and 2026-04-30. The first 5 buckets shipped under the old naming scheme (`v0.9.1` through `v0.9.5`) and are equivalent to drain buckets `v0.9.1-1` through `v0.9.1-5` under the new convention. Buckets `v0.9.1-6` through `v0.9.1-8` shipped under the new naming.
 
 ### Drain buckets shipped, all rolling into release v0.9.1
 
@@ -157,6 +157,61 @@ Per user directive: ship every remaining issue in v0.9.1 (no carryover to v0.9.2
 - #1215 — `.pxd` line-ending cleanup.
 
 (15 other older tech-debt issues from earlier milestones remain open and out of scope for v0.9.1.)
+
+---
+
+## Pending release: v0.9.2
+
+Drain buckets accumulating toward release `v0.9.2`. First bucket `v0.9.2-1` is open; further buckets (`-2`, `-3`, …) will be added as work surfaces.
+
+### Milestone: v0.9.2-1 — SSE transport DRY refactor + tracker carryovers
+
+**Status:** 🚧 in progress — opened 2026-04-30 immediately after the v0.9.1 release-cut.
+
+*Goal:* Fix the 3 SSE-transport bugs reported in #1237 by establishing a transport-agnostic dispatch layer (`ViewRuntime` + `Transport` Protocol) that both WebSocket and SSE share. The 3 bugs are fixed as a side-effect of routing SSE through the shared path, not as 3 separate one-off patches. Decision captured in [ADR-016](docs/adr/016-transport-runtime-interface.md).
+
+#### Headliner — #1237 SSE transport bug bundle (P1, 1 PR, 3 sub-bugs)
+
+- [ ] **PR: SSE transport DRY refactor** — closes #1237. Three SSE bugs filed post-v0.9.1-cut against the `use_websocket: False` mode (NYC Claims prototype):
+  1. URL kwargs not resolved — SSE reads `request.path` (the SSE endpoint URL) instead of the actual page URL. WebSocket equivalent at `websocket.py:1851` reads `data["url"]` from the client mount frame.
+  2. `LiveViewSSE.sendMessage()` missing — `_executePatch()` at `18-navigation.js:317-321` calls `liveViewWS.sendMessage({type: 'url_change', ...})`, crashes with `TypeError` over SSE. Eight other JS call sites also affected.
+  3. `handle_params()` never invoked over SSE — Phoenix-parity contract. Views that read URL state in `handle_params` keep mount-time defaults.
+
+  **Approach** (per ADR-016): new `python/djust/runtime.py` (~280 LoC) factors out `dispatch_mount` / `dispatch_event` / `dispatch_url_change` so both transports share one code path. New SSE `POST /djust/sse/<sid>/message/` endpoint dispatches identically to a WS frame. WebSocket's `handle_url_change` becomes a thin shim over `ViewRuntime.dispatch_url_change` (proves the shared codepath). `LiveViewSSE.sendMessage(data)` mirrors `LiveViewWebSocket.sendMessage` so existing call sites work transparently. The Referer header is deliberately NOT used (privacy + spoofability + correctness — see ADR-016).
+
+  **Scope** (~1100 LoC, ~750 of which is tests + docs):
+  - New `python/djust/runtime.py`
+  - `python/djust/sse.py` (+120 / -30): new `/message/` endpoint, `_sse_mount_view` shrinks to thin wrapper, `_sse_handle_event` deletes
+  - `python/djust/websocket.py` (+15 / -50): `handle_url_change` shim only — other handlers unchanged in this PR
+  - `python/djust/static/djust/src/03b-sse.js` (+90): `sendMessage`, `_sendMountFrame`, `sendEvent` delegating
+  - Tests: `python/tests/test_sse.py` (+200), new `python/djust/tests/test_runtime.py` (~150), new `python/tests/test_sse_ws_symmetry.py` (~80), `tests/js/sse-transport.test.js` (+120)
+  - Docs: `docs/sse-transport.md` (+40 / -8), `CHANGELOG.md` entry, `docs/adr/016-transport-runtime-interface.md` (this PR — already merged separately)
+  - Branch: `feat/sse-runtime-1237`
+
+  **Phasing** — PR-A scope is intentionally minimal; only `handle_url_change` migrates to the runtime (proves the shared codepath). Subsequent PRs migrate `handle_event`, `handle_mount`, `handle_mount_batch`, etc., none blocked by this one. See ADR-016 §Phasing.
+
+#### Tracker carryovers from v0.9.1 retro (P2, deferred)
+
+- [ ] **#1234 — pipeline-bypass CI check (ongoing)** — scheduled GitHub Action that runs `scripts/audit-pipeline-bypass.py` daily and flags merged PRs without retro markers within 24h. Part 2 of #1212 (part 1 shipped as the audit script in PR #1229). v0.9.1 retro Action Tracker #200.
+- [ ] **#1235 — isolated cargo-test target for `filter_registry::tests`** — `OnceLock`-gated short-circuit test silently no-ops when a prior test in the same process registered a filter. Either a `cargo test --test filter_registry_isolated` target or a fresh-process spawn for the affected case. Carryover from #1180 item 4. v0.9.1 retro Action Tracker #201.
+- [ ] **#1236 — watch-list for release-workflow-touching dep bumps** — manual risk-review at refile time for any dependabot PR modifying `.github/workflows/release.yml`. Triggered by PR #1233 (action-gh-release v2 → v3) landing in the same window as the v0.9.1 cut. v0.9.1 retro Action Tracker #202.
+
+#### Sequencing
+
+1. **#1237 first** — headline real-bug fix; the architecture extraction unlocks all three sub-bugs together.
+2. **#1234 / #1235 / #1236** — bundle as 1-3 small follow-up PRs (P2, mechanical). Order doesn't matter; touch disjoint files.
+
+#### Acceptance for v0.9.2-1
+
+- #1237 closed (all 3 sub-bugs fixed, runtime + transport interface in place, symmetry test green).
+- All 3 carryover issues either closed or explicitly deferred to `v0.9.2-2` with rationale.
+- Retro: `/pipeline-retro --milestone v0.9.2-1` per the established cadence.
+
+#### Pipeline runner notes
+
+- `/pipeline-drain --milestone v0.9.2-1 --label tech-debt` to triage carryovers.
+- `/pipeline-run --milestone v0.9.2-1` to start the #1237 PR.
+- Apply v0.9.1 retro lessons proactively: single-implementer-per-checkout (#180/#1172), two-commit shape impl+tests / docs+CHANGELOG (#181/#1173), reproducer-first per Stage 4 (#1218/#1210).
 
 ---
 

--- a/docs/adr/016-transport-runtime-interface.md
+++ b/docs/adr/016-transport-runtime-interface.md
@@ -1,0 +1,218 @@
+# ADR-016: Transport Runtime Interface
+
+**Status**: Proposed
+**Date**: 2026-04-30
+**Target version**: v0.9.2-1 (PR-A: minimal extraction); subsequent PRs migrate the rest
+**Related**: #1237 (3 SSE bugs that motivate the refactor),
+v0.9.1 retro Action #181 (two-commit shape), v0.9.1 retro Action #180
+(single-implementer-per-checkout)
+
+---
+
+## Context
+
+djust ships two transports today: WebSocket (`python/djust/websocket.py`,
+4,912 lines) and Server-Sent Events (`python/djust/sse.py`, 815 lines).
+SSE was added in v0.3.4 (PR #377) for environments that block
+WebSocket. It implements its own mount + event-dispatch pipeline rather
+than reusing the WebSocket consumer's logic.
+
+The two paths have **diverged**. Issue #1237 surfaced three SSE-specific
+bugs that all trace back to the same structural problem — every feature
+has to be implemented twice or the SSE side falls behind:
+
+1. URL kwargs not resolved (SSE reads `request.path`, which is the SSE
+   endpoint URL, not the page URL).
+2. `LiveViewSSE.sendMessage()` doesn't exist on the client (eight WS
+   call sites assume it does and crash with `TypeError` over SSE).
+3. `handle_params()` is never invoked over SSE (Phoenix-parity
+   contract; works correctly under WS at `websocket.py:2129`).
+
+The reporter proposed three workarounds (Referer header, ad-hoc
+`sendMessage` shim, manual `handle_params` call inside the SSE mount
+flow). Patching all three in place would fix the symptoms but leaves
+the root structural problem — and the next feature would diverge again.
+
+## Decision
+
+Introduce a transport-agnostic **`ViewRuntime`** that owns the mounted
+view instance and the dispatch pipeline (mount, event, url_change), and
+a **`Transport`** Protocol that abstracts the wire (WS frame send vs SSE
+queue push). Both transports become thin adapters whose job is wire-level
+framing only:
+
+```
+                    ┌─────────────────────────────┐
+                    │       ViewRuntime           │
+                    │  (transport-agnostic)       │
+                    │                             │
+                    │  • view_instance, session_id│
+                    │  • dispatch_message(data)   │
+                    │  • dispatch_mount/event/    │
+                    │      url_change             │
+                    │  • render → patches         │
+                    └────────┬────────────────────┘
+                             │ self.transport.send(data)
+                             ▼
+                    ┌─────────────────────────────┐
+                    │   Transport (Protocol)      │
+                    │   async send(data: dict)    │
+                    │   async send_error(...)     │
+                    │   async close(code)         │
+                    └────────┬────────────────────┘
+                             │
+                  ┌──────────┴──────────┐
+                  ▼                     ▼
+        WSConsumerTransport    SSESessionTransport
+        (wraps send_json)      (wraps queue.put_nowait)
+```
+
+The runtime imports the already-shared utilities from
+`websocket_utils.py` (`_validate_event_security`, `_call_handler`,
+`_format_handler_not_found_error`, `_safe_error`) — none are duplicated.
+
+### Client-side payoff
+
+SSE gains a single `POST /djust/sse/<sid>/message/` endpoint that
+accepts the same `{"type": "...", ...}` envelope a WebSocket frame
+would carry, dispatched through the same `ViewRuntime`. With that in
+place, `LiveViewSSE.sendMessage(data)` becomes one method that POSTs
+the JSON; every existing `liveViewWS.sendMessage(...)` call site
+(`18-navigation.js`, `02-response-handler.js`, `13-lazy-hydration.js`,
+`15-uploads.js`) works transparently when SSE is active. **No
+callsite-by-callsite branching.**
+
+### Server-side payoff
+
+The first WebSocket handler migrated to the shared runtime is
+`handle_url_change` (websocket.py:3875-3922 → ~10-line shim over
+`ViewRuntime.dispatch_url_change`). Subsequent PRs progressively
+migrate `handle_event`, `handle_mount`, `handle_mount_batch`, etc.
+Each migration is independent; nothing in this ADR forces the full
+4,912-line consumer to migrate at once.
+
+### Why NOT the Referer header for SSE URL kwargs
+
+The reporter's workaround read `request.META.get("HTTP_REFERER")`
+to discover the page URL server-side. We deliberately do not ship this:
+
+- **Privacy.** Browsers strip Referer under
+  `Referrer-Policy: no-referrer` (a common security default), or send
+  only the origin (not the path).
+- **Spoofability.** Referer is client-controlled. Using it to resolve
+  `pk` lets a same-origin user mount a view bound to a record they
+  shouldn't have access to.
+- **Correctness.** Referer reflects where the page *came from*, not
+  the page itself, after `pushState`-driven navigation.
+
+The mount-frame approach (client sends `url: window.location.pathname`)
+mirrors what WebSocket already does — first-party data over an
+authenticated session, validated by `django.urls.resolve()`.
+
+## Phasing
+
+PR-A (v0.9.2-1, ~1100 LOC):
+
+- New `python/djust/runtime.py` — `ViewRuntime`, `Transport`,
+  `WSConsumerTransport`, `SSESessionTransport`, three dispatchers.
+- New `POST /djust/sse/<sid>/message/` endpoint.
+- New SSE client mount-frame flow (`_sendMountFrame()` in
+  `03b-sse.js` posts `url: window.location.pathname` on connect).
+- WebSocket `handle_url_change` migrated to shim over
+  `ViewRuntime.dispatch_url_change` (proves the shared codepath).
+- `LiveViewSSE.sendMessage(data)` + `sendEvent` delegating to it.
+- Tests: ~7 in `python/tests/test_sse.py` + new `test_runtime.py`
+  (~150 LoC) + new `test_sse_ws_symmetry.py` (~80 LoC) + 6 in
+  `tests/js/sse-transport.test.js`.
+
+Subsequent PRs (no fixed schedule, none blocked by PR-A):
+
+- Migrate `handle_event` to runtime — large; touches cache config,
+  async-pending, patch compression, embedded children, actors.
+- Migrate `handle_mount` to runtime — largest; owns actors,
+  snapshots, sticky child views.
+- Migrate `handle_mount_batch`, `handle_request_html`,
+  `handle_live_redirect_mount`.
+- Embedded child-view dispatch over SSE.
+
+## Future transports
+
+The `Transport` Protocol generalises beyond WS+SSE. Adding a new
+transport reduces to: implement `Transport.send`, add a wire-level
+adapter that calls `runtime.dispatch_message(data)` when frames
+arrive. View lifecycle, dispatch, and rendering don't change.
+
+| Transport | When it earns its keep | Effort |
+|---|---|---|
+| **HTTP Long Polling** | Networks blocking both WS and SSE (rare; some legacy corporate proxies). Universal HTTP compatibility, higher per-frame overhead. | ~150 LoC: session holder + GET-with-timeout + reuse `/message/` endpoint. |
+| **WebTransport (HTTP/3)** | Lower-latency over QUIC; once Firefox stable >12 months and CDN/proxy support matures. UDP often blocked on corporate networks today. | ~250 LoC: aioquic-based session + adapter. |
+| **HTTP/2 Server Push** | Never. Chrome removed support in 2022; effectively dead. | n/a |
+| **gRPC-Web streaming** | Never. Too heavy for a Django framework (Envoy proxy + protobuf framing). | n/a |
+
+**Recommendation.** Ship WS + SSE in PR-A. File a tracker issue for
+long-polling fallback gated on a concrete user reporting an environment
+where SSE doesn't work. Add a 2026 watch-list item for WebTransport.
+Don't pre-build either — the architecture pays the future-flexibility
+cost regardless.
+
+## Consequences
+
+### Positive
+
+- One bug-fix surface for shared lifecycle behaviour
+  (`handle_params`, URL-kwarg resolution, error envelopes,
+  rate-limiting). New transports inherit correctness instead of
+  re-implementing it.
+- Symmetry tests (`test_sse_ws_symmetry.py`) lock in identical
+  behaviour across transports. Future regressions trip the test.
+- WebSocket consumer can shrink from 4,912 lines toward a thin
+  Channels-specific layer over many PRs.
+- Adding a third transport (long-polling, WebTransport) does not
+  require duplicating dispatch logic.
+
+### Negative
+
+- Two-class indirection (`Transport` + `ViewRuntime`) costs marginal
+  cognitive load when reading the WebSocket consumer end-to-end.
+  Mitigated by the migration being incremental and well-named.
+- `LiveViewConsumer` retains its existing handlers in PR-A — they
+  coexist with the runtime for one or more PRs. Until `handle_event`
+  migrates, the runtime's `dispatch_event` is only used by SSE,
+  meaning event-dispatch logic still has a brief WS-vs-runtime split
+  (acknowledged tradeoff to keep PR-A small).
+
+### Neutral
+
+- Public API unchanged. `LiveViewSSE.sendEvent`, the `/event/`
+  endpoint, the `?view=` GET-mount flow all stay (the latter two as
+  back-compat aliases). Internal helpers `_sse_mount_view`,
+  `_sse_handle_event` shrink to thin wrappers and are marked private.
+
+## Implementation notes
+
+- `dispatch_mount` early-returns if `runtime.view_instance is not
+  None` to handle the legacy GET-mount + new POST mount-frame race.
+- `33-sw-registration.js` monkey-patches `ws.sendMessage` for
+  reconnection buffering. With SSE also exposing `sendMessage`,
+  verify the SW wrapper short-circuits on `LiveViewSSE` instances;
+  add a one-line guard if not.
+- `dispatch_mount` does NOT support actor-based mount in PR-A
+  (matching the documented SSE limitation). Emits a structured error
+  envelope instead of crashing.
+- Two-commit shape per Action #181: implementation + tests in commit
+  one; docs (`docs/sse-transport.md` + `CHANGELOG.md`) in commit two.
+
+## References
+
+- Plan file: `/Users/tip/.claude/plans/sequential-hugging-brooks.md`
+- Issue: https://github.com/djust-org/djust/issues/1237
+- WebSocket consumer: `python/djust/websocket.py:3875-3922`
+  (`handle_url_change`), `:1851-1852` (page-URL extraction), `:2129`
+  (`handle_params` call)
+- SSE module: `python/djust/sse.py:148-313` (`_sse_mount_view`),
+  `:243` (the `request.path` mis-use), `:812-815` (URL patterns)
+- Client SSE: `python/djust/static/djust/src/03b-sse.js` (full file)
+- Client WS for reference: `python/djust/static/djust/src/03-websocket.js:981-1008`
+  (`sendMessage`)
+- Shared utilities: `python/djust/websocket_utils.py`
+  (`_validate_event_security`, `_call_handler`)


### PR DESCRIPTION
## Summary

- Documents the architectural decision behind the planned #1237 fix in **ADR-016**.
- Opens the **v0.9.2-1 drain bucket** as the first iteration toward release v0.9.2.
- Closes out ROADMAP's "Pending release: v0.9.1" block (now `## Released: v0.9.1`).

## What's in ADR-016

Captures the design call that shipping a transport-agnostic `ViewRuntime` + `Transport` Protocol is the right answer to #1237's three SSE-transport bugs. Key sections:

- **Why a shared interface beats three one-off patches** — the bugs are symptoms of WS and SSE diverging into 4912 + 815 lines of parallel code.
- **Why NOT the Referer header** for SSE URL kwargs (privacy / spoofability / correctness).
- **Phasing** — PR-A (v0.9.2-1) migrates only `handle_url_change` to prove the shared codepath; subsequent PRs migrate the rest. Nothing in the ADR forces the full WS consumer to migrate at once.
- **Future transports** — `Transport` Protocol generalises to HTTP long-polling (~150 LOC) and WebTransport (~250 LOC). Recommendation is to ship WS+SSE in PR-A and file trackers gated on concrete demand; don't pre-build either.

## What's in the v0.9.2-1 milestone

- **Headline** — #1237 SSE transport bug bundle (1 PR, 3 sub-bugs: URL-kwarg resolution, missing `sendMessage`, missing `handle_params`).
- **Carryovers** — #1234 (pipeline-bypass CI check), #1235 (cargo-test isolation), #1236 (release-workflow dep-bump watch-list). All P2, deferred from v0.9.1 retro.
- Sequencing locked: #1237 first, carryovers can follow as 1-3 small PRs in any order.
- Pipeline-runner notes call out the v0.9.1 retro lessons that apply (single-implementer-per-checkout, two-commit shape, reproducer-first Stage 4).

## Test plan
- [ ] ADR renders in GitHub markdown preview without broken refs
- [ ] ROADMAP.md milestone block matches the format used by prior milestones
- [ ] Top-of-file status reflects v0.9.1 released
- [ ] No links to issues/PRs that don't exist (#1234/#1235/#1236/#1237 verified open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)