### PR TITLE
chore(v0.9.2-1): retro-gate audit GHA + cargo-test isolation + release-deps watchlist

### DIFF
--- a/.github/workflows/check-release-workflow-deps.yml
+++ b/.github/workflows/check-release-workflow-deps.yml
@@ -1,0 +1,65 @@
+name: Check release-workflow-deps
+
+# Mechanical guard: any PR that modifies release-critical workflow files
+# requires a manual risk review (signaled by the `release-workflow-reviewed`
+# label on the PR). Triggered by PR #1233 (action-gh-release v2 → v3
+# landing in the same window as the v0.9.1 cut); v0.9.1 retro Action
+# Tracker #202 / GitHub #1236.
+#
+# Why a label-based gate (vs CODEOWNERS or auto-merge denylist):
+# - Self-contained — no repo-admin setup needed for branch protection
+#   path rules.
+# - Visible — the label is a clear audit-trail for "yes, a human
+#   reviewed this dep bump".
+# - Mutable — a reviewer can add the label after manual review without
+#   forcing the dependabot author to re-push.
+#
+# To pass the check on a flagged PR:
+#   1. Manually review the dep bump (release-notes, breaking changes,
+#      Node version requirements, etc.).
+#   2. Add the `release-workflow-reviewed` label via the GitHub UI or
+#      `gh pr edit <PR> --add-label release-workflow-reviewed`.
+#   3. The check re-evaluates on label change and turns green.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - '.github/workflows/release.yml'
+      - '.github/workflows/publish.yml'
+      - '.github/workflows/release-drafter.yml'
+      - '.github/workflows/pre-release-security-audit.yml'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify reviewer label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels \
+            --jq '[.labels[].name] | join(",")')
+          echo "PR #$PR_NUMBER labels: $LABELS"
+          if echo ",$LABELS," | grep -q ',release-workflow-reviewed,'; then
+            echo "✅ release-workflow-reviewed label present."
+            exit 0
+          fi
+          cat <<'EOF'
+          ::error::This PR modifies release-critical workflow files but does
+          ::error::not have the `release-workflow-reviewed` label.
+          ::error::
+          ::error::Release-workflow dep bumps need explicit risk review at
+          ::error::refile time (see #1236). After reviewing the dep bump's
+          ::error::release notes, breaking changes, and Node version
+          ::error::requirements, add the label via:
+          ::error::
+          ::error::    gh pr edit $PR_NUMBER --add-label release-workflow-reviewed
+          EOF
+          exit 1

--- a/.github/workflows/retro-gate-audit.yml
+++ b/.github/workflows/retro-gate-audit.yml
@@ -46,9 +46,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LIMIT="${{ github.event.inputs.limit || '50' }}"
-          # Capture stdout to both the log and a file for the summary step.
+          # `audit-pipeline-bypass.py` exits 1 when it finds flagged PRs.
+          # Capture that exit code without failing the step — the whole
+          # point of this workflow is to *surface* findings as
+          # annotations, not turn the daily cron red. The annotations
+          # themselves are the alert mechanism.
+          set +o pipefail
           python scripts/audit-pipeline-bypass.py --limit "$LIMIT" \
-            | tee audit-output.txt
+            > audit-output.txt 2>&1
+          AUDIT_EXIT=$?
+          set -o pipefail
+          cat audit-output.txt
+          echo "audit_exit=$AUDIT_EXIT" >> "$GITHUB_OUTPUT"
           # If the script printed any "potential bypass" rows, surface
           # them as annotations.
           if grep -q "potential bypass" audit-output.txt; then

--- a/.github/workflows/retro-gate-audit.yml
+++ b/.github/workflows/retro-gate-audit.yml
@@ -1,0 +1,82 @@
+name: Retro Gate Audit
+
+# Runs `scripts/audit-pipeline-bypass.py` daily to flag merged PRs that
+# shipped without a Stage 14 retro comment. Part 2 of #1212 (audit
+# pipeline-bypass merges); part 1 was the audit script itself, shipped
+# in PR #1229. Filed as #1234 / v0.9.1 retro Action Tracker #200.
+#
+# The script is read-only by default — it scans `gh pr list --state merged`
+# and prints a summary table. This workflow runs the script and surfaces
+# any flagged PRs as workflow annotations (visible in the Actions UI)
+# without opening issues, to avoid issue spam during steady-state operation.
+# An operator who wants to investigate a flagged PR can re-run the script
+# locally with `--since N` for more detail.
+
+on:
+  schedule:
+    # 13:00 UTC daily — chosen to be after typical US/EU merge hours so
+    # PRs merged earlier in the day get their 24h retro grace window.
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+    # Manual trigger — useful for smoke-testing and ad-hoc audits.
+    inputs:
+      limit:
+        description: 'Number of recent merged PRs to scan'
+        required: false
+        default: '50'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Run pipeline-bypass audit
+        id: audit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LIMIT="${{ github.event.inputs.limit || '50' }}"
+          # Capture stdout to both the log and a file for the summary step.
+          python scripts/audit-pipeline-bypass.py --limit "$LIMIT" \
+            | tee audit-output.txt
+          # If the script printed any "potential bypass" rows, surface
+          # them as annotations.
+          if grep -q "potential bypass" audit-output.txt; then
+            echo "flagged=true" >> "$GITHUB_OUTPUT"
+            grep "potential bypass" audit-output.txt | while IFS= read -r line; do
+              echo "::warning::Retro gate: $line"
+            done
+          else
+            echo "flagged=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Append summary
+        if: always()
+        run: |
+          {
+            echo "## Retro Gate Audit"
+            echo ""
+            if [ "${{ steps.audit.outputs.flagged }}" = "true" ]; then
+              echo "⚠️ Found PRs without retro markers. See annotations above."
+              echo ""
+            else
+              echo "✅ No flagged PRs."
+              echo ""
+            fi
+            echo "<details><summary>Full audit output</summary>"
+            echo ""
+            echo '```'
+            cat audit-output.txt
+            echo '```'
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   short-circuits on `LiveViewSSE` instances since SSE uses `fetch()`
   directly and doesn't need the WS reconnection buffer.
 
+### Developer Experience
+
+- **Pipeline-bypass CI check — daily retro-gate audit (#1234).** New
+  scheduled GHA `.github/workflows/retro-gate-audit.yml` runs
+  `scripts/audit-pipeline-bypass.py` daily at 13:00 UTC against the most
+  recent 50 merged PRs and surfaces any PR missing retro markers as
+  workflow annotations. Part 2 of #1212 (part 1 was the audit script
+  shipped in PR #1229). Manual `workflow_dispatch` trigger included
+  for ad-hoc audits.
+- **Isolated cargo-test target for `filter_registry::tests` (#1235).**
+  The hot-path short-circuit tests for the `ANY_CUSTOM_FILTERS_REGISTERED`
+  AtomicBool now live at
+  `crates/djust_templates/tests/test_filter_registry_isolated.rs` (an
+  integration-test binary). Cargo runs each integration-test file in
+  its own process, so the process-global flag starts clean for every
+  run — the previous `OnceLock` workaround that gated the in-module
+  test on whether a prior test had already registered a filter is no
+  longer needed. Carryover from #1180 item 4.
+- **Release-workflow dep-bump label gate (#1236).** New GHA
+  `.github/workflows/check-release-workflow-deps.yml` runs on PRs
+  modifying release-critical workflow files (`release.yml`, `publish.yml`,
+  `release-drafter.yml`, `pre-release-security-audit.yml`) and fails
+  unless the PR carries the `release-workflow-reviewed` label, forcing
+  explicit human risk-review before merge. Triggered by PR #1233
+  (action-gh-release v2 → v3) landing in the same window as the v0.9.1
+  cut. The `release-workflow-reviewed` label was added to the repo
+  alongside this workflow.
+
 ## [0.9.1] - 2026-04-30
 
 Polish release on top of `0.9.0`. Five drain buckets shipped between the `0.9.0` GA bump and this tag (`0.9.1-1` through `0.9.1-5` under the new SemVer-pre-release-suffix milestone naming convention adopted 2026-04-30; equivalent to historical `v0.9.1`/`v0.9.2`/`v0.9.3`/`v0.9.4`/`v0.9.5` drain buckets under the old naming). Headlined by a real-bug VDOM fix (#1205), a broadcast-recovery fix (#1202), the Debug Panel UI (#1151), and a RichSelect ergonomics expansion (#1204).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bincode",
  "criterion",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "chrono",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "criterion",

--- a/crates/djust_templates/src/filter_registry.rs
+++ b/crates/djust_templates/src/filter_registry.rs
@@ -363,78 +363,14 @@ fn format_py_err(py: Python<'_>, name: &str, err: &PyErr) -> String {
     )
 }
 
-#[cfg(test)]
-mod tests {
-    //! Unit tests for the hot-path short-circuit guard (#1162).
-    //!
-    //! Note: the [`ANY_CUSTOM_FILTERS_REGISTERED`] flag is process-global
-    //! and **never resets** for the lifetime of the process — once any
-    //! test registers a filter, every subsequent test sees the flag as
-    //! ``true``. That's the intended production semantics (see the
-    //! ``static`` doc comment), so these tests assert the
-    //! pre-registration state in ordering-independent ways.
-    //!
-    //! Functional cross-checks (registration → render → custom filter
-    //! produces output) live in the Python regression suite at
-    //! ``tests/unit/test_rust_custom_filters_1121.py``.
-    use super::*;
-    use std::sync::atomic::Ordering;
-    use std::sync::OnceLock;
-
-    /// Once this is set, the AtomicBool guard is observed flipped.
-    /// Used so the "before-registration" assertion in
-    /// [`test_atomicbool_short_circuit_when_no_filters_registered`] is
-    /// only made if no other test has already registered a filter.
-    static ALREADY_REGISTERED_BEFORE_TEST: OnceLock<bool> = OnceLock::new();
-
-    #[test]
-    fn test_atomicbool_short_circuit_when_no_filters_registered() {
-        // If a prior test in the same process has already registered
-        // anything, this assertion is meaningless — skip it. Cargo
-        // doesn't guarantee ordering.
-        let was_registered = *ALREADY_REGISTERED_BEFORE_TEST
-            .get_or_init(|| ANY_CUSTOM_FILTERS_REGISTERED.load(Ordering::Acquire));
-        if was_registered {
-            return;
-        }
-        // Pre-registration: ``is_custom_filter_safe`` must short-circuit
-        // and never touch the Mutex. We can't observe Mutex state from
-        // here, but we can assert the lookup returns ``false`` for
-        // arbitrary names — including names we know would be
-        // ``is_safe=true`` if registered. The guard means we never
-        // reach the HashMap.
-        assert!(!is_custom_filter_safe("definitely_not_registered_xyz"));
-        // And the apply path returns ``None`` (filter miss) so the
-        // built-in renderer falls through to the standard
-        // ``Unknown filter`` error.
-        let value = Value::String("x".to_string());
-        let result = apply_custom_filter(
-            "definitely_not_registered_xyz",
-            &value,
-            None,
-            None,
-            false,
-            true,
-        );
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_apply_custom_filter_short_circuits_when_no_filters_registered() {
-        // Same invariant as above, isolated. Independent of
-        // registration state of other tests because we use a name that
-        // can't possibly be registered.
-        let value = Value::String("x".to_string());
-        let result = apply_custom_filter(
-            "__provably_unregistered_name__",
-            &value,
-            None,
-            None,
-            false,
-            true,
-        );
-        // None == miss; an unknown name is always a miss whether or
-        // not the AtomicBool guard short-circuited the Mutex.
-        assert!(result.is_none());
-    }
-}
+// Tests for the hot-path short-circuit guard (#1162) live in an isolated
+// integration test at `tests/test_filter_registry_isolated.rs`. Cargo runs
+// each integration-test file in its own process binary, which gives the
+// `ANY_CUSTOM_FILTERS_REGISTERED` AtomicBool a guaranteed-clean starting
+// state — unlike in-module unit tests where the static persists across
+// every test in the same `cargo test` binary. See #1235 / v0.9.1 retro
+// Action Tracker #201 for the rationale.
+//
+// Functional cross-checks (registration → render → custom filter produces
+// output) live in the Python regression suite at
+// `tests/unit/test_rust_custom_filters_1121.py`.

--- a/crates/djust_templates/tests/test_filter_registry_isolated.rs
+++ b/crates/djust_templates/tests/test_filter_registry_isolated.rs
@@ -1,0 +1,60 @@
+//! Isolated integration test for filter_registry hot-path short-circuit (#1235).
+//!
+//! Cargo runs each integration-test file in its own process binary, so the
+//! process-global `ANY_CUSTOM_FILTERS_REGISTERED` flag in
+//! `djust_templates::filter_registry` starts as `false` here regardless of
+//! what other tests do. That makes the assertion below ordering-independent
+//! and meaningful — unlike the previous in-module test, which had to
+//! `OnceLock`-gate itself to silently no-op when a prior test had already
+//! flipped the flag.
+//!
+//! Background: #1162 introduced the AtomicBool short-circuit so apps with
+//! zero custom filters skip the Mutex-protected lookup entirely. We need a
+//! test that proves the short-circuit is observable on a fresh process.
+//! See #1180 item 4 / v0.9.1 retro Action #201 / GitHub #1235.
+
+use djust_core::Value;
+use djust_templates::filter_registry::{apply_custom_filter, is_custom_filter_safe};
+
+#[test]
+fn test_atomicbool_short_circuit_when_no_filters_registered() {
+    // Pre-registration (which is guaranteed in this process because no
+    // other test in this binary has registered anything):
+    // `is_custom_filter_safe` must short-circuit and never touch the
+    // Mutex-protected HashMap. Asserting via the public API: the lookup
+    // returns `false` for an arbitrary name, including names we know
+    // would resolve to `is_safe=true` if registered.
+    assert!(!is_custom_filter_safe("definitely_not_registered_xyz"));
+
+    // The apply path likewise short-circuits — returns `None` (filter
+    // miss), so the renderer falls through to the standard "Unknown
+    // filter" error.
+    let value = Value::String("x".to_string());
+    let result = apply_custom_filter(
+        "definitely_not_registered_xyz",
+        &value,
+        None,
+        None,
+        false,
+        true,
+    );
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_apply_custom_filter_short_circuits_for_provably_unregistered_name() {
+    // Independent of registration state of other tests because the name
+    // is provably unregistered (no production code or test ever
+    // registers `__provably_unregistered_name__`). Belt-and-suspenders
+    // alongside the test above.
+    let value = Value::String("x".to_string());
+    let result = apply_custom_filter(
+        "__provably_unregistered_name__",
+        &value,
+        None,
+        None,
+        false,
+        true,
+    );
+    assert!(result.is_none());
+}


### PR DESCRIPTION
Closes #1234.
Closes #1235.
Closes #1236.

## Summary

Three small P2 carryovers from the v0.9.1 release retro, bundled per the v0.9.2-1 milestone scoping. All touch disjoint files; no ordering deps.

## What's in this PR

### #1234 — Pipeline-bypass CI check (ongoing)

New scheduled GHA `.github/workflows/retro-gate-audit.yml` runs `scripts/audit-pipeline-bypass.py --limit 50` daily at 13:00 UTC. Flagged PRs surface as workflow annotations in the Actions UI; no auto-issue creation (avoids spam in steady state). Manual `workflow_dispatch` trigger included for ad-hoc audits / smoke testing.

Part 2 of #1212 (part 1 was the audit script itself, shipped in PR #1229).

### #1235 — Isolated cargo-test target for `filter_registry::tests`

Moves the two filter_registry hot-path short-circuit tests from the in-module `#[cfg(test)]` block to a new integration-test file `crates/djust_templates/tests/test_filter_registry_isolated.rs`. Cargo runs each integration-test file in its own process binary, so the process-global `ANY_CUSTOM_FILTERS_REGISTERED` AtomicBool starts as `false` for every run.

The `OnceLock`-gated workaround that silently no-op'd the test when a prior test had already registered a filter is no longer needed. The in-module test block is replaced with a comment pointing at the new file.

Carryover from #1180 item 4.

### #1236 — Release-workflow-deps watch-list

New `.github/workflows/check-release-workflow-deps.yml` runs on PRs modifying release-critical workflow files (`release.yml`, `publish.yml`, `release-drafter.yml`, `pre-release-security-audit.yml`) and fails unless the PR carries the `release-workflow-reviewed` label.

Triggered by PR #1233 (action-gh-release v2 → v3 landing in the same window as the v0.9.1 cut). The label `release-workflow-reviewed` was added to the repo alongside this workflow (`gh label create release-workflow-reviewed`).

## Two-commit shape (Action #181)

- `e21620c6` — implementation (3 new files, 1 modified, Cargo.lock auto-update)
- `8abf8a37` — CHANGELOG `[Unreleased]` Developer Experience section

## Test plan

- [ ] `make test-rust` (or `cargo test -p djust_templates`) green — verifies the moved tests still pass and the in-module deletions don't break anything else
- [ ] CI green on this PR (the new workflow files don't trigger on this PR's paths since `check-release-workflow-deps.yml` only runs on PRs *modifying* release files, and `retro-gate-audit.yml` is scheduled)
- [ ] Manual smoke-test post-merge: `gh workflow run retro-gate-audit.yml` and verify it runs the audit script against recent merged PRs
- [ ] Manual smoke-test post-merge: open a draft PR touching `.github/workflows/release.yml` (e.g., a whitespace change) without the label, verify the gate fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)