### PR TITLE
fix(sse): explicit use_actors error envelope in ViewRuntime.dispatch_mount (#1240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   treated as "socket closed" and forwarded to the SW. The patch now
   short-circuits on `LiveViewSSE` instances since SSE uses `fetch()`
   directly and doesn't need the WS reconnection buffer.
+- **`ViewRuntime.dispatch_mount` rejects `use_actors=True` views with a
+  structured error envelope over SSE (#1240).** Closes plan-fidelity
+  gap from #1237 — actor-based state management requires the
+  channel-layer code in `websocket.py` which the runtime path doesn't
+  traverse. Previously a `use_actors=True` mount over SSE would
+  partially succeed and fail downstream with an opaque `AttributeError`.
+  Now `dispatch_mount` short-circuits with a clear "use_actors is not
+  supported over SSE; mount over WebSocket instead" envelope. ADR-016
+  §Implementation notes promised this guard; PR #1239 deferred it to
+  this follow-up.
 
 ### Developer Experience
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -192,14 +192,16 @@ Drain buckets accumulating toward release `v0.9.2`. First bucket `v0.9.2-1` is o
 
 #### Tracker carryovers from v0.9.1 retro (P2, deferred)
 
-- [ ] **#1234 — pipeline-bypass CI check (ongoing)** — scheduled GitHub Action that runs `scripts/audit-pipeline-bypass.py` daily and flags merged PRs without retro markers within 24h. Part 2 of #1212 (part 1 shipped as the audit script in PR #1229). v0.9.1 retro Action Tracker #200.
-- [ ] **#1235 — isolated cargo-test target for `filter_registry::tests`** — `OnceLock`-gated short-circuit test silently no-ops when a prior test in the same process registered a filter. Either a `cargo test --test filter_registry_isolated` target or a fresh-process spawn for the affected case. Carryover from #1180 item 4. v0.9.1 retro Action Tracker #201.
-- [ ] **#1236 — watch-list for release-workflow-touching dep bumps** — manual risk-review at refile time for any dependabot PR modifying `.github/workflows/release.yml`. Triggered by PR #1233 (action-gh-release v2 → v3) landing in the same window as the v0.9.1 cut. v0.9.1 retro Action Tracker #202.
+- [x] ~~**#1234 — pipeline-bypass CI check (ongoing)**~~ ✅ Shipped (PR #1241). Daily-cron `.github/workflows/retro-gate-audit.yml` calls `scripts/audit-pipeline-bypass.py --limit 50` and surfaces flagged PRs as workflow annotations. v0.9.1 retro Action Tracker #200.
+- [x] ~~**#1235 — isolated cargo-test target for `filter_registry::tests`**~~ ✅ Shipped (PR #1241). New integration-test file `crates/djust_templates/tests/test_filter_registry_isolated.rs`; in-module `OnceLock` workaround removed. v0.9.1 retro Action Tracker #201.
+- [x] ~~**#1236 — watch-list for release-workflow-touching dep bumps**~~ ✅ Shipped (PR #1241). New `.github/workflows/check-release-workflow-deps.yml` requires the `release-workflow-reviewed` label on PRs modifying release-critical workflow files. v0.9.1 retro Action Tracker #202.
+- [x] ~~**#1240 — explicit `use_actors` error envelope in `ViewRuntime.dispatch_mount` over SSE**~~ ✅ Shipped. Stage 11 review of #1239 flagged plan-fidelity slippage on plan §Risks #3 / ADR-016 — closed in this PR with a 5-line guard + 1 test. Filed post-#1239-merge as immediate-follow-up.
 
 #### Sequencing
 
-1. **#1237 first** — headline real-bug fix; the architecture extraction unlocks all three sub-bugs together.
-2. **#1234 / #1235 / #1236** — bundle as 1-3 small follow-up PRs (P2, mechanical). Order doesn't matter; touch disjoint files.
+1. **#1237 first** — ✅ shipped in PR #1239. Headline real-bug fix; architecture extraction unlocked all three sub-bugs.
+2. **#1234 / #1235 / #1236** — ✅ shipped together in PR #1241 (bundled, mechanical, disjoint files).
+3. **#1240** — ✅ shipped as immediate follow-up to PR #1239 (Stage 11 finding); rode alone since the carryovers had already shipped.
 
 #### Acceptance for v0.9.2-1
 

--- a/python/djust/runtime.py
+++ b/python/djust/runtime.py
@@ -282,6 +282,20 @@ class ViewRuntime:
         if view_instance is None:
             return  # _instantiate_view already pushed an error
 
+        # ---- use_actors limitation guard (#1240 / ADR-016 §Implementation) ----
+        # SSE doesn't have a bidirectional channel for actor messages and
+        # the actor channel-layer code lives in `websocket.py`, which the
+        # runtime path doesn't traverse. Emit a structured error envelope
+        # rather than letting the mount partially succeed and fail
+        # downstream with an opaque AttributeError.
+        if getattr(view_instance, "use_actors", False):
+            await self.transport.send_error(
+                "use_actors is not supported over SSE; mount over WebSocket instead",
+                error_type="mount_error",
+                view_class=view_path,
+            )
+            return
+
         self.view_instance = view_instance
 
         # Stash transport identity on the view (used by VDOM caching).

--- a/python/djust/tests/test_runtime.py
+++ b/python/djust/tests/test_runtime.py
@@ -336,3 +336,59 @@ class TestMountIdempotency:
         assert runtime.view_instance is sentinel
         # No frames were emitted.
         assert transport.sent == []
+
+
+# ------------------------------------------------------------------ #
+# use_actors over SSE — ADR-016 §Implementation / #1240
+# ------------------------------------------------------------------ #
+
+
+class _FakeViewWithActors(_FakeView):
+    """A view subclass that opts into actor-based state management.
+
+    Used to verify that ``dispatch_mount`` emits a structured error
+    envelope rather than letting the mount partially succeed and fail
+    downstream when the actor channel-layer code (in ``websocket.py``)
+    isn't reachable on the runtime path.
+    """
+
+    use_actors = True
+
+
+class TestDispatchMountUseActorsGuard:
+    @pytest.mark.asyncio
+    async def test_dispatch_mount_use_actors_emits_error_envelope(self):
+        """#1240: when a use_actors=True view tries to mount over a
+        runtime whose transport doesn't support actor messages (i.e.,
+        SSE), emit a structured error envelope and skip the mount.
+
+        Plan-fidelity gate from ADR-016 §Implementation notes."""
+        from djust.runtime import ViewRuntime
+
+        transport = MockTransport()
+        runtime = ViewRuntime(transport)
+
+        view = _FakeViewWithActors()
+        runtime._instantiate_view = MagicMock(return_value=view)
+        runtime._check_auth = AsyncMock(return_value=None)
+        runtime._resolve_url_kwargs = MagicMock(return_value={})
+
+        with _patch_allowed_modules(["djust."]):
+            await runtime.dispatch_mount(
+                {
+                    "type": "mount",
+                    "view": "djust.tests.test_runtime._FakeViewWithActors",
+                    "params": {},
+                    "url": "/",
+                }
+            )
+
+        # Structured error envelope emitted.
+        assert len(transport.errors) == 1
+        err = transport.errors[0]
+        assert err["type"] == "error"
+        assert "use_actors" in err["error"]
+        # Mount did NOT succeed — runtime stays unmounted.
+        assert runtime.view_instance is None
+        # The view's mount() was never called (kwargs_received stays None).
+        assert view.kwargs_received is None


### PR DESCRIPTION
Closes #1240.

## Summary

Stage 11 review of PR #1239 flagged a 🟡 plan-fidelity slippage against ADR-016 §Implementation notes / plan §Risks #3:

> \`dispatch_mount\` does NOT support actor-based mount in PR-A (matching the documented SSE limitation). Emits a structured error envelope instead of crashing.

PR #1239 didn't ship the explicit guard. This PR adds it.

## What changed

**Implementation** (`python/djust/runtime.py`, ~15 LoC including comment):

A 5-line guard right after \`_instantiate_view\` returns, before the runtime caches the instance:

\`\`\`python
if getattr(view_instance, \"use_actors\", False):
    await self.transport.send_error(
        \"use_actors is not supported over SSE; mount over WebSocket instead\",
        error_type=\"mount_error\",
        view_class=view_path,
    )
    return
\`\`\`

**Test** (\`python/djust/tests/test_runtime.py\`, ~50 LoC including a new \`_FakeViewWithActors\` fixture and one \`TestDispatchMountUseActorsGuard\` class with \`test_dispatch_mount_use_actors_emits_error_envelope\`).

The test asserts:
1. Structured error envelope emitted (\`type: 'error'\`, message contains \`use_actors\`).
2. Runtime stays unmounted (\`view_instance is None\`).
3. The view's \`mount()\` was never invoked (\`kwargs_received is None\`).

## Two-commit shape (Action #181)

- \`680c6230\` — implementation + test
- \`db83412e\` — CHANGELOG \`[Unreleased]\` Fixed entry + ROADMAP marks v0.9.2-1 complete

## Why it matters

Without this guard, a \`use_actors=True\` view mounted over SSE would partially succeed (the runtime would cache \`view_instance\` and proceed) and fail downstream with an opaque \`AttributeError\` when the actor channel-layer code in \`websocket.py\` isn't reachable. Now it short-circuits with a clear error envelope that names the limitation and points the user at WebSocket.

## Test plan

- [x] \`pytest python/djust/tests/test_runtime.py -v\` — all 39 runtime tests pass (was 38, +1 new)
- [x] No regression in \`python/tests/test_sse.py\` or \`python/tests/test_sse_ws_symmetry.py\`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)