### PR TITLE
fix(vdom): correct keyed/unkeyed mixed-children diff round-trip (#1260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **VDOM: mixed keyed/unkeyed children diff round-trip correctness
+  (#1260).** Surfaced by proptest during v0.9.2rc1 pre-flight. The
+  LIS optimization in `diff_keyed_children`
+  (`crates/djust_vdom/src/diff.rs`) skipped emitting `MoveChild` patches
+  for keyed children whose trivial-length-1 LIS made them appear
+  "in place" — relying on other patches' implicit position shifts to
+  land them at the correct absolute index. This works for fully-keyed
+  sibling lists (where all moves coordinate via absolute indices) but
+  breaks when unkeyed siblings are interleaved (their patches use
+  positions relative to other unkeyed nodes only). The keyed child
+  ended up stranded at an arbitrary index after all patches applied.
+  Fix detects `has_unkeyed_siblings` upfront; in the mixed case, falls
+  back to "always emit MoveChild when `old_idx != new_idx`" instead of
+  the LIS-implicit-position optimization. The fully-keyed path is
+  unchanged. Audit weakness #5/#6 (rated 🟡 with warnings only)
+  upgraded to 🟠 by this fuzz finding; this is the actual fix.
+  4 deterministic regression tests in
+  `crates/djust_vdom/tests/test_mixed_keyed_unkeyed_reorder_1260.rs`
+  + permanent proptest seed in `fuzz_test.proptest-regressions`.
+
 ## [0.9.2rc1] - 2026-05-01
 
 First release candidate for `0.9.2`. Bundles three drain buckets shipped after `0.9.1` (2026-04-30): `0.9.2-1` (SSE transport DRY refactor — 5 issues, headlined by #1237), `0.9.2-2` (pipeline-template canon batch — 3 issues), `0.9.2-3` (VDOM correctness hardening Phase 1 — 5 issues). Plus the v0.9.2-3 audit doc (`docs/vdom/AUDIT-2026-04-30.md`). 13 issues closed across 5 PRs (#1238, #1239, #1241, #1242, #1246, #1247, #1257, #1258); 1 known issue surfaced during RC pre-flight (#1260 — fuzz-test mixed-keyed/unkeyed diff round-trip; deferred to v0.9.2-4 before stable).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "0.9.1"
+version = "0.9.2-rc.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "0.9.1"
+version = "0.9.2-rc.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "0.9.1"
+version = "0.9.2-rc.1"
 dependencies = [
  "bincode",
  "criterion",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "0.9.1"
+version = "0.9.2-rc.1"
 dependencies = [
  "ahash",
  "chrono",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "0.9.1"
+version = "0.9.2-rc.1"
 dependencies = [
  "ahash",
  "criterion",

--- a/crates/djust_vdom/src/diff.rs
+++ b/crates/djust_vdom/src/diff.rs
@@ -537,11 +537,34 @@ fn diff_keyed_children(
         lis_set.insert(new_idx_for_surviving[lis_pos]);
     }
 
+    // Issue #1260 / audit weakness #5/#6: the LIS-skip optimisation is only
+    // sound for FULLY-KEYED sibling lists. With unkeyed siblings interleaved,
+    // the assumption "MoveChild patches for non-LIS keyed children — plus
+    // implicit shifts from inserts/removes — will land in-LIS keyed children
+    // at their new absolute positions" breaks: unkeyed-sibling patches use
+    // RELATIVE-position pairing among unkeyed nodes and don't coordinate with
+    // keyed-sibling positions. A surviving keyed child can be left stranded
+    // (proptest-shrunk reproducer:
+    //   tree_a = section[#text*4, div key=f]
+    //   tree_b = section[div key=f, #text*2]
+    // — with the old algorithm the keyed div_f had a single-element LIS,
+    // was marked "in place", and never received a MoveChild even though its
+    // absolute index changed from 4 to 0.)
+    //
+    // Fix: when the sibling list is mixed (any unkeyed child in either old or
+    // new), emit MoveChild for every surviving keyed child whose old_idx
+    // differs from its new_idx. The LIS optimisation still applies to the
+    // fully-keyed case, where it correctly minimises the patch count.
+    let has_unkeyed_siblings =
+        old.iter().any(|n| n.key.is_none()) || new.iter().any(|n| n.key.is_none());
+
     vdom_trace!(
-        "  LIS optimization: {} surviving keyed nodes, LIS length={}, moves needed={}",
+        "  LIS optimization: {} surviving keyed nodes, LIS length={}, moves needed={}, \
+         has_unkeyed_siblings={}",
         old_indices_in_new_order.len(),
         lis_positions.len(),
-        old_indices_in_new_order.len() - lis_positions.len()
+        old_indices_in_new_order.len() - lis_positions.len(),
+        has_unkeyed_siblings
     );
 
     // Find keyed nodes to add, move, or diff
@@ -568,11 +591,19 @@ fn diff_keyed_children(
                     // order and don't need MoveChild patches. All non-LIS
                     // elements must be moved because other moves may shift
                     // their positions even when old_idx == new_idx.
-                    if lis_set.contains(&new_idx) {
+                    //
+                    // (#1260) The skip is only safe in a FULLY-KEYED list.
+                    // With unkeyed siblings interleaved, the implicit "other
+                    // patches will land me at new_idx" assumption breaks —
+                    // see the comment on `has_unkeyed_siblings` above. In
+                    // that case, fall back to "always emit MoveChild when
+                    // old_idx != new_idx" for surviving keyed children.
+                    let lis_skip_safe = lis_set.contains(&new_idx) && !has_unkeyed_siblings;
+                    if lis_skip_safe {
                         if old_idx != new_idx {
-                            vdom_trace!("  SKIP MOVE key={} (in LIS, stays in place)", key);
+                            vdom_trace!("  SKIP MOVE key={} (in LIS, fully-keyed list)", key);
                         }
-                    } else {
+                    } else if !lis_set.contains(&new_idx) || old_idx != new_idx {
                         vdom_trace!("  MOVE key={} from {} to {}", key, old_idx, new_idx);
                         patches.push(Patch::MoveChild {
                             path: path.to_vec(),

--- a/crates/djust_vdom/tests/fuzz_test.proptest-regressions
+++ b/crates/djust_vdom/tests/fuzz_test.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 2381cf497d108e6df2bcba53149e5aeb963962eed6cbd2ffc8d22fc056fda90f # shrinks to tree_a = VNode { tag: "section", attrs: {}, children: [VNode { tag: "#text", attrs: {}, children: [], text: Some("A"), key: None, djust_id: None, cached_html: None }, VNode { tag: "#text", attrs: {}, children: [], text: Some("A"), key: None, djust_id: None, cached_html: None }, VNode { tag: "#text", attrs: {}, children: [], text: Some("A"), key: None, djust_id: None, cached_html: None }, VNode { tag: "#text", attrs: {}, children: [], text: Some("a"), key: None, djust_id: None, cached_html: None }, VNode { tag: "div", attrs: {}, children: [], text: None, key: Some("f"), djust_id: None, cached_html: None }], text: None, key: None, djust_id: None, cached_html: None }, tree_b = VNode { tag: "section", attrs: {}, children: [VNode { tag: "div", attrs: {}, children: [], text: None, key: Some("f"), djust_id: None, cached_html: None }, VNode { tag: "#text", attrs: {}, children: [], text: Some("A"), key: None, djust_id: None, cached_html: None }, VNode { tag: "#text", attrs: {}, children: [], text: Some("a"), key: None, djust_id: None, cached_html: None }], text: None, key: None, djust_id: None, cached_html: None }

--- a/crates/djust_vdom/tests/test_mixed_keyed_unkeyed_reorder_1260.rs
+++ b/crates/djust_vdom/tests/test_mixed_keyed_unkeyed_reorder_1260.rs
@@ -1,0 +1,228 @@
+//! Regression test for #1260: VDOM diff/patch round-trip fails on
+//! mixed keyed/unkeyed siblings under reorder + count-change.
+//!
+//! Audit context: docs/vdom/AUDIT-2026-04-30.md weaknesses #5 + #6
+//! upgraded from yellow (warnings only) to red (real correctness bug)
+//! after the proptest fuzz_test::round_trip_correctness shrunk to the
+//! minimal failing case captured below.
+//!
+//! The bug: when the surviving keyed child is the SOLE entry in its
+//! group, the LIS-skip optimisation in `diff_keyed_children` decided
+//! it was "in place" because a single-element LIS is trivially of
+//! length one. With unkeyed siblings interleaved, the keyed child's
+//! absolute position changed but no `MoveChild` was emitted. Other
+//! patches (remove/move of unkeyed siblings) couldn't re-position
+//! the keyed child, so the round-trip diverged.
+//!
+//! The fix: when any unkeyed siblings are interleaved with keyed
+//! siblings (the mixed case), `diff_keyed_children` always emits
+//! `MoveChild` for surviving keyed children whose `old_idx != new_idx`
+//! — the LIS-skip optimisation only stays safe in fully-keyed lists.
+
+use djust_vdom::diff::diff_nodes;
+use djust_vdom::patch::apply_patches;
+use djust_vdom::{Patch, VNode};
+use std::collections::HashMap;
+
+/// Structural equality check ignoring djust_id (mirrors fuzz_test.rs helper).
+fn structurally_equal(a: &VNode, b: &VNode) -> bool {
+    if a.tag != b.tag || a.text != b.text {
+        return false;
+    }
+    let a_attrs: HashMap<String, String> = a
+        .attrs
+        .iter()
+        .filter(|(k, _)| k.as_str() != "dj-id")
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    let b_attrs: HashMap<String, String> = b
+        .attrs
+        .iter()
+        .filter(|(k, _)| k.as_str() != "dj-id")
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    if a_attrs != b_attrs {
+        return false;
+    }
+    if a.children.len() != b.children.len() {
+        return false;
+    }
+    a.children
+        .iter()
+        .zip(b.children.iter())
+        .all(|(ca, cb)| structurally_equal(ca, cb))
+}
+
+/// Recursively assign synthetic djust_ids (mirrors fuzz_test.rs helper).
+fn assign_ids(node: &mut VNode, counter: &mut u64) {
+    node.djust_id = Some(format!("t{}", counter));
+    *counter += 1;
+    for child in &mut node.children {
+        assign_ids(child, counter);
+    }
+}
+
+/// Build the proptest-shrunk minimal reproducer for #1260.
+///
+///   tree_a:
+///     <section>
+///       #text "A"   (unkeyed)
+///       #text "A"   (unkeyed)
+///       #text "A"   (unkeyed)
+///       #text "a"   (unkeyed)
+///       <div key="f"/>
+///
+///   tree_b:
+///     <section>
+///       <div key="f"/>   (moved to front)
+///       #text "A"        (unkeyed)
+///       #text "a"        (unkeyed)
+///
+/// The keyed `<div key="f">` moves from position 4 to position 0 while
+/// the count of unkeyed siblings drops from 4 to 2. The diff must
+/// emit a `MoveChild` for the keyed `<div>` (or otherwise produce
+/// patches that yield a structurally-equal `tree_b`).
+fn build_trees() -> (VNode, VNode) {
+    let tree_a = VNode::element("section").with_children(vec![
+        VNode::text("A"),
+        VNode::text("A"),
+        VNode::text("A"),
+        VNode::text("a"),
+        VNode::element("div").with_key("f"),
+    ]);
+
+    let tree_b = VNode::element("section").with_children(vec![
+        VNode::element("div").with_key("f"),
+        VNode::text("A"),
+        VNode::text("a"),
+    ]);
+
+    (tree_a, tree_b)
+}
+
+#[test]
+fn issue_1260_mixed_keyed_unkeyed_reorder_round_trip() {
+    let (mut tree_a, mut tree_b) = build_trees();
+
+    // Mirror fuzz_test.rs: assign synthetic djust_ids to every node so
+    // apply_patches can resolve nodes by id after structural shifts.
+    let mut counter = 0u64;
+    assign_ids(&mut tree_a, &mut counter);
+    assign_ids(&mut tree_b, &mut counter);
+
+    let patches = diff_nodes(&tree_a, &tree_b, &[]);
+    let mut applied = tree_a.clone();
+    apply_patches(&mut applied, &patches);
+
+    assert!(
+        structurally_equal(&applied, &tree_b),
+        "round-trip failed for #1260\nA: {:#?}\nB: {:#?}\nPatches: {:#?}\nApplied: {:#?}",
+        tree_a,
+        tree_b,
+        patches,
+        applied,
+    );
+}
+
+#[test]
+fn issue_1260_keyed_div_must_emit_move_child() {
+    // Asserts the *cause*, not just the symptom: under mixed siblings
+    // the surviving keyed `<div key="f">` MUST receive a MoveChild
+    // patch. Before the fix, the LIS-skip optimisation suppressed it.
+    let (mut tree_a, mut tree_b) = build_trees();
+
+    let mut counter = 0u64;
+    assign_ids(&mut tree_a, &mut counter);
+    let keyed_old_id = tree_a.children[4].djust_id.clone();
+    assign_ids(&mut tree_b, &mut counter);
+
+    let patches = diff_nodes(&tree_a, &tree_b, &[]);
+
+    let move_for_keyed = patches.iter().any(|p| {
+        matches!(
+            p,
+            Patch::MoveChild { child_d, to, .. }
+                if child_d == &keyed_old_id && *to == 0
+        )
+    });
+    assert!(
+        move_for_keyed,
+        "expected MoveChild(child_d={:?}, to=0) for the keyed <div key=\"f\">. \
+         Without it the LIS-skip optimisation strands the keyed sibling at the \
+         wrong position when unkeyed siblings are interleaved. Patches: {:#?}",
+        keyed_old_id, patches,
+    );
+}
+
+/// Symmetric variant: the keyed child moves from front to BACK while
+/// unkeyed siblings shrink. Same bug class, opposite direction.
+#[test]
+fn issue_1260_keyed_to_back_with_unkeyed_shrink() {
+    let mut tree_a = VNode::element("section").with_children(vec![
+        VNode::element("div").with_key("k"),
+        VNode::text("X"),
+        VNode::text("Y"),
+        VNode::text("Z"),
+    ]);
+    let mut tree_b = VNode::element("section")
+        .with_children(vec![VNode::text("X"), VNode::element("div").with_key("k")]);
+
+    let mut counter = 0u64;
+    assign_ids(&mut tree_a, &mut counter);
+    assign_ids(&mut tree_b, &mut counter);
+
+    let patches = diff_nodes(&tree_a, &tree_b, &[]);
+    let mut applied = tree_a.clone();
+    apply_patches(&mut applied, &patches);
+
+    assert!(
+        structurally_equal(&applied, &tree_b),
+        "round-trip failed (keyed-to-back).\nA: {:#?}\nB: {:#?}\nPatches: {:#?}\nApplied: {:#?}",
+        tree_a,
+        tree_b,
+        patches,
+        applied,
+    );
+}
+
+/// Two surviving keyed children with unkeyed siblings — both keyed
+/// nodes change absolute position even though their RELATIVE order
+/// among keyed siblings is preserved (so LIS would skip both of them).
+#[test]
+fn issue_1260_two_keyed_in_lis_with_unkeyed_shrink() {
+    // old: [u-A, u-B, k-1, u-C, k-2]
+    // new: [k-1, k-2, u-A]
+    // Both keyed nodes remain in the same relative order (k-1 before k-2)
+    // — LIS=[0,1] would mark both as "in place" — yet both moved
+    // absolute positions.
+    let mut tree_a = VNode::element("section").with_children(vec![
+        VNode::text("A"),
+        VNode::text("B"),
+        VNode::element("div").with_key("k1"),
+        VNode::text("C"),
+        VNode::element("div").with_key("k2"),
+    ]);
+    let mut tree_b = VNode::element("section").with_children(vec![
+        VNode::element("div").with_key("k1"),
+        VNode::element("div").with_key("k2"),
+        VNode::text("A"),
+    ]);
+
+    let mut counter = 0u64;
+    assign_ids(&mut tree_a, &mut counter);
+    assign_ids(&mut tree_b, &mut counter);
+
+    let patches = diff_nodes(&tree_a, &tree_b, &[]);
+    let mut applied = tree_a.clone();
+    apply_patches(&mut applied, &patches);
+
+    assert!(
+        structurally_equal(&applied, &tree_b),
+        "round-trip failed (two keyed in LIS, unkeyed shrink).\n\
+         A: {:#?}\nB: {:#?}\nPatches: {:#?}\nApplied: {:#?}",
+        tree_a,
+        tree_b,
+        patches,
+        applied,
+    );
+}


### PR DESCRIPTION
Closes #1260.

## Summary

Surfaced by proptest during v0.9.2rc1 pre-flight. The LIS optimization in `diff_keyed_children` skipped emitting `MoveChild` patches for keyed children whose trivial-length-1 LIS made them appear "in place" — relying on other patches' implicit position shifts to land them at their correct absolute index. This is sound for fully-keyed sibling lists (all moves coordinate via absolute indices) but breaks when unkeyed siblings are interleaved (unkeyed patches use positions relative to other unkeyed nodes only).

The shrunk reproducer:
- `tree_a = section[#text*4, div key=f]` (4 unkeyed, 1 keyed at end)
- `tree_b = section[div key=f, #text*2]` (keyed at front, 2 unkeyed)

Diff produces patches that, when applied to `tree_a`, yield `[A, div, a]` instead of `[div, A, a]` — the keyed `<div>` is stranded at the wrong index because no `MoveChild` was emitted.

## Fix

Detect `has_unkeyed_siblings` upfront in `diff_keyed_children`. When the mixed case is detected, fall back to "always emit `MoveChild` when `old_idx != new_idx`" instead of the LIS-implicit-position optimization. The fully-keyed code path is unchanged (no perf regression for the common case).

```rust
let lis_skip_safe = lis_set.contains(&new_idx) && !has_unkeyed_siblings;
```

## Audit context

Audit weakness #5/#6 (`docs/vdom/AUDIT-2026-04-30.md`) was rated 🟡 with warnings only — PR #1258 shipped the DJE-050/051 stable error codes but didn't fix the underlying patch generation. This fuzz finding upgrades the severity to 🟠 (real correctness bug under realistic shapes); this PR is the actual fix.

## Tests

- **Permanent proptest seed**: `crates/djust_vdom/tests/fuzz_test.proptest-regressions` — committed so the failing case is auto-replayed on every `cargo test` and prevents regression.
- **4 deterministic regression tests**: `crates/djust_vdom/tests/test_mixed_keyed_unkeyed_reorder_1260.rs` covers the shrunk reproducer + 3 variants (keyed-to-back, two-keyed-with-unkeyed, structurally_equal MoveChild presence checks). Hand-written so future readers can understand the bug class without proptest mechanics.
- **Full crate suite**: 194 djust_vdom tests pass (was 190 baseline + 4 new). All other test groups unchanged. `cargo clippy -p djust_vdom -- -D warnings` clean.

## Two-commit shape (Action #181)

- `423ee525` — implementation + 2 test files + Cargo.lock refresh
- `b2eb410a` — CHANGELOG `[Unreleased]` Fixed entry

## Self-applicability check (per #1248)

This PR is a runtime correctness fix, not a new mandatory rule. The new check (Stage 7 self-applicability) doesn't have a "would this fire on this PR" question for runtime-fix PRs — moot.

## Test plan

- [x] Fuzz test passes: `cargo test -p djust_vdom --test fuzz_test` → 6/6
- [x] New regression test passes: `cargo test -p djust_vdom --test test_mixed_keyed_unkeyed_reorder_1260` → 4/4
- [x] Full crate suite: 194/194
- [x] Clippy clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)