### PR TITLE
chore(pipeline): v0.9.2-4 carryovers — Stage 7 + Stage 5/9/10 + audit-script (#1248-#1251)

### DIFF
--- a/.pipeline-templates/bugfix-state.json
+++ b/.pipeline-templates/bugfix-state.json
@@ -155,6 +155,11 @@
           "done": false
         },
         {
+          "action": "BUNDLING CHECK (#1209 / #1251): after staging files but before `git commit`, run `git diff --cached --stat` and verify the line counts match what you planned to ship. If a staged file shows significantly more lines than expected, the working tree had pre-existing uncommitted modifications that got bundled. Investigate before committing. Pattern from pipeline-skill commit bf1a67f which silently bundled 130 unintended lines.",
+          "done": false,
+          "mandatory": true
+        },
+        {
           "action": "git status clean",
           "done": false,
           "mandatory": true
@@ -249,6 +254,11 @@
           "done": false
         },
         {
+          "action": "CANON-PR SELF-APPLICABILITY CHECK (#1247 retro / #1248): if this PR adds a new mandatory checklist item or self-review rule, explicitly answer two questions in the Stage 7 output. (a) Does the new rule false-positive on this PR's own diff? If yes, narrow the scope before merge. (b) Would the new rule have caught the originating bug at the stage it adds? If no, reconsider the stage placement. Skip this item only when the PR doesn't introduce new canon (the typical feature/bugfix case).",
+          "done": false,
+          "mandatory": false
+        },
+        {
           "action": "output REVIEW_PASSED or REVIEW_FAILED",
           "done": false,
           "mandatory": true
@@ -315,6 +325,11 @@
           "mandatory": true
         },
         {
+          "action": "BUNDLING CHECK (#1209 / #1251): after staging files but before `git commit`, run `git diff --cached --stat` and verify the line counts match what you planned to ship. If a staged file shows significantly more lines than expected, the working tree had pre-existing uncommitted modifications that got bundled. Investigate before committing. Pattern from pipeline-skill commit bf1a67f which silently bundled 130 unintended lines.",
+          "done": false,
+          "mandatory": true
+        },
+        {
           "action": "this Stage 9 commit must include ONLY docs + CHANGELOG hunks; no implementation code (the two-commit shape gate)",
           "done": false,
           "mandatory": true
@@ -354,6 +369,11 @@
         {
           "action": "git add each file from changes.txt to catch new files",
           "done": false
+        },
+        {
+          "action": "BUNDLING CHECK (#1209 / #1251): after staging files but before `git commit`, run `git diff --cached --stat` and verify the line counts match what you planned to ship. If a staged file shows significantly more lines than expected, the working tree had pre-existing uncommitted modifications that got bundled. Investigate before committing. Pattern from pipeline-skill commit bf1a67f which silently bundled 130 unintended lines.",
+          "done": false,
+          "mandatory": true
         },
         {
           "action": "git diff --check \u2014 no conflict markers",
@@ -487,7 +507,7 @@
       "status": "pending",
       "verdict": null,
       "run_as": "subagent",
-      "subagent_prompt": "Write retrospective for feature: {task_description}. Project: {project_path}. PR #{pr_number}. Run 'gh pr view {pr_number} --json commits,title,body' to get PR details (branch deleted after merge). Rate quality 1-5, what went well, lessons learned, improvements. STEP A (MANDATORY): use the Write tool to create pr/feedback/retro-{pr_number}.md with the full retro body — DO NOT use bash heredoc (`cat > file <<EOF`), which fails silently under zsh `set -o noclobber` and leaves stale content (#1245). The Write tool bypasses shell redirection. STEP B (MANDATORY): post via `gh pr comment {pr_number} --body-file pr/feedback/retro-{pr_number}.md` — DO NOT use `--body \"$(cat ...)\"`, which dutifully posts whatever the file currently contains (e.g., a leftover Stage 11 review) when STEP A silently failed. The `--body-file` form passes the file path directly; gh re-reads it at post time. STEP C (MANDATORY): verify with `gh pr view {pr_number} --json comments` that at least one comment matches the audit-script retro-marker regex (`retrospective|quality:\\s*\\d|lessons\\s+learned|retro_complete|what\\s+went\\s+well`). MANDATORY: Append to .pipeline-log.md (create if needed, ensure in .gitignore). Your FINAL output line MUST be exactly 'RETRO_COMPLETE'.",
+      "subagent_prompt": "Write retrospective for feature: {task_description}. Project: {project_path}. PR #{pr_number}. Run 'gh pr view {pr_number} --json commits,title,body' to get PR details (branch deleted after merge). Rate quality 1-5, what went well, lessons learned, improvements. STEP A (MANDATORY): use the Write tool to create pr/feedback/retro-{pr_number}.md with the full retro body — DO NOT use bash heredoc (`cat > file <<EOF`), which fails silently under zsh `set -o noclobber` and leaves stale content (#1245). The Write tool bypasses shell redirection. STEP B (MANDATORY): post via `gh pr comment {pr_number} --body-file pr/feedback/retro-{pr_number}.md` — DO NOT use `--body \"$(cat ...)\"`, which dutifully posts whatever the file currently contains (e.g., a leftover Stage 11 review) when STEP A silently failed. The `--body-file` form passes the file path directly; gh re-reads it at post time. STEP C (MANDATORY): verify with `gh pr view {pr_number} --json comments` that at least one comment matches the audit-script retro-marker regex — see `scripts/lib/retro_markers.py:RETRO_MARKER_REGEX` for the canonical pattern (single source of truth per #1249). The regex matches headings/sentinels like `Retrospective`, `Quality: <digit>`, `Lessons learned`, `RETRO_COMPLETE`, `What went well` (case-insensitive). MANDATORY: Append to .pipeline-log.md (create if needed, ensure in .gitignore). Your FINAL output line MUST be exactly 'RETRO_COMPLETE'.",
       "checklist": [
         {
           "action": "rate quality 1-5",

--- a/.pipeline-templates/feature-state.json
+++ b/.pipeline-templates/feature-state.json
@@ -155,6 +155,11 @@
           "done": false
         },
         {
+          "action": "BUNDLING CHECK (#1209 / #1251): after staging files but before `git commit`, run `git diff --cached --stat` and verify the line counts match what you planned to ship. If a staged file shows significantly more lines than expected, the working tree had pre-existing uncommitted modifications that got bundled. Investigate before committing. Pattern from pipeline-skill commit bf1a67f which silently bundled 130 unintended lines.",
+          "done": false,
+          "mandatory": true
+        },
+        {
           "action": "git status clean",
           "done": false,
           "mandatory": true
@@ -244,6 +249,11 @@
           "done": false
         },
         {
+          "action": "CANON-PR SELF-APPLICABILITY CHECK (#1247 retro / #1248): if this PR adds a new mandatory checklist item or self-review rule, explicitly answer two questions in the Stage 7 output. (a) Does the new rule false-positive on this PR's own diff? If yes, narrow the scope before merge. (b) Would the new rule have caught the originating bug at the stage it adds? If no, reconsider the stage placement. Skip this item only when the PR doesn't introduce new canon (the typical feature/bugfix case).",
+          "done": false,
+          "mandatory": false
+        },
+        {
           "action": "output REVIEW_PASSED or REVIEW_FAILED",
           "done": false,
           "mandatory": true
@@ -310,6 +320,11 @@
           "mandatory": true
         },
         {
+          "action": "BUNDLING CHECK (#1209 / #1251): after staging files but before `git commit`, run `git diff --cached --stat` and verify the line counts match what you planned to ship. If a staged file shows significantly more lines than expected, the working tree had pre-existing uncommitted modifications that got bundled. Investigate before committing. Pattern from pipeline-skill commit bf1a67f which silently bundled 130 unintended lines.",
+          "done": false,
+          "mandatory": true
+        },
+        {
           "action": "this Stage 9 commit must include ONLY docs + CHANGELOG hunks; no implementation code (the two-commit shape gate)",
           "done": false,
           "mandatory": true
@@ -349,6 +364,11 @@
         {
           "action": "git add each file from changes.txt to catch new files",
           "done": false
+        },
+        {
+          "action": "BUNDLING CHECK (#1209 / #1251): after staging files but before `git commit`, run `git diff --cached --stat` and verify the line counts match what you planned to ship. If a staged file shows significantly more lines than expected, the working tree had pre-existing uncommitted modifications that got bundled. Investigate before committing. Pattern from pipeline-skill commit bf1a67f which silently bundled 130 unintended lines.",
+          "done": false,
+          "mandatory": true
         },
         {
           "action": "git diff --check \u2014 no conflict markers",
@@ -482,7 +502,7 @@
       "status": "pending",
       "verdict": null,
       "run_as": "subagent",
-      "subagent_prompt": "Write retrospective for feature: {task_description}. Project: {project_path}. PR #{pr_number}. Run 'gh pr view {pr_number} --json commits,title,body' to get PR details (branch deleted after merge). Rate quality 1-5, what went well, lessons learned, improvements. STEP A (MANDATORY): use the Write tool to create pr/feedback/retro-{pr_number}.md with the full retro body — DO NOT use bash heredoc (`cat > file <<EOF`), which fails silently under zsh `set -o noclobber` and leaves stale content (#1245). The Write tool bypasses shell redirection. STEP B (MANDATORY): post via `gh pr comment {pr_number} --body-file pr/feedback/retro-{pr_number}.md` — DO NOT use `--body \"$(cat ...)\"`, which dutifully posts whatever the file currently contains (e.g., a leftover Stage 11 review) when STEP A silently failed. The `--body-file` form passes the file path directly; gh re-reads it at post time. STEP C (MANDATORY): verify with `gh pr view {pr_number} --json comments` that at least one comment matches the audit-script retro-marker regex (`retrospective|quality:\\s*\\d|lessons\\s+learned|retro_complete|what\\s+went\\s+well`). MANDATORY: Append to .pipeline-log.md (create if needed, ensure in .gitignore). Your FINAL output line MUST be exactly 'RETRO_COMPLETE'.",
+      "subagent_prompt": "Write retrospective for feature: {task_description}. Project: {project_path}. PR #{pr_number}. Run 'gh pr view {pr_number} --json commits,title,body' to get PR details (branch deleted after merge). Rate quality 1-5, what went well, lessons learned, improvements. STEP A (MANDATORY): use the Write tool to create pr/feedback/retro-{pr_number}.md with the full retro body — DO NOT use bash heredoc (`cat > file <<EOF`), which fails silently under zsh `set -o noclobber` and leaves stale content (#1245). The Write tool bypasses shell redirection. STEP B (MANDATORY): post via `gh pr comment {pr_number} --body-file pr/feedback/retro-{pr_number}.md` — DO NOT use `--body \"$(cat ...)\"`, which dutifully posts whatever the file currently contains (e.g., a leftover Stage 11 review) when STEP A silently failed. The `--body-file` form passes the file path directly; gh re-reads it at post time. STEP C (MANDATORY): verify with `gh pr view {pr_number} --json comments` that at least one comment matches the audit-script retro-marker regex — see `scripts/lib/retro_markers.py:RETRO_MARKER_REGEX` for the canonical pattern (single source of truth per #1249). The regex matches headings/sentinels like `Retrospective`, `Quality: <digit>`, `Lessons learned`, `RETRO_COMPLETE`, `What went well` (case-insensitive). MANDATORY: Append to .pipeline-log.md (create if needed, ensure in .gitignore). Your FINAL output line MUST be exactly 'RETRO_COMPLETE'.",
       "checklist": [
         {
           "action": "rate quality 1-5",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Developer Experience
+
+- **Pipeline-template canon: Stage 7 self-applicability check for canon
+  PRs (#1248).** New optional checklist item in
+  `.pipeline-templates/{feature,bugfix}-state.json` Stage 7 fires when
+  a PR adds new mandatory rules. Asks: (a) does the new rule
+  false-positive on this PR's own diff? (b) would the new rule have
+  caught the originating bug at the stage it adds? Both must be
+  explicitly answered. v0.9.2-2 retro Action Tracker #206.
+- **Pipeline-template canon: Stage 5/9/10 bundling check (#1251).**
+  New mandatory checklist item runs `git diff --cached --stat`
+  immediately before `git commit` and verifies the staged line counts
+  match the planned scope. Catches the failure mode where
+  `git add <file>` silently bundles pre-existing uncommitted
+  modifications (the pattern that hit pipeline-skill commit `bf1a67f`,
+  silently bundling 130 unintended lines). v0.9.2-2 retro Action
+  Tracker #209.
+- **Audit script: extract retro-marker regex to shared constants
+  module (#1249).** Created `scripts/lib/retro_markers.py` with
+  `RETRO_MARKER_REGEX`. The audit script
+  (`scripts/audit-pipeline-bypass.py`) now imports the canonical
+  constant rather than embedding the literal. Stage 14 `subagent_prompt`
+  text in both pipeline templates references the script-canonical file
+  rather than re-defining the regex. Single source of truth across
+  consumers. v0.9.2-2 retro Action Tracker #207. 4 unit tests at
+  `scripts/lib/test_retro_markers.py`.
+- **Audit script: scan direct-to-main commits + `Audit-bypass-reason:`
+  trailer support (#1250).** The retro-gate audit GHA previously
+  scanned merged PRs only; direct commits to main bypassed it (e.g.,
+  the v0.9.2-2 milestone-open commit `18e5b117`). The audit now also
+  lists direct-to-main commits since the lookback window, filters out
+  PR-squash commits via `(#NNN)` subject suffix, and honors an
+  `Audit-bypass-reason: <text>` commit-message trailer for
+  legitimate exemptions (e.g., docs-only ROADMAP updates per the
+  pipeline-drain skill). v0.9.2-2 retro Action Tracker #208.
+
 ### Fixed
 
 - **VDOM: mixed keyed/unkeyed children diff round-trip correctness

--- a/scripts/audit-pipeline-bypass.py
+++ b/scripts/audit-pipeline-bypass.py
@@ -14,11 +14,19 @@ that flags merged PRs without retros within 24 hours of merge) is
 deferred to a follow-up; this script is the one-time audit + reusable
 diagnostic.
 
+In addition to merged PRs, the script also scans direct-to-main commits
+since ``--lookback`` (default ``30 days ago``) and flags any that lack a
+``Audit-bypass-reason: ...`` trailer in the commit body. PR-squash
+commits (subject ends with ``(#NNN)``) are filtered out automatically.
+This catches the bypass shape #1250 was filed for: ROADMAP-update
+pushes that skip the PR/retro flow entirely.
+
 Usage:
 
     python scripts/audit-pipeline-bypass.py
     python scripts/audit-pipeline-bypass.py --since 1175
     python scripts/audit-pipeline-bypass.py --limit 100
+    python scripts/audit-pipeline-bypass.py --lookback "60 days ago"
 
 Flags PRs as a "potential bypass" if their comments contain none of the
 retro markers (``Retrospective``, ``Quality:``, ``Lessons learned``,
@@ -35,11 +43,30 @@ import json
 import re
 import subprocess
 import sys
+from pathlib import Path
 
-RETRO_MARKERS = re.compile(
-    r"retrospective|quality:\s*\d|lessons\s+learned|retro_complete|what\s+went\s+well",
-    re.IGNORECASE,
-)
+# Make ``scripts.lib.retro_markers`` importable both when this file is
+# invoked as ``python scripts/audit-pipeline-bypass.py`` from the repo
+# root (in which case ``scripts/`` is on sys.path) and when invoked in
+# other ways. Adding the repo root keeps ``scripts.lib.retro_markers``
+# resolvable via PEP 420 namespace packages.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.lib.retro_markers import RETRO_MARKER_REGEX  # noqa: E402
+
+RETRO_MARKERS = re.compile(RETRO_MARKER_REGEX, re.IGNORECASE)
+
+#: PR-squash commit subjects end with `` (#NNN)`` (the GitHub squash-merge
+#: convention). Direct-to-main commits typically don't carry that suffix.
+PR_SQUASH_SUFFIX = re.compile(r"\s\(#\d+\)\s*$")
+
+#: Trailer line in a commit body declaring why a direct-to-main commit is
+#: exempt from the retro audit (e.g., ``Audit-bypass-reason:
+#: docs-only-roadmap-update``). One match anywhere in the commit body is
+#: sufficient.
+AUDIT_BYPASS_TRAILER = re.compile(r"^audit-bypass-reason:\s*\S+", re.IGNORECASE | re.MULTILINE)
 
 
 def gh(args: list[str]) -> str:
@@ -98,6 +125,74 @@ def has_retro(pr_number: int) -> tuple[bool, int]:
     return (bool(RETRO_MARKERS.search(combined)), len(comments))
 
 
+def direct_main_commits(lookback: str) -> list[tuple[str, str, str]]:
+    """Return direct-to-main commits since ``lookback``, excluding PR squashes.
+
+    Filed as #1250 (v0.9.2-2 retro Action Tracker #208) — the original
+    audit only scanned merged PRs, missing the bypass shape where a
+    commit is pushed directly to ``main`` without going through PR /
+    retro. Examples include the milestone-open commit pattern that the
+    pipeline-drain skill instructs.
+
+    Returns a list of ``(sha, subject, body)`` tuples for each candidate
+    direct commit. Subjects ending with `` (#NNN)`` are filtered out
+    because they're squashed-PR commits whose retros are scanned by
+    ``merged_prs`` instead.
+
+    Empty list on failure (git error, no commits in range, etc.).
+    """
+    try:
+        # ``--first-parent main`` walks the main-branch line only;
+        # ``--no-merges`` keeps merge commits out (the squash workflow
+        # produces non-merge commits anyway, but defensive); the
+        # ``%x1f`` field separator is unit-separator (0x1F) which is
+        # safe inside commit subjects/bodies. ``%x1e`` is record-separator
+        # (0x1E) for splitting commits.
+        out = subprocess.check_output(
+            [
+                "git",
+                "log",
+                "--first-parent",
+                "main",
+                f"--since={lookback}",
+                "--no-merges",
+                "--format=%H%x1f%s%x1f%b%x1e",
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+
+    commits: list[tuple[str, str, str]] = []
+    for record in out.split("\x1e"):
+        record = record.strip()
+        if not record:
+            continue
+        parts = record.split("\x1f")
+        if len(parts) < 2:
+            continue
+        sha = parts[0].strip()
+        subject = parts[1] if len(parts) > 1 else ""
+        body = parts[2] if len(parts) > 2 else ""
+        # Filter out PR-squash commits: subject ends with " (#NNN)".
+        if PR_SQUASH_SUFFIX.search(subject):
+            continue
+        commits.append((sha, subject, body))
+    return commits
+
+
+def commit_is_exempt(body: str) -> bool:
+    """Return True if commit body declares an audit-bypass reason.
+
+    The trailer ``Audit-bypass-reason: <reason>`` (case-insensitive) on
+    its own line marks a commit as legitimately exempt — typical use
+    case is ROADMAP-update commits the pipeline-drain skill instructs.
+    Without an explicit reason, direct commits are flagged.
+    """
+    return bool(AUDIT_BYPASS_TRAILER.search(body or ""))
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
     parser.add_argument(
@@ -120,12 +215,22 @@ def main() -> int:
             "automated bumps that don't need retros)."
         ),
     )
+    parser.add_argument(
+        "--lookback",
+        type=str,
+        default="30 days ago",
+        help=(
+            "Time window for direct-to-main commit scan (passed to "
+            "git log --since; default: '30 days ago'). PR-squash commits "
+            "are filtered out automatically."
+        ),
+    )
     args = parser.parse_args()
 
     prs = merged_prs(args.since, args.limit)
     if not prs:
         print("No merged PRs found (gh authentication issue or empty repo).")
-        return 0
+        # Fall through to direct-commit scan; gh failure shouldn't block git checks.
 
     if not args.dependabot:
         prs = [p for p in prs if not p.get("author", {}).get("login", "").startswith("dependabot")]
@@ -140,18 +245,49 @@ def main() -> int:
     print(f"Audited {len(prs)} merged PRs (excluding dependabot).")
     print(f"Found {len(bypassed)} PRs without retro markers in comments.\n")
 
-    if not bypassed:
-        print("All audited PRs have retros.")
+    # Stage 2: scan direct-to-main commits since lookback (#1250).
+    direct = direct_main_commits(args.lookback)
+    flagged_direct: list[tuple[str, str]] = []
+    for sha, subject, body in direct:
+        if not commit_is_exempt(body):
+            flagged_direct.append((sha, subject))
+
+    print(
+        f"Audited {len(direct)} direct-to-main commits since '{args.lookback}' "
+        f"(excluding PR-squash commits)."
+    )
+    print(
+        f"Found {len(flagged_direct)} direct commits without an `Audit-bypass-reason:` trailer.\n"
+    )
+
+    if not bypassed and not flagged_direct:
+        print("All audited PRs and direct commits have retros / bypass reasons.")
         return 0
 
-    print("PRs without retro markers (oldest first):")
-    print(f"  {'PR':<6} {'merged':<12} {'comments':<9}  title")
-    print(f"  {'-' * 6} {'-' * 12} {'-' * 9}  {'-' * 60}")
-    for n, merged, title, count in sorted(bypassed):
-        title_short = title[:60]
-        print(f"  #{n:<5} {merged:<12} {count:<9}  {title_short}")
+    if bypassed:
+        print("PRs without retro markers (oldest first):")
+        print(f"  {'PR':<6} {'merged':<12} {'comments':<9}  title")
+        print(f"  {'-' * 6} {'-' * 12} {'-' * 9}  {'-' * 60}")
+        for n, merged, title, count in sorted(bypassed):
+            title_short = title[:60]
+            # Marker string ``potential bypass`` is what the GHA workflow
+            # greps for to surface annotations; preserve it.
+            print(f"  #{n:<5} {merged:<12} {count:<9}  {title_short}  (potential bypass)")
+        print()
 
-    print()
+    if flagged_direct:
+        print("Direct-to-main commits without `Audit-bypass-reason:` trailer:")
+        print(f"  {'sha':<10}  subject")
+        print(f"  {'-' * 10}  {'-' * 60}")
+        for sha, subject in flagged_direct:
+            sha_short = sha[:9]
+            subject_short = subject[:60]
+            print(f"  {sha_short:<10}  {subject_short}  (potential bypass)")
+        print()
+        print("To exempt a commit, add a trailer to its message, e.g.:")
+        print("  Audit-bypass-reason: docs-only-roadmap-update")
+        print()
+
     print("Next step: post a backfill retro comment on each PR via")
     print('  gh pr comment <N> --body "$(cat <retro-file>)"')
     print()
@@ -160,7 +296,7 @@ def main() -> int:
     print("PR was merged outside pipeline-run entirely — file as a")
     print("'pipeline-bypass merge' for milestone-retro tracking.")
     print()
-    return 1 if bypassed else 0
+    return 1 if (bypassed or flagged_direct) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/lib/retro_markers.py
+++ b/scripts/lib/retro_markers.py
@@ -1,0 +1,40 @@
+"""Canonical retro-marker regex for pipeline-run Stage 14 audit gates.
+
+Filed as #1249 (extract retro-marker regex to shared constants module —
+v0.9.2-2 retro Action Tracker #207). Previously the regex was defined
+in two places: ``scripts/audit-pipeline-bypass.py`` and the Stage 14
+``subagent_prompt`` text in ``.pipeline-templates/{feature,bugfix}-state.json``.
+Two-source-of-truth bugs (the prompts drift from the audit script's
+detection rule) are silent and only surface when an audit run flags a
+PR whose retro comment matched the prompt's regex but not the
+script's. This module is the canonical one truth.
+
+Callers compile with their own ``re`` flags (typically ``re.IGNORECASE``)
+so the constant stays portable across re-vs-regex backends.
+
+Example::
+
+    import re
+    from scripts.lib.retro_markers import RETRO_MARKER_REGEX
+
+    pattern = re.compile(RETRO_MARKER_REGEX, re.IGNORECASE)
+    has_retro = bool(pattern.search(comment_body))
+"""
+
+from __future__ import annotations
+
+#: Regex matching the textual markers a Stage 14 retro comment is required
+#: to contain. Match is case-insensitive (callers should compile with
+#: ``re.IGNORECASE``). Five marker shapes are accepted:
+#:
+#: * ``Retrospective`` (heading or prose)
+#: * ``Quality: <digit>`` (the 1-5 self-rating line)
+#: * ``Lessons learned`` (the lessons-learned section)
+#: * ``RETRO_COMPLETE`` (the mandatory final-line sentinel)
+#: * ``What went well`` (one of the standard retro headings)
+#:
+#: At least one match in the comment body is sufficient to count the PR
+#: as having a Stage 14 retro.
+RETRO_MARKER_REGEX = (
+    r"retrospective|quality:\s*\d|lessons\s+learned|retro_complete|what\s+went\s+well"
+)

--- a/scripts/lib/test_retro_markers.py
+++ b/scripts/lib/test_retro_markers.py
@@ -1,0 +1,93 @@
+"""Unit tests for ``scripts/lib/retro_markers.py``.
+
+Filed as #1249 (extract retro-marker regex to shared constants module).
+The regex was previously defined in two places (the audit script and the
+Stage 14 ``subagent_prompt`` text in the pipeline templates). These
+tests lock the canonical pattern's behavior so future template updates
+that re-embed the regex literal can be caught by a CI grep.
+
+Run with::
+
+    pytest scripts/lib/test_retro_markers.py -v
+"""
+
+from __future__ import annotations
+
+import re
+
+from scripts.lib.retro_markers import RETRO_MARKER_REGEX
+
+
+COMPILED = re.compile(RETRO_MARKER_REGEX, re.IGNORECASE)
+
+
+# Positive cases — these should match the canonical retro-marker regex.
+POSITIVE_CASES = [
+    # Stage 14 retro shapes from real PRs.
+    "## Retrospective\n\nQuality: 5/5 — went well.",
+    "Quality: 4 — lessons learned about kwargs forwarding.",
+    "Lessons learned: always grep before pasting.",
+    "Final line: RETRO_COMPLETE",
+    "What went well: TDD-first surfaced the bug early.",
+    # Lowercase variants — regex is case-insensitive.
+    "what went well? everything.",
+    "retrospective notes from the v0.9.5 retro arc.",
+    # Loose whitespace handling.
+    "Quality:  3 (mid-retro)",
+    "lessons   learned: don't merge on a Friday.",
+]
+
+# Negative cases — these should NOT match.
+NEGATIVE_CASES = [
+    "Implementation note: refactored helper.",
+    "feat: add retro audit script",
+    "Just a regular PR comment about quality assurance.",  # "quality" without ":<digit>"
+    "Lessons from the trenches:",  # missing "learned"
+    "",  # empty
+    "Stage 11 review: APPROVE.",
+]
+
+
+def test_positive_cases_match():
+    """Every documented retro-marker shape must match the regex."""
+    for text in POSITIVE_CASES:
+        assert COMPILED.search(text), f"Expected match but got none for: {text!r}"
+
+
+def test_negative_cases_do_not_match():
+    """Non-retro text must NOT match the regex (no false positives)."""
+    for text in NEGATIVE_CASES:
+        assert not COMPILED.search(text), f"Expected no match but found one in: {text!r}"
+
+
+def test_regex_is_a_string_not_pattern():
+    """The constant must be a raw regex string so callers can choose flags."""
+    assert isinstance(RETRO_MARKER_REGEX, str), (
+        "RETRO_MARKER_REGEX must be a string (callers compile with their own flags). "
+        "If a pre-compiled Pattern is needed too, expose it under a different name."
+    )
+
+
+def test_audit_script_uses_constant():
+    """The audit script must import the constant rather than re-embedding the regex.
+
+    Catches future regressions where the regex is copy-pasted back into the
+    audit script (the failure mode #1249 was filed to prevent).
+    """
+    audit_script = __import__("pathlib").Path(__file__).parent.parent / "audit-pipeline-bypass.py"
+    text = audit_script.read_text(encoding="utf-8")
+    # The script must import RETRO_MARKER_REGEX from this module.
+    assert "RETRO_MARKER_REGEX" in text, (
+        "audit-pipeline-bypass.py must import RETRO_MARKER_REGEX from scripts.lib.retro_markers"
+    )
+    # The literal regex pattern must NOT appear inline a second time.
+    inline_literal = (
+        r"retrospective|quality:\s*\d|lessons\s+learned|retro_complete|what\s+went\s+well"
+    )
+    occurrences = text.count(inline_literal)
+    # Allow 0 occurrences (constant is imported); reject 1+ inline literal hits
+    # which would mean the script ALSO embeds it directly.
+    assert occurrences == 0, (
+        f"audit-pipeline-bypass.py should not embed the regex literal directly; "
+        f"found {occurrences} occurrence(s). Import RETRO_MARKER_REGEX instead."
+    )


### PR DESCRIPTION
Closes #1248.
Closes #1249.
Closes #1250.
Closes #1251.

## Summary

Four P2 carryover items from the v0.9.2-2 retro (Action Tracker rows #206-#209), bundled as one grouped PR. All touch djust-repo files at mostly-disjoint locations (`.pipeline-templates/*.json`, `scripts/audit-pipeline-bypass.py`, new `scripts/lib/retro_markers.py`).

| # | What | Where |
|---|---|---|
| #1248 | Stage 7 self-applicability check (mandatory: false) | both templates Stage 7 |
| #1249 | Extract retro-marker regex to shared module | new `scripts/lib/retro_markers.py` + audit script + Stage 14 prompts |
| #1250 | Audit script scans direct-to-main commits + `Audit-bypass-reason:` trailer | `scripts/audit-pipeline-bypass.py` |
| #1251 | Stage 5/9/10 bundling-check (mandatory: true) | both templates Stages 5/9/10 |

A 5th carryover (#1259 — pipeline-drain skill audit-as-leverage recipe) is a `pipeline-skill` repo change; deferred to a separate PR there. After this PR + the pipeline-skill PR, all v0.9.2-N retro carryovers should be closed.

## Two-commit shape (Action #181)

- `e2d84767` — implementation + tests + 2 new files
- `7d8cdc4f` — CHANGELOG `[Unreleased]` Developer Experience entries

## Self-applicability check (#1248 itself, ate own dog food)

- (a) Does the new Stage 7 rule false-positive on this PR? **No** — implementer self-applied the new bundling check (#1251) on this PR's commit; `git diff --cached --stat` showed 326+/17- matching expected scope, no unintended bundles.
- (b) Would the rule have caught the originating bug? **Yes** — the v0.9.2-2 pipeline-skill `bf1a67f` 130-line silent bundle would have been flagged.

## Tests

- `scripts/lib/test_retro_markers.py`: 4/4 passed (positive cases: "Quality:", "lessons learned"; negative cases; type/integration audits).
- `python/tests/test_audit_command.py`: 52/52 passed (existing tests, audit-script changes didn't regress).
- Audit script smoke-test: `python scripts/audit-pipeline-bypass.py --limit 5 --lookback "1 day ago"` runs cleanly and surfaces `18e5b117` (the v0.9.2-2 milestone-open direct-push) as the canonical flagged commit.

## Test plan

- [x] All new + existing tests pass
- [x] Both pipeline templates symmetric (verified via jq diff of inserts)
- [x] Audit script smoke-test surfaces expected direct-to-main commit
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)