### PR TITLE
docs(audits): Lifecycle Coverage + Decorator/Tag Contract audits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that don't match any DataTableMixin handler (#1275 generalized).
   Each audit ships with a 4-phase improvement roadmap, test gaps,
   strategic observations, and a companion canon update for
-  `CLAUDE.md` / `PR-checklist`. Pre-staged issues for each
-  not-yet-filed weakness are listed inline in the audit docs and will
-  be filed during v0.9.3 milestone planning.
+  `CLAUDE.md` / `PR-checklist`. Pre-staged issues filed for each
+  not-yet-tracked weakness (#1283-#1291). Audit-driven Phase 1 fixes
+  blocking v0.9.2 stable will land in the v0.9.2-5 drain bucket;
+  Phase 2/3 fixes targeted for v0.9.3.
 
 - **Production Deployment guide extended with Tier 1/2/3 patterns
   (`docs/website/guides/deployment.md`).** Adds 8 new sections to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Lifecycle Coverage Audit + Decorator/Tag Contract Audit
+  (`docs/audits/lifecycle-2026-05.md`, `docs/audits/decorator-contract-2026-05.md`).**
+  Two companion audit docs modeled on the v0.9.2-4 VDOM audit. Document
+  the canonical state-type × lifecycle-hook matrix and the
+  decorator/tag-name dispatch contract, surfaced from 10 downstream
+  consumer bug reports (#1267, #1273-#1281). The lifecycle audit
+  catalogues 8 ranked weaknesses including the central control-flow
+  gaps in `mount()` (#1280, #1281). The decorator/tag audit catalogues
+  8 weaknesses including the `data_table` tag emitting 23 event names
+  that don't match any DataTableMixin handler (#1275 generalized).
+  Each audit ships with a 4-phase improvement roadmap, test gaps,
+  strategic observations, and a companion canon update for
+  `CLAUDE.md` / `PR-checklist`. Pre-staged issues for each
+  not-yet-filed weakness are listed inline in the audit docs and will
+  be filed during v0.9.3 milestone planning.
+
 - **Production Deployment guide extended with Tier 1/2/3 patterns
   (`docs/website/guides/deployment.md`).** Adds 8 new sections to the
   canonical deployment guide based on patterns surfaced from real-world

--- a/docs/audits/decorator-contract-2026-05.md
+++ b/docs/audits/decorator-contract-2026-05.md
@@ -281,9 +281,9 @@ This would have caught #1275 the day the prefix divergence first landed. ~50 LoC
 
 ## 9. Sequencing
 
-- **v0.9.3 opener** (~3 days, 3 PRs): Phase 1 quick wins. Fix the `on_` prefix in data_table integration (closes #1275 + the new pagination bug). Fix `@action` re-raise (closes #1276). Add auto-refresh to DataTableMixin (closes #1279). Each is a focused PR with regression tests.
-- **v0.9.3 mid** (~2 days, 2 PRs): Phase 2 linter foundation + capability. Lock in the contract; pre-push hook fails on drift.
-- **v0.9.3 late** (~3 days, ~6 PRs): Phase 3 decorator-contract spec tests. One test class per decorator; one test per docstring claim. This is mostly mechanical but high-leverage — catches future drift before it reaches users.
+- **v0.9.2-5 drain bucket** (~3 days, 3 PRs): Phase 1 quick wins. **Blocks v0.9.2 stable** because all four cited bugs (#1275, #1276, #1279, #1291) are 🔴 production-deploy-blocker class. Fix the `on_` prefix in data_table integration (closes #1275). Add the missing pagination handlers (closes #1291). Fix `@action` re-raise contract (closes #1276). Add auto-refresh to DataTableMixin (closes #1279). Each is a focused PR with regression tests.
+- **v0.9.3** (~2 days, 2 PRs): Phase 2 linter foundation + capability (closes #1290). Lock in the contract; pre-push hook fails on drift.
+- **v0.9.3 late** (~3 days, ~6 PRs): Phase 3 decorator-contract spec tests (closes #1287, #1288, #1289). One test class per decorator; one test per docstring claim. This is mostly mechanical but high-leverage — catches future drift before it reaches users.
 - **Continuous**: Phase 4 documentation alongside Phase 1/2/3 PRs.
 
 ---

--- a/docs/audits/decorator-contract-2026-05.md
+++ b/docs/audits/decorator-contract-2026-05.md
@@ -1,0 +1,305 @@
+# djust Decorator/Tag Contract Audit — 2026-05
+
+**Status**: Snapshot in time. Synthesized from `python/djust/decorators.py` (12 decorators), `python/djust/components/templatetags/djust_components.py` (28+ tag-emit defaults), `components/mixins/data_table.py` (24 handler defs), `python/djust/websocket_utils.py:155-198` (dispatcher's exact-match handler lookup).
+
+**Companion audit**: `lifecycle-2026-05.md` (sibling — orthogonal state-flow surface).
+
+**Scope**: Every decorator's promise vs. implementation; every template-tag emit-name default vs. matching mixin handler; the dispatcher's name-resolution contract; the symbol-cross-reference linter that would have caught #1275 at import time.
+
+---
+
+## 1. Architecture at a glance
+
+```
+{% data_table sort_event="table_sort" ... %}    # tag default in djust_components.py:509
+        ↓
+template renders dj-click="{{ sort_event }}"     # table.html:31 → "table_sort"
+        ↓
+JS click handler in 09-event-binding.js
+        ↓
+WS frame: {"event": "table_sort", ...}            # event name = the literal value
+        ↓
+LiveViewConsumer.handle_event                     # websocket.py:2529
+        ↓
+_validate_event_security(ws, event_name, view, ...)   # websocket_utils.py:155
+        ↓
+handler = getattr(view, event_name, None)         # websocket_utils.py:173 — EXACT MATCH
+        ↓
+if not handler: return _format_handler_not_found_error(view, event_name)
+        ↓
+is_event_handler(handler)?    # checks func._djust_decorators["event_handler"]
+        ↓
+handler(self, **coerced_params)
+```
+
+### The contract — three places must agree
+
+| Layer | Who decides the name | Where |
+|---|---|---|
+| Tag-emit default | author of `djust_components.py:509` | template-tag function param |
+| DOM attribute | template author | `table.html:31` (`dj-click="{{ sort_event }}"`) |
+| Handler method | author of mixin/view | `data_table.py:476` (`def on_table_sort`) |
+
+**Failure mode**: any of the three drifts and the WS dispatch hits `_format_handler_not_found_error`. Currently surfaces as a "no handler found for event: <name>" error frame to the client, with typo suggestions in DEBUG mode (`websocket_utils.py:36-88`).
+
+---
+
+## 2. Decorator inventory
+
+12 decorators in `python/djust/decorators.py`. Cataloged with the contract each promises and the actual implementation behavior.
+
+| Decorator | `_djust_decorators` key | Re-render trigger | Documented promise | Drift status |
+|---|---|---|---|---|
+| `@event_handler` | `"event_handler"` | Yes — full handler path; `_changed_keys` populated post-handler | "Mark method as event handler with parameter introspection. Stores metadata for validation and debug panel." | ✓ Promise matches implementation |
+| `@action` | `"action"` (+ implicit `"event_handler"`) | Yes; sets `_action_state[name]` at entry, `result` or `error` at exit | "Auto-tracked pending/error/result state. Templates access via `{{ create_todo.pending }}`." | **✗ #1276** — exception **re-raised** at `decorators.py:379`; consumer (`handle_event` exception handler) sends a `{"type":"error"}` frame instead of triggering re-render. Template never sees `error` field. |
+| `@server_function` | `"server_function"` | No — RPC return value JSON-serialized straight to caller | "Same-origin browser RPC. No VDOM re-render, no assigns diff." | ✓ Promise matches |
+| `@background` | (only `"background": True` flag) | Yes — flushes current state, then re-renders on `start_async` callback completion | "Run handler in background after flushing current state. Current view state flushed to client before handler runs." | ✓ matches; **gap**: docstring silent on return-value handling. Sync/async return value is discarded unless the method is also `@action`. |
+| `@debounce(wait, max_wait)` | `"debounce"` | No (client-side) | "Client-side debounce. Metadata for JS to debounce events." | ✓ matches; **gap**: docstring doesn't say "client-side only". The server runs the handler exactly once per dispatch. |
+| `@throttle(interval, leading, trailing)` | `"throttle"` | No (client-side) | "Client-side throttle." | ✓ matches; same gap as debounce |
+| `@cache(ttl, key_params)` | `"cache"` | No (client-side cache) | "Client-side response cache. Browser caches handler responses." | ✓ matches; **gap**: no manual invalidation API documented |
+| `@rate_limit(rate, burst)` | `"rate_limit"` | Conditional — drops event when bucket empty, no re-render | "Server-side rate limiting using per-handler token bucket." | ✓ matches |
+| `@permission_required(perms)` | `"permission_required"` | Conditional — denies → no re-render, sends error frame | "Require Django permission(s) before handler executes." | ✓ matches; enforcement happens in dispatcher (`auth.py:check_handler_permission`), not in decorator (decorator is metadata-only) |
+| `@reactive` | (returns `property` descriptor) | Yes on setter — calls `self.update()` if `hasattr(self, 'update')` | "Create a reactive property that triggers re-render on change." | **🟡 Drift** — silent no-op on subclasses missing `update()` (e.g., a non-LiveView subclass or one that forgot `super().__init__()`). No warning. |
+| `@computed` | (returns `_ComputedProperty` descriptor) | No — lazy property | "Memoized or plain computed property." | ✓ matches; **gap**: cache-dict mutation in `__set__` not thread-safe (no lock); `start_async` callbacks running concurrently could race |
+| `@event` (deprecated) | delegates to `@event_handler` | Yes (delegated) | "Deprecated alias for @event_handler." | ✓ matches; emits `DeprecationWarning` at decoration time (not call time) |
+
+### Decorator stackability
+
+Order matters for some pairs:
+
+- `@event_handler` outer, `@background` inner: ✓ standard
+- `@event_handler` outer, `@action` inner: ✓ `@action` builds on `@event_handler` semantics
+- `@event_handler` + `@server_function`: **✗ Mutually exclusive** — guarded at decoration time (`decorators.py:450-456`)
+- `@debounce` / `@throttle` / `@cache` / `@rate_limit`: pure metadata, freely stack on `@event_handler` or `@action`
+
+The marker contract is documented (`is_event_handler` / `is_action` predicates at `decorators.py:220-230, 396-398`) but the **stackability constraints are not user-visible** beyond the import-time guard for `@event_handler`/`@server_function`.
+
+---
+
+## 3. Tag-emit vs handler-name cross-reference
+
+The most distinctive new finding of this audit. The dispatcher does **exact-match** lookup on the event name in the WS frame:
+
+```python
+# websocket_utils.py:173
+handler = getattr(owner_instance, event_name, None)
+```
+
+The template renders `dj-click="{{ sort_event }}"` literally (`table.html:31, 87, 92, 94, 96`). So if `sort_event="table_sort"` (the default in `djust_components.py:509`), the WS frame's `event_name` is **`"table_sort"`** — and the dispatcher looks for `view.table_sort`, not `view.on_table_sort`.
+
+### `data_table` defaults vs `DataTableMixin` handlers
+
+| Tag default | Tag file:line | Expected handler (exact match) | Mixin handler defined? | Mixin file:line | Status |
+|---|---|---|---|---|---|
+| `sort_event="table_sort"` | djust_components.py:509 | `table_sort` | ✗ only `on_table_sort` | data_table.py:476 | **✗ #1275** |
+| `prev_event="table_prev"` | :512 | `table_prev` | ✗ no `on_table_prev` either | — | **✗ NEW (filed below)** |
+| `next_event="table_next"` | :513 | `table_next` | ✗ no `on_table_next` either | — | **✗ NEW (filed below)** |
+| `select_event="table_select"` | :516 | `table_select` | ✗ only `on_table_select` | data_table.py:505 | ✗ same shape as #1275 |
+| `search_event="table_search"` | :520 | `table_search` | ✗ only `on_table_search` | data_table.py:486 | ✗ same shape |
+| `filter_event="table_filter"` | :523 | `table_filter` | ✗ only `on_table_filter` | data_table.py:492 | ✗ same shape |
+| `page_event="table_page"` | :529 | `table_page` | ✗ only `on_table_page` | data_table.py:523 | ✗ same shape |
+| `edit_event="table_cell_edit"` | :534 | `table_cell_edit` | ✗ only `on_table_cell_edit` | data_table.py:534 | ✗ same shape |
+| `reorder_event="table_reorder"` | :537 | `table_reorder` | ✗ only `on_table_reorder` | data_table.py:552 | ✗ same shape |
+| `visibility_event="table_visibility"` | :541 | `table_visibility` | ✗ only `on_table_visibility` | data_table.py:559 | ✗ same shape |
+| `density_event="table_density"` | :544 | `table_density` | ✗ only `on_table_density` | data_table.py:565 | ✗ same shape |
+| `edit_row_event="table_row_edit"` | :547 | `table_row_edit` | ✗ only `on_table_row_edit` | data_table.py:572 | ✗ same shape |
+| `save_row_event="table_row_save"` | :548 | `table_row_save` | ✗ only `on_table_row_save` | data_table.py:579 | ✗ same shape |
+| `cancel_row_event="table_row_cancel"` | :549 | `table_row_cancel` | ✗ only `on_table_row_cancel` | data_table.py:587 | ✗ same shape |
+| `expand_event="table_expand"` | :553 | `table_expand` | ✗ only `on_table_expand` | data_table.py:600 | ✗ same shape |
+| `bulk_action_event="table_bulk_action"` | :556 | `table_bulk_action` | ✗ only `on_table_bulk_action` | data_table.py:609 | ✗ same shape |
+| `export_event="table_export"` | :558 | `table_export` | ✗ only `on_table_export` | data_table.py:619 | ✗ same shape |
+| `group_event="table_group"` | :561 | `table_group` | ✗ only `on_table_group` | data_table.py:651 | ✗ same shape |
+| `group_toggle_event="table_group_toggle"` | :562 | `table_group_toggle` | ✗ only `on_table_group_toggle` | data_table.py:656 | ✗ same shape |
+| `row_drag_event="table_row_drag"` | :580 | `table_row_drag` | ✗ only `on_table_row_drag` | data_table.py:667 | ✗ same shape |
+| `copy_event="table_copy"` | :582 | `table_copy` | ✗ only `on_table_copy` | data_table.py:689 | ✗ same shape |
+| `import_event="table_import"` | :586 | `table_import` | ✗ only `on_table_import` | data_table.py:724 | ✗ same shape |
+| `expression_event="table_expression"` | :595 | `table_expression` | ✗ only `on_table_expression` | data_table.py:804 | ✗ same shape |
+| `row_click_event=""` | :599 | (disabled) | N/A | — | ✓ explicit opt-out |
+
+**Summary**: 23 out of 24 default emit names dispatch to a handler that **does not exist**. The one exception (`row_click_event=""`) is intentionally disabled. The bug isn't just #1275 — it's the **whole `data_table` integration over WebSocket**.
+
+The mixin author chose the `on_*` prefix convention (Phoenix LiveView style); the tag author chose bare names. Neither is wrong in isolation; the framework needs to pick one and enforce it.
+
+### Other tag families
+
+| Tag | Emit param | Default | Handler convention | Notes |
+|---|---|---|---|---|
+| `{% pagination %}` | `prev_event="page_prev"`, `next_event="page_next"` (djust_components.py:836) | bare names | unspecified — caller wires | OK as long as the caller knows |
+| `{% toast_container %}` | `dismiss_event="dismiss_toast"` (:363) | bare name | unspecified | OK with caller-supplied handler |
+| `{% notifications_dropdown %}` | `open_event="toggle_notifications"` (:2170) | bare name | unspecified | OK with caller-supplied handler |
+| `{% empty_state %}` | `action_event=""` (:1442) | empty (caller chooses) | N/A | ✓ |
+| `{% search_command %}` | `search_event=""` (:1777) | empty | N/A | ✓ |
+
+The data_table tag is the one that auto-wires the entire DataTableMixin, and the entire wiring is broken.
+
+---
+
+## 4. Current weaknesses, ranked
+
+🔴 = production-deploy-blocker class. 🟡 = should-fix.
+
+| # | Weakness | Cite | Impact | Effort | Issue |
+|---|---|---|---|---|---|
+| 1 | `data_table` tag emits 23 event names that don't match any DataTableMixin handler. Every tablesort/filter/page/select/etc. interaction returns "no handler found" over WS. | `djust_components.py:509-595` (defaults), `data_table.py:476-804` (handlers), `websocket_utils.py:173` (exact-match dispatch), `table.html:31, 87` (template renders raw value) | 🔴 | M (rename one side) | [#1275](https://github.com/djust-org/djust/issues/1275) |
+| 2 | `prev_event="table_prev"` and `next_event="table_next"` have no matching handler at all (neither `table_prev` nor `on_table_prev` exists). Pagination is fully broken in `data_table` over WS. | `djust_components.py:512-513`, `table.html:94, 96` | 🔴 | S | (file new — see §6) |
+| 3 | `@action` re-raises exception after recording state; dispatcher sends error frame instead of triggering re-render. Template never sees `{{ name.error }}`. Promise/implementation drift. | `decorators.py:374-379` (re-raise), `websocket.py:2695-2708` (error-frame path), `decorators.py:262-268` (docstring promise) | 🔴 | M | [#1276](https://github.com/djust-org/djust/issues/1276) |
+| 4 | `DataTableMixin.on_table_sort/filter/page` mutate state but don't call `refresh_table()`. Even if #1275/#2 are fixed, the dispatcher would call them and the rows wouldn't change. | `data_table.py:476-529` (handlers), `data_table.py:1326-1345` (`refresh_table` exists but not auto-called) | 🔴 | S | [#1279](https://github.com/djust-org/djust/issues/1279) |
+| 5 | `@reactive` silent no-op on subclasses missing `update()`. `hasattr` guard hides the contract violation. | `decorators.py:520-521` | 🟡 | S | (file new) |
+| 6 | `@background` discards return value silently. No clear contract for "what does the handler return?". User confused if return value not in `_action_state` (only `@action` populates it). | `decorators.py:954-979` | 🟡 | S | (file new — doc-only) |
+| 7 | `@computed` cache-dict mutation not thread-safe. Concurrent property access from `start_async` callback races against template-render access. | `decorators.py:656-664` (no lock) | 🟡 | M | (file new) |
+| 8 | No symbol cross-reference linter for tag-emit defaults vs handler names. The class of bug #1275 is impossible to catch without a static check; runtime "no handler found" comes too late. | (no current static check exists) | 🟡 | M | (file new — see linter sketch §7) |
+
+---
+
+## 5. Test gaps
+
+| Area | Gap | Reproducer outline |
+|---|---|---|
+| Tag-emit symmetry | No test that `data_table` tag's default emit names match a DataTableMixin handler | Render `{% data_table %}`; click each interactive element; assert dispatcher resolves the handler |
+| `@action` exception → template error visibility | No test that exception-raising `@action` re-renders with `{{ action.error }}` populated | Define `@action def fail(): raise ValueError("boom")`; trigger event; assert next render has `_action_state["fail"]["error"] = "boom"` AND no error frame sent |
+| Decorator stackability | No test grid for valid/invalid stack orders | `@event_handler @background`, `@background @event_handler`, `@action @event_handler`, etc. |
+| `@reactive` setter on non-LiveView | No test that `@reactive` raises a clear error on classes missing `update()` | Subclass without `update()`; mutate property; expect AttributeError or warning |
+| `@computed` thread safety | No test for concurrent access | Two threads access memoized property; assert no `KeyError` or stale read |
+
+---
+
+## 6. Improvement roadmap
+
+### Phase 1 — Quick wins (~3 PRs)
+
+| # | Fix | Files | Effort | Closes |
+|---|---|---|---|---|
+| 1 | **Resolve the `on_` prefix divergence**. Pick one convention and apply it project-wide. Recommendation: keep DataTableMixin handlers as `on_table_*` (Phoenix-style, distinguishes "event handler" from "regular method"), and update `djust_components.py:509-595` defaults to `on_table_*` strings. Also update `table.html` in the same PR. | `djust_components.py`, `table.html`, `pagination.html`, `data_table.py` (no rename needed) | M | #1275 + weakness #2 |
+| 2 | **Fix `@action` re-raise contract**. Either: (a) catch and **don't** re-raise; consumer re-renders with `_action_state[name]["error"]` populated; OR (b) update docstring to match reality (re-raise IS the contract; client receives error frame). Recommendation: (a) — matches the docstring's promise and most user-test expectations. | `decorators.py:374-379` | M | #1276 |
+| 3 | **Add auto-refresh to DataTableMixin handlers**. Each `on_table_sort/filter/page/...` handler should call `self.refresh_table()` after mutating state. Add a `@_auto_refresh` decorator local to the mixin to avoid repetition. | `data_table.py:476-628` | S | #1279 |
+
+### Phase 2 — Symbol cross-reference linter (split-foundation)
+
+| Initiative | Effort | Closes |
+|---|---|---|
+| **Foundation**: build the linter — `scripts/check-handler-contracts.py`. Walk the AST of `templatetags/djust_components.py`; extract every `*_event=` default value. Walk every `mixins/*.py`; extract every `def on_*` (or whichever convention is chosen in Phase 1). Cross-reference; fail if any default isn't covered by a handler. Run as part of pre-push hook (Makefile target + pre-push wrapper). | M | Weakness #8 (foundation) |
+| **Capability**: extend linter to catch cross-package mismatches (third-party packages registering djust components). Provide a programmatic API: `register_tag_emit_default(tag, param, handler)` that the linter can introspect. | M | Weakness #8 (capability) |
+
+### Phase 3 — Decorator-contract spec tests
+
+| Initiative | Effort | Impact |
+|---|---|---|
+| For every decorator, write a spec-test class with one test per docstring claim. E.g., `@action` docstring says "exception sets `_action_state[name]["error"]`" → test asserts that. Currently zero such tests; Audit B's findings hinge on the gap. | M | Locks the contract; future docstring-vs-implementation drift fails CI |
+| Document decorator stackability as a matrix in `docs/STATE_MANAGEMENT_API.md`. Validate the matrix's invariants in tests. | S | User-visible contract for "can I stack X with Y?" |
+| Add `@reactive` warn-on-missing-update assertion at `__set_name__` time, not at set-time. Catches the silent-no-op class. | S | Closes weakness #5 |
+
+### Phase 4 — Documentation
+
+- Audit table in §3 belongs in `docs/STATE_MANAGEMENT_API.md` as a canonical reference for component-tag authors.
+- Decorator inventory in §2 belongs alongside or replaces the existing decorator docs (currently scattered across `decorators.py` docstrings + a few guides).
+
+---
+
+## 7. Linter sketch
+
+`scripts/check-handler-contracts.py` (proposed):
+
+```python
+"""
+Cross-reference tag-emit defaults against handler-name registry.
+Catches bugs of class #1275 at pre-push (or pre-commit) time.
+
+Exit 0 = all defaults match a handler. Exit 1 = mismatches found.
+"""
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TAG_FILES = [ROOT / "python/djust/components/templatetags/djust_components.py"]
+MIXIN_FILES = list((ROOT / "python/djust/components/mixins").glob("*.py"))
+
+def extract_event_defaults(path: Path) -> dict[str, str]:
+    """Return {param_name: default_value} for every kwarg ending in _event."""
+    tree = ast.parse(path.read_text())
+    out = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for arg, default in zip(
+            node.args.kwonlyargs + node.args.args[-len(node.args.defaults):],
+            node.args.kw_defaults + list(node.args.defaults),
+        ):
+            if arg.arg.endswith("_event") and isinstance(default, ast.Constant):
+                if isinstance(default.value, str) and default.value:
+                    out.setdefault(default.value, []).append(f"{path.name}:{node.lineno}")
+    return out
+
+def extract_handler_names(path: Path) -> set[str]:
+    """Return every method def name on classes in this file (one filter pass)."""
+    tree = ast.parse(path.read_text())
+    return {
+        n.name for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef)
+    }
+
+emit_defaults = {}
+for f in TAG_FILES:
+    for name, sites in extract_event_defaults(f).items():
+        emit_defaults.setdefault(name, []).extend(sites)
+
+all_handlers = set()
+for f in MIXIN_FILES:
+    all_handlers |= extract_handler_names(f)
+
+mismatches = [
+    (name, sites) for name, sites in emit_defaults.items()
+    if name not in all_handlers
+]
+
+if mismatches:
+    print(f"Found {len(mismatches)} tag-emit defaults with no matching handler:")
+    for name, sites in mismatches:
+        print(f"  '{name}' — emitted at {', '.join(sites)}; no handler in mixins/")
+    sys.exit(1)
+else:
+    print(f"OK — {len(emit_defaults)} tag-emit defaults all matched.")
+```
+
+This would have caught #1275 the day the prefix divergence first landed. ~50 LoC, runs in under 100ms.
+
+---
+
+## 8. Strategic observations
+
+1. **The `data_table` integration is the load-bearing example of this whole class.** 23 broken emit names in one component. If the prefix divergence is fixed there (Phase 1 #1) and the linter is added (Phase 2), the pattern won't recur. If only the linter is added without fixing data_table, it will fail on every CI run from day 1 — also useful, but a worse user experience.
+
+2. **The dispatcher's "no handler found" error in DEBUG mode already does typo suggestions** (`websocket_utils.py:36-88`). It computes `difflib.get_close_matches(event_name, public_methods)` and surfaces "Did you mean: on_table_sort?" to the user. This is a great runtime band-aid, but the linter is the right place to catch it — not at user-click-time.
+
+3. **The `@action` re-raise is the most consequential decorator drift.** The docstring's "On exception (re-raised after recording)" sounds like it acknowledges re-raise, but the consumer behavior (error frame, no re-render) breaks the visible contract. Doc-claim-verbatim TDD (#1046) would have caught this; it's exactly the failure mode that canon was created for. Phase 1 #2 should land alongside a regression test.
+
+4. **Decorator stackability is implicit.** Users compose decorators by trial and error. The audit's stackability matrix (§2) needs to be exposed as user-facing docs + locked in tests. The current contract is "guard at decoration time for `@event_handler`/`@server_function` mutual exclusion; everything else is silent." That's not enough.
+
+5. **The decorator metadata system (`func._djust_decorators` dict) is the right design.** Per CLAUDE.md canon (#1198), it's already established as the single source for marker detection. The audit's findings don't require changing the metadata system — they require **using it more strictly** (linter; contract tests).
+
+---
+
+## 9. Sequencing
+
+- **v0.9.3 opener** (~3 days, 3 PRs): Phase 1 quick wins. Fix the `on_` prefix in data_table integration (closes #1275 + the new pagination bug). Fix `@action` re-raise (closes #1276). Add auto-refresh to DataTableMixin (closes #1279). Each is a focused PR with regression tests.
+- **v0.9.3 mid** (~2 days, 2 PRs): Phase 2 linter foundation + capability. Lock in the contract; pre-push hook fails on drift.
+- **v0.9.3 late** (~3 days, ~6 PRs): Phase 3 decorator-contract spec tests. One test class per decorator; one test per docstring claim. This is mostly mechanical but high-leverage — catches future drift before it reaches users.
+- **Continuous**: Phase 4 documentation alongside Phase 1/2/3 PRs.
+
+---
+
+## 10. Companion canon update
+
+When this audit lands, add to `CLAUDE.md` under "Process canonicalizations" and `docs/PULL_REQUEST_CHECKLIST.md`:
+
+> **Tag-emit / handler symbol cross-reference** (Audit B — 2026-05). Any
+> change to a template-tag's `*_event=` default OR a corresponding mixin
+> handler must run `scripts/check-handler-contracts.py` (added in
+> Phase 2) before commit. The pre-push hook enforces this; bypassing it
+> reproduces #1275's failure mode.
+>
+> **Decorator-contract spec tests** (Audit B — 2026-05). Adding any new
+> decorator (or modifying an existing decorator's contract) requires a
+> spec test in `tests/test_decorator_contracts.py` that asserts each
+> docstring claim. The contract is the docstring; the test locks it in.
+> Skipping reproduces #1276's failure mode.

--- a/docs/audits/lifecycle-2026-05.md
+++ b/docs/audits/lifecycle-2026-05.md
@@ -158,8 +158,8 @@ Verdicts: ✓ tested + works, ? unverified, ✗ known broken.
 
 ## 7. Sequencing
 
-- **v0.9.3 opener** (~3 days, 3 PRs): Phase 1 quick wins — drain `_async_tasks` + flush `_pending_push_events` in `handle_mount` (closes #1280). Add 2 regression tests. Ship the audit doc itself in the same PR or one ahead. This bug class disappears for new users.
-- **v0.9.3 mid** (~5 days, 4 PRs): Phase 2 split-foundation — private state re-render gate (foundation PR + capability PR per Action Tracker #163), then AsyncResult envelope, then `_action_state` persistence, then snapshot-truncation warning. These four are independent but should land in the same milestone for a coherent release note.
+- **v0.9.2-5 drain bucket** (~1-2 days, 1-2 PRs): Phase 1 quick wins — drain `_async_tasks` + flush `_pending_push_events` in `handle_mount` (closes #1280, #1283). Add 2 regression tests. **Blocks v0.9.2 stable** because #1280 is 🔴 production-deploy-blocker class; shipping 0.9.2 with a known broken `mount() + assign_async()` would re-burn the same downstream consumers who reported it.
+- **v0.9.3** (~5 days, 4 PRs): Phase 2 split-foundation — private state re-render gate (foundation PR + capability PR per Action Tracker #163; closes #1281, #1286), AsyncResult envelope (#1274), `_action_state` persistence (#1284), snapshot-truncation warning (#1285). Mount-time pre-snapshot (Weakness #7) lands in the same window. These five are independent but should land in the same milestone for a coherent release note.
 - **v0.10 planning**: Phase 3 architectural work. Move change-detection into Rust is ADR-class; benefits from a planning cycle.
 - **Continuous**: Phase 4 documentation. Pick up alongside Phase 1/2 PRs.
 

--- a/docs/audits/lifecycle-2026-05.md
+++ b/docs/audits/lifecycle-2026-05.md
@@ -1,0 +1,177 @@
+# djust Lifecycle Coverage Audit — 2026-05
+
+**Status**: Snapshot in time. Synthesized from a state-type × hook matrix walk through `python/djust/websocket.py` (5,300+ LoC), `mixins/async_work.py`, `mixins/rust_bridge.py`, `decorators.py`, and the just-shipped `runtime.py` transport abstraction.
+
+**Companion audit**: `decorator-contract-2026-05.md` (sibling audit covering the orthogonal decorator/tag-name surface).
+
+**Scope**: Every (state-type, lifecycle-hook) cell in the matrix below. Two transports: WebSocket (`websocket.py`) and SSE (`sse.py`/`runtime.py`). What does the framework promise re: re-render, serialization, and reconnect-restoration for each cell?
+
+---
+
+## 1. Architecture at a glance
+
+Three concentric layers run on each user event:
+
+```
+JS event binding (09-event-binding.js)
+        ↓
+Transport frame (WS or SSE)
+        ↓
+LiveViewConsumer.handle_event / handle_mount   (websocket.py)
+        ↓
+_validate_event_security — getattr(view, event_name, None)   (websocket_utils.py:173)
+        ↓
+Pre-handler snapshot via _snapshot_assigns                    (websocket.py:163)
+        ↓
+Handler invocation (decorators.py wraps for @event_handler / @action / @background)
+        ↓
+Post-handler snapshot + _compute_changed_keys                 (websocket.py:222)
+        ↓
+_sync_state_to_rust → render_with_diff                         (rust_bridge.py)
+        ↓
+_send_update(patches) → _flush_push_events → _dispatch_async_work
+```
+
+### State-type catalog
+
+| State type | Where stored | Visible to template? | Persisted across reconnect? |
+|---|---|---|---|
+| Public state (`self.x`) | `view.__dict__`, non-`_` | ✓ | ✓ |
+| Private state (`self._x`) | `view.__dict__`, `_`-prefixed | ✓ via `get_context_data()` | ✓ if in `_user_private_keys` |
+| `AsyncResult` (from `assign_async`) | view attr (a `frozen` dataclass) | ✓ via attr access | ✗ not JSON-serializable |
+| `_action_state` dict (from `@action`) | `view._action_state[name]` | ✓ template injection | ✗ runtime-only |
+| `_pending_push_events` | view list | N/A (out-of-band) | N/A |
+| `_async_tasks` | view dict | N/A | N/A (regenerated) |
+| `_changed_keys` | view set | N/A (Rust-only) | N/A |
+
+### Lifecycle hooks
+
+| Hook | Code site | What it does |
+|---|---|---|
+| `mount(request, **kwargs)` | `websocket.py:1616` (handle_mount) → user code at line 2100 | Initial setup; class attrs initialized |
+| `@event_handler` runtime path | `websocket.py:2529` (handle_event) | Event dispatch → handler → re-render |
+| `@action` runtime path | `decorators.py:340-393` (action wrapper) | Wraps event_handler; records `_action_state[name]` |
+| `start_async()` callback completion | `websocket.py:827` (`_run_async_work`) | Background work drains; view re-renders |
+| Navigation / `live_redirect` | `websocket.py:3974+` | New mount; state reset |
+| `push_to_view` / `push_event` | broadcasts | Out-of-band frames |
+| WS reconnect | `websocket.py:1954-2001` (state restore path) | Session-state restored before mount |
+
+---
+
+## 2. State-type × hook matrix
+
+Verdicts: ✓ tested + works, ? unverified, ✗ known broken.
+
+| State type | `mount()` | `@event_handler` | `@action` | `start_async` | `push_event` | URL change | WS reconnect |
+|---|---|---|---|---|---|---|---|
+| Public state | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ reset | ✓ restored |
+| Private state | ✓ | **✗ #1281** | ✗ same | ✗ same | ? | ✓ reset | ✓ if in `_user_private_keys` |
+| `AsyncResult` | **✗ #1280** | ✓ | ✓ | ✓ | ? | ✓ reset | **✗ Gap-D** |
+| `_action_state` | ? | ✓ | ✓ | N/A | ? | ✗ reset | **✗ Gap-C** |
+| `_pending_push_events` | **✗ Gap-E** | ✓ flushed | ✓ flushed | ✓ flushed | ✓ self | N/A | N/A |
+| `_async_tasks` | **✗ #1280** | ✓ drained | ✓ drained | N/A | ? | ✓ reset | ✓ |
+| `_changed_keys` | N/A | ✓ pre/post | ✓ pre/post | ? snapshot only | N/A | ✓ reset | ? |
+
+**5 ✗ cells** drive the ranked weaknesses below.
+
+---
+
+## 3. Current weaknesses, ranked
+
+🔴 = production-deploy-blocker class. 🟡 = should-fix. Effort: S/M/L.
+
+| # | Weakness | Cite | Impact | Effort | Issue |
+|---|---|---|---|---|---|
+| 1 | `mount()` doesn't drain `_async_tasks`. `assign_async()`/`start_async()` called from `mount()` is queued but never spawned. View shows pending state forever until user triggers any event. | `websocket.py:2352` (handle_mount end has no `_dispatch_async_work` call); compare `websocket.py:921, 1218, 1287` (drain calls in event/deferred paths) | 🔴 | S | [#1280](https://github.com/djust-org/djust/issues/1280) |
+| 2 | Private state changes (`self._x = ...`) don't trigger re-render. `_snapshot_assigns` filters all `_*` attrs from change-detection (`if k.startswith("_"): continue`). Changes survive in `__dict__` and persist via `_user_private_keys` but template stays stale until next event. | `websocket.py:163-219` (`_snapshot_assigns`), `websocket.py:222-233` (`_compute_changed_keys` operates on already-filtered snapshots) | 🔴 | M | [#1281](https://github.com/djust-org/djust/issues/1281) |
+| 3 | `_pending_push_events` queued during `mount()` is never flushed pre-response. Notifications/alerts emitted by `mount()` or `on_mount` hooks lose the mount-window delivery. | `websocket.py:2352` (no `_flush_push_events` before `send_json(response)`); compare `websocket.py:921` (drained in `_run_async_work`), `websocket.py:1082, 1110, 1211` (drained in event/deferred paths) | 🟡 | S | (file as new issue) |
+| 4 | `_action_state` not persisted across reconnect. After `@action` completes successfully or with error, the dict survives in-memory but is discarded on disconnect. On reconnect, template reading `{{ create_todo.error }}` sees fresh empty state — UI silently desyncs from prior outcome. | `decorators.py:349-378` (`_action_state` stamped at runtime), `live_view.py:_get_private_state` (saves only `_user_private_keys` attrs) | 🟡 | M | (file as new issue) |
+| 5 | `AsyncResult` not session-serializable. `frozen` dataclass with no `to_dict`. `_get_private_state` JSON-encodes each value; `AsyncResult` gets coerced to `str()` and silently dropped. On reconnect, attribute is `None` or missing entirely → templates raise `VariableDoesNotExist`. | `async_result.py` (frozen dataclass), `live_view.py:_get_private_state` (`json.dumps(...)` fallback) | 🟡 | M | [#1274](https://github.com/djust-org/djust/issues/1274) (sibling — same root: serializer allowlist) |
+| 6 | `_snapshot_assigns` content fingerprint truncates at 100 list items + 50 dict keys. Mutations inside a list of 101+ are missed; "stale-after-grow" class. | `websocket.py:188-212` (the `len(v) < 100` / `len(v) < 50` guards) | 🟡 | S | (file as new issue) |
+| 7 | `mount()` lacks pre/post snapshot. Differs from `@event_handler` which captures both. Means a mount-time mutation has no `_changed_keys` and forces full HTML render. (Acceptable for first render; not for replays/snapshot-restore.) | `websocket.py:2100, 2168, 2208` (mount path: no `_capture_dirty_baseline` paired with `_compute_changed_keys`) | 🟡 | M | (file as new issue) |
+| 8 | Dual change-detection paths with divergent semantics. Explicit `_changed_keys` (set via `set_changed_keys()`) → partial Rust render. Implicit (snapshot diff) → only public attrs. The two never meet — explicit path can include `_x`, snapshot can't. | `rust_bridge.py:707` (Rust receives `_changed_keys`); `websocket.py:222` (snapshot diff filters `_x`) | 🟡 | M | (file as new issue) |
+
+---
+
+## 4. Test gaps
+
+| Area | Gap | Reproducer outline |
+|---|---|---|
+| `mount()` + `start_async()` | No test asserts the queued task actually completes post-mount | Mount a view that calls `self.start_async(self._loader)`; assert `self._loader` ran and sent a patch frame |
+| `mount()` + `push_event()` | No test asserts mount-time push events reach client | Mount a view that calls `self.push_event("hello", {})`; assert client received frame |
+| Private state re-render | No test asserts `self._x = ...` in handler triggers patch | Handler mutates `self._cache`; assert `_cache`-backed template fragment patches |
+| `_action_state` reconnect | No test asserts `{{ action.error }}` survives WS disconnect → reconnect | `@action` raises; disconnect; reconnect; assert error visible |
+| `AsyncResult` reconnect | No test asserts `AsyncResult.pending()` survives session round-trip | `assign_async()` in mount; disconnect mid-fetch; reconnect; assert state |
+| Snapshot truncation | No test for list-with-100+ in-place mutations | Make `self.items` of length 101; mutate `items[50]['name']`; assert detected |
+
+---
+
+## 5. Improvement roadmap
+
+### Phase 1 — Quick wins (~3 PRs)
+
+| # | Fix | Files | Effort | Closes |
+|---|---|---|---|---|
+| 1 | Add `await self._dispatch_async_work()` and `await self._flush_push_events()` before final `send_json(response)` in `handle_mount` | `websocket.py:2352` | S | Weaknesses #1, #3 → #1280 |
+| 2 | Add 2 regression tests: mount-time `start_async` completes + mount-time `push_event` delivered | `tests/test_lifecycle_mount_async.py` (new) | S | Test gap |
+
+### Phase 2 — Correctness hardening (split-foundation per Action #163)
+
+| Initiative | Effort | Closes |
+|---|---|---|
+| **Foundation**: extend `_snapshot_assigns` to optionally include `_user_private_keys` attrs in change detection. Gate behind opt-in flag for backwards compatibility, then flip default in v0.10. | M | #1281 (foundation) |
+| **Capability**: flip default; add migration note in CHANGELOG; update `docs/STATE_MANAGEMENT_API.md` to document private-state re-render semantics | M | #1281 (capability) |
+| `AsyncResult` serializable envelope: implement `to_dict`/`from_dict`; register in `serialization.py:normalize_django_value` | M | Weakness #5 (sibling to Audit F #1274) |
+| `_action_state` session persistence: extend `_get_private_state`/`_restore_private_state` to include action state with serializable result/error | M | Weakness #4 |
+| Mount-time pre-snapshot: capture `_capture_dirty_baseline()` before user `mount()` to enable partial re-render on snapshot-restore path | M | Weakness #7 |
+| Unify change-detection: single source of truth for `_changed_keys` whether it came from explicit `set_changed_keys()` or snapshot diff | M | Weakness #8 |
+
+### Phase 3 — Architectural (multi-PR)
+
+| Initiative | Effort | Impact |
+|---|---|---|
+| Move change-detection into Rust — declared changed keys at render time instead of pre/post snapshot in Python | L | Eliminates snapshot overhead; closes truncation gaps (#6); enables partial-dict patching for lists |
+| Unify state serialization across public/private/action/async — single `_capture_persisted_state()` method on LiveView | M | Reduces drift; one canonical contract for "what survives reconnect" |
+| Add `on_state_changed(self, keys)` observability hook for time-travel/debug-overlay/external-state-store integrations | S-M | Pays back on debug tooling and time-travel features |
+
+### Phase 4 — Documentation
+
+- The lifecycle matrix above belongs in `docs/STATE_MANAGEMENT_API.md` as the canonical contract reference, not buried in this audit.
+- The mount path's "queue-without-drain" semantics need a user-facing note in `docs/website/guides/loading-states.md` (complete after #1280 lands).
+- The `_user_private_keys` opt-in mechanism needs first-class documentation; currently surfaced only in code comments.
+
+---
+
+## 6. Strategic observations
+
+1. **The mount path is the under-tested critical path.** Mount is the first-impression hook (initial HTML, async loading state setup). Phase 1 alone adds the load-bearing tests. Every other lifecycle hook (event, push, async-completion) calls `_dispatch_async_work` and `_flush_push_events`; mount is the lone outlier. This asymmetry should be removed before more hooks are added.
+
+2. **Change-detection has two sources of truth that disagree on private state.** Explicit `set_changed_keys({"_x"})` would mark `_x` as changed and pass to Rust — but the snapshot-diff path filters `_x` before computing diffs. Users who write `self.set_changed_keys({"_x"})` get correct behavior; users who rely on auto-detection don't. The fix is structural (pick one path), not a new flag.
+
+3. **Reconnect-restoration is asymmetric across state types.** Public state is auto-persisted/restored. Private state is conditionally persisted (must be in `_user_private_keys`). `_action_state` and `AsyncResult` are unconditionally lost. This is a contract gap, not a bug per se — but it means `@action` and `assign_async` look like they "just work" until a reconnect. Phase 2 establishes the contract; users get a single sentence: "X survives reconnect; Y does not."
+
+4. **The `_snapshot_assigns` truncation guards are pragmatic but invisible.** A list of 101 items mutating an inner field silently breaks change-detection. No warning is emitted; the patch frame just doesn't include the change. The fix is either (a) raise the threshold, (b) emit a `vdom_trace!()`-style warning when the threshold trips, or (c) document the threshold in the public API. Phase 1 should add option (b).
+
+5. **Process payoff aligned with VDOM audit findings**: like the VDOM audit, the central recurring class here is "scope of change-detection vs. scope of template-context dependency." The VDOM audit's #1205 (`list[Model]` `__eq__` pk-only) and this audit's weakness #2 (`_x` filtered) are the same shape: change-detection sees less than the template depends on. A unified test pattern — "mutation-after-render assertion across all state-types" — would catch both classes.
+
+---
+
+## 7. Sequencing
+
+- **v0.9.3 opener** (~3 days, 3 PRs): Phase 1 quick wins — drain `_async_tasks` + flush `_pending_push_events` in `handle_mount` (closes #1280). Add 2 regression tests. Ship the audit doc itself in the same PR or one ahead. This bug class disappears for new users.
+- **v0.9.3 mid** (~5 days, 4 PRs): Phase 2 split-foundation — private state re-render gate (foundation PR + capability PR per Action Tracker #163), then AsyncResult envelope, then `_action_state` persistence, then snapshot-truncation warning. These four are independent but should land in the same milestone for a coherent release note.
+- **v0.10 planning**: Phase 3 architectural work. Move change-detection into Rust is ADR-class; benefits from a planning cycle.
+- **Continuous**: Phase 4 documentation. Pick up alongside Phase 1/2 PRs.
+
+---
+
+## 8. Companion canon update
+
+When this audit lands, add to `CLAUDE.md` under "Process canonicalizations":
+
+> **Lifecycle-matrix maintenance** (Audit A — 2026-05). When adding any new
+> state-type, lifecycle-hook, or transport, update the matrix in
+> `docs/audits/lifecycle-2026-05.md` AND add a regression test for each new
+> cell. The matrix is the contract; the tests lock it in. Skipping this step
+> reproduces the failure mode that produced #1280, #1281, and the four
+> Phase-2 weaknesses cataloged here.


### PR DESCRIPTION
## Summary

Two companion audit docs modeled on the v0.9.2-4 VDOM audit
(`docs/vdom/AUDIT-2026-04-30.md`), commissioned in response to 10
downstream-consumer bug reports (#1267, #1273-#1281). Driven by a
plan-mode review and the user's question "Is there additional audits
we need to do to ensure proper implementation?".

- **Lifecycle Coverage Audit** (`docs/audits/lifecycle-2026-05.md`, 177
  lines) — state-type × lifecycle-hook matrix; 8 ranked weaknesses;
  4-phase improvement roadmap. Catches the `mount()` control-flow gap
  rooting #1280 (no `_dispatch_async_work` call) and #1281 (private
  state filtered from change-detection).
- **Decorator/Tag Contract Audit**
  (`docs/audits/decorator-contract-2026-05.md`, 305 lines) — 12-decorator
  inventory; 24-row tag-emit ↔ handler-name cross-reference revealing
  that 23 of `data_table`'s default `*_event=` values dispatch to
  handlers that don't exist (generalizes #1275 + new pagination gap
  #1291); proposes a ~50 LoC `scripts/check-handler-contracts.py`
  linter that would catch this class at pre-push time.

## Why this audit shape

- All 10 bug reports came from real-world downstream usage, not from
  framework-internal tests. They cluster into 7 root-cause classes,
  not 10 — each maps to one auditable surface area.
- The VDOM audit (PR #1257) demonstrated the same shape: ~200-line
  audit doc + grep evidence + ranked weaknesses → drove 5 PRs in
  ~75 min wall-clock with no review surprises (#1252-#1256).
- Audits A + B together cover 7 of the 10 bugs systematically; the
  remaining 3 (#1267, #1273, #1274, #1277, #1278) are flagged for
  Audits C/D/E/F/G in v0.9.3 (post-stable).

## Sequencing — v0.9.2-5 blocks v0.9.2 stable

Per the audits' own rankings, **seven 🔴 production-deploy-blocker
class** weaknesses are surfaced. Shipping v0.9.2 stable with these
known-broken would re-burn the downstream consumers who reported them.

- **Phase 1 → v0.9.2-5 drain bucket** (~4 days, 4-5 PRs) — blocks
  v0.9.2 stable. Closes #1280, #1283 (mount async/push-events drain),
  #1275 + #1291 (data_table tag-name + pagination handlers), #1276
  (`@action` re-raise contract), #1279 (DataTableMixin auto-refresh).
- **Phase 2 → v0.9.3** — private-state re-render gate (#1281, #1286),
  AsyncResult envelope (#1274), `_action_state` persistence (#1284),
  snapshot-truncation warning (#1285), decorator linter (#1290).
- **Phase 3 → v0.9.3 late** — decorator-contract spec tests (#1287,
  #1288, #1289).

## Pre-staged issues

8 new issues filed alongside this PR (#1283-#1290 from the audit
docs; #1291 the data_table pagination gap surfaced separately).

| Audit | Phase 1 (v0.9.2-5) | Phase 2 (v0.9.3) | Phase 3 (v0.9.3 late) |
|---|---|---|---|
| A — Lifecycle | #1280, #1283 | #1281, #1284, #1285, #1286, #1274 | — |
| B — Decorator/Tag | #1275, #1276, #1279, #1291 | #1290 | #1287, #1288, #1289 |

## What's in the docs

Each audit ships with:
1. Architecture-at-a-glance diagram with file:line citations.
2. Centerpiece table (state matrix for A; decorator inventory + tag
   cross-reference for B).
3. Ranked weaknesses table with cite + impact + effort + issue link.
4. Test gaps section with reproducer outlines.
5. 4-phase improvement roadmap.
6. Strategic observations.
7. Sequencing recommendation for v0.9.2-5 + v0.9.3 milestones.
8. Companion canon update for `CLAUDE.md` / `PR-checklist`.

## Test plan

- [ ] Reviewer reads both audit docs end-to-end.
- [ ] Reviewer spot-checks 3-5 file:line citations to confirm accuracy.
- [ ] Reviewer confirms the data_table cross-reference table by
      grepping `def on_table_*` in `mixins/data_table.py` and
      `*_event=` in `templatetags/djust_components.py`.
- [ ] Reviewer confirms the dispatcher's exact-match contract at
      `websocket_utils.py:173`.
- [ ] Single-PR audit-only shape; no code, no runnable changes; CI
      green expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)