### PR TITLE
fix(decorators): document @background + @action interaction contract (#1299)

### DIFF
--- a/python/djust/decorators.py
+++ b/python/djust/decorators.py
@@ -974,6 +974,23 @@ def background(func: F) -> F:
         def auto_save(self, **kwargs):
             # Debounced and runs in background
             self.save_draft()
+
+    Combining ``@background`` and ``@action``:
+        @event_handler
+        @background
+        @action
+        def slow_op(self, **kwargs):
+            ...
+
+    When combined, ``@action`` catches ``Exception`` and records it in
+    ``self._action_state[name]["error"]`` (does **not** re-raise — see
+    @action docs).  Because ``@action`` never re-raises, ``@background``'s
+    ``start_async`` never sees the exception — ``handle_async_result`` is
+    called with ``error=None`` even when the handler body raised.  The
+    error signal is ``_action_state[name]["error"]``, NOT
+    ``handle_async_result``'s ``error`` parameter.  Checks that only
+    inspect ``handle_async_result`` for errors will miss ``@action``
+    failures.
     """
 
     if asyncio.iscoroutinefunction(func):

--- a/python/djust/tests/test_action_decorator_contract.py
+++ b/python/djust/tests/test_action_decorator_contract.py
@@ -162,3 +162,119 @@ class TestActionLazyInitializesActionState:
         v.lazy_handler()
         assert hasattr(v, "_action_state")
         assert v._action_state["lazy_handler"]["result"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# #1299: @action + @background combo — error in _action_state, not callback.
+# ---------------------------------------------------------------------------
+
+
+class _ActionBackgroundHost:
+    """Minimal host that provides both @action's _action_state and
+    @background's start_async + handle_async_result."""
+
+    def __init__(self):
+        self._action_state = {}
+        self._async_tasks = {}
+        self.handle_async_result_calls = []
+        self._task_counter = 0
+
+    def start_async(self, callback, *args, name=None, **kw):
+        if name is None:
+            self._task_counter += 1
+            name = f"_async_{self._task_counter}"
+        self._async_tasks[name] = (callback, args, kw)
+
+    def handle_async_result(self, name, result=None, error=None):
+        self.handle_async_result_calls.append((name, result, error))
+
+
+class TestActionBackgroundCombo:
+    """#1299: @action + @background contract.
+
+    When combined, @action swallows exceptions → @background never sees them.
+    The error signal is _action_state[name]["error"], NOT handle_async_result's
+    error parameter.
+    """
+
+    def test_action_background_raises_error_in_action_state_not_re_raised(self):
+        from djust.decorators import action, background, event_handler
+
+        class TestView(_ActionBackgroundHost):
+            @event_handler
+            @background
+            @action
+            def slow_op(self, **kwargs):
+                raise ValueError("boom")
+
+        view = TestView()
+        view.slow_op()
+
+        # The callback should be scheduled via start_async.
+        assert len(view._async_tasks) == 1
+        _, (cb, args, kwargs) = list(view._async_tasks.items())[0]
+
+        # Run the callback.  It must NOT re-raise — @action swallows.
+        result = cb(*args, **kwargs)
+        assert result is None, "@action swallowed the exception; callback returns None"
+
+        # Error is recorded in _action_state.
+        state = view._action_state["slow_op"]
+        assert state["error"] == "boom"
+        assert state["pending"] is False
+        assert state["result"] is None
+
+    def test_action_background_handle_async_result_receives_error_none(self):
+        """When @action swallows the exception, the callback returns normally,
+        so _run_async_work would call handle_async_result with error=None.
+        """
+        from djust.decorators import action, background, event_handler
+
+        class TestView(_ActionBackgroundHost):
+            @event_handler
+            @background
+            @action
+            def slow_op(self, **kwargs):
+                raise ValueError("boom")
+
+        view = TestView()
+        view.slow_op()
+        _, (cb, args, kwargs) = list(view._async_tasks.items())[0]
+
+        # Simulate what _run_async_work does on success.
+        result = cb(*args, **kwargs)
+        view.handle_async_result("slow_op", result=result, error=None)
+
+        assert len(view.handle_async_result_calls) == 1
+        assert view.handle_async_result_calls[0] == ("slow_op", None, None), (
+            "handle_async_result receives error=None because @action "
+            "swallowed the exception — the error is in _action_state"
+        )
+
+        # _action_state still has the real error.
+        assert view._action_state["slow_op"]["error"] == "boom"
+
+    def test_action_background_success_populates_result(self):
+        """Happy path: @action + @background success still works."""
+        from djust.decorators import action, background, event_handler
+
+        class TestView(_ActionBackgroundHost):
+            @event_handler
+            @background
+            @action
+            def slow_op(self, **kwargs):
+                return {"ok": True}
+
+        view = TestView()
+        view.slow_op()
+        _, (cb, args, kwargs) = list(view._async_tasks.items())[0]
+
+        result = cb(*args, **kwargs)
+        assert result == {"ok": True}
+
+        view.handle_async_result("slow_op", result=result, error=None)
+        assert view.handle_async_result_calls[0] == ("slow_op", {"ok": True}, None)
+
+        state = view._action_state["slow_op"]
+        assert state["error"] is None
+        assert state["result"] == {"ok": True}


### PR DESCRIPTION
## Summary
- Documents the `@background` + `@action` stacking contract in the `@background` docstring
- Adds 3 spec tests locking the contract: exception swallowed, `handle_async_result` receives `error=None`, success path works
- When stacked (`@event_handler` → `@background` → `@action`), `@action` swallows exceptions and records to `_action_state[name]["error"]` without re-raising. `@background`'s `start_async` never sees the exception, so `handle_async_result` is called with `error=None`. The error signal is exclusively in `_action_state`.

## Test plan
- [ ] 3 new tests in `TestActionBackgroundCombo` pass
- [ ] Full test suite passes (~5610 tests)
- [ ] Existing `@action` contract tests (8 tests) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)