### PR TITLE
fix(websocket): preserve mount-time push events in batch mount path (#1295)

### DIFF
--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -2373,7 +2373,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
         frame.
 
         Returns a ``(success: bool, payload: dict, error: Optional[str],
-        navigate_frame: Optional[dict])`` tuple:
+        navigate_frame: Optional[dict], push_events: list)`` tuple:
 
         - ``success=True`` and ``payload`` is the captured ``mount`` frame
           merged with the caller-supplied ``target_id``.
@@ -2387,6 +2387,11 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
           ``handle_mount_batch`` can forward the redirect to the client
           in the batch response — without this, the frame was silently
           dropped and the user was never redirected.
+        - ``push_events`` (Fix #1295): ``push_event`` frames captured
+          during mount. When ``mount()`` calls ``push_event()``,
+          ``_flush_push_events`` fires with ``send_json`` swapped for the
+          collector, so push events land in ``captured[]``.  The caller
+          flushes them after the batch response so they reach the client.
 
         Isolation: errors in one view MUST NOT propagate and kill the
         batch (see plan §2.3 "atomicity relaxed").
@@ -2437,9 +2442,15 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
         # Fix #4: capture "navigate" frames too — those are emitted when
         # auth or on_mount hooks redirect instead of mounting, and were
         # previously silently dropped.
+        # Fix #1295: also capture "push_event" frames. When mount() calls
+        # push_event(), _flush_push_events runs with send_json swapped for
+        # _collect — so push events land in captured[]. Extract them and
+        # return them so handle_mount_batch can flush them after the batch
+        # response (they'd otherwise be silently dropped).
         mount_frame = None
         error_frame = None
         navigate_frame = None
+        push_events: list = []
         for frame in captured:
             ftype = frame.get("type")
             if ftype == "mount":
@@ -2448,6 +2459,8 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 error_frame = frame
             elif ftype == "navigate":
                 navigate_frame = frame
+            elif ftype == "push_event":
+                push_events.append(frame)
 
         if navigate_frame is not None:
             # Redirect — surface through the batch response so the
@@ -2457,11 +2470,17 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             nav_payload = dict(navigate_frame)
             nav_payload["target_id"] = target_id
             nav_payload["view"] = view_path
-            return False, {"target_id": target_id, "view": view_path}, None, nav_payload
+            return (
+                False,
+                {"target_id": target_id, "view": view_path},
+                None,
+                nav_payload,
+                push_events,
+            )
 
         if error_frame is not None:
             err_msg = error_frame.get("message", "mount failed")
-            return False, {"target_id": target_id, "view": view_path}, err_msg, None
+            return False, {"target_id": target_id, "view": view_path}, err_msg, None, push_events
 
         if mount_frame is None:
             return (
@@ -2469,11 +2488,12 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 {"target_id": target_id, "view": view_path},
                 "mount produced no frame",
                 None,
+                push_events,
             )
 
         # Inject target_id for client-side per-view DOM targeting.
         mount_frame["target_id"] = target_id
-        return True, mount_frame, None, None
+        return True, mount_frame, None, None, push_events
 
     async def handle_mount_batch(self, data: Dict[str, Any]):
         """Mount multiple views in one frame and reply with one batch frame.
@@ -2503,6 +2523,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
         successes: list = []
         failures: list = []
         navigates: list = []
+        all_push_events: list = []
         for view_data in views_list:
             if not isinstance(view_data, dict):
                 failures.append(
@@ -2517,7 +2538,9 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             if client_timezone and "client_timezone" not in view_data:
                 view_data = dict(view_data)
                 view_data["client_timezone"] = client_timezone
-            ok, payload, err, nav = await self._mount_one(view_data)
+            ok, payload, err, nav, push_events = await self._mount_one(view_data)
+            if push_events:
+                all_push_events.extend(push_events)
             if ok:
                 successes.append(payload)
                 continue
@@ -2537,6 +2560,14 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
         if navigates:
             response["navigate"] = navigates
         await self.send_json(response)
+
+        # Fix #1295: flush push events that were captured during mount.
+        # When mount() calls push_event(), _flush_push_events fires with
+        # send_json swapped for _collect in _mount_one — so push events
+        # land in captured[] instead of being sent. We extract them in
+        # _mount_one and flush them here after the batch response.
+        for frame in all_push_events:
+            await self.send_json(frame)
 
     async def handle_event(self, data: Dict[str, Any]):
         """Handle client events"""

--- a/tests/unit/test_sw_advanced.py
+++ b/tests/unit/test_sw_advanced.py
@@ -108,6 +108,18 @@ class _NonSnapshot(LiveView):
         return {"count": self.count}
 
 
+class _PushEventOnMount(LiveView):
+    """View that calls push_event() during mount() — exercises #1295."""
+
+    template = "<div dj-root><span>Hello</span></div>"
+
+    def mount(self, request, **kwargs):
+        self.push_event("greeting", {"msg": "Welcome"})
+
+    def get_context_data(self, **kwargs):
+        return {}
+
+
 # ---------------------------------------------------------------------------
 # 4-8. State snapshot unit tests — LiveView API surface only.
 # ---------------------------------------------------------------------------
@@ -237,6 +249,24 @@ def _make_fake_consumer():
             return None
 
     return _FakeConsumer()
+
+
+def _make_fake_consumer_with_push_events():
+    """Same as _make_fake_consumer but preserves the real _flush_push_events.
+
+    The default fake consumer overrides _flush_push_events to a no-op so
+    that tests that don't use push_event() don't accidentally trip over
+    missing view_instance setup.  When we DO want to test push_event
+    capture (mount_batch + push_event in mount()), we need the real
+    implementation so the queued events flow into the collector.
+    """
+    consumer = _make_fake_consumer()
+    # Remove the no-op override — LiveViewConsumer's real _flush_push_events
+    # calls self.send_json for each queued event, which in this fake
+    # consumer appends to sent_frames (or captured[] when send_json is
+    # swapped by _mount_one's collector).
+    del type(consumer)._flush_push_events
+    return consumer
 
 
 # ---------------------------------------------------------------------------
@@ -468,6 +498,47 @@ class TestMountBatch:
         assert "span" in tags, (
             "mount_batch view html should contain rendered <span>, got tags: %s" % tags
         )
+
+    def test_mount_batch_preserves_push_events_from_mount(self):
+        """#1295: push_event() during mount() is not silently dropped.
+
+        When a batch-mounted view calls push_event() in its mount() method,
+        the push event must reach the client — not be swallowed by the
+        _mount_one capture extractor (which previously only pulled mount,
+        error, and navigate frames).
+        """
+        consumer = _make_fake_consumer_with_push_events()
+        data = {
+            "type": "mount_batch",
+            "views": [
+                {
+                    "view": "tests.unit.test_sw_advanced._PushEventOnMount",
+                    "params": {},
+                    "url": "/",
+                    "target_id": "greeter",
+                },
+            ],
+        }
+        asyncio.run(consumer.handle_mount_batch(data))
+
+        # The mount_batch frame must still be present.
+        batch_frames = [f for f in consumer.sent_frames if f.get("type") == "mount_batch"]
+        assert len(batch_frames) == 1
+        assert len(batch_frames[0]["views"]) == 1
+
+        # The push_event frame must arrive AFTER the batch frame.
+        push_frames = [f for f in consumer.sent_frames if f.get("type") == "push_event"]
+        assert len(push_frames) == 1, (
+            "push_event() from mount() must survive the _mount_one collector; "
+            "got 0 push_event frames (all frames: %s)" % consumer.sent_frames
+        )
+        assert push_frames[0]["event"] == "greeting"
+        assert push_frames[0]["payload"] == {"msg": "Welcome"}
+
+        # Verify ordering: push_event after mount_batch.
+        batch_idx = consumer.sent_frames.index(batch_frames[0])
+        push_idx = consumer.sent_frames.index(push_frames[0])
+        assert push_idx > batch_idx, "push_event must flush after mount_batch, not before"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes #1295: `_mount_one`'s capture extractor previously only pulled `mount`/`error`/`navigate` frames from the collector, silently dropping `push_event` frames emitted during `mount()`
- When a batch-mounted view calls `push_event()` in its `mount()` method, the push event was captured but never extracted or sent to the client
- Now `_mount_one` also extracts `push_event` frames and returns them as a 5th tuple element; `handle_mount_batch` flushes them after the batch response

## Test plan
- [x] New test `test_mount_batch_preserves_push_events_from_mount` verifies push events survive the collector
- [x] Full test suite passes (4099 tests)
- [x] Existing mount_batch tests (4 tests) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)