### PR TITLE
fix: _action_state persists across WS reconnects (#1284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from user-defined private attrs set in ``mount()`` or event handlers.
   9 regression cases in ``test_skip_render_private_state.py``.
 
+- **``_action_state`` now persists across WebSocket reconnects (#1284).**
+  The ``@action`` decorator populates ``_action_state[action_name]`` with
+  ``{pending, error, result}`` so templates can reference
+  ``{{ action_name.error }}``. Previously ``_action_state`` was initialized
+  before ``_framework_attrs`` capture in ``__init__``, putting it in the
+  framework-internal set that ``_snapshot_user_private_attrs`` and
+  ``_restore_private_state`` exclude. It now initializes after the capture,
+  so the standard user-private save/restore cycle handles it automatically.
+  6 regression cases in ``test_action_state_reconnect.py``.
+
 ## [0.9.2] - 2026-05-02
 
 ### Fixed

--- a/python/djust/live_view.py
+++ b/python/djust/live_view.py
@@ -457,12 +457,6 @@ class LiveView(
         self._temporary_assigns_initialized: bool = False  # Track if temp assigns are set up
         self._streams: Dict[str, Stream] = {}  # Stream collections
         self._stream_operations: list = []  # Pending stream operations for this render
-        # v0.8.0 — @action server-action state. Each entry is keyed by the
-        # action's method name and holds {"pending": bool, "error": str|None,
-        # "result": Any}. Populated by the @action decorator's wrapper at
-        # handler entry/exit; exposed to templates by ContextMixin's
-        # get_context_data() for `{{ <action_name>.pending }}` access.
-        self._action_state: Dict[str, Dict[str, Any]] = {}
         # Initialize navigation support (live_patch, live_redirect)
         self._init_navigation()
 
@@ -512,6 +506,11 @@ class LiveView(
         # Snapshot framework-set attrs so we can distinguish them from
         # user-defined _private attrs set in mount() or event handlers.
         self._framework_attrs: frozenset = frozenset(self.__dict__.keys())
+
+        # v0.8.0 — @action server-action state. Initialized AFTER
+        # _framework_attrs capture so it is treated as user-private
+        # state and persisted across reconnects (#1284).
+        self._action_state: Dict[str, Dict[str, Any]] = {}
 
     # ============================================================================
     # DIRTY TRACKING — cumulative since mount or last mark_clean() (v0.5.1)

--- a/python/tests/test_action_state_reconnect.py
+++ b/python/tests/test_action_state_reconnect.py
@@ -1,0 +1,106 @@
+"""Regression tests for #1284 — _action_state persistence across WS reconnect.
+
+When a WS disconnect/reconnect cycle occurs, ``_action_state`` (populated by
+the ``@action`` decorator with ``{pending, error, result}`` per action name)
+was not persisted because it was initialized BEFORE ``_framework_attrs`` capture
+in ``__init__``, putting it in the framework-internal set excluded from
+``_snapshot_user_private_attrs`` / ``_restore_private_state``.
+
+The fix moves ``_action_state`` initialization to AFTER ``_framework_attrs``
+capture so it participates in the standard user-private save/restore cycle.
+"""
+
+from djust import LiveView
+from djust.decorators import action
+
+
+class _ActionView(LiveView):
+    """View with an @action handler that populates _action_state."""
+
+    @action
+    def create_todo(self, title: str = "", **kwargs):
+        if not title:
+            raise ValueError("title required")
+        return {"id": 1, "title": title}
+
+
+class TestActionStateInPrivateKeys:
+    """_action_state appears in _user_private_keys and is save/restore-able."""
+
+    def test_action_state_in_user_private_keys(self):
+        view = _ActionView()
+        view._snapshot_user_private_attrs()
+        assert "_action_state" in view._user_private_keys, (
+            "#1284: _action_state must be in _user_private_keys so it is persisted"
+        )
+
+    def test_action_state_not_in_framework_attrs(self):
+        view = _ActionView()
+        assert "_action_state" not in view._framework_attrs, (
+            "#1284: _action_state must NOT be in _framework_attrs; "
+            "otherwise _snapshot_user_private_attrs and _restore_private_state skip it"
+        )
+
+    def test_action_state_saved_by_get_private_state(self):
+        view = _ActionView()
+        view._snapshot_user_private_attrs()
+        # Simulate an action handler run
+        view._action_state["create_todo"] = {
+            "pending": False,
+            "error": None,
+            "result": {"id": 1, "title": "hello"},
+        }
+        private = view._get_private_state()
+        assert "_action_state" in private
+        assert private["_action_state"]["create_todo"]["result"]["title"] == "hello"
+
+    def test_action_state_restored_by_restore_private_state(self):
+        view = _ActionView()
+        view._snapshot_user_private_attrs()
+
+        saved = {
+            "_action_state": {
+                "create_todo": {
+                    "pending": False,
+                    "error": "title required",
+                    "result": None,
+                }
+            },
+            "_other_private": "value",
+        }
+        view._restore_private_state(saved)
+
+        assert "_action_state" in view._user_private_keys
+        assert view._action_state["create_todo"]["error"] == "title required"
+
+    def test_action_state_persisted_after_mount(self):
+        """End-to-end: snapshot, simulate handler, save → restore → state intact."""
+        view1 = _ActionView()
+        view1._snapshot_user_private_attrs()
+        # Simulate @action handler populating state
+        view1._action_state["create_todo"] = {
+            "pending": False,
+            "error": None,
+            "result": {"id": 1, "title": "hello"},
+        }
+        saved = view1._get_private_state()
+
+        # Simulate reconnect: fresh view, restore
+        view2 = _ActionView()
+        view2._restore_private_state(saved)
+
+        assert "_action_state" in view2._user_private_keys
+        assert view2._action_state["create_todo"]["result"]["id"] == 1
+
+    def test_empty_action_state_saved_and_restored(self):
+        """Empty _action_state (no actions run yet) still persists correctly."""
+        view = _ActionView()
+        view._snapshot_user_private_attrs()
+
+        saved = view._get_private_state()
+        assert "_action_state" in saved
+        assert saved["_action_state"] == {}
+
+        view2 = _ActionView()
+        view2._restore_private_state({"_action_state": {}})
+        assert view2._action_state == {}


### PR DESCRIPTION
## Summary
- Moves `_action_state` initialization to after `_framework_attrs` capture in `__init__`
- This puts it in the user-private state set, so `_snapshot_user_private_attrs` / `_get_private_state` / `_restore_private_state` handle it automatically
- On reconnect, `_action_state` (populated by `@action` handlers with `{pending, error, result}`) is now restored from session
- 6 regression tests in `test_action_state_reconnect.py`

## Test plan
- [x] `make test-python` — 4105 passed, 0 failed
- [x] New test file with 6 cases: keyset membership, save, restore, end-to-end persist, empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)