### PR TITLE
fix(serialization): emit one-shot warning when snapshot fingerprint is truncated for large containers (#1285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so the standard user-private save/restore cycle handles it automatically.
   6 regression cases in ``test_action_state_reconnect.py``.
 
+- **Snapshot truncation warning for large lists/dicts (#1285).**
+  ``_snapshot_assigns()`` now emits a one-shot ``logger.warning`` per view
+  class when a list has ≥100 items or a dict has ≥50 keys. These containers
+  have truncated content fingerprints (list: only ``(id, length)``; dict:
+  only ``len(v)`` instead of a key tuple), so in-place mutations inside them
+  are not detected by auto-diff. The warning tells developers to use
+  ``set_changed_keys()`` or assign a new reference. 10 regression cases in
+  ``test_snapshot_truncation_warning.py``.
+
 ## [0.9.2] - 2026-05-02
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -186,7 +186,7 @@ Drain buckets accumulating toward release `v0.9.3`. First bucket `v0.9.3-1` coll
 
 ### Milestone: v0.9.3-2 — #1281 private-state re-render (split-foundation)
 
-**Status:** ⬜ planning — #1281 is the headliner.
+**Status:** 🔄 in progress — #1281 + #1284 merged; #1285 in PR #1326.
 
 *Goal:* Fix the private-state re-render gap: handlers that mutate only
 `self._*` private state get `noop` from the Rust diff because the
@@ -197,12 +197,12 @@ short-circuit so `render_with_diff()` always runs when
 
 #### Tasks
 
-- [ ] **#1281 — Private state changes don't trigger Rust diff re-render** (🔴 split-foundation). Handler mutates `self._x`; diff sees no public change → `noop`; template depends on `self._x` via `get_context_data()`.
+- [x] **#1281 — Private state changes don't trigger Rust diff re-render** (🔴 split-foundation). Fixed in PR #1323: `_snapshot_assigns()` now uses `_framework_attrs` membership instead of `k.startswith("_")`. 9 regression cases.
 
 #### Related audit items (deferred)
 
-- #1284 — `_action_state` persistence across reconnects
-- #1285 — snapshot truncation warning
+- [x] #1284 — `_action_state` persistence across reconnects (PR #1324 merged)
+- [x] #1285 — snapshot truncation warning (PR #1326 open)
 - #1286 — change-detection unification (Python vs Rust)
 
 #### Acceptance

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -160,6 +160,10 @@ def _should_expose_timing() -> bool:
     )
 
 
+# Per-view-class set to suppress duplicate truncation warnings (#1285).
+_TRUNCATION_WARNED: set = set()
+
+
 def _snapshot_assigns(view_instance):
     """Fast identity+hash snapshot of public assigns for change detection.
 
@@ -207,8 +211,37 @@ def _snapshot_assigns(view_instance):
                     snapshot[k] = (vid, len(v))
             else:
                 snapshot[k] = (vid, len(v))
+                if v and len(v) >= 100:
+                    _cls = type(view_instance).__qualname__
+                    if _cls not in _TRUNCATION_WARNED:
+                        _TRUNCATION_WARNED.add(_cls)
+                        logger.warning(
+                            "[djust] %s: list '%s' has %d items — content "
+                            "fingerprint truncated. In-place mutations inside "
+                            "list elements will NOT be detected by auto-diff. "
+                            "Use self.set_changed_keys({'%s'}) or assign a "
+                            "new list reference.",
+                            _cls,
+                            k,
+                            len(v),
+                            k,
+                        )
         elif isinstance(v, dict):
             snapshot[k] = (vid, len(v), tuple(v.keys()) if len(v) < 50 else len(v))
+            if len(v) >= 50:
+                _cls = type(view_instance).__qualname__
+                if _cls not in _TRUNCATION_WARNED:
+                    _TRUNCATION_WARNED.add(_cls)
+                    logger.warning(
+                        "[djust] %s: dict '%s' has %d keys — key fingerprint "
+                        "truncated. Key additions/removals will NOT be detected "
+                        "by auto-diff. Use self.set_changed_keys({'%s'}) or "
+                        "assign a new dict reference.",
+                        _cls,
+                        k,
+                        len(v),
+                        k,
+                    )
         elif isinstance(v, set):
             snapshot[k] = (vid, len(v))
         elif isinstance(v, _IMMUTABLE_TYPES):

--- a/python/tests/test_snapshot_truncation_warning.py
+++ b/python/tests/test_snapshot_truncation_warning.py
@@ -1,0 +1,136 @@
+"""Regression tests for #1285 — snapshot truncation warning.
+
+``_snapshot_assigns()`` truncates content fingerprinting for large
+containers: lists ≥ 100 items store only ``(id, length)``; dicts ≥ 50
+keys store only ``len(v)`` instead of a tuple of keys. In-place mutations
+inside these containers are missed by change detection.
+
+A one-shot ``logger.warning`` is emitted per view class to alert
+developers that auto-diff won't detect mutations inside these containers.
+"""
+
+import logging
+
+from djust import LiveView
+from djust.websocket import _snapshot_assigns, _TRUNCATION_WARNED
+
+
+class _ListView(LiveView):
+    pass
+
+
+class _DictView(LiveView):
+    pass
+
+
+class TestSnapshotTruncationWarning:
+    """#1285: warning emitted on first truncation; suppressed on subsequent."""
+
+    def setup_method(self):
+        _TRUNCATION_WARNED.clear()
+
+    def test_list_truncation_emits_warning(self, caplog):
+        view = _ListView()
+        view.items = [{"id": i} for i in range(150)]
+
+        with caplog.at_level(logging.WARNING, logger="djust"):
+            _snapshot_assigns(view)
+
+        assert len(caplog.records) == 1
+        assert "list 'items' has 150 items" in caplog.text
+        assert "content fingerprint truncated" in caplog.text
+        assert "set_changed_keys" in caplog.text
+
+    def test_list_truncation_suppressed_on_second_call(self, caplog):
+        view = _ListView()
+        view.items = [{"id": i} for i in range(150)]
+
+        with caplog.at_level(logging.WARNING, logger="djust"):
+            _snapshot_assigns(view)
+            _snapshot_assigns(view)
+
+        assert len(caplog.records) == 1, (
+            "#1285: truncation warning must fire only once per view class"
+        )
+
+    def test_list_below_threshold_no_warning(self, caplog):
+        view = _ListView()
+        view.items = [{"id": i} for i in range(99)]
+
+        with caplog.at_level(logging.WARNING, logger="djust"):
+            _snapshot_assigns(view)
+
+        assert len(caplog.records) == 0
+
+    def test_empty_list_no_warning(self, caplog):
+        view = _ListView()
+        view.items = []
+
+        with caplog.at_level(logging.WARNING, logger="djust"):
+            _snapshot_assigns(view)
+
+        assert len(caplog.records) == 0
+
+    def test_dict_truncation_emits_warning(self, caplog):
+        view = _DictView()
+        view.config = {str(i): i for i in range(60)}
+
+        with caplog.at_level(logging.WARNING, logger="djust"):
+            _snapshot_assigns(view)
+
+        assert len(caplog.records) == 1
+        assert "dict 'config' has 60 keys" in caplog.text
+        assert "key fingerprint truncated" in caplog.text
+
+    def test_dict_truncation_suppressed_on_second_call(self, caplog):
+        view = _DictView()
+        view.config = {str(i): i for i in range(60)}
+
+        with caplog.at_level(logging.WARNING, logger="djust"):
+            _snapshot_assigns(view)
+            _snapshot_assigns(view)
+
+        assert len(caplog.records) == 1
+
+    def test_dict_below_threshold_no_warning(self, caplog):
+        view = _DictView()
+        view.config = {str(i): i for i in range(49)}
+
+        with caplog.at_level(logging.WARNING, logger="djust"):
+            _snapshot_assigns(view)
+
+        assert len(caplog.records) == 0
+
+    def test_different_view_classes_each_warn_once(self, caplog):
+        """Each view class gets its own one-shot warning."""
+        view1 = _ListView()
+        view1.items = [{"id": i} for i in range(150)]
+
+        view2 = _DictView()
+        view2.config = {str(i): i for i in range(60)}
+
+        with caplog.at_level(logging.WARNING, logger="djust"):
+            _snapshot_assigns(view1)
+            _snapshot_assigns(view2)
+
+        assert len(caplog.records) == 2
+
+    def test_exact_threshold_list_no_warning(self, caplog):
+        """List at exactly 99 items is below threshold, no warning."""
+        view = _ListView()
+        view.items = [{"id": i} for i in range(99)]
+
+        with caplog.at_level(logging.WARNING, logger="djust"):
+            _snapshot_assigns(view)
+
+        assert len(caplog.records) == 0
+
+    def test_exact_threshold_dict_no_warning(self, caplog):
+        """Dict at exactly 49 keys is below threshold, no warning."""
+        view = _DictView()
+        view.config = {str(i): i for i in range(49)}
+
+        with caplog.at_level(logging.WARNING, logger="djust"):
+            _snapshot_assigns(view)
+
+        assert len(caplog.records) == 0


### PR DESCRIPTION
## Summary
- `_snapshot_assigns()` now emits a one-shot `logger.warning` per view class when a list has ≥100 items or a dict has ≥50 keys
- The warning tells developers that auto-diff won't detect in-place mutations inside these containers and suggests using `set_changed_keys()` or assigning a new reference
- 10 regression cases covering: list/dict warning emission, per-call suppression, per-class deduplication, below-threshold, empty containers, exact threshold boundaries

## Test plan
- [x] 10 new regression tests in `test_snapshot_truncation_warning.py` all pass
- [x] Full test suite passes (4115 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)