### PR TITLE
fix: @reactive __set_name__ validation + @background return-value docs (#1287, #1288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **@reactive now fails at class-definition time on classes missing ``update()`` (#1287).**
+  The ``@reactive`` decorator previously guarded ``self.update()`` with
+  ``hasattr(self, 'update')``, silently no-opping when the host class lacked
+  the method. It now uses ``__set_name__`` to validate at class-definition
+  time, raising ``TypeError`` with a clear message. The ``_ReactiveProperty``
+  descriptor also calls ``update()`` automatically for both default and
+  custom setters. 6 regression cases in
+  ``test_decorator_reactive_requires_update.py``.
+
+- **@background docstring now documents return-value contract (#1288).**
+  The decorator's docstring mentions that handler return values are
+  discarded and points users to ``@action`` + ``_action_state`` for
+  result tracking. 2 regression cases in
+  ``test_background_return_value_docs.py``.
+
 ## [0.9.3rc1] - 2026-05-02
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -211,6 +211,24 @@ short-circuit so `render_with_diff()` always runs when
 - [x] Audit A Phase 2 (#1284, #1285, #1286) all addressed — #1286 in PR #1327.
 - Then: commission v0.9.3-3 or cut v0.9.3 release.
 
+### Milestone: v0.9.3-3 — audit B decorator contracts (#1287-#1290)
+
+**Status:** 🔄 in progress — #1287 + #1288 done, #1289 + #1290 remaining.
+
+*Goal:* Close all 4 audit B findings: `@reactive` silent no-op, `@background` return-value docs, `@computed` thread-safety, handler-contracts linter.
+
+#### Tasks
+
+- [x] **#1287 — `@reactive` silent no-op when subclass missing `update()`** (🟡). Replace `hasattr` guard with `__set_name__` assertion. ✅
+- [x] **#1288 — `@background` return value contract is undocumented** (🟡). Doc-only: update docstring. ✅
+- [ ] **#1289 — `@computed` cache-dict mutation not thread-safe** (🟡). Add per-instance `threading.Lock`.
+- [ ] **#1290 — `scripts/check-handler-contracts.py` linter** (🟡). New AST-based static checker.
+
+#### Acceptance
+
+- All 4 audit B issues closed.
+- Then: commission v0.9.3-4 or cut v0.9.3 release.
+
 ### Milestone: v0.9.2-7 — broken-anchor cleanup (pre-stable trivial drain) ✅ shipped
 
 **Status:** ✅ shipped 2026-05-02. 1 issue closed via 1 PR. Smallest pre-stable drain bucket: a 1-line broken-anchor fix that's been carried since the deployment guide was written. Pre-existing on main (flagged as 🟡 in PR #1265 Stage 11 review and filed as #1266 rather than scope-creeping the deployment-guide PR — three consecutive milestones now use the canon "🟡 plan-fidelity findings get a separate small PR").

--- a/python/djust/decorators.py
+++ b/python/djust/decorators.py
@@ -516,11 +516,48 @@ def is_server_function(func: Any) -> bool:
     return bool(getattr(func, "_djust_decorators", {}).get("server_function"))
 
 
-def reactive(func: Callable) -> property:
+class _ReactiveProperty:
+    """Descriptor for @reactive properties with __set_name__ validation (#1287).
+
+    Validates at class-definition time that the host class has an ``update()``
+    method, rather than silently no-opping at runtime when it doesn't.
+    """
+
+    def __init__(self, fget, fset=None):
+        self.fget = fget
+        self.fset = fset
+
+    def __set_name__(self, owner, name):
+        if not hasattr(owner, "update"):
+            raise TypeError(
+                f"@reactive property '{name}' on {owner.__name__} requires "
+                f"the host class to have an 'update()' method (typically "
+                f"inherited from LiveView)."
+            )
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        return self.fget(obj)
+
+    def __set__(self, obj, value):
+        if self.fset is None:
+            raise AttributeError("can't set attribute")
+        old_value = self.fget(obj)
+        self.fset(obj, value)
+        if old_value != value:
+            obj.update()
+
+    def setter(self, fset):
+        return type(self)(self.fget, fset)
+
+
+def reactive(func: Callable):
     """
     Create a reactive property that triggers re-render on change.
 
-    Usage:
+    Usage::
+
         class MyView(LiveView):
             @reactive
             def count(self):
@@ -529,22 +566,22 @@ def reactive(func: Callable) -> property:
             @count.setter
             def count(self, value):
                 self._count = value
+
+    The host class must have an ``update()`` method (inherited from
+    ``LiveView``).  A ``TypeError`` is raised at class-definition time if
+    it doesn't, rather than silently no-opping at runtime.
     """
-    # Create internal property name
     internal_name = f"_{func.__name__}_reactive"
 
     def _getter(self):
         return getattr(self, internal_name, None)
 
     def _setter(self, value):
-        old_value = getattr(self, internal_name, None)
         setattr(self, internal_name, value)
 
-        # Trigger update if value changed
-        if old_value != value and hasattr(self, "update"):
-            self.update()
-
-    return property(_getter, _setter)
+    prop = _ReactiveProperty(_getter, _setter)
+    prop.__doc__ = func.__doc__
+    return prop
 
 
 def state(default: Any = None):
@@ -966,6 +1003,12 @@ def background(func: F) -> F:
                 '''Optional: handle completion or errors.'''
                 if error:
                     self.error = f"Generation failed: {error}"
+
+    **Return values are discarded.**  The handler's return value is not
+    captured — ``start_async()`` discards it.  Mutate ``self.<attr>`` to
+    surface results to templates, or combine with ``@action`` for
+    ``_action_state`` tracking (the ``@action`` decorator populates
+    ``_action_state[name]`` with ``{pending, error, result}``).
 
     The @background decorator can be combined with other decorators:
         @event_handler

--- a/python/djust/tests/test_skip_render_private_state.py
+++ b/python/djust/tests/test_skip_render_private_state.py
@@ -3,7 +3,7 @@
 ``_snapshot_assigns()`` previously used ``k.startswith("_")`` to skip
 ALL underscore-prefixed attrs from change detection. This meant a handler
 that mutated only private state (e.g. ``self._orders``) would produce
-identical pre/post snapshots → ``skip_render = True`` → client received
+identical pre/post snapshots -> ``skip_render = True`` -> client received
 a noop frame instead of a render.
 
 The fix replaces the blanket prefix check with membership in
@@ -18,9 +18,10 @@ from djust.websocket import _snapshot_assigns
 
 
 class _PrivateStateView(LiveView):
-    """Minimal view that sets private state in mount()."""
+    """Minimal view that sets private state post-init."""
 
-    def mount(self, request, **kwargs):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.title = "Home"
         self._orders = []
         self._cache = {}
@@ -34,7 +35,6 @@ class TestFrameworkPrivateAttrsExcluded:
         view.count = 0
         view.name = "test"
         snap = _snapshot_assigns(view)
-        # Framework _-prefixed set at init time are excluded
         assert "_changed_keys" not in snap
         assert "_skip_render" not in snap
 
@@ -50,10 +50,8 @@ class TestFrameworkPrivateAttrsExcluded:
 class TestUserPrivateAttrsIncluded:
     """User ``_``-prefixed attrs set after __init__ ARE in the snapshot."""
 
-    def test_user_private_attrs_in_snapshot_after_mount(self):
+    def test_user_private_attrs_in_snapshot(self):
         view = _PrivateStateView()
-        view.init_table_state()  # simulate mount lifecycle
-        view.mount(request={})
         snap = _snapshot_assigns(view)
         assert "_orders" in snap
         assert "_cache" in snap
@@ -62,16 +60,20 @@ class TestUserPrivateAttrsIncluded:
         """User-set private attrs are NOT in _framework_attrs (proving
         they're not accidentally excluded by membership check)."""
         view = _PrivateStateView()
-        view.init_table_state()
-        view.mount(request={})
         assert "_orders" not in view._framework_attrs
         assert "_cache" not in view._framework_attrs
 
     def test_framework_private_attrs_are_in_framework_attrs(self):
-        """Sanity: framework _-prefixed attrs ARE in _framework_attrs."""
+        """Sanity: framework _-prefixed attrs ARE in _framework_attrs.
+
+        Note: _framework_attrs itself, _skip_render, and _changed_keys
+        are assigned AFTER the frozenset capture, so they're
+        self-referentially absent. But other framework attrs set during
+        __init__ (before the capture) are present.
+        """
         view = LiveView()
-        assert "_changed_keys" in view._framework_attrs
-        assert "_skip_render" in view._framework_attrs
+        assert "_ws_consumer" in view._framework_attrs
+        assert "_session_id" in view._framework_attrs
 
 
 class TestChangeDetectionWithPrivateState:
@@ -79,8 +81,6 @@ class TestChangeDetectionWithPrivateState:
 
     def test_mutating_only_private_state_changes_snapshot(self):
         view = _PrivateStateView()
-        view.init_table_state()
-        view.mount(request={})
         view.title = "Before"
 
         pre = _snapshot_assigns(view)
@@ -88,25 +88,20 @@ class TestChangeDetectionWithPrivateState:
         view._cache["key"] = "value"
         post = _snapshot_assigns(view)
 
-        # pre/post must differ — without this, skip_render would be True.
         assert pre != post, (
             "#1281: mutating only _-prefixed user state must change the "
             "snapshot so skip_render is NOT triggered"
         )
 
     def test_mutating_nothing_keeps_snapshot_equal(self):
-        """Existing optimization: no mutation → no render."""
         view = _PrivateStateView()
-        view.init_table_state()
-        view.mount(request={})
 
         pre = _snapshot_assigns(view)
         post = _snapshot_assigns(view)
 
-        assert pre == post, "no mutation → snapshots should be equal → noop"
+        assert pre == post, "no mutation -> snapshots should be equal -> noop"
 
     def test_mutating_public_state_changes_snapshot(self):
-        """Existing behavior preserved: public attr changes trigger render."""
         view = LiveView()
         view.count = 0
 
@@ -118,8 +113,6 @@ class TestChangeDetectionWithPrivateState:
 
     def test_mutating_both_public_and_private_changes_snapshot(self):
         view = _PrivateStateView()
-        view.init_table_state()
-        view.mount(request={})
         view.title = "Before"
 
         pre = _snapshot_assigns(view)
@@ -132,8 +125,6 @@ class TestChangeDetectionWithPrivateState:
     def test_reassign_private_state_changes_snapshot(self):
         """Reassigning a _private attr (new id()) is detected."""
         view = _PrivateStateView()
-        view.init_table_state()
-        view.mount(request={})
 
         pre = _snapshot_assigns(view)
         view._orders = [{"id": 1}]  # reassign, not in-place mutate

--- a/python/tests/test_background_return_value_docs.py
+++ b/python/tests/test_background_return_value_docs.py
@@ -1,0 +1,28 @@
+"""Regression test for #1288 — @background docstring documents return-value contract.
+
+The ``@background`` decorator discards handler return values. This must be
+documented in the decorator's docstring so users aren't confused when their
+handler's return value silently disappears.
+"""
+
+from djust.decorators import background
+
+
+class TestBackgroundReturnValueDocs:
+    """#1288: @background docstring mentions return-value discard."""
+
+    def test_docstring_mentions_return_values_are_discarded(self):
+        """@background docstring must document return-value contract."""
+        doc = background.__doc__
+        assert doc is not None, "@background must have a docstring"
+        assert "discarded" in doc, (
+            "#1288: @background docstring must mention return values are discarded"
+        )
+
+    def test_docstring_mentions_action_state_alternative(self):
+        """@background docstring must point users to @action for result tracking."""
+        doc = background.__doc__
+        assert "_action_state" in doc, (
+            "#1288: @background docstring must mention @action/"
+            "_action_state as alternative for result tracking"
+        )

--- a/python/tests/test_decorator_reactive_requires_update.py
+++ b/python/tests/test_decorator_reactive_requires_update.py
@@ -1,0 +1,111 @@
+"""Regression tests for #1287 — @reactive requires host class to have update().
+
+``@reactive`` properties should fail at class-definition time (via
+``__set_name__``) when the host class lacks an ``update()`` method,
+rather than silently no-opping at runtime.
+"""
+
+import pytest
+
+from djust import LiveView
+from djust.decorators import reactive
+
+
+class TestReactiveRequiresUpdate:
+    """#1287: @reactive raises TypeError when host class lacks update()."""
+
+    def test_reactive_on_non_liveview_class_raises_typeerror(self):
+        """A plain class without update() fails at class-definition time."""
+        with pytest.raises(TypeError, match="requires.*update"):
+
+            class BadMixin:  # noqa: F811
+                @reactive
+                def x(self):
+                    return self._x
+
+    def test_reactive_on_class_with_explicit_update_works(self):
+        """A LiveView subclass that defines its own update() works."""
+        update_calls = []
+
+        class MyView(LiveView):
+            def update(self):
+                update_calls.append(True)
+
+            @reactive
+            def count(self):
+                return self._count
+
+        assert hasattr(MyView, "count")
+
+    def test_reactive_setter_triggers_update(self):
+        """Setting a @reactive property calls self.update()."""
+        update_calls = []
+
+        class MyView(LiveView):
+            def update(self):
+                update_calls.append(True)
+
+            @reactive
+            def count(self):
+                return self._count
+
+        view = MyView()
+        view.count = 42
+
+        assert len(update_calls) == 1, "#1287: @reactive setter must call update()"
+
+    def test_reactive_no_update_when_value_unchanged(self):
+        """Setting to the same value skips update()."""
+        update_calls = []
+
+        class MyView(LiveView):
+            def update(self):
+                update_calls.append(True)
+
+            @reactive
+            def count(self):
+                return self._count
+
+        view = MyView()
+        view.count = 42
+        assert len(update_calls) == 1
+
+        view.count = 42  # Same value
+        assert len(update_calls) == 1, "unchanged value should not trigger update()"
+
+    def test_reactive_with_custom_setter_triggers_update(self):
+        """A custom setter (via @count.setter) still triggers update() via
+        the descriptor's __set__."""
+        update_calls = []
+
+        class MyView(LiveView):
+            def update(self):
+                update_calls.append(True)
+
+            @reactive
+            def count(self):
+                return self._count_store
+
+            @count.setter
+            def count(self, value):
+                self._count_store = value
+
+        view = MyView()
+        view.count = 42
+
+        assert view._count_store == 42
+        assert len(update_calls) == 1, "#1287: @reactive with custom setter must call update()"
+
+    def test_reactive_descriptor_doc_propagates(self):
+        """@reactive propagates the function's docstring."""
+
+        class MyView(LiveView):
+            def update(self):
+                pass
+
+            @reactive
+            def count(self):
+                """The current count."""
+                return self._count
+
+        assert MyView.__dict__["count"].__doc__ == "The current count."


### PR DESCRIPTION
## Summary
- **#1287**: `@reactive` now validates at class-definition time that the host class has `update()` via `__set_name__`, raising `TypeError` instead of silently no-opping at runtime. The `_ReactiveProperty` descriptor handles `update()` for both default and custom setters. 6 regression cases.
- **#1288**: `@background` docstring now documents that handler return values are discarded and points to `@action` + `_action_state` as alternative. 2 regression cases.
- Fixed stale `test_skip_render_private_state.py` tests (removed nonexistent `init_table_state()` calls, fixed `_framework_attrs` assertions).

## Test plan
- [x] 8 new regression tests for #1287 + #1288
- [x] Full suite: 6881 passed, 20 skipped
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)