### PR TITLE
fix: @computed memoized cache is now thread-safe (#1289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   result tracking. 2 regression cases in
   ``test_background_return_value_docs.py``.
 
+- **@computed memoized cache is now thread-safe (#1289).**
+  The ``@computed`` decorator's memoized form previously mutated the
+  per-instance cache dict without synchronization, creating a race
+  window between threads (e.g. a ``@background`` callback and template
+  rendering). A per-instance ``threading.Lock`` now protects the
+  check-then-act cache mutation. 3 regression cases in
+  ``test_decorator_computed_thread_safety.py``.
+
 ## [0.9.3rc1] - 2026-05-02
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -213,7 +213,7 @@ short-circuit so `render_with_diff()` always runs when
 
 ### Milestone: v0.9.3-3 — audit B decorator contracts (#1287-#1290)
 
-**Status:** 🔄 in progress — #1287 + #1288 done, #1289 + #1290 remaining.
+**Status:** 🔄 in progress — #1287 + #1288 done, #1289 in PR, #1290 remaining.
 
 *Goal:* Close all 4 audit B findings: `@reactive` silent no-op, `@background` return-value docs, `@computed` thread-safety, handler-contracts linter.
 
@@ -221,7 +221,7 @@ short-circuit so `render_with_diff()` always runs when
 
 - [x] **#1287 — `@reactive` silent no-op when subclass missing `update()`** (🟡). Replace `hasattr` guard with `__set_name__` assertion. ✅
 - [x] **#1288 — `@background` return value contract is undocumented** (🟡). Doc-only: update docstring. ✅
-- [ ] **#1289 — `@computed` cache-dict mutation not thread-safe** (🟡). Add per-instance `threading.Lock`.
+- [x] **#1289 — `@computed` cache-dict mutation not thread-safe** (🟡). Add per-instance `threading.Lock`. ✅
 - [ ] **#1290 — `scripts/check-handler-contracts.py` linter** (🟡). New AST-based static checker.
 
 #### Acceptance

--- a/python/djust/decorators.py
+++ b/python/djust/decorators.py
@@ -8,6 +8,7 @@ event handlers, reactive state, and computed properties.
 import asyncio
 import functools
 import logging
+import threading
 import warnings
 from typing import Callable, Any, TypeVar, Union, cast, List, Optional
 
@@ -716,13 +717,17 @@ def computed(*deps):
 
         @functools.wraps(func)
         def _inner(self):
-            cache = self.__dict__.setdefault("_djust_computed_cache", {})
-            deps_seen = self.__dict__.setdefault("_djust_computed_deps", {})
-            current = _fingerprint(self)
-            if deps_seen.get(attr_name) != current or attr_name not in cache:
-                cache[attr_name] = func(self)
-                deps_seen[attr_name] = current
-            return cache[attr_name]
+            lock = self.__dict__.get("_djust_computed_lock")
+            if lock is None:
+                lock = self.__dict__.setdefault("_djust_computed_lock", threading.Lock())
+            with lock:
+                cache = self.__dict__.setdefault("_djust_computed_cache", {})
+                deps_seen = self.__dict__.setdefault("_djust_computed_deps", {})
+                current = _fingerprint(self)
+                if deps_seen.get(attr_name) != current or attr_name not in cache:
+                    cache[attr_name] = func(self)
+                    deps_seen[attr_name] = current
+                return cache[attr_name]
 
         prop = _ComputedProperty(_inner)
         prop._is_computed = True

--- a/python/tests/test_decorator_computed_thread_safety.py
+++ b/python/tests/test_decorator_computed_thread_safety.py
@@ -1,0 +1,133 @@
+"""Regression tests for #1289 — @computed cache-dict mutation is thread-safe.
+
+Before the fix, concurrent property access from background threads could
+race against template rendering on the main loop, potentially causing
+KeyError or stale reads due to the cache-dict mutation not being
+protected by a lock.
+"""
+
+import threading
+
+from djust import LiveView
+from djust.decorators import computed
+
+
+class TestComputedThreadSafety:
+    """#1289: @computed memoized cache is thread-safe."""
+
+    def test_concurrent_computed_access_no_errors(self):
+        """50 threads accessing a memoized @computed property concurrently
+        should complete without KeyError or stale reads."""
+        errors = []
+
+        class DashView(LiveView):
+            def update(self):
+                pass
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.items = [
+                    {"category": "A", "price": 10, "qty": 2},
+                    {"category": "A", "price": 5, "qty": 1},
+                    {"category": "B", "price": 20, "qty": 3},
+                ]
+                self.filter = "A"
+
+            @computed("items", "filter")
+            def filtered_total(self):
+                return sum(
+                    i["price"] * i["qty"] for i in self.items if i["category"] == self.filter
+                )
+
+        view = DashView()
+
+        # Warm up the cache
+        expected = view.filtered_total
+        assert expected == 25  # (10*2 + 5*1)
+
+        barrier = threading.Barrier(50)
+
+        def access_property():
+            barrier.wait()  # synchronize to maximize contention
+            try:
+                for _ in range(100):
+                    result = view.filtered_total
+                    if result != expected:
+                        errors.append(f"stale read: expected {expected}, got {result}")
+            except Exception as e:
+                errors.append(f"{type(e).__name__}: {e}")
+
+        threads = [threading.Thread(target=access_property) for _ in range(50)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0, f"#1289: concurrent @computed access produced errors: {errors}"
+
+    def test_cache_remains_consistent_after_concurrent_access(self):
+        """Cache should remain consistent and match the recomputed value
+        after concurrent access."""
+        side_effect_count = 0
+
+        class DashView(LiveView):
+            def update(self):
+                pass
+
+            @computed("counter")
+            def expensive(self):
+                nonlocal side_effect_count
+                side_effect_count += 1
+                return self.counter * 2
+
+        view = DashView()
+        view.counter = 5
+
+        # Warm up
+        result = view.expensive
+        assert result == 10
+
+        barrier = threading.Barrier(50)
+
+        def access():
+            barrier.wait()
+            for _ in range(50):
+                view.expensive  # noqa: B018
+
+        threads = [threading.Thread(target=access) for _ in range(50)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Cache should still be correct and no re-computation
+        # since counter didn't change.
+        assert view.expensive == 10
+        # side_effect_count might be >1 if threads recomputed before
+        # the lock was acquired, but should be bounded by thread count
+        # not thread_count * iterations (which would indicate no
+        # caching at all).
+        assert side_effect_count <= 51, (
+            f"#1289: excessive recomputations ({side_effect_count}), "
+            f"expected <= 51 (1 warmup + 50 thread first-access races)"
+        )
+
+    def test_lock_exists_on_instance(self):
+        """The per-instance lock is created lazily on __dict__."""
+
+        class DashView(LiveView):
+            def update(self):
+                pass
+
+            @computed("a")
+            def my_prop(self):
+                return self.a * 2
+
+        view = DashView()
+        assert "_djust_computed_lock" not in view.__dict__
+
+        view.a = 3
+        _ = view.my_prop
+
+        assert "_djust_computed_lock" in view.__dict__
+        assert isinstance(view.__dict__["_djust_computed_lock"], type(threading.Lock()))


### PR DESCRIPTION
## Summary
- **#1289**: `@computed` memoized cache is now thread-safe. Added per-instance `threading.Lock` to protect the check-then-act cache mutation in the memoized `@computed` path. Previously, concurrent access from background threads (e.g. `@background` callbacks) and the main loop (template rendering) could race on the cache dict.

## Test plan
- [x] 3 new thread-safety regression tests (50-thread concurrent access, cache consistency, lock existence)
- [x] Full suite: 6884 passed, 20 skipped
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)