### PR TITLE
feat: handler-contracts linter cross-references tag-emit defaults (#1290)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -192,3 +192,14 @@ repos:
         always_run: true
         pass_filenames: false
         stages: [pre-push]
+
+      # Cross-reference tag-emit _event defaults against component/mixin
+      # handler methods. Catches #1275-class (stale/typo'd emit default)
+      # bugs before they reach CI (#1290).
+      - id: check-handler-contracts
+        name: check handler contracts
+        entry: bash -c '.venv/bin/python scripts/check-handler-contracts.py'
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [pre-push]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   check-then-act cache mutation. 3 regression cases in
   ``test_decorator_computed_thread_safety.py``.
 
+- **New ``make check-handler-contracts`` linter (#1290).**
+  ``scripts/check-handler-contracts.py`` cross-references template-tag
+  ``_event`` emit defaults against component/mixin handler method names,
+  catching #1275-class (stale/typo'd emit default) bugs at pre-push
+  time. 44 emit defaults (26 framework, 18 app-level) validated clean.
+  Added to pre-push hook. 7 test cases in
+  ``test_check_handler_contracts.py``.
 ## [0.9.3rc1] - 2026-05-02
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,10 @@ dev-build: ## Build Rust extensions in development mode
 roadmap-lint: ## Mechanical ROADMAP-vs-codebase drift check (use pipeline-roadmap-audit skill for semantic audit)
 	@.venv/bin/python scripts/roadmap-lint.py $(if $(VERBOSE),--verbose,)
 
+.PHONY: check-handler-contracts
+check-handler-contracts: ## Cross-reference tag-emit _event defaults against handler methods (closes #1290)
+	@.venv/bin/python scripts/check-handler-contracts.py
+
 .PHONY: docs-lint
 docs-lint: ## Sweep docs/**/*.md for stale .md cross-references (closes #1075)
 	@.venv/bin/python scripts/docs-lint.py $(if $(VERBOSE),--verbose,)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -213,7 +213,7 @@ short-circuit so `render_with_diff()` always runs when
 
 ### Milestone: v0.9.3-3 — audit B decorator contracts (#1287-#1290)
 
-**Status:** 🔄 in progress — #1287 + #1288 done, #1289 in PR, #1290 remaining.
+**Status:** ✅ shipped 2026-05-02. All 4 audit B issues closed via 3 merged PRs (#1328 `@reactive` + `@background`, #1329 `@computed` thread-safety, #1330 handler-contracts linter).
 
 *Goal:* Close all 4 audit B findings: `@reactive` silent no-op, `@background` return-value docs, `@computed` thread-safety, handler-contracts linter.
 
@@ -221,8 +221,8 @@ short-circuit so `render_with_diff()` always runs when
 
 - [x] **#1287 — `@reactive` silent no-op when subclass missing `update()`** (🟡). Replace `hasattr` guard with `__set_name__` assertion. ✅
 - [x] **#1288 — `@background` return value contract is undocumented** (🟡). Doc-only: update docstring. ✅
-- [x] **#1289 — `@computed` cache-dict mutation not thread-safe** (🟡). Add per-instance `threading.Lock`. ✅
-- [ ] **#1290 — `scripts/check-handler-contracts.py` linter** (🟡). New AST-based static checker.
+- [x] **#1289 — `@computed` cache-dict mutation not thread-safe** (🟡). Per-instance `threading.Lock` protects cache mutation check-then-act block. ✅
+- [x] **#1290 — `scripts/check-handler-contracts.py` linter** (🟡). AST-based static checker cross-references tag-emit defaults against mixin handler names. 44 emit defaults (26 framework, 18 app-level) validated clean. ✅
 
 #### Acceptance
 

--- a/scripts/check-handler-contracts.py
+++ b/scripts/check-handler-contracts.py
@@ -1,0 +1,175 @@
+"""Cross-reference tag-emit defaults against handler-name registry.
+
+Catches bugs of class #1275 at pre-push (or pre-commit) time.
+Used by ``make check-handler-contracts`` and the pre-push hook.
+
+Exit 0 = all defaults match a handler. Exit 1 = mismatches found.
+"""
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Events intentionally designed for user LiveView handlers — no framework
+# mixin provides a default handler.  Adding a new app-level event here is
+# the expected workflow; failing to add it will cause the linter to
+# surface a possible #1275-class (stale/typo'd emit default) mismatch.
+_APP_LEVEL_EVENTS = {
+    "clear_notifications",
+    "copy_code",
+    "date_next_month",
+    "date_prev_month",
+    "date_select",
+    "dismiss_toast",
+    "grid_cell_edit",
+    "kanban_add_card",
+    "kanban_add_column",
+    "kanban_move",
+    "load_more",
+    "mark_notification_read",
+    "page_next",
+    "page_prev",
+    "toggle_notifications",
+    "toggle_split_menu",
+    "tree_expand",
+    "tree_select",
+}
+
+
+def extract_event_defaults(path: Path) -> dict:
+    """Return {default_value: [site]} for every kwarg ending in _event."""
+    tree = ast.parse(path.read_text())
+    out = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        args_with_defaults = node.args.args[-len(node.args.defaults):]
+        for arg, default in zip(args_with_defaults, node.args.defaults):
+            if arg.arg.endswith("_event") and isinstance(default, ast.Constant):
+                if isinstance(default.value, str) and default.value:
+                    out.setdefault(default.value, []).append(
+                        f"{path.name}:{node.lineno}"
+                    )
+        for arg, default in zip(
+            node.args.kwonlyargs, node.args.kw_defaults
+        ):
+            if (
+                default
+                and arg.arg.endswith("_event")
+                and isinstance(default, ast.Constant)
+                and isinstance(default.value, str)
+                and default.value
+            ):
+                out.setdefault(default.value, []).append(
+                    f"{path.name}:{node.lineno} (kwonly)"
+                )
+    return out
+
+
+def extract_handler_names(path: Path) -> set:
+    """Return every method def name in this file."""
+    tree = ast.parse(path.read_text())
+    return {
+        n.name
+        for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef)
+    }
+
+
+def run(tag_files, handler_files, app_level_events=None):
+    """Core logic exposed for testing.
+
+    Returns (exit_code, message).
+    """
+    if app_level_events is None:
+        app_level_events = _APP_LEVEL_EVENTS
+
+    emit_defaults = {}
+    for f in tag_files:
+        for name, sites in extract_event_defaults(f).items():
+            emit_defaults.setdefault(name, []).extend(sites)
+
+    all_handlers = set()
+    for f in handler_files:
+        all_handlers |= extract_handler_names(f)
+
+    mismatches = [
+        (name, sites)
+        for name, sites in emit_defaults.items()
+        if name not in all_handlers and name not in app_level_events
+    ]
+
+    if mismatches:
+        lines = [
+            f"Found {len(mismatches)} tag-emit defaults "
+            f"with no matching handler:"
+        ]
+        for name, sites in mismatches:
+            lines.append(
+                f"  '{name}' — emitted at {', '.join(sites)}; "
+                f"no handler in mixins/ or components/"
+            )
+        return 1, "\n".join(lines)
+
+    app_count = sum(1 for n in emit_defaults if n in app_level_events)
+    return 0, (
+        f"OK — {len(emit_defaults)} tag-emit defaults checked "
+        f"({len(emit_defaults) - app_count} framework, "
+        f"{app_count} app-level) against {len(all_handlers)} handler names"
+    )
+
+
+def build_arg_parser():
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[1])
+    p.add_argument(
+        "--tag-files", nargs="*", action="extend",
+        default=None,
+        help="Tag/module files to scan for _event defaults",
+    )
+    p.add_argument(
+        "--mixin-dir",
+        default=None,
+        help="Directory of mixin files providing handler methods",
+    )
+    p.add_argument(
+        "--component-files", nargs="*", action="extend",
+        default=None,
+        help="Additional component files providing handler methods",
+    )
+    return p
+
+
+def main(argv=None):
+    args = build_arg_parser().parse_args(argv)
+
+    tag_files = [Path(p) for p in (args.tag_files or [])]
+    if not tag_files:
+        tag_files = [
+            ROOT / "python/djust/components/templatetags/djust_components.py",
+        ]
+
+    handler_files = []
+    if args.mixin_dir:
+        handler_files.extend(sorted(Path(args.mixin_dir).glob("*.py")))
+    else:
+        handler_files.extend(
+            sorted((ROOT / "python/djust/components/mixins").glob("*.py"))
+        )
+    if args.component_files:
+        handler_files.extend(Path(p) for p in args.component_files)
+    else:
+        handler_files.extend([
+            ROOT / "python/djust/components/base.py",
+            ROOT / "python/djust/components/rust_handlers.py",
+        ])
+
+    exit_code, msg = run(tag_files, handler_files)
+    print(msg)
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_check_handler_contracts.py
+++ b/tests/test_check_handler_contracts.py
@@ -1,0 +1,216 @@
+"""Tests for scripts/check-handler-contracts.py — #1290."""
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+import pytest
+
+
+def _write_file(directory, name, content):
+    p = directory / name
+    p.write_text(textwrap.dedent(content))
+    return p
+
+
+_SELF = pathlib.Path(__file__).resolve()
+_LINTER = _SELF.parents[1] / "scripts" / "check-handler-contracts.py"
+
+
+def _run(*, tag_files, handler_files, mixin_dir=None):
+    """Run the linter via subprocess with given fixture files.
+
+    Returns (exit_code, stdout).
+    """
+    args = [sys.executable, str(_LINTER)]
+    for tf in tag_files:
+        args.extend(["--tag-files", str(tf)])
+    if mixin_dir is not None:
+        args.extend(["--mixin-dir", str(mixin_dir)])
+    else:
+        # Point mixin-dir at an empty temp directory so we don't pick
+        # up the real mixins during fixture tests.
+        args.extend(["--mixin-dir", str(tag_files[0].parent)])
+    for hf in handler_files:
+        args.extend(["--component-files", str(hf)])
+    result = subprocess.run(args, capture_output=True, text=True)
+    return result.returncode, result.stdout
+
+
+class TestHandlerContractsLinter:
+    """Core checks for the handler-contracts cross-reference linter."""
+
+    def test_all_matched_passes(self):
+        """Exit 0 when every emit default has a matching handler."""
+        with tempfile.TemporaryDirectory() as tmp:
+            d = pathlib.Path(tmp)
+            tag = _write_file(
+                d,
+                "tags.py",
+                """
+                def data_table(
+                    sort_event="on_table_sort",
+                    prev_event="on_table_prev",
+                ):
+                    pass
+            """,
+            )
+            mixin = _write_file(
+                d,
+                "mixins.py",
+                """
+                def on_table_sort(self):
+                    pass
+                def on_table_prev(self):
+                    pass
+            """,
+            )
+            exit_code, stdout = _run(tag_files=[tag], handler_files=[mixin])
+            assert exit_code == 0, f"expected exit 0, got {exit_code}: {stdout}"
+            assert "OK" in stdout
+            assert "2" in stdout  # 2 emit defaults
+
+    def test_mismatch_fails(self):
+        """Exit 1 when an emit default has no matching handler."""
+        with tempfile.TemporaryDirectory() as tmp:
+            d = pathlib.Path(tmp)
+            tag = _write_file(
+                d,
+                "tags.py",
+                """
+                def data_table(
+                    sort_event="on_table_sort",
+                    prev_event="stale_event_name",
+                ):
+                    pass
+            """,
+            )
+            mixin = _write_file(
+                d,
+                "mixins.py",
+                """
+                def on_table_sort(self):
+                    pass
+            """,
+            )
+            exit_code, stdout = _run(tag_files=[tag], handler_files=[mixin])
+            assert exit_code == 1, f"expected exit 1, got {exit_code}: {stdout}"
+            assert "stale_event_name" in stdout
+
+    def test_mismatch_not_silenced_by_unrelated_whitelist(self):
+        """Mismatch is flagged even when app-level events are whitelisted."""
+        with tempfile.TemporaryDirectory() as tmp:
+            d = pathlib.Path(tmp)
+            tag = _write_file(
+                d,
+                "tags.py",
+                """
+                def data_table(
+                    sort_event="on_table_sort",
+                    prev_event="broken_handler",
+                ):
+                    pass
+            """,
+            )
+            mixin = _write_file(
+                d,
+                "mixins.py",
+                """
+                def on_table_sort(self):
+                    pass
+            """,
+            )
+            exit_code, stdout = _run(tag_files=[tag], handler_files=[mixin])
+            assert exit_code == 1, f"expected exit 1, got {exit_code}: {stdout}"
+            assert "broken_handler" in stdout
+
+    def test_empty_inputs(self):
+        """No emit defaults and no handlers = clean pass."""
+        with tempfile.TemporaryDirectory() as tmp:
+            d = pathlib.Path(tmp)
+            tag = _write_file(
+                d,
+                "tags.py",
+                """
+                def empty_tag():
+                    pass
+            """,
+            )
+            empty = _write_file(
+                d,
+                "empty.py",
+                """
+                pass
+            """,
+            )
+            exit_code, stdout = _run(tag_files=[tag], handler_files=[empty])
+            assert exit_code == 0, f"expected exit 0, got {exit_code}: {stdout}"
+            assert "0" in stdout
+
+    def test_kwonly_event_defaults(self):
+        """Keyword-only args with _event suffixes are also checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            d = pathlib.Path(tmp)
+            tag = _write_file(
+                d,
+                "tags.py",
+                """
+                def toast(*, dismiss_event="dismiss_toast"):
+                    pass
+            """,
+            )
+            mixin = _write_file(
+                d,
+                "mixins.py",
+                """
+                def dismiss_toast(self):
+                    pass
+            """,
+            )
+            exit_code, stdout = _run(tag_files=[tag], handler_files=[mixin])
+            assert exit_code == 0, f"expected exit 0, got {exit_code}: {stdout}"
+
+    def test_multiple_tag_files_aggregated(self):
+        """Emit defaults from multiple tag files are all checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            d = pathlib.Path(tmp)
+            tag1 = _write_file(
+                d,
+                "tags_a.py",
+                """
+                def comp1(click_event="on_click"):
+                    pass
+            """,
+            )
+            tag2 = _write_file(
+                d,
+                "tags_b.py",
+                """
+                def comp2(toggle_event="on_toggle"):
+                    pass
+            """,
+            )
+            mixin = _write_file(
+                d,
+                "mixins.py",
+                """
+                def on_click(self): pass
+                def on_toggle(self): pass
+            """,
+            )
+            exit_code, stdout = _run(tag_files=[tag1, tag2], handler_files=[mixin])
+            assert exit_code == 0, f"expected exit 0, got {exit_code}: {stdout}"
+            assert "2" in stdout
+
+    @pytest.mark.slow
+    def test_real_codebase_passes(self):
+        """Smoke test: the real codebase passes the linter with no args."""
+        result = subprocess.run(
+            [sys.executable, str(_LINTER)],
+            capture_output=True,
+            text=True,
+            cwd=str(_SELF.parents[1]),
+        )
+        assert result.returncode == 0, f"real codebase must pass: {result.stdout}{result.stderr}"


### PR DESCRIPTION
## Summary

- New `scripts/check-handler-contracts.py` AST-based linter cross-references template-tag `_event` emit defaults against component/mixin handler method names
- Catches #1275-class (stale/typo'd emit default) bugs at pre-push time
- 44 emit defaults scanned: 26 framework events (all matched), 18 app-level events (whitelisted)
- Added `make check-handler-contracts` target + pre-push hook entry
- 7 test cases (6 fixture-based + 1 real codebase smoke test)

## Test plan
- [x] `make check-handler-contracts` passes clean
- [x] 6 fixture-based tests pass
- [x] Real codebase smoke test passes
- [x] Pre-push hook runs successfully on push
- [ ] CI green

Closes #1290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)