### PR TITLE
fix: document OUT-OF-REPO Action Tracker status convention (#1310)

### DIFF
--- a/RETRO.md
+++ b/RETRO.md
@@ -8,6 +8,15 @@ at the top is the single source of truth for all outstanding items.
 Items from retrospectives that need resolution. Every item must have a GitHub
 issue or be explicitly closed with a reason.
 
+**Status values:**
+- **Open** — actionable in THIS repo; has a GitHub issue
+- **Closed** — resolved, with a reason (PR reference, commit, test coverage)
+- **OUT-OF-REPO** — blocked on work in a different repository. The Notes column
+  must point at the upstream repo + issue number (e.g., "Awaiting
+  djust-org/pipeline-skill#NN"). These rows do NOT count against the
+  djust-repo's open-tracker total. They advance to Closed when the
+  cross-repo work is completed.
+
 | # | Action | Source | GitHub | Status | Notes |
 |---|--------|--------|--------|--------|-------|
 | 1 | HTML-escape CSRF token value in renderer.rs | PR #708 | #715 | Closed | Fixed in PR #721 (manual escape chain) |


### PR DESCRIPTION
## Summary

Documents the OUT-OF-REPO status value in the Action Tracker conventions in `RETRO.md`. Each status value now has a clear description: Open (actionable in this repo), Closed (resolved with reason), OUT-OF-REPO (blocked on work in a different repository).

Row #210 (#1259) was already marked OUT-OF-REPO — this PR adds the convention text that defines it.

Also updates the pipeline-retro skill:
- `--actions`: OUT-OF-REPO items displayed in their own group, counted separately from Open
- `--reconcile`: verifies OUT-OF-REPO rows have upstream repo references in Notes
- Skill template example includes an OUT-OF-REPO row

## Test plan
- [x] Docs/skill-only change — no code changes
- [x] Existing OUT-OF-REPO row (#210) already conforms to the documented convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)