### PR TITLE
fix: add behavior-change migration block to Stage 9 checklist (#1313)

### DIFF
--- a/.pipeline-templates/bugfix-state.json
+++ b/.pipeline-templates/bugfix-state.json
@@ -330,6 +330,11 @@
           "mandatory": true
         },
         {
+          "action": "If this PR changes a documented API contract (decorator semantics, function signature, attribute behavior, error envelope), the CHANGELOG entry MUST include a 'Behavior change' block with: (a) what changed, (b) who's affected, (c) migration path. PR #1294 is the canonical reference example.",
+          "done": false,
+          "mandatory": false
+        },
+        {
           "action": "BUNDLING CHECK (#1209 / #1251): after staging files but before `git commit`, run `git diff --cached --stat` and verify the line counts match what you planned to ship. If a staged file shows significantly more lines than expected, the working tree had pre-existing uncommitted modifications that got bundled. Investigate before committing. Pattern from pipeline-skill commit bf1a67f which silently bundled 130 unintended lines.",
           "done": false,
           "mandatory": true

--- a/.pipeline-templates/feature-state.json
+++ b/.pipeline-templates/feature-state.json
@@ -325,6 +325,11 @@
           "mandatory": true
         },
         {
+          "action": "If this PR changes a documented API contract (decorator semantics, function signature, attribute behavior, error envelope), the CHANGELOG entry MUST include a 'Behavior change' block with: (a) what changed, (b) who's affected, (c) migration path. PR #1294 is the canonical reference example.",
+          "done": false,
+          "mandatory": false
+        },
+        {
           "action": "BUNDLING CHECK (#1209 / #1251): after staging files but before `git commit`, run `git diff --cached --stat` and verify the line counts match what you planned to ship. If a staged file shows significantly more lines than expected, the working tree had pre-existing uncommitted modifications that got bundled. Investigate before committing. Pattern from pipeline-skill commit bf1a67f which silently bundled 130 unintended lines.",
           "done": false,
           "mandatory": true


### PR DESCRIPTION
## Summary
- Adds a behavior-change CHANGELOG migration block checklist item to Stage 9 (Documentation) in both `bugfix-state.json` and `feature-state.json`
- The item prompts: when a PR changes a documented API contract, the CHANGELOG entry must include what changed, who's affected, and migration path
- Non-mandatory (`mandatory: false`) — only fires when the PR actually changes contracts; author judges, Stage 11 reviewer verifies

## Test plan
- [x] DOCS_ONLY — template JSON files only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)