### PR TITLE
ci: CodeQL concurrency block + correct v0.9.3-4 retro misdiagnosis (#1340)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,15 @@ on:
     # Run weekly on Sunday at midnight
     - cron: '0 0 * * 0'
 
+# Cancel superseded analyses when commits push rapidly to a PR. The latest
+# commit's analysis is what matters; older runs are obsolete and only add
+# noise to the PR check list. See #1340 for the investigation that surfaced
+# this — the v0.9.3 drain misattributed real CodeQL alerts to "stale
+# check-runs"; this block reduces the noise that fueled that misdiagnosis.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   security-events: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CodeQL workflow now cancels superseded analyses on rapid PR pushes (#1340).**
+  Added `concurrency: { group: ${{ github.workflow }}-${{ github.ref }},
+  cancel-in-progress: true }` to `.github/workflows/codeql.yml`. The latest
+  commit's analysis is what matters; older runs are obsolete and only add
+  noise to the PR check list. Investigation in #1340 surfaced that the
+  v0.9.3 drain's "stale CodeQL check-run" framing was a misdiagnosis — most
+  "stale CodeQL fail" check-runs were real GitHub Advanced Security alerts,
+  not stale leftovers. The `--admin` merge requirement comes from the
+  1-approving-review rule (solo maintainer can't self-approve), not from
+  CodeQL. This concurrency block reduces the run-list noise that fueled
+  the misdiagnosis without changing merge behavior. Triage of the 8 real
+  open CodeQL alerts (1 high-severity) tracked in #1343.
+
 ### Fixed
 
 - **`python/djust/tests/` now included in `make test-python` + `check-test-coverage` target (#1339).**

--- a/RETRO.md
+++ b/RETRO.md
@@ -258,7 +258,7 @@ issue or be explicitly closed with a reason.
 | 216 | Elevate single-script-transformation pattern to canon for bulk renames | Retro v0.9.2-5 / PR #1293 (23-site rename) | #1312 | Closed | Resolved in v0.9.3-4 via PR #1336 (rule canonicalized in CLAUDE.md "Process canonicalizations from v0.9.3-4 retro arc"). New. PR #1293 used a single Python script to rename 23 emit-name strings across 4 files in one atomic pass — zero regressions, no partial-state windows. Action #180 lists the pattern as a "safe alternative" to incremental Edit calls when working in parallel agents; v0.9.2-5 demonstrated it's the right shape for sequential single-implementer bulk operations too. Failure modes of incremental Edit-tool calls for bulk renames: partial-state intermediate trips pre-commit hooks, ~23 Edit calls vs 1 script + 1 invocation burns agent context, 23 hunks vs 1 script raise reviewer cognitive load. Worth elevating in CLAUDE.md "Process canonicalizations" Stage 5 (Implementation) section. |
 | 217 | Behavior-change CHANGELOG migration block as Stage 9 checklist item | Retro v0.9.2-5 / PR #1294 (`@action` re-raise contract change) | #1313 | Closed | Resolved in v0.9.3-4 via PR #1337 (behavior-change migration block added to Stage 9 in feature + bugfix templates). New. PR #1294 changed `@action`'s re-raise contract — a behavior change for any code that wrapped `@action` calls in try/except. The CHANGELOG entry included an explicit "Behavior change" block: (a) what changed, (b) who's affected, (c) migration path ("re-raise explicitly inside the handler"). Stage 11 reviewer confirmed this was the right level of detail. Worth canonicalizing as a Stage 9 (Documentation) checklist item: when a PR changes a documented API contract (decorator semantics, function signature, attribute behavior, error envelope), the CHANGELOG entry MUST include a "Behavior change" block with these 3 fields. PR #1294 is the canonical reference example. |
 | 218 | Add `make check-test-coverage` target (grep test files, verify CI collects them) | Retro v0.9.3-4 / PR #1338 | #1339 | Open | |
-| 219 | Investigate workaround for stale CodeQL check-run blocking PR merges | Retro v0.9.3-4 / PRs #1331, #1332 | #1340 | Open | GitHub-side issue — may be a platform bug. 7+ PRs in v0.9.3 series required --admin merge. |
+| 219 | Investigate workaround for stale CodeQL check-run blocking PR merges | Retro v0.9.3-4 / PRs #1331, #1332 | #1340 | Closed | Closed via #1340 closing PR. Investigation surfaced misdiagnosis: branch protection has zero `required_status_checks`, so CodeQL never blocked merges per protection rules; `--admin` is needed because of the 1-approving-review rule (solo maintainer can't self-approve). The "CodeQL fail 3s" was GitHub Advanced Security's *real alert-summary* check (PR #1331's was a real high-severity alert at `client.js:1132`, now open on main). codeql.yml gained a `concurrency:` block to reduce noise; real alerts triage tracked in #1343. |
 
 ## v0.9.3-4 — Process drain bucket: pipeline template canon, audit convention, RETRO convention (PRs #1331–#1338)
 
@@ -277,7 +277,9 @@ PR #1338 moved `test_skip_render_private_state.py` from `python/djust/tests/` to
 **2. CodeQL stale check-run is the dominant CI pain point across this drain.**
 PRs #1331, #1332 (and likely others in the v0.9.3 drain series) required `--admin` merge because a prior CodeQL check-run was not cleaned up after re-run. The check-run stays in a stale "pending" or "failure" state while the re-run passes. GitHub-side issue with no repo-level fix currently known.
 
-**Action taken**: Open — tracked in Action Tracker #219 (GitHub #1340).
+> **[2026-05-02 correction — see #1340 closing PR]**: This finding misdiagnosed cause as correlation. Verified facts: (a) branch protection has zero `required_status_checks`, so CodeQL was never a protection-rule blocker; (b) the actual `--admin` blocker is the 1-approving-review rule (solo maintainer can't self-approve); (c) the "CodeQL fail 3s" check-run is GitHub Advanced Security's *alert-summary* check — it fails when a real new alert is introduced, not because the check is stale. PR #1331's CodeQL "fail" was a real high-severity alert (`js/unvalidated-dynamic-method-call` at `client.js:1132`), now open on main and tracked in #1343 alongside 7 other unrated alerts. The codeql.yml `concurrency:` block landed in the #1340 closing PR reduces noise but is not the merge fix.
+
+**Action taken**: Closed via #1340. Concurrency block landed; misdiagnosis corrected here. Real CodeQL alerts triage tracked in #1343.
 
 **3. Pre-commit hook commit-swallow pattern continues but mitigation is proven.**
 PRs #1331, #1332 both hit the pre-commit stash-restore cycle: ruff/ruff-format modified staged files, stash-pop restored originals, commit silently didn't register. The `&& git log -1 --oneline` post-commit verification (Action #122) caught both immediately. The underlying hook behavior hasn't changed, but the mitigation works reliably — 0 commits lost this drain.
@@ -321,7 +323,7 @@ PRs #1331, #1332 both hit the pre-commit stash-restore cycle: ruff/ruff-format m
 ### Open Items
 
 - [ ] CI test-collection gap — tracked in Action Tracker #218 (GitHub #1339)
-- [ ] CodeQL stale check-run workaround — tracked in Action Tracker #219 (GitHub #1340)
+- [x] ~~CodeQL stale check-run workaround~~ — closed via #1340 closing PR. Misdiagnosis corrected; concurrency block added to codeql.yml; real alerts (1 high-severity) tracked separately in #1343.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -274,8 +274,8 @@ short-circuit so `render_with_diff()` always runs when
 
 **Tech-debt — process (P2):**
 
-- [ ] **#1339 — Add `make check-test-coverage` target** to verify all test files are collected by CI. PR #1338 surfaced that `python/djust/tests/` was excluded from `make test-python`'s explicit paths — tests in that directory were silently never collected. The check target greps for `class Test` / `def test_` across all test files and verifies each is collected.
-- [ ] **#1340 — Investigate workaround for stale CodeQL check-run blocking PR merges.** 7+ PRs in the v0.9.3 series required `--admin` merge because stale CodeQL check-runs weren't cleaned up after re-run. Investigate whether auto-cleanup is possible, whether branch protection can be configured to only look at the latest check-run, or whether this is a GitHub bug to report.
+- [x] ~~**#1339 — Add `make check-test-coverage` target** to verify all test files are collected by CI.~~ ✅ — Closed via PR #1341 (commit b989b0ae). `make check-test-coverage` greps test files and verifies CI collection; pre-push hook gates on it.
+- [x] ~~**#1340 — Investigate workaround for stale CodeQL check-run blocking PR merges.** 7+ PRs in the v0.9.3 series required `--admin` merge because stale CodeQL check-runs weren't cleaned up after re-run. Investigate whether auto-cleanup is possible, whether branch protection can be configured to only look at the latest check-run, or whether this is a GitHub bug to report.~~ ✅ — Investigation surfaced misdiagnosis: branch protection has zero `required_status_checks`; the actual `--admin` driver is the 1-approving-review rule on a solo-maintainer repo. The "CodeQL fail" check-runs were real GitHub Advanced Security alerts, not stale leftovers. Closed via PR adding `concurrency:` to codeql.yml (reduces run-list noise) + RETRO/ROADMAP misdiagnosis correction; real-alerts triage filed as #1343.
 
 #### Acceptance
 


### PR DESCRIPTION
Closes #1340.

## Summary

Investigation of #1340 surfaced that the v0.9.3-4 retro's "stale CodeQL check-run blocking PR merges" framing was a **misdiagnosis** — cause was confused with correlation.

**Verified facts:**

1. **Branch protection has zero `required_status_checks`** (confirmed via `gh api repos/djust-org/djust/branches/main/protection` and both rulesets). CodeQL was never a protection-rule blocker.
2. **The actual `--admin` driver is the 1-approving-review rule** (solo maintainer can't self-approve). PR #1338 had `CodeQL skipping 2s` (clean) but still merged via `--admin` because `reviewDecision: REVIEW_REQUIRED`.
3. **The "CodeQL fail 3s" check-run is GitHub Advanced Security's alert-summary check** (`app: GitHub Advanced Security`). It fails when a real new alert is introduced. PR #1331's "fail" was a real high-severity finding (`js/unvalidated-dynamic-method-call` at `python/djust/static/djust/client.js:1132`), bypassed via `--admin` and **still open on main**.
4. **8 open CodeQL alerts on main** (1 high, 7 unrated) — real findings, not noise.

## Changes

### `.github/workflows/codeql.yml`
Adds a `concurrency:` block:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```
Cancels superseded analyses on rapid PR pushes — the latest commit's analysis is what matters; older runs are obsolete and only add noise to the PR check list. Reduces the run-list noise that fueled the misdiagnosis. **Does not change merge behavior** — CodeQL was never a protection-rule blocker.

### `RETRO.md`
- v0.9.3-4 finding #2 ("CodeQL stale check-run is the dominant CI pain point") gets an in-place `[2026-05-02 correction]` callout above the original text. Both misdiagnosis and correction stay visible for transparency.
- Action Tracker row #219 status flips to Closed with the corrected diagnosis.
- Open Items checklist row marked done.

### `ROADMAP.md`
- v0.9.3-5 task #1340 struck through with closure note.
- v0.9.3-5 task #1339 also struck through (was already merged via PR #1341 — minor lag fix while in the area).

### `CHANGELOG.md`
- `### Changed` entry under `[Unreleased]` for the workflow change.

## Out of scope (deferred)

- **Triage of the 8 open CodeQL alerts** (especially the 1 high-severity at `client.js:1132`) — filed as #1343.
- Re-evaluating the 1-approving-review rule for solo-maintainer development — not pursued.
- Adding a runbook explaining `--admin` is the standard mechanism for solo dev — deferred until pain continues.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/codeql.yml'))"` succeeds.
- [x] `git diff` for impl commit (`fdf391c1`) is workflow-only; gate 1 (no CHANGELOG in impl) passes.
- [x] `git diff` for docs commit (`05922b28`) is docs-only (RETRO/ROADMAP/CHANGELOG); gate 2 passes.
- [ ] Real test happens once this PR's commits push — only the latest CodeQL run should remain active.

## Two-commit shape

- `fdf391c1` — impl-only (`.github/workflows/codeql.yml`)
- `05922b28` — docs-only (`CHANGELOG.md`, `RETRO.md`, `ROADMAP.md`)