### PR TITLE
feat(cli): promote `djust deploy` to a first-class subcommand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,12 @@ dependencies = [
     "msgpack>=1.0.0,<2",
     "markdown>=3.0,<4",
     "nh3>=0.2,<1",
+    # `djust deploy` is a first-class CLI command, so click + requests are
+    # base deps rather than gated behind a `[deploy]` extra. Both are tiny
+    # and ubiquitous; the `deploy` extra below is kept as a no-op alias for
+    # back-compat with installers that already pin `djust[deploy]`.
+    "click>=8.0,<9",
+    "requests>=2.28,<3",
 ]
 
 [project.optional-dependencies]
@@ -72,10 +78,7 @@ tenants-postgres = [
 ]
 theming = []  # No extra deps beyond djust core
 admin = []  # No extra deps beyond djust core
-deploy = [
-    "click>=8.0,<9",
-    "requests>=2.28,<3",
-]
+deploy = []  # Back-compat alias; click + requests now ship as base deps for `djust deploy`
 components = [
     "markdown>=3.0,<4",
     "nh3>=0.2,<1",

--- a/python/djust/cli.py
+++ b/python/djust/cli.py
@@ -9,6 +9,9 @@ Usage:
 
     python -m djust mcp install            Write .mcp.json for Claude Code / Cursor
 
+    djust deploy <slug>                    Deploy current directory to djustlive.com
+    djust deploy login                     Log in to djustlive.com
+
     python -m djust.cli stats             Show state backend statistics
     python -m djust.cli health            Run health checks on backends
     python -m djust.cli profile           Show profiling statistics
@@ -870,7 +873,82 @@ def cmd_clear(args):
         sys.exit(1)
 
 
+DEPLOY_HELP = """\
+Usage: djust deploy [<slug>] [--from-git] [--dir DIR]
+       djust deploy login | logout
+       djust deploy status [<slug>]
+
+Deploy the current directory to djustlive.com.
+
+Commands:
+  djust deploy login          Log in to djustlive.com (stores token in ~/.djustlive/credentials)
+  djust deploy logout         Remove stored credentials
+  djust deploy status [slug]  Show deployment status (optionally for one project)
+  djust deploy <slug>         Deploy current directory to project <slug> (default action)
+  djust deploy <slug> --from-git
+                              Deploy the latest pushed commit instead of the local working tree
+
+Environment:
+  DJUST_SERVER                Override the djustlive server URL (default: https://djustlive.com)
+
+Note:
+  The project must already exist on djustlive.com. Sign up and create one
+  at https://djustlive.com before your first deploy.
+"""
+
+
+def cmd_deploy(rest):
+    """Delegate to the Click-based deploy CLI in djust.deploy_cli."""
+    try:
+        from djust.deploy_cli import cli as deploy_cli
+    except ImportError as e:
+        print(f"Error: deploy CLI requires the 'deploy' extra: pip install 'djust[deploy]'\n  {e}")
+        return 1
+
+    if not rest or rest[0] in ("-h", "--help"):
+        print(DEPLOY_HELP)
+        return 0
+
+    first = rest[0]
+
+    # Pass-through subcommands that already exist on the Click group.
+    if first in ("login", "logout", "status"):
+        argv = rest
+    elif first == "--from-git":
+        # `djust deploy --from-git <slug>` — delegate to the git-based deploy.
+        argv = ["deploy", *rest[1:]]
+    elif first.startswith("-"):
+        # Unknown flag at the top level — show help.
+        print(DEPLOY_HELP)
+        return 1
+    else:
+        # `djust deploy <slug> [...]` — default to the directory flow,
+        # which works against the prebuilt-image pipeline (no git required).
+        argv = ["deploy-dir", *rest]
+
+    try:
+        deploy_cli.main(args=argv, prog_name="djust deploy", standalone_mode=False)
+    except Exception as e:  # ClickException, etc.
+        # Click's exceptions render themselves; everything else falls through.
+        try:
+            import click
+
+            if isinstance(e, click.ClickException):
+                e.show()
+                return e.exit_code
+        except ImportError:
+            pass
+        print(f"Error: {e}")
+        return 1
+    return 0
+
+
 def main():
+    # `deploy` is detected before argparse so the Click subcommand owns its
+    # own argv (flags, prompts, streaming output) without argparse interference.
+    if len(sys.argv) >= 2 and sys.argv[1] == "deploy":
+        sys.exit(cmd_deploy(sys.argv[2:]) or 0)
+
     parser = argparse.ArgumentParser(
         description="djust CLI - Developer tools for djust framework",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -949,6 +1027,13 @@ def main():
     mcp_parser = subparsers.add_parser("mcp", help="MCP server management")
     mcp_sub = mcp_parser.add_subparsers(dest="mcp_command")
     mcp_sub.add_parser("install", help="Write .mcp.json for Claude Code / Cursor")
+
+    # deploy command (intercepted before argparse — listed here for --help discovery)
+    subparsers.add_parser(
+        "deploy",
+        help="Deploy current directory to djustlive.com (run `djust deploy --help`)",
+        add_help=False,
+    )
 
     # clear command
     clear_parser = subparsers.add_parser("clear", help="Clear state backend caches")

--- a/python/djust/deploy_cli.py
+++ b/python/djust/deploy_cli.py
@@ -75,7 +75,7 @@ def load_credentials() -> dict:
     """Load credentials from disk, raising ClickException if absent."""
     path = credentials_path()
     if not path.exists():
-        raise click.ClickException("Not logged in. Run `djust-deploy login` first.")
+        raise click.ClickException("Not logged in. Run `djust deploy login` first.")
     return json.loads(path.read_text())
 
 
@@ -410,8 +410,12 @@ def deploy_dir(ctx: click.Context, project_slug: str, source_dir: str) -> None:
                     status = data.get("status")
                     click.echo(f"Status: {status}")
 
-                    if status in ("active", "failed", "cancelled", "superseded"):
-                        if status == "active":
+                    # `deploying` means the k8s resources have been created
+                    # and the readiness probe passed; the deployment row
+                    # may still flip to `active` later, but the app is
+                    # already serving so we can return.
+                    if status in ("active", "deploying", "failed", "cancelled", "superseded"):
+                        if status in ("active", "deploying"):
                             container_url = data.get("container_url")
                             if container_url:
                                 click.echo(f"Application available at: {container_url}")


### PR DESCRIPTION
## Summary

\`djust-deploy\` is now reachable as \`djust deploy <slug>\` from the main CLI. Lets any developer with djust installed ship their project to djustlive.com without learning a second command name.

\`\`\`
djust deploy login           # one-time, ~/.djustlive/credentials
djust deploy logout
djust deploy status [slug]
djust deploy <slug>          # default: directory upload + prebuilt-container path
djust deploy <slug> --from-git
\`\`\`

The shim intercepts \`deploy\` before argparse and delegates to the existing Click group in \`djust.deploy_cli:cli\` — keeps all subcommands working, no duplication. Legacy \`djust-deploy\` entry point stays for back-compat.

## Other changes

- \`click\` + \`requests\` promoted to base deps (were behind \`[deploy]\` extra). The extra is now a no-op alias so existing pins still resolve.
- \`Not logged in\` message points at \`djust deploy login\`.
- Tarball-upload poll loop accepts \`deploying\` as a terminal success state — readiness probe has already passed at that point.

## Test plan

- [x] \`pytest python/tests/test_deploy_cli.py\` — 31/31 pass
- [x] \`ruff check\` — clean
- [x] End-to-end: \`djust deploy djust-scaffold\` ships the scaffold to \`https://umf8-djust-scaffold.djustlive.app/\` (HTTP 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)