### PR TITLE
fix: address 2 real CodeQL findings (#1343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`_mount_one` now returns a consistent 5-tuple from every path (#1343).**
+  The `except Exception` branch in `LiveViewConsumer._mount_one`
+  (`websocket.py:2469`) returned a 4-tuple while every other path
+  returned a 5-tuple `(ok, payload, err, nav, push_events)`. The single
+  caller in `handle_mount_batch` unpacks 5 values; the mismatch raised
+  `ValueError: not enough values to unpack`, masking the per-view error
+  in the batch `failed[]` plumbing. Surfaced by CodeQL `py/mixed-tuple-returns`
+  alert. Returns `[]` for `push_events` from the exception path. 1 regression
+  test in `test_sw_advanced.py::TestMountBatch::test_mount_one_returns_5_tuple_on_unhandled_exception`.
+
+- **`deploy_cli.py` no longer has a bare `except: pass` for transient
+  status-poll errors (#1343).** Surfaced by CodeQL `py/empty-except` alert.
+  Replaced with `logger.debug("status poll failed; retrying", exc_info=True)`
+  + an explanatory comment. CLAUDE.md security rule #5 forbids bare
+  `except: pass` framework-wide.
+
 - **`python/djust/tests/` now included in `make test-python` + `check-test-coverage` target (#1339).**
   The Makefile's test targets used explicit pytest paths (`tests/ python/tests/`)
   which override pyproject.toml's testpaths, silently excluding `python/djust/tests/`

--- a/python/djust/deploy_cli.py
+++ b/python/djust/deploy_cli.py
@@ -421,7 +421,9 @@ def deploy_dir(ctx: click.Context, project_slug: str, source_dir: str) -> None:
                                 click.echo(f"Application available at: {container_url}")
                         return
             except requests.RequestException:
-                pass
+                # Transient network error during status poll; the loop's
+                # next iteration will retry. Logged at debug to avoid noise.
+                logger.debug("status poll failed; retrying", exc_info=True)
 
         click.echo("Deployment timed out waiting for completion.")
 

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -2466,7 +2466,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             safe_err = "mount failed"
             if getattr(_settings, "DEBUG", False):
                 safe_err = str(exc)[:200]
-            return False, {"target_id": target_id, "view": view_path}, safe_err, None
+            return False, {"target_id": target_id, "view": view_path}, safe_err, None, []
         finally:
             # Only restore if the try-block didn't already restore (else
             # we'd double-restore harmlessly). Idempotent.

--- a/tests/unit/test_sw_advanced.py
+++ b/tests/unit/test_sw_advanced.py
@@ -433,6 +433,37 @@ class TestMountBatch:
         assert len(batch_frames[0]["views"]) == 1
         assert batch_frames[0]["views"][0]["target_id"] == "only"
 
+    def test_mount_one_returns_5_tuple_on_unhandled_exception(self):
+        """#1343 (CodeQL py/mixed-tuple-returns at websocket.py:2400):
+        ``_mount_one`` previously returned a 4-tuple in the
+        ``except Exception`` branch but a 5-tuple on every other path.
+        The caller in ``handle_mount_batch`` unpacks 5 values; the
+        mismatch raised ``ValueError: not enough values to unpack``,
+        which masked the per-view error in the batch ``failed[]``
+        plumbing. All return paths must now yield a 5-tuple
+        ``(ok, payload, err, nav, push_events)``.
+        """
+        consumer = _make_fake_consumer()
+        result = asyncio.run(
+            consumer._mount_one(
+                {
+                    "target_id": "regress",
+                    "view": "tests.unit.test_sw_advanced._DoesNotExist",
+                    "params": {},
+                    "url": "/",
+                }
+            )
+        )
+        assert len(result) == 5, (
+            "_mount_one must return a 5-tuple on every path; got %d-tuple" % len(result)
+        )
+        ok, payload, err, nav, push_events = result
+        assert ok is False
+        assert payload["target_id"] == "regress"
+        assert err is not None
+        assert nav is None
+        assert push_events == []
+
     def test_mount_batch_failure_isolated_in_failed_array(self):
         """One invalid view_path → failed[] entry, others succeed."""
         consumer = _make_fake_consumer()


### PR DESCRIPTION
## Summary

Closes the two real findings from `gh api 'repos/djust-org/djust/code-scanning/alerts?state=open'` (filed as #1343):

- **`websocket.py:2469`** (`py/mixed-tuple-returns`) — `_mount_one`'s `except Exception` branch returned a 4-tuple while every other path returned a 5-tuple `(ok, payload, err, nav, push_events)`. Caller in `handle_mount_batch` unpacks 5 values → `ValueError: not enough values to unpack`. Fixed by returning `[]` as `push_events` from the exception path.
- **`deploy_cli.py:423-424`** (`py/empty-except`) — bare `except requests.RequestException: pass` violated CLAUDE.md security rule #5. Replaced with `logger.debug("status poll failed; retrying", exc_info=True)` + explanatory comment.

## Two-commit shape (Action #181)

- `2ff4b506` — impl + regression test
- `489279d4` — CHANGELOG entry

## CodeQL alert closure

The other 6 open CodeQL alerts were dismissed via `gh api -X PATCH ... -f state=dismissed`:
- 1× `client.js:1132` — framework-managed Promise resolver, not user-controlled method dispatch (false positive)
- 5× `runtime.py:81-90` — Protocol member stubs (`def x(self) -> str: ...`); the `...` IS the body (false positive)

After this PR merges, `gh api 'repos/djust-org/djust/code-scanning/alerts?state=open'` returns 0 open alerts.

## Test plan

- [x] `pytest tests/unit/test_sw_advanced.py::TestMountBatch::test_mount_one_returns_5_tuple_on_unhandled_exception` passes (new regression)
- [x] `pytest tests/unit/test_sw_advanced.py::TestMountBatch::test_mount_batch_failure_isolated_in_failed_array` still passes (no regression)
- [x] Pre-push hooks pass (full suite + handler-contracts + dead-private-methods + ...)

Closes #1343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)