### PR TITLE
fix: explanatory comment on cli.py ImportError handler (#1343)

### DIFF
--- a/python/djust/cli.py
+++ b/python/djust/cli.py
@@ -937,6 +937,9 @@ def cmd_deploy(rest):
                 e.show()
                 return e.exit_code
         except ImportError:
+            # click isn't importable in this environment; fall through to
+            # the generic error-print path below which handles `e` without
+            # needing the click-aware rendering.
             pass
         print(f"Error: {e}")
         return 1


### PR DESCRIPTION
## Summary

Closes the last open CodeQL alert in the v0.9.3-6 drain bucket (alert #2304, `py/empty-except` at `cli.py:939`).

The `except ImportError: pass` in `_run_deploy_subcommand`'s ClickException-rendering path is functionally correct — if `click` can't be imported, fall through to the generic `print(f"Error: {e}")` path below. CodeQL flagged it because there was no explanatory comment.

This alert was introduced by the #1347 (djust deploy CLI) merge into main, surfacing during the next CodeQL scan.

## Test plan

- [x] No behavior change (comment-only addition)
- [x] Pre-push hooks pass

After merge, `gh api 'repos/djust-org/djust/code-scanning/alerts?state=open'` should return 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)