### PR TITLE
fix(transitions): respect CSS transition-duration; await all transitionend events

### DIFF
--- a/python/djust/static/djust/src/41-dj-transition.js
+++ b/python/djust/static/djust/src/41-dj-transition.js
@@ -44,12 +44,55 @@
 //
 // On `transitionend`, phase-2 classes are removed (they typically
 // carry the `transition-*` helper and are not needed once the animation
-// has completed). A 600 ms fallback timeout cleans up phase-2 classes if
-// `transitionend` never fires (e.g. zero-duration transitions or
+// has completed). A computed fallback timeout cleans up phase-2 classes
+// if `transitionend` never fires (e.g. zero-duration transitions or
 // display: none).
+//
+// The fallback duration is auto-derived from the element's computed
+// `transition-duration` + `transition-delay` (longest pair across all
+// transitioning properties) plus a 50ms grace window. For multi-property
+// transitions, we count expected `transitionend` events from
+// `transition-property` and only run cleanup after all have fired —
+// otherwise the first-finishing property would cut off slower ones.
+//
+// `_FALLBACK_MS_DEFAULT` is the fallback used only when computed-style
+// reading fails or yields zero (e.g. element has no transition rule yet).
 
 const _djTransitionState = new WeakMap();
-const _FALLBACK_MS = 600;
+const _FALLBACK_MS_DEFAULT = 600;
+
+function _parseTimeMs(s) {
+    // CSS time tokens: "550ms", "0.55s", "0s". Returns 0 on parse failure.
+    const t = (s || '').trim();
+    if (!t) return 0;
+    if (t.endsWith('ms')) return parseFloat(t) || 0;
+    if (t.endsWith('s')) return (parseFloat(t) || 0) * 1000;
+    return 0;
+}
+
+function _computeTransitionTiming(el) {
+    // Inspect `transition-property`, `transition-duration`, `transition-delay`
+    // and return {maxMs, propsCount}. CSS spec: when *-duration / *-delay
+    // have fewer comma-separated values than -property, they cycle. When
+    // they have more, extras are ignored.
+    const cs = (typeof getComputedStyle === 'function') ? getComputedStyle(el) : null;
+    if (!cs) return { maxMs: 0, propsCount: 0 };
+    const props = (cs.transitionProperty || '')
+        .split(',').map(s => s.trim()).filter(s => s && s !== 'none');
+    const durations = (cs.transitionDuration || '')
+        .split(',').map(s => _parseTimeMs(s));
+    const delays = (cs.transitionDelay || '')
+        .split(',').map(s => _parseTimeMs(s));
+    if (props.length === 0) return { maxMs: 0, propsCount: 0 };
+    let maxMs = 0;
+    for (let i = 0; i < props.length; i++) {
+        const dur = durations[i % durations.length] || 0;
+        const del = delays[i % delays.length] || 0;
+        const total = dur + del;
+        if (total > maxMs) maxMs = total;
+    }
+    return { maxMs: maxMs, propsCount: props.length };
+}
 
 function _parseSpec(raw) {
     const input = (raw || '').trim();
@@ -99,6 +142,12 @@ function _runTransition(el, spec) {
         _raf(function () {
             el.classList.add(spec.single);
 
+            // Compute timing AFTER the class is applied so the new
+            // transition rule is reflected in getComputedStyle.
+            const timing = _computeTransitionTiming(el);
+            const fallbackMs = timing.maxMs > 0 ? timing.maxMs + 50 : _FALLBACK_MS_DEFAULT;
+            let remainingEvents = timing.propsCount || 1;
+
             function cleanup() {
                 if (!el.isConnected) {
                     _djTransitionState.delete(el);
@@ -111,11 +160,12 @@ function _runTransition(el, spec) {
 
             function onEnd(ev) {
                 if (ev.target !== el) return;
-                cleanup();
+                remainingEvents--;
+                if (remainingEvents <= 0) cleanup();
             }
             state.onEnd = onEnd;
             el.addEventListener('transitionend', onEnd);
-            state.fallback = setTimeout(cleanup, _FALLBACK_MS);
+            state.fallback = setTimeout(cleanup, fallbackMs);
         });
         return;
     }
@@ -130,9 +180,15 @@ function _runTransition(el, spec) {
         el.classList.add(spec.active);
         el.classList.add(spec.end);
 
+        // Compute timing AFTER active+end land so getComputedStyle picks
+        // up the transition rule from the active class.
+        const timing = _computeTransitionTiming(el);
+        const fallbackMs = timing.maxMs > 0 ? timing.maxMs + 50 : _FALLBACK_MS_DEFAULT;
+        let remainingEvents = timing.propsCount || 1;
+
         function cleanup() {
             // Guard against detached elements — if the node has been
-            // removed from the DOM before this fires (typically the 600 ms
+            // removed from the DOM before this fires (typically the
             // fallback path), skip classList/listener work. classList on
             // a detached node is technically safe but any parentNode
             // access downstream would NPE.
@@ -148,15 +204,20 @@ function _runTransition(el, spec) {
 
         function onEnd(ev) {
             // Only react to transitions on THIS element, not bubbled
-            // transitions from children.
+            // transitions from children. Decrement the expected event
+            // count and only cleanup once all properties have finished —
+            // otherwise the fastest property would cut off slower ones.
             if (ev.target !== el) return;
-            cleanup();
+            remainingEvents--;
+            if (remainingEvents <= 0) cleanup();
         }
         state.onEnd = onEnd;
         el.addEventListener('transitionend', onEnd);
 
-        // Fallback in case transitionend never fires.
-        state.fallback = setTimeout(cleanup, _FALLBACK_MS);
+        // Fallback in case transitionend never fires (zero-duration
+        // transitions or detached/hidden elements). Sized from the
+        // computed transition duration + 50ms grace.
+        state.fallback = setTimeout(cleanup, fallbackMs);
     });
 }
 

--- a/python/djust/static/djust/src/42-dj-remove.js
+++ b/python/djust/static/djust/src/42-dj-remove.js
@@ -45,6 +45,39 @@
 const _pendingRemovals = new WeakMap();   // Element -> { fallback, onEnd, observer, spec }
 const _REMOVE_FALLBACK_MS = 600;
 
+function _parseTimeMs(s) {
+    // CSS time tokens: "550ms", "0.55s", "0s". Returns 0 on parse failure.
+    const t = (s || '').trim();
+    if (!t) return 0;
+    if (t.endsWith('ms')) return parseFloat(t) || 0;
+    if (t.endsWith('s')) return (parseFloat(t) || 0) * 1000;
+    return 0;
+}
+
+function _computeTransitionTiming(el) {
+    // Returns {maxMs, propsCount} from the element's computed transition
+    // styles. Same logic as 41-dj-transition.js — duplicated here rather
+    // than shared because the source files are concatenated as separate
+    // modules (no cross-file imports).
+    const cs = (typeof getComputedStyle === 'function') ? getComputedStyle(el) : null;
+    if (!cs) return { maxMs: 0, propsCount: 0 };
+    const props = (cs.transitionProperty || '')
+        .split(',').map(s => s.trim()).filter(s => s && s !== 'none');
+    const durations = (cs.transitionDuration || '')
+        .split(',').map(s => _parseTimeMs(s));
+    const delays = (cs.transitionDelay || '')
+        .split(',').map(s => _parseTimeMs(s));
+    if (props.length === 0) return { maxMs: 0, propsCount: 0 };
+    let maxMs = 0;
+    for (let i = 0; i < props.length; i++) {
+        const dur = durations[i % durations.length] || 0;
+        const del = delays[i % delays.length] || 0;
+        const total = dur + del;
+        if (total > maxMs) maxMs = total;
+    }
+    return { maxMs: maxMs, propsCount: props.length };
+}
+
 function _parseRemoveSpec(raw) {
     if (raw === null || raw === undefined) return null;
     const parts = String(raw).trim().split(/\s+/).filter(Boolean);
@@ -62,15 +95,21 @@ function _parseRemoveSpec(raw) {
 }
 
 function _durationFor(el) {
+    // Explicit dj-remove-duration attribute wins (clamped to 0–30s).
     const raw = el.getAttribute && el.getAttribute('dj-remove-duration');
-    if (raw === null || raw === undefined || raw === '') return _REMOVE_FALLBACK_MS;
-    const n = parseInt(raw, 10);
-    if (!Number.isFinite(n)) return _REMOVE_FALLBACK_MS;
-    // Clamp to a sane range so a malformed attribute can't leak a pending
-    // removal indefinitely or fire before the frame has had a chance to paint.
-    if (n < 0) return 0;
-    if (n > 30000) return 30000;
-    return n;
+    if (raw !== null && raw !== undefined && raw !== '') {
+        const n = parseInt(raw, 10);
+        if (Number.isFinite(n)) {
+            if (n < 0) return 0;
+            if (n > 30000) return 30000;
+            return n;
+        }
+    }
+    // No author override — read from computed style. Falls back to the
+    // hardcoded default only if no transition is declared.
+    const timing = _computeTransitionTiming(el);
+    if (timing.maxMs > 0) return timing.maxMs + 50;
+    return _REMOVE_FALLBACK_MS;
 }
 
 function _teardownState(el, state) {
@@ -125,9 +164,19 @@ function _runRemove(el, spec) {
     const state = { spec: spec };
     _pendingRemovals.set(el, state);
 
+    // Count expected transitionend events (one per transitioning property)
+    // so the first-finishing property doesn't cut off slower ones. The
+    // count is read AFTER the active class has had a chance to apply —
+    // for the 3-token form, that's after the next frame; for the 1-token
+    // form, the class is added synchronously in maybeDeferRemoval before
+    // _runRemove is called.
+    const timing = _computeTransitionTiming(el);
+    let remainingEvents = timing.propsCount || 1;
+
     function onEnd(ev) {
         if (ev.target !== el) return;
-        _finalizeRemoval(el);
+        remainingEvents--;
+        if (remainingEvents <= 0) _finalizeRemoval(el);
     }
     state.onEnd = onEnd;
     el.addEventListener('transitionend', onEnd);


### PR DESCRIPTION
## Summary

Two bugs in `dj-transition` (`41-dj-transition.js`) and `dj-remove`
(`42-dj-remove.js`) capped animations at 600ms and cut multi-property
transitions short. This PR fixes both at the source-only level.

## Bugs fixed

### 1. Hard-coded 600ms fallback truncated long transitions

```js
const _FALLBACK_MS = 600;
state.fallback = setTimeout(cleanup, _FALLBACK_MS);
```

Any animation longer than 600ms got cut off mid-flight: `cleanup()`
removed the `active` class, dropping the `transition:` rule and
snapping properties to their final values.

### 2. First `transitionend` triggered cleanup

```js
function onEnd(ev) {
    if (ev.target !== el) return;
    cleanup();   // ← fires on FIRST property to finish
}
```

For `transition: opacity 500ms, transform 1500ms`, the opacity event
at 500ms triggered cleanup, snapping the in-flight transform to its
final value at 500ms instead of 1500ms.

## Fix

- Read `transition-property`, `transition-duration`, `transition-delay`
  from `getComputedStyle(el)` after the `active` class lands
- Use `max(duration + delay) + 50ms` as the fallback timeout
- Count expected `transitionend` events from `transition-property`
  and only cleanup after all have fired
- Preserve `dj-remove-duration` attribute as an explicit override
  (still wins, clamped 0–30s)
- Zero-duration / `display:none` cases still hit the 600ms default
  via `_computeTransitionTiming` returning `{maxMs: 0}`

## Source-only — bundle deferred

This PR does **not** include the rebuilt `client.js`/`client.min.js`
bundle. The bundle has 392 pre-existing eslint warnings that block
`--max-warnings 0`, unrelated to this change. Tracking cleanup at #1351.

Bundle should be rebuilt + committed in a follow-up after #1351.
Until then, `make build-js` produces the new bundle locally and
contributors can use `SKIP=build-js,eslint` to commit JS source
changes (named-skip mechanism, not `--no-verify`).

## Test plan

- [x] Source files lint clean (`npx eslint python/djust/static/djust/src/41-dj-transition.js python/djust/static/djust/src/42-dj-remove.js`)
- [x] `make build-js` regenerates bundles successfully (52 modules → 606480 bytes)
- [x] Manually verified at scaffold's `/features-v09/transition/` with 1.8s entry + 1.5s exit + 1.2s delayed layout-collapse — all phases complete cleanly with rebuilt bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)