### PR TITLE
fix: db.notifications permanent-failure handling + dj-transition CSS-duration (#1348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`dj-transition` now respects CSS `transition-duration` instead of a hard-coded 600ms fallback (#1348).**
+  The fallback timeout is auto-derived from the element's computed
+  `transition-duration` + `transition-delay` (longest pair across all
+  transitioning properties) plus a 50ms grace window. For multi-property
+  transitions, expected `transitionend` events are counted from
+  `transition-property` and cleanup runs only after all have fired —
+  otherwise the first-finishing property would cut off slower ones.
+  `_FALLBACK_MS_DEFAULT` (600ms) is used only when computed-style
+  reading fails or yields zero. Same auto-derivation extended to
+  `dj-remove`. Source-only commit; bundle (`client.js`) rebuild
+  deferred per #1351 (392 pre-existing eslint warnings block
+  `--max-warnings 0`).
+
+- **`db.notifications` exits cleanly on permanent failures instead of
+  retrying forever.** Background — incident 2026-05-05: a 3.5-day-old
+  djust deploy missing the optional `psycopg[binary]>=3.2` dependency
+  had `_run()` retrying `_connect()` every 1 second forever (~302,000
+  attempts), accumulating 15.4 GiB of anonymous heap from un-reaped
+  asyncio Task / coroutine closure state. The kubelet hit memory
+  pressure, transitioned to NodeNotReady for ~7 seconds, which was
+  enough for cnpg to fail over the postgres-cluster primary →
+  3-minute platform outage. Fix: when `_connect()` raises
+  `DatabaseNotificationNotSupported` (missing psycopg or non-postgres
+  engine), treat as PERMANENT — log once at WARNING with
+  operator-actionable wording, set `_stopping = True`, fire
+  `_ready_event`, return from the loop. Process restart re-enables
+  once the cause is fixed. Transient failures
+  (`ConnectionRefusedError`, `OSError`, timeout, etc.) retain their
+  1-second-backoff retry behaviour. 2 regression tests in
+  `python/djust/tests/test_notifications_permanent_failure.py`
+  (`test_run_exits_immediately_on_permanent_failure`,
+  `test_run_retries_transient_connect_failures`).
+
 - **In-memory state backend no longer panics on concurrent same-session
   HTTP renders (#1353).** When two HTTP requests for the same
   ``(session, view_path)`` pair shared a cached ``RustLiveView`` (the

--- a/python/djust/db/notifications.py
+++ b/python/djust/db/notifications.py
@@ -260,6 +260,26 @@ class PostgresNotifyListener:
         while not self._stopping:
             try:
                 conn = await self._connect()
+            except DatabaseNotificationNotSupported as exc:
+                # Permanent failures: missing psycopg dependency, non-postgres
+                # backend, etc. Retrying every second forever doesn't help and
+                # leaks asyncio Task state per attempt — see incident
+                # 2026-05-05 where a 3.5-day-old deploy with psycopg2-instead-
+                # of-psycopg3 accumulated 15 GiB of orphaned Task closures.
+                # Log once at WARNING and exit. Re-raises happen via
+                # ``ensure_listening`` callers; the singleton stays present
+                # so a fixed deploy can re-trigger startup naturally.
+                logger.warning(
+                    "pg listener disabled (permanent failure): %s — "
+                    "fix the cause and restart the process to re-enable",
+                    exc,
+                )
+                if self._ready_event is not None:
+                    # Unblock any caller awaiting the ready event so they
+                    # don't hang forever on a process that won't ever listen.
+                    self._ready_event.set()
+                self._stopping = True
+                return
             except Exception as exc:  # noqa: BLE001
                 logger.warning("pg listener connect failed: %s — retrying in 1s", exc)
                 await asyncio.sleep(1.0)

--- a/python/djust/static/djust/src/41-dj-transition.js
+++ b/python/djust/static/djust/src/41-dj-transition.js
@@ -44,12 +44,55 @@
 //
 // On `transitionend`, phase-2 classes are removed (they typically
 // carry the `transition-*` helper and are not needed once the animation
-// has completed). A 600 ms fallback timeout cleans up phase-2 classes if
-// `transitionend` never fires (e.g. zero-duration transitions or
+// has completed). A computed fallback timeout cleans up phase-2 classes
+// if `transitionend` never fires (e.g. zero-duration transitions or
 // display: none).
+//
+// The fallback duration is auto-derived from the element's computed
+// `transition-duration` + `transition-delay` (longest pair across all
+// transitioning properties) plus a 50ms grace window. For multi-property
+// transitions, we count expected `transitionend` events from
+// `transition-property` and only run cleanup after all have fired —
+// otherwise the first-finishing property would cut off slower ones.
+//
+// `_FALLBACK_MS_DEFAULT` is the fallback used only when computed-style
+// reading fails or yields zero (e.g. element has no transition rule yet).
 
 const _djTransitionState = new WeakMap();
-const _FALLBACK_MS = 600;
+const _FALLBACK_MS_DEFAULT = 600;
+
+function _parseTimeMs(s) {
+    // CSS time tokens: "550ms", "0.55s", "0s". Returns 0 on parse failure.
+    const t = (s || '').trim();
+    if (!t) return 0;
+    if (t.endsWith('ms')) return parseFloat(t) || 0;
+    if (t.endsWith('s')) return (parseFloat(t) || 0) * 1000;
+    return 0;
+}
+
+function _computeTransitionTiming(el) {
+    // Inspect `transition-property`, `transition-duration`, `transition-delay`
+    // and return {maxMs, propsCount}. CSS spec: when *-duration / *-delay
+    // have fewer comma-separated values than -property, they cycle. When
+    // they have more, extras are ignored.
+    const cs = (typeof getComputedStyle === 'function') ? getComputedStyle(el) : null;
+    if (!cs) return { maxMs: 0, propsCount: 0 };
+    const props = (cs.transitionProperty || '')
+        .split(',').map(s => s.trim()).filter(s => s && s !== 'none');
+    const durations = (cs.transitionDuration || '')
+        .split(',').map(s => _parseTimeMs(s));
+    const delays = (cs.transitionDelay || '')
+        .split(',').map(s => _parseTimeMs(s));
+    if (props.length === 0) return { maxMs: 0, propsCount: 0 };
+    let maxMs = 0;
+    for (let i = 0; i < props.length; i++) {
+        const dur = durations[i % durations.length] || 0;
+        const del = delays[i % delays.length] || 0;
+        const total = dur + del;
+        if (total > maxMs) maxMs = total;
+    }
+    return { maxMs: maxMs, propsCount: props.length };
+}
 
 function _parseSpec(raw) {
     const input = (raw || '').trim();
@@ -99,6 +142,12 @@ function _runTransition(el, spec) {
         _raf(function () {
             el.classList.add(spec.single);
 
+            // Compute timing AFTER the class is applied so the new
+            // transition rule is reflected in getComputedStyle.
+            const timing = _computeTransitionTiming(el);
+            const fallbackMs = timing.maxMs > 0 ? timing.maxMs + 50 : _FALLBACK_MS_DEFAULT;
+            let remainingEvents = timing.propsCount || 1;
+
             function cleanup() {
                 if (!el.isConnected) {
                     _djTransitionState.delete(el);
@@ -111,11 +160,12 @@ function _runTransition(el, spec) {
 
             function onEnd(ev) {
                 if (ev.target !== el) return;
-                cleanup();
+                remainingEvents--;
+                if (remainingEvents <= 0) cleanup();
             }
             state.onEnd = onEnd;
             el.addEventListener('transitionend', onEnd);
-            state.fallback = setTimeout(cleanup, _FALLBACK_MS);
+            state.fallback = setTimeout(cleanup, fallbackMs);
         });
         return;
     }
@@ -130,9 +180,15 @@ function _runTransition(el, spec) {
         el.classList.add(spec.active);
         el.classList.add(spec.end);
 
+        // Compute timing AFTER active+end land so getComputedStyle picks
+        // up the transition rule from the active class.
+        const timing = _computeTransitionTiming(el);
+        const fallbackMs = timing.maxMs > 0 ? timing.maxMs + 50 : _FALLBACK_MS_DEFAULT;
+        let remainingEvents = timing.propsCount || 1;
+
         function cleanup() {
             // Guard against detached elements — if the node has been
-            // removed from the DOM before this fires (typically the 600 ms
+            // removed from the DOM before this fires (typically the
             // fallback path), skip classList/listener work. classList on
             // a detached node is technically safe but any parentNode
             // access downstream would NPE.
@@ -148,15 +204,20 @@ function _runTransition(el, spec) {
 
         function onEnd(ev) {
             // Only react to transitions on THIS element, not bubbled
-            // transitions from children.
+            // transitions from children. Decrement the expected event
+            // count and only cleanup once all properties have finished —
+            // otherwise the fastest property would cut off slower ones.
             if (ev.target !== el) return;
-            cleanup();
+            remainingEvents--;
+            if (remainingEvents <= 0) cleanup();
         }
         state.onEnd = onEnd;
         el.addEventListener('transitionend', onEnd);
 
-        // Fallback in case transitionend never fires.
-        state.fallback = setTimeout(cleanup, _FALLBACK_MS);
+        // Fallback in case transitionend never fires (zero-duration
+        // transitions or detached/hidden elements). Sized from the
+        // computed transition duration + 50ms grace.
+        state.fallback = setTimeout(cleanup, fallbackMs);
     });
 }
 

--- a/python/djust/static/djust/src/42-dj-remove.js
+++ b/python/djust/static/djust/src/42-dj-remove.js
@@ -45,6 +45,39 @@
 const _pendingRemovals = new WeakMap();   // Element -> { fallback, onEnd, observer, spec }
 const _REMOVE_FALLBACK_MS = 600;
 
+function _parseTimeMs(s) {
+    // CSS time tokens: "550ms", "0.55s", "0s". Returns 0 on parse failure.
+    const t = (s || '').trim();
+    if (!t) return 0;
+    if (t.endsWith('ms')) return parseFloat(t) || 0;
+    if (t.endsWith('s')) return (parseFloat(t) || 0) * 1000;
+    return 0;
+}
+
+function _computeTransitionTiming(el) {
+    // Returns {maxMs, propsCount} from the element's computed transition
+    // styles. Same logic as 41-dj-transition.js — duplicated here rather
+    // than shared because the source files are concatenated as separate
+    // modules (no cross-file imports).
+    const cs = (typeof getComputedStyle === 'function') ? getComputedStyle(el) : null;
+    if (!cs) return { maxMs: 0, propsCount: 0 };
+    const props = (cs.transitionProperty || '')
+        .split(',').map(s => s.trim()).filter(s => s && s !== 'none');
+    const durations = (cs.transitionDuration || '')
+        .split(',').map(s => _parseTimeMs(s));
+    const delays = (cs.transitionDelay || '')
+        .split(',').map(s => _parseTimeMs(s));
+    if (props.length === 0) return { maxMs: 0, propsCount: 0 };
+    let maxMs = 0;
+    for (let i = 0; i < props.length; i++) {
+        const dur = durations[i % durations.length] || 0;
+        const del = delays[i % delays.length] || 0;
+        const total = dur + del;
+        if (total > maxMs) maxMs = total;
+    }
+    return { maxMs: maxMs, propsCount: props.length };
+}
+
 function _parseRemoveSpec(raw) {
     if (raw === null || raw === undefined) return null;
     const parts = String(raw).trim().split(/\s+/).filter(Boolean);
@@ -62,15 +95,21 @@ function _parseRemoveSpec(raw) {
 }
 
 function _durationFor(el) {
+    // Explicit dj-remove-duration attribute wins (clamped to 0–30s).
     const raw = el.getAttribute && el.getAttribute('dj-remove-duration');
-    if (raw === null || raw === undefined || raw === '') return _REMOVE_FALLBACK_MS;
-    const n = parseInt(raw, 10);
-    if (!Number.isFinite(n)) return _REMOVE_FALLBACK_MS;
-    // Clamp to a sane range so a malformed attribute can't leak a pending
-    // removal indefinitely or fire before the frame has had a chance to paint.
-    if (n < 0) return 0;
-    if (n > 30000) return 30000;
-    return n;
+    if (raw !== null && raw !== undefined && raw !== '') {
+        const n = parseInt(raw, 10);
+        if (Number.isFinite(n)) {
+            if (n < 0) return 0;
+            if (n > 30000) return 30000;
+            return n;
+        }
+    }
+    // No author override — read from computed style. Falls back to the
+    // hardcoded default only if no transition is declared.
+    const timing = _computeTransitionTiming(el);
+    if (timing.maxMs > 0) return timing.maxMs + 50;
+    return _REMOVE_FALLBACK_MS;
 }
 
 function _teardownState(el, state) {
@@ -125,9 +164,19 @@ function _runRemove(el, spec) {
     const state = { spec: spec };
     _pendingRemovals.set(el, state);
 
+    // Count expected transitionend events (one per transitioning property)
+    // so the first-finishing property doesn't cut off slower ones. The
+    // count is read AFTER the active class has had a chance to apply —
+    // for the 3-token form, that's after the next frame; for the 1-token
+    // form, the class is added synchronously in maybeDeferRemoval before
+    // _runRemove is called.
+    const timing = _computeTransitionTiming(el);
+    let remainingEvents = timing.propsCount || 1;
+
     function onEnd(ev) {
         if (ev.target !== el) return;
-        _finalizeRemoval(el);
+        remainingEvents--;
+        if (remainingEvents <= 0) _finalizeRemoval(el);
     }
     state.onEnd = onEnd;
     el.addEventListener('transitionend', onEnd);

--- a/python/djust/tests/test_notifications_permanent_failure.py
+++ b/python/djust/tests/test_notifications_permanent_failure.py
@@ -1,0 +1,118 @@
+"""Regression test for the 2026-05-05 incident.
+
+A deployed djust app missing the optional ``psycopg[binary]>=3.2``
+dependency had ``PostgresNotifyListener._run()`` retrying every 1
+second for 3.5 days (~302,000 attempts), each leaving asyncio Task
+state behind. The Daphne worker accumulated 15 GiB of anonymous
+heap before kubelet tripped from memory pressure.
+
+The fix: detect ``DatabaseNotificationNotSupported`` (raised by
+``_import_psycopg`` when the driver is missing, and by ``_build_dsn``
+on a non-postgres backend) as a permanent failure, log once, set
+``_stopping``, and exit the loop. Transient failures (anything else)
+keep their existing 1-second-backoff retry behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from djust.db.exceptions import DatabaseNotificationNotSupported
+from djust.db.notifications import PostgresNotifyListener
+
+
+@pytest.fixture(autouse=True)
+def _isolate_listener_singleton():
+    """Each test gets a fresh listener instance.
+
+    The class-level singleton would otherwise leak state across tests
+    in the same process.
+    """
+    PostgresNotifyListener._instance = None
+    yield
+    PostgresNotifyListener._instance = None
+
+
+@pytest.mark.asyncio
+async def test_run_exits_immediately_on_permanent_failure(monkeypatch, caplog):
+    """psycopg-not-installed (or non-postgres backend) → loop exits, no retry.
+
+    Pre-fix this would retry every 1s forever, leaking Task state.
+    The fix: log once at WARNING, set ``_stopping``, and return.
+    """
+    listener = PostgresNotifyListener()
+
+    call_count = 0
+
+    async def fake_connect():
+        nonlocal call_count
+        call_count += 1
+        raise DatabaseNotificationNotSupported(
+            "psycopg (>=3.2) is required for djust.db notifications."
+        )
+
+    monkeypatch.setattr(listener, "_connect", fake_connect)
+    listener._ready_event = asyncio.Event()
+
+    with caplog.at_level(logging.WARNING, logger="djust.db.notifications"):
+        await asyncio.wait_for(listener._run(), timeout=2.0)
+
+    assert call_count == 1, (
+        f"expected one connect attempt for a permanent failure, got {call_count}"
+    )
+    assert listener._stopping is True, (
+        "permanent failure must flip _stopping so future ensure_task_started "
+        "calls don't restart the loop"
+    )
+    assert listener._ready_event.is_set(), (
+        "_ready_event must be set even on permanent failure so awaiters don't hang"
+    )
+
+    # Exactly one WARNING about being disabled — and not the looping
+    # "retrying in 1s" message that pre-fix code would have emitted.
+    permanent_logs = [r for r in caplog.records if "permanent failure" in r.getMessage()]
+    assert len(permanent_logs) == 1
+    retry_logs = [r for r in caplog.records if "retrying in 1s" in r.getMessage()]
+    assert retry_logs == [], "permanent failure path must not emit the retry log line"
+
+
+@pytest.mark.asyncio
+async def test_run_retries_transient_connect_failures(monkeypatch, caplog):
+    """Transient OperationalError-style failures still retry (existing behaviour).
+
+    Guards against an over-aggressive interpretation of the fix that
+    would also drop the loop on transient DB outages.
+    """
+    listener = PostgresNotifyListener()
+
+    attempts = 0
+
+    async def fake_connect():
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise ConnectionRefusedError("postgres temporarily unreachable")
+        # On the third attempt, raise the permanent error to break the loop
+        # so the test can assert on retry behaviour without hanging forever.
+        raise DatabaseNotificationNotSupported("switching to permanent to terminate the test")
+
+    # Sleep 0 so the test runs fast.
+    async def fake_sleep(_):
+        return
+
+    monkeypatch.setattr(listener, "_connect", fake_connect)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    with caplog.at_level(logging.WARNING, logger="djust.db.notifications"):
+        await asyncio.wait_for(listener._run(), timeout=2.0)
+
+    # Two transient retries + one permanent = 3 attempts.
+    assert attempts == 3
+    retry_logs = [r for r in caplog.records if "retrying in 1s" in r.getMessage()]
+    assert len(retry_logs) == 2, (
+        f"expected 2 retry log lines for the 2 transient failures, "
+        f"got {len(retry_logs)}: {[r.getMessage() for r in retry_logs]}"
+    )


### PR DESCRIPTION
## Summary

Two fixes that landed on the same branch as a result of in-flight WIP. Combines the scope of (now-superseded) PR #1352:

### 1. `db.notifications` exits cleanly on permanent failures (production-incident-driven)

Background — incident 2026-05-05: a 3.5-day-old djust deploy missing the optional `psycopg[binary]>=3.2` dependency had `_run()` retrying `_connect()` every 1 second forever (~302,000 attempts), accumulating 15.4 GiB of anonymous heap. Kubelet hit memory pressure, transitioned to NodeNotReady for ~7 seconds — long enough for cnpg to fail over the postgres-cluster primary → 3-minute platform outage.

**Fix**: when `_connect()` raises `DatabaseNotificationNotSupported` (missing psycopg or non-postgres engine), treat as PERMANENT — log once at WARNING with operator-actionable wording, set `_stopping = True`, fire `_ready_event`, return. Process restart re-enables once the cause is fixed. Transient failures (`ConnectionRefusedError`, `OSError`, timeout) keep their 1-second-backoff retry behaviour.

**Tests**: 2 cases in `python/djust/tests/test_notifications_permanent_failure.py`:
- `test_run_exits_immediately_on_permanent_failure` (missing psycopg → ONE attempt, ONE warning, `_stopping` flipped, `_ready_event` set)
- `test_run_retries_transient_connect_failures` (`ConnectionRefused` still retries 1s/attempt — regression guard)

### 2. `dj-transition` respects CSS `transition-duration` (#1348)

The fallback timeout is auto-derived from the element's computed `transition-duration` + `transition-delay` (longest pair across all transitioning properties) plus a 50ms grace window. For multi-property transitions, expected `transitionend` events are counted from `transition-property` and cleanup runs only after all have fired — otherwise the first-finishing property would cut off slower ones. `_FALLBACK_MS_DEFAULT` (600ms) is used only when computed-style reading fails or yields zero. Same auto-derivation extended to `dj-remove`.

**Source-only commit**: bundle (`client.js`) rebuild deferred per #1351 (223 pre-existing eslint warnings block `--max-warnings 0`). Bundle should be rebuilt + committed separately once #1351 lands.

## Two-commit shape

- `0fea6bb9` — fix(transitions): respect CSS transition-duration; await all transitionend events
- `2b5c3292` — fix(db.notifications): stop retrying permanent failures forever
- `12c4f28a` — docs(changelog): note both fixes

## Test plan

- [x] `pytest python/djust/tests/test_notifications_permanent_failure.py` passes (2 new tests)
- [x] No regression in existing pytest suite (rebased onto current main; pre-push hook ran full suite)
- [x] CHANGELOG entries for both fixes

## Closes

- Closes #1348 (`dj-transition` 600ms cutoff)
- Supersedes PR #1352 (same dj-transition fix on a separate branch)
- Mitigates 2026-05-05 production incident (no specific issue filed; tracked via this PR's CHANGELOG entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)