### PR TITLE
fix(auth): sticky-child views fail closed when request unstamped (#1380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sticky-child views with overridden `get_object()` no longer silently skip per-event object-permission checks (#1380, deferred from PR #1378 Stage 11 🟡 #2).** When a sticky/embedded child view's `owner_request` is `None` (the parent failed to stamp `request` because `mixins/sticky.py:212-218`'s read-only-child constraint raised `AttributeError`), `_validate_event_security` now FAILS CLOSED if the child opted into the object-permission lifecycle: sends a `permission_denied` error frame and logs a `WARNING` instead of returning the handler. Views that did NOT override `get_object` are unchanged (no security check is active for them, so silent fall-through is correct). Companion change: `mixins/sticky.py:215` `logger.debug` → `logger.warning` on the read-only-child path so the upstream gap is observable in production logs at its source.
+
 ## [0.9.5rc1] - 2026-05-06
 
 ### Added

--- a/python/djust/mixins/sticky.py
+++ b/python/djust/mixins/sticky.py
@@ -206,14 +206,19 @@ class StickyChildRegistry:
                 continue
             # Update request back-reference so handlers see the new request.
             # Some child types (slot descriptors, read-only proxies) can't
-            # accept a `request` attr — that's expected and fine; the child
-            # just doesn't get the live request handle. Log at DEBUG so the
-            # absence is observable without spamming production logs.
+            # accept a `request` attr. When this happens, downstream
+            # per-event object-permission checks for this child WILL fail
+            # closed (websocket_utils.py:234, #1380) — log at WARNING so
+            # the gap is observable at its source rather than silently at
+            # the denial site.
             try:
                 child.request = new_request
             except AttributeError:
-                logger.debug(
-                    "sticky child %s does not accept request attribute (expected for read-only proxies)",
+                logger.warning(
+                    "sticky child %s does not accept request attribute "
+                    "(read-only proxy?); per-event object-permission "
+                    "checks will fail closed for this child until "
+                    "request is stamped",
                     sticky_id,
                 )
             survivors[sticky_id] = child

--- a/python/djust/websocket_utils.py
+++ b/python/djust/websocket_utils.py
@@ -231,7 +231,31 @@ async def _validate_event_security(
     # has_object_permission() raise anything other than PermissionDenied
     # (e.g., AttributeError in the developer's body), treat as denial.
     # Security code should not fail-open when the auth predicate crashes.
-    if owner_request:
+    if owner_request is None:
+        # #1380: when a view overrides get_object() but `request` was
+        # never stamped on the instance (e.g., a sticky child whose
+        # parent could not propagate the request through a read-only-
+        # proxy descriptor — see mixins/sticky.py), we MUST NOT silently
+        # skip the per-event object-permission check. Fail closed instead.
+        # Views that did not opt into the object-permission lifecycle
+        # (no get_object override) keep the original no-op semantics.
+        from .auth.core import _has_custom_get_object
+
+        if _has_custom_get_object(owner_instance):
+            logger.warning(
+                "Per-event object-permission check skipped on %s: "
+                "owner_request is None (child view did not receive a "
+                "request handle from parent). Failing closed.",
+                type(owner_instance).__name__,
+            )
+            await ws.send_error(
+                "Access denied for this object.",
+                code="permission_denied",
+            )
+            return None
+        # No custom get_object → no object-permission lifecycle → fall
+        # through silently (preserves the existing no-op contract).
+    else:
         from .auth.core import check_object_permission
 
         try:

--- a/tests/integration/test_object_permission_event.py
+++ b/tests/integration/test_object_permission_event.py
@@ -467,3 +467,90 @@ def test_embedded_child_view_uses_child_get_object(rf):
     assert _ChildView._get_object_called is True, (
         "child's get_object MUST be called when child is the dispatch target"
     )
+
+
+# -- Tests: sticky-child fail-closed when request unstamped (#1380) -------
+
+
+@pytest.mark.asyncio
+async def test_per_event_fails_closed_when_request_missing_with_custom_get_object(rf):
+    """Case 10 (#1380, reproducer): when a view overrides get_object()
+    but `view.request` is None at event time (e.g., a sticky child whose
+    parent could not stamp the request handle through a read-only-proxy
+    descriptor), _validate_event_security MUST fail closed.
+
+    On parent commit the bare `if owner_request:` gate at
+    websocket_utils.py:234 silently SKIPS the per-event object-permission
+    check, returning the handler — bypassing object-level authorization
+    for the affected child views.
+
+    The fix sends a permission_denied frame and returns None when the
+    view has a custom get_object override but request is missing.
+    """
+    from djust.websocket_utils import _validate_event_security
+
+    request = rf.get("/")
+    request.user = AnonymousUser()
+    _DenyEventView._handler_ran = False
+    # Construct view + mount, but do NOT stamp view.request (simulates
+    # the read-only-proxy sticky-child failure mode in mixins/sticky.py).
+    view = _DenyEventView()
+    view.mount(request, document_id=1)
+    # Defensive: ensure request really is None on the instance.
+    view.request = None
+
+    ws = _mock_ws()
+    rl = MagicMock()
+    rl.check_handler = MagicMock(return_value=True)
+    rl.should_disconnect = MagicMock(return_value=False)
+
+    handler = await _validate_event_security(ws, "update_value", view, rl)
+
+    # Fail-closed: handler returned None, error frame sent with the
+    # canonical permission_denied code, WS NOT closed (per-event denial
+    # semantics — user is authenticated; only this object/action denied),
+    # handler body did NOT execute.
+    assert handler is None, "missing request + custom get_object MUST fail closed; got handler back"
+    assert ws.send_error.called, "send_error must be called on fail-closed"
+    code = ws.send_error.call_args.kwargs.get("code")
+    assert code == "permission_denied", (
+        f"fail-closed must send permission_denied frame; got code={code}"
+    )
+    assert not ws.close.called, "per-event denial must not close the WS"
+    assert _DenyEventView._handler_ran is False, (
+        "handler body must NOT execute when per-event check fails closed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_per_event_missing_request_no_override_still_allowed(rf):
+    """Case 11 (#1380, regression): a view that does NOT override
+    get_object() must continue to dispatch handlers even if `view.request`
+    is None at event time. The fail-closed branch is gated by
+    `_has_custom_get_object` so views that didn't opt into the
+    object-permission lifecycle are unaffected.
+    """
+    from djust.websocket_utils import _validate_event_security
+
+    request = rf.get("/")
+    request.user = AnonymousUser()
+    _NoOverrideEventView._handler_ran = False
+    view = _NoOverrideEventView()
+    view.mount(request)
+    view.request = None  # simulate unstamped child
+
+    ws = _mock_ws()
+    rl = MagicMock()
+    rl.check_handler = MagicMock(return_value=True)
+    rl.should_disconnect = MagicMock(return_value=False)
+
+    handler = await _validate_event_security(ws, "update_value", view, rl)
+
+    # No override → no-op path: handler returned, no error frame, no close.
+    assert handler is not None, (
+        "no-override views must continue to dispatch handlers even when "
+        "request is unstamped (the per-event check is opt-in via "
+        "_has_custom_get_object)"
+    )
+    assert not ws.send_error.called, "no-override path must not send a permission_denied frame"
+    assert not ws.close.called


### PR DESCRIPTION
## Summary

Fixes the silent-skip bug in per-event object-permission enforcement when a sticky/embedded child view's `owner_request` is `None`. Per the security-class fail-closed canon, when the check **cannot run** but the developer **opted into** the lifecycle (overrode `get_object()`), the framework now denies by default rather than silently allowing.

**Source**: PR #1378 Stage 11 review 🟡 #2 (deferred from v0.9.5-1b).

## What changed

- **`python/djust/websocket_utils.py`** — `_validate_event_security` gains a fail-closed branch: when `owner_request is None` AND `_has_custom_get_object(owner_instance)` is True, send `permission_denied` error frame + `logger.warning` and return `None` (deny). When `owner_request is None` AND no override, fall through silently (correct — no security check is active).
- **`python/djust/mixins/sticky.py`** — read-only-child `AttributeError` handler upgrades from `logger.debug` to `logger.warning` and amends the message to call out the security implication. Observability only; no semantic change.
- **`tests/integration/test_object_permission_event.py`** — Cases 10 + 11: reproducer (fail-closed when missing-request + override) and regression (no-override path unchanged).

## Closes

- Closes #1380

## Test plan

- [x] Reproducer Test A fails on parent (silent-skip returns the handler)
- [x] Reproducer Test A passes after fix
- [x] Regression Test B: no-override views still allowed when request missing
- [x] Existing 9 cases in `test_object_permission_event.py` continue passing (now 11 total)
- [x] Wider integration suite (`test_object_permission_*`, `test_sticky_redirect_flow.py`) — 25/25 passing
- [x] Full pytest suite — 4743 passed, 14 skipped

## Wire-protocol shape

Denial frame matches v0.9.5-1b convention exactly: `{"type": "error", "error": "Access denied for this object.", "code": "permission_denied"}`. WS stays open (per-event denial does not close the connection).

## Defense-in-depth alignment

- Layer 1 (`mixins/sticky.py`): warning surfaces the `request`-missing gap at its source.
- Layer 2 (`websocket_utils.py`): fail-closed branch prevents silent bypass.

The two are complementary — the security guarantee is at layer 2; layer 1 is observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)