### PR TITLE
feat(audit): X008 walks MRO + recognizes broader URL-kwarg patterns (#1382, #1383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **X008 audit heuristic now walks same-module MRO and recognizes broader URL-kwarg-binding shapes (#1382, #1383, deferred from PR #1381 Stage 11).** Two improvements to `python/djust/audit_ast.py`:
+  - `_class_has_attribute` and `_class_defines_method` accept an optional `class_index` parameter and walk the same-module MRO via static analysis when supplied. The X008 IDOR-shape checker uses this so views inheriting `permission_required` from a base mixin (or inheriting `has_object_permission` / `check_permissions` overrides) are correctly classified. Cross-module bases are silently skipped — by design, the static analysis is module-local. Cycle guard via visited-set in `_walk_mro_static` prevents recursion on `class A(B): ...; class B(A): ...`.
+  - `_mount_assigns_url_kwarg_id` now recognizes three additional RHS shapes beyond bare `self.x = x`: `self.kwargs["x"]` (Subscript), `int(x)` / `str(x)` / `uuid(x)` / `UUID(x)` (whitelisted casts; literal arguments like `int(42)` correctly do NOT match), and `(self.)kwargs.get("x"[, default])`. Reduces false-negatives from views using mixins or coercion.
+
+  10 new test cases in `TestX008IDORShapeNeedsObjectPermission` cover the new branches plus the X001-non-co-fire invariant.
+
 ### Fixed
 
 - **Sticky-child views with overridden `get_object()` no longer silently skip per-event object-permission checks (#1380, deferred from PR #1378 Stage 11 🟡 #2).** When a sticky/embedded child view's `owner_request` is `None` (the parent failed to stamp `request` because `mixins/sticky.py:212-218`'s read-only-child constraint raised `AttributeError`), `_validate_event_security` now FAILS CLOSED if the child opted into the object-permission lifecycle: sends a `permission_denied` error frame and logs a `WARNING` instead of returning the handler. Views that did NOT override `get_object` are unchanged (no security check is active for them, so silent fall-through is correct). Companion change: `mixins/sticky.py:215` `logger.debug` → `logger.warning` on the read-only-child path so the upstream gap is observable in production logs at its source.

--- a/python/djust/audit_ast.py
+++ b/python/djust/audit_ast.py
@@ -53,7 +53,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Set, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -300,6 +300,22 @@ def _is_format_string(node: ast.AST) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _module_class_index(tree: ast.AST) -> Dict[str, ast.ClassDef]:
+    """Map module-level class names to their ``ast.ClassDef`` nodes.
+
+    Used by helpers that need to walk a same-module MRO chain (e.g.,
+    X008's permission_required / has_object_permission inheritance
+    check, #1382). Cross-module bases are silently skipped — by
+    design we only walk classes visible in the current AST.
+    """
+    out: Dict[str, ast.ClassDef] = {}
+    if isinstance(tree, ast.Module):
+        for stmt in tree.body:
+            if isinstance(stmt, ast.ClassDef):
+                out[stmt.name] = stmt
+    return out
+
+
 class _FileContext:
     """Per-file state passed to every checker."""
 
@@ -308,6 +324,7 @@ class _FileContext:
         self.tree = tree
         self.source_lines = source_lines
         self.findings: List[ASTFinding] = []
+        self.class_index: Dict[str, ast.ClassDef] = _module_class_index(tree)
 
     def emit(
         self,
@@ -673,24 +690,75 @@ def _check_mark_safe(ctx: _FileContext) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _class_has_attribute(cls: ast.ClassDef, name: str) -> bool:
-    """Return True if class defines an attribute named ``name`` (any value)."""
-    for stmt in cls.body:
-        if isinstance(stmt, ast.Assign):
-            for target in stmt.targets:
-                if isinstance(target, ast.Name) and target.id == name:
+def _walk_mro_static(
+    cls: ast.ClassDef,
+    class_index: Mapping[str, ast.ClassDef],
+) -> Iterator[ast.ClassDef]:
+    """Yield ``cls`` and each same-module ancestor reachable via
+    ``ast.Name`` bases, with a visited-set guard against cycles.
+
+    Cross-module bases (``ast.Attribute``, unresolved ``Name``) are
+    silently skipped — we only walk classes present in
+    ``class_index``. The traversal order is depth-first via a stack;
+    callers should not rely on Python's C3 linearization semantics
+    (this is a static approximation, not a runtime MRO).
+    """
+    visited: Set[str] = set()
+    stack: List[ast.ClassDef] = [cls]
+    while stack:
+        node = stack.pop()
+        if node.name in visited:
+            continue
+        visited.add(node.name)
+        yield node
+        for base in node.bases:
+            if isinstance(base, ast.Name):
+                ancestor = class_index.get(base.id)
+                if ancestor is not None and ancestor.name not in visited:
+                    stack.append(ancestor)
+
+
+def _class_has_attribute(
+    cls: ast.ClassDef,
+    name: str,
+    class_index: Optional[Mapping[str, ast.ClassDef]] = None,
+) -> bool:
+    """Return True if class (or any same-module ancestor when
+    ``class_index`` is supplied) defines an attribute named ``name``.
+
+    Note: any assignment counts — including ``permission_required = ""``
+    on a base. X008 treats this as a recommendation rather than an
+    enforcement, so a permissive interpretation is acceptable.
+    """
+    nodes: Iterable[ast.ClassDef] = (
+        _walk_mro_static(cls, class_index) if class_index is not None else (cls,)
+    )
+    for node in nodes:
+        for stmt in node.body:
+            if isinstance(stmt, ast.Assign):
+                for target in stmt.targets:
+                    if isinstance(target, ast.Name) and target.id == name:
+                        return True
+            elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                if stmt.target.id == name:
                     return True
-        elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
-            if stmt.target.id == name:
-                return True
     return False
 
 
-def _class_defines_method(cls: ast.ClassDef, name: str) -> bool:
-    """Return True if class defines a method named ``name`` directly."""
-    for stmt in cls.body:
-        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)) and stmt.name == name:
-            return True
+def _class_defines_method(
+    cls: ast.ClassDef,
+    name: str,
+    class_index: Optional[Mapping[str, ast.ClassDef]] = None,
+) -> bool:
+    """Return True if class (or any same-module ancestor when
+    ``class_index`` is supplied) defines a method named ``name``."""
+    nodes: Iterable[ast.ClassDef] = (
+        _walk_mro_static(cls, class_index) if class_index is not None else (cls,)
+    )
+    for node in nodes:
+        for stmt in node.body:
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)) and stmt.name == name:
+                return True
     return False
 
 
@@ -701,22 +769,95 @@ def _mount_method(cls: ast.ClassDef) -> Optional[ast.FunctionDef | ast.AsyncFunc
     return None
 
 
+# Cast functions whose argument is treated as a passthrough for X008
+# binding-pattern detection. Bounded whitelist keeps the false-positive
+# surface tight (literal casts like ``int(42)`` must not match).
+_X008_CAST_FUNCS: frozenset[str] = frozenset({"int", "str", "uuid", "UUID"})
+
+
+def _rhs_yields_kwarg_name(value: ast.AST, param_names: Set[str]) -> Optional[str]:
+    """Inspect an assignment RHS and return the URL-kwarg name it
+    surfaces, or None.
+
+    Recognised shapes (#1383):
+      * ``X`` — bare ``Name`` matching a mount kwarg.
+      * ``self.kwargs["X"]`` / ``kwargs["X"]`` — Subscript with string-
+        constant index.
+      * ``int(X)`` / ``str(X)`` / ``uuid(X)`` / ``UUID(X)`` —
+        whitelisted casts whose first argument is a ``Name`` matching a
+        mount kwarg. ``int(42)`` and friends are rejected because the
+        argument is not a ``Name``.
+      * ``kwargs.get("X"[, default])`` / ``self.kwargs.get("X"[, default])``
+        — string-constant first argument; trailing default is a
+        fallback, not a different contract.
+    """
+    # Bare Name.
+    if isinstance(value, ast.Name) and value.id in param_names:
+        return value.id
+
+    # Subscript: (self.)kwargs["name"].
+    if isinstance(value, ast.Subscript):
+        idx = value.slice
+        if isinstance(idx, ast.Constant) and isinstance(idx.value, str):
+            container = value.value
+            # ``kwargs["x"]`` — bare Name.
+            if isinstance(container, ast.Name) and container.id == "kwargs":
+                return idx.value
+            # ``self.kwargs["x"]`` — Attribute on self.
+            if (
+                isinstance(container, ast.Attribute)
+                and container.attr == "kwargs"
+                and isinstance(container.value, ast.Name)
+                and container.value.id == "self"
+            ):
+                return idx.value
+
+    # Call: whitelisted cast OR (self.)kwargs.get(...).
+    if isinstance(value, ast.Call):
+        func = value.func
+        # Whitelisted cast: ``int(x)`` / ``str(x)`` / etc.
+        if isinstance(func, ast.Name) and func.id in _X008_CAST_FUNCS and value.args:
+            inner = value.args[0]
+            if isinstance(inner, ast.Name) and inner.id in param_names:
+                return inner.id
+            return None
+        # ``(self.)kwargs.get("x"[, default])``.
+        if isinstance(func, ast.Attribute) and func.attr == "get" and value.args:
+            container = func.value
+            is_kwargs = (isinstance(container, ast.Name) and container.id == "kwargs") or (
+                isinstance(container, ast.Attribute)
+                and container.attr == "kwargs"
+                and isinstance(container.value, ast.Name)
+                and container.value.id == "self"
+            )
+            if is_kwargs:
+                first = value.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    return first.value
+
+    return None
+
+
 def _mount_assigns_url_kwarg_id(mount_func: ast.AST) -> Optional[str]:
-    """If mount() does ``self.X_id = X_id`` (or ``self.X = X``) where the
-    name on the right matches a parameter name from the mount signature,
+    """If mount() binds a URL kwarg to ``self.X_id`` (or ``self.X``)
+    via any of the recognised RHS shapes (see ``_rhs_yields_kwarg_name``),
     return the attribute name (e.g. 'document_id'). Otherwise None.
 
-    The pattern: URL kwargs are passed as keyword args to mount() and
-    the user assigns them to ``self`` for later access from event
-    handlers. This is the canonical IDOR shape from ADR-017.
+    The pattern: URL kwargs are passed to mount() (as positional/keyword
+    args, or via ``self.kwargs``) and the user assigns them to ``self``
+    for later access from event handlers. This is the canonical IDOR
+    shape from ADR-017 (#1373) extended in #1383 to cover Subscript,
+    cast, and ``.get()`` shapes.
     """
     if not isinstance(mount_func, (ast.FunctionDef, ast.AsyncFunctionDef)):
         return None
     # Collect parameter names (excluding self, request).
     param_names = {arg.arg for arg in mount_func.args.args if arg.arg not in ("self", "request")}
     param_names.update(arg.arg for arg in mount_func.args.kwonlyargs)
-    if not param_names:
-        return None
+    # ``self.kwargs[...]`` and ``kwargs.get(...)`` shapes don't require
+    # an explicit param name — the kwarg is named in the RHS literal.
+    # We still want to detect them, so don't bail early on empty
+    # ``param_names``.
     for stmt in ast.walk(mount_func):
         if not isinstance(stmt, ast.Assign):
             continue
@@ -726,12 +867,13 @@ def _mount_assigns_url_kwarg_id(mount_func: ast.AST) -> Optional[str]:
             if not (isinstance(target.value, ast.Name) and target.value.id == "self"):
                 continue
             attr_name = target.attr
-            # Match self.X = X (or self.X_id = X_id) where X is a kwarg.
-            if isinstance(stmt.value, ast.Name) and stmt.value.id in param_names:
-                # Must look like an id-bearing attribute: ends in _id, or
-                # the value comes from a kwarg whose name ends in _id.
-                if attr_name.endswith("_id") or stmt.value.id.endswith("_id"):
-                    return attr_name
+            kwarg_name = _rhs_yields_kwarg_name(stmt.value, param_names)
+            if kwarg_name is None:
+                continue
+            # Must look like an id-bearing attribute: the LHS attr or
+            # the recovered kwarg name ends in _id.
+            if attr_name.endswith("_id") or kwarg_name.endswith("_id"):
+                return attr_name
     return None
 
 
@@ -768,13 +910,15 @@ def _check_idor_shape_needs_object_permission(ctx: _FileContext) -> None:
         # Must have role-level permission_required (the shape this check
         # targets — public views or auth-handled-elsewhere views are not
         # X008 candidates).
-        if not _class_has_attribute(cls, "permission_required"):
+        if not _class_has_attribute(cls, "permission_required", ctx.class_index):
             continue
         # Must NOT already have an object-level auth hook. Either is
-        # sufficient as the developer's escape hatch.
-        if _class_defines_method(cls, "has_object_permission"):
+        # sufficient as the developer's escape hatch. (#1382 — walk
+        # the same-module MRO so an override on a base mixin is
+        # honoured.)
+        if _class_defines_method(cls, "has_object_permission", ctx.class_index):
             continue
-        if _class_defines_method(cls, "check_permissions"):
+        if _class_defines_method(cls, "check_permissions", ctx.class_index):
             continue
         # Must bind a URL kwarg id to self via mount().
         mount = _mount_method(cls)

--- a/python/tests/test_audit_ast.py
+++ b/python/tests/test_audit_ast.py
@@ -529,6 +529,255 @@ class TestX008IDORShapeNeedsObjectPermission:
             f"X001 should NOT fire when no .get(pk=user_input) is present; got: {codes}"
         )
 
+    # ------------------------------------------------------------------
+    # #1382 — MRO walk for permission_required / has_object_permission /
+    # check_permissions. X008's class-level checks should consult the
+    # same-module inheritance chain rather than only the immediate class
+    # body.
+    # ------------------------------------------------------------------
+
+    def test_x008_mro_inherits_permission_required_from_base(self) -> None:
+        """When ``permission_required`` is declared on a base mixin in
+        the same module and the subclass otherwise matches the IDOR
+        shape, X008 should fire. Pre-#1382 the check only looked at the
+        immediate class body and missed inherited markers."""
+        findings = _scan("""
+            from djust import LiveView
+            from djust.decorators import event_handler
+
+            class BaseDocMixin:
+                permission_required = "documents.access"
+
+            class DocumentDetailView(BaseDocMixin, LiveView):
+                def mount(self, request, document_id=None, **kwargs):
+                    self.document_id = document_id
+
+                @event_handler()
+                def add_comment(self, body=""):
+                    Comment.objects.create(
+                        document_id=self.document_id, body=body
+                    )
+        """)
+        assert "X008" in _codes(findings), (
+            f"X008 should fire when permission_required is inherited; got: {_codes(findings)}"
+        )
+
+    def test_x008_mro_skips_when_base_has_object_permission(self) -> None:
+        """If a base class in the same module overrides
+        ``has_object_permission``, the subclass inherits the safe
+        lifecycle and X008 must NOT fire."""
+        findings = _scan("""
+            from djust import LiveView
+            from djust.decorators import event_handler
+
+            class SafeBase(LiveView):
+                def has_object_permission(self, request, obj):
+                    return obj.owner_id == request.user.id
+
+            class DocumentDetailView(SafeBase):
+                permission_required = "documents.access"
+
+                def mount(self, request, document_id=None, **kwargs):
+                    self.document_id = document_id
+
+                @event_handler()
+                def add_comment(self, body=""):
+                    Comment.objects.create(
+                        document_id=self.document_id, body=body
+                    )
+        """)
+        assert "X008" not in _codes(findings), (
+            f"X008 must NOT fire when has_object_permission is inherited; got: {_codes(findings)}"
+        )
+
+    def test_x008_mro_skips_when_base_has_check_permissions(self) -> None:
+        """The legacy ``check_permissions`` hook should also propagate
+        through MRO and suppress X008."""
+        findings = _scan("""
+            from djust import LiveView
+            from djust.decorators import event_handler
+
+            class LegacyBase(LiveView):
+                def check_permissions(self, request):
+                    return True
+
+            class DocumentDetailView(LegacyBase):
+                permission_required = "documents.access"
+
+                def mount(self, request, document_id=None, **kwargs):
+                    self.document_id = document_id
+
+                @event_handler()
+                def add_comment(self, body=""):
+                    pass
+        """)
+        assert "X008" not in _codes(findings), (
+            f"X008 must NOT fire when check_permissions is inherited; got: {_codes(findings)}"
+        )
+
+    def test_x008_mro_unresolvable_base_does_not_crash(self) -> None:
+        """If a base class is imported from another module (and thus
+        not resolvable in the current AST), the walker should silently
+        skip it — but still apply local class-body checks. Here the
+        local class declares ``permission_required`` directly, so X008
+        should still fire."""
+        findings = _scan("""
+            from elsewhere import RemoteAuthMixin
+            from djust import LiveView
+            from djust.decorators import event_handler
+
+            class DocumentDetailView(RemoteAuthMixin, LiveView):
+                permission_required = "documents.access"
+
+                def mount(self, request, document_id=None, **kwargs):
+                    self.document_id = document_id
+
+                @event_handler()
+                def add_comment(self, body=""):
+                    Comment.objects.create(
+                        document_id=self.document_id, body=body
+                    )
+        """)
+        assert "X008" in _codes(findings), (
+            f"X008 should fire even with cross-module base; got: {_codes(findings)}"
+        )
+
+    def test_x008_mro_inheritance_cycle_does_not_recurse(self) -> None:
+        """A pathological cycle (``A(B)``, ``B(A)``) must terminate via
+        the visited-set guard. We don't assert a specific finding —
+        only that scanning completes without recursion error."""
+        # No assertion on findings — just confirm the scan terminates.
+        _scan("""
+            class A(B):
+                pass
+
+            class B(A):
+                pass
+        """)
+
+    # ------------------------------------------------------------------
+    # #1383 — Broader URL-kwarg RHS patterns. ``mount()`` may bind URL
+    # kwargs to ``self`` via several shapes beyond bare ``self.x = x``.
+    # ------------------------------------------------------------------
+
+    def test_x008_kwarg_subscript_binding_triggers(self) -> None:
+        """``self.kwargs["document_id"]`` (Django CBV-style) bound to
+        ``self.document_id`` should be recognised."""
+        findings = _scan("""
+            from djust import LiveView
+            from djust.decorators import event_handler
+
+            class DocumentDetailView(LiveView):
+                permission_required = "documents.access"
+
+                def mount(self, request, **kwargs):
+                    self.document_id = self.kwargs["document_id"]
+
+                @event_handler()
+                def add_comment(self, body=""):
+                    Comment.objects.create(
+                        document_id=self.document_id, body=body
+                    )
+        """)
+        assert "X008" in _codes(findings), (
+            f"X008 should fire on self.kwargs[...] binding; got: {_codes(findings)}"
+        )
+
+    def test_x008_int_cast_binding_triggers(self) -> None:
+        """``self.x = int(x)`` (whitelisted cast) should still be
+        recognised as a URL-kwarg binding."""
+        findings = _scan("""
+            from djust import LiveView
+            from djust.decorators import event_handler
+
+            class DocumentDetailView(LiveView):
+                permission_required = "documents.access"
+
+                def mount(self, request, document_id=None, **kwargs):
+                    self.document_id = int(document_id)
+
+                @event_handler()
+                def add_comment(self, body=""):
+                    Comment.objects.create(
+                        document_id=self.document_id, body=body
+                    )
+        """)
+        assert "X008" in _codes(findings), (
+            f"X008 should fire on int(...) cast binding; got: {_codes(findings)}"
+        )
+
+    def test_x008_kwargs_get_binding_triggers(self) -> None:
+        """``self.x = kwargs.get("x")`` should be recognised."""
+        findings = _scan("""
+            from djust import LiveView
+            from djust.decorators import event_handler
+
+            class DocumentDetailView(LiveView):
+                permission_required = "documents.access"
+
+                def mount(self, request, **kwargs):
+                    self.document_id = kwargs.get("document_id")
+
+                @event_handler()
+                def add_comment(self, body=""):
+                    Comment.objects.create(
+                        document_id=self.document_id, body=body
+                    )
+        """)
+        assert "X008" in _codes(findings), (
+            f"X008 should fire on kwargs.get('...') binding; got: {_codes(findings)}"
+        )
+
+    def test_x008_kwargs_get_with_default_binding_triggers(self) -> None:
+        """``kwargs.get("x", default)`` (two-arg form) should also
+        match — the second arg is a fallback, not a different
+        contract."""
+        findings = _scan("""
+            from djust import LiveView
+            from djust.decorators import event_handler
+
+            class DocumentDetailView(LiveView):
+                permission_required = "documents.access"
+
+                def mount(self, request, **kwargs):
+                    self.document_id = kwargs.get("document_id", None)
+
+                @event_handler()
+                def add_comment(self, body=""):
+                    Comment.objects.create(
+                        document_id=self.document_id, body=body
+                    )
+        """)
+        assert "X008" in _codes(findings), (
+            f"X008 should fire on kwargs.get('...', default); got: {_codes(findings)}"
+        )
+
+    def test_x008_int_cast_unrelated_value_does_not_trigger_via_pattern(self) -> None:
+        """``self.document_id = int(42)`` is a literal cast — the
+        argument is not a URL kwarg name, so X008 should NOT fire on
+        the binding alone. (Other parts of the shape may be missing,
+        too; the point is the binding-pattern matcher must reject this
+        case.)"""
+        findings = _scan("""
+            from djust import LiveView
+            from djust.decorators import event_handler
+
+            class DocumentDetailView(LiveView):
+                permission_required = "documents.access"
+
+                def mount(self, request, **kwargs):
+                    self.document_id = int(42)
+
+                @event_handler()
+                def add_comment(self, body=""):
+                    Comment.objects.create(
+                        document_id=self.document_id, body=body
+                    )
+        """)
+        assert "X008" not in _codes(findings), (
+            f"X008 must NOT fire on int(42) literal cast; got: {_codes(findings)}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Suppression

--- a/python/tests/test_audit_ast.py
+++ b/python/tests/test_audit_ast.py
@@ -644,16 +644,36 @@ class TestX008IDORShapeNeedsObjectPermission:
 
     def test_x008_mro_inheritance_cycle_does_not_recurse(self) -> None:
         """A pathological cycle (``A(B)``, ``B(A)``) must terminate via
-        the visited-set guard. We don't assert a specific finding —
-        only that scanning completes without recursion error."""
-        # No assertion on findings — just confirm the scan terminates.
-        _scan("""
-            class A(B):
-                pass
+        the visited-set guard in ``_walk_mro_static``.
 
-            class B(A):
-                pass
-        """)
+        Both classes are detail-view-shaped (LiveView base, mount binds
+        a URL kwarg, event handler reads ``self.<x>_id``) so the X008
+        checker actually walks the MRO graph and exercises the cycle
+        guard. Without the guard, this would StackOverflow or hang."""
+        # Fence: bound the recursion budget to ensure infinite recursion
+        # would observably fail rather than silently churn.
+        import sys
+
+        original_limit = sys.getrecursionlimit()
+        try:
+            sys.setrecursionlimit(200)
+            _scan("""
+                from djust import LiveView
+                from djust.decorators import event_handler
+
+                class A(B, LiveView):
+                    permission_required = "documents.access"
+                    def mount(self, request, document_id=None, **kwargs):
+                        self.document_id = document_id
+                    @event_handler()
+                    def add_comment(self, body=""):
+                        Comment.objects.create(document_id=self.document_id, body=body)
+
+                class B(A):
+                    pass
+            """)
+        finally:
+            sys.setrecursionlimit(original_limit)
 
     # ------------------------------------------------------------------
     # #1383 — Broader URL-kwarg RHS patterns. ``mount()`` may bind URL


### PR DESCRIPTION
## Summary

Two improvements to the X008 IDOR-shape audit heuristic in `python/djust/audit_ast.py`. Both surfaced as 🟡 findings on PR #1381 Stage 11 review (deferred from v0.9.5-1c).

### #1382: walk same-module MRO

`_class_has_attribute` and `_class_defines_method` accept an optional `class_index` and walk the same-module MRO via static analysis when supplied. X008 uses this so views inheriting `permission_required` from a base mixin (or inheriting `has_object_permission`/`check_permissions` overrides) are correctly classified.

- Cross-module bases are silently skipped — by design, module-local analysis only.
- Cycle guard via visited-set in `_walk_mro_static` prevents recursion on `class A(B): ...; class B(A): ...`.
- Backward-compat: `class_index=None` default → identical behavior to pre-patch implementation.

### #1383: broader URL-kwarg patterns

`_mount_assigns_url_kwarg_id` now recognizes three additional RHS shapes:
- `self.kwargs["x"]` — Django CBV-style (Subscript)
- `int(x)` / `str(x)` / `uuid(x)` / `UUID(x)` — whitelisted casts (literal `int(42)` correctly does NOT match)
- `(self.)kwargs.get("x"[, default])` — safe-default idiom

## Closes

- Closes #1382
- Closes #1383

## Test plan

- [x] 17 X008 tests pass (7 baseline + 10 new)
- [x] Full `test_audit_ast.py` — 69/69
- [x] Full pytest — 4743 passed, 14 skipped
- [x] Cycle-guard test strengthened (commit `b4545f7e`) to actually invoke `_walk_mro_static` on a detail-view-shaped class graph; bounded `sys.setrecursionlimit(200)` ensures unguarded recursion would observably fail
- [x] `audit_ast.run_ast_audit` smoke against `examples/demo_project/` runs cleanly (X008 = 0; no new false-positives)

## Stage 11 follow-up notes

Per the Stage 7+8 self-review, three advisory items remain:
- 🟡 Cast whitelist `{int, str, uuid, UUID}` could be extended to `{bool, float, Decimal}` (low priority — false-negatives in audit tools are acceptable)
- 💚 X008 finding message could call out the cross-module-base limitation; can amend `docs/website/guides/authorization.md` later
- 💚 `_event_handler_reads_self_attr` is class-body-local, not MRO-aware (out of scope per plan; potential follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)