### PR TITLE
feat(canon): 8 retro-filed canon items + emit_one_shot_class_warning helper

### DIFF
--- a/.pipeline-templates/bugfix-state.json
+++ b/.pipeline-templates/bugfix-state.json
@@ -92,6 +92,11 @@
           "mandatory": true
         },
         {
+          "action": "VERIFY CITED CAUSE FOR RETRO-FILED ISSUES (#1345, v0.9.3-5 retro): for tech-debt / investigation issues, verify the cited cause is accurate against current evidence before locking the fix scope. If the issue title encodes a hypothesis (often the case for retro-filed items), the executor inherits the hypothesis. Two consecutive items in v0.9.3-5 (#1339, #1340) had misdiagnosed causes; correct framing would have shipped the right fix faster. Run `gh issue view <N>` and read the full body, then trace the cited symptom against current code BEFORE writing the plan.",
+          "done": false,
+          "mandatory": true
+        },
+        {
           "action": "read codebase for current state",
           "done": false
         },
@@ -255,6 +260,11 @@
         },
         {
           "action": "Tautology check (Action #1200): for every new 'action happened' test assertion, ask 'would this pass if the action didn't run?' Tests that mock-and-call without invoking the SUT fail this check.",
+          "done": false,
+          "mandatory": true
+        },
+        {
+          "action": "DISCONFIRMING CITATION (#1386, v0.9.5-1 retro): identify at least one specific claim in the implementation (a docstring claim about exception class hierarchy, a comment claiming 'no callers', an assertion about wire-protocol shape, a Python version compat assumption) and actively try to DISPROVE it via grep / inspect / test. If the disproof attempt finds the claim wrong, file a 🟡 finding. If the claim survives, document the verification. Empirical: across v0.9.5-1 (-1a/-1b/-1c) Stage 7 caught 0 findings, Stage 11 caught 7 🟡 — the framing 'implementer reviews own diff' biases toward confirmation. Active falsification compresses Stage 11 findings into Stage 7 (cheaper, earlier).",
           "done": false,
           "mandatory": true
         },

--- a/.pipeline-templates/feature-state.json
+++ b/.pipeline-templates/feature-state.json
@@ -254,6 +254,11 @@
           "mandatory": true
         },
         {
+          "action": "DISCONFIRMING CITATION (#1386, v0.9.5-1 retro): identify at least one specific claim in the implementation (a docstring claim about exception class hierarchy, a comment claiming 'no callers', an assertion about wire-protocol shape, a Python version compat assumption) and actively try to DISPROVE it via grep / inspect / test. If the disproof attempt finds the claim wrong, file a 🟡 finding. If the claim survives, document the verification. Empirical: across v0.9.5-1 (-1a/-1b/-1c) Stage 7 caught 0 findings, Stage 11 caught 7 🟡 — the framing 'implementer reviews own diff' biases toward confirmation. Active falsification compresses Stage 11 findings into Stage 7 (cheaper, earlier).",
+          "done": false,
+          "mandatory": true
+        },
+        {
           "action": "CANON-PR SELF-APPLICABILITY CHECK (#1247 retro / #1248): if this PR adds a new mandatory checklist item or self-review rule, explicitly answer two questions in the Stage 7 output. (a) Does the new rule false-positive on this PR's own diff? If yes, narrow the scope before merge. (b) Would the new rule have caught the originating bug at the stage it adds? If no, reconsider the stage placement. Skip this item only when the PR doesn't introduce new canon (the typical feature/bugfix case).",
           "done": false,
           "mandatory": false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **New framework helper: `djust.utils.emit_one_shot_class_warning(cls, key, message, *args)` (#1392).** Reusable pattern for "framework can't help mechanically; tell the developer loudly." Sets a class-level sentinel attr `_djust_warned_<key>` so subsequent instances of the same class don't repeat the warning. Subclasses get their own sentinel via `cls.__dict__.get` (avoids attribute inheritance). Refactored the existing snapshot-truncation warning in `python/djust/websocket.py` to use it. Pattern from PR #1326, canonicalized via Retro v0.9.3-2 finding #4.
+
 ### Changed
+
+- **Process canon batch: 8 retro-filed items into CLAUDE.md, pipeline templates, and `docs/website/guides/authorization.md` (#1345, #1377, #1385, #1386, #1389, #1391, #1393).**
+  - `.pipeline-templates/bugfix-state.json` Stage 4: mandatory checklist item to verify cited cause for retro-filed issues before locking the fix scope (#1345).
+  - `.pipeline-templates/feature-state.json` + `bugfix-state.json` Stage 7: mandatory checklist item requiring disconfirming citations during self-review — bias toward active falsification rather than passive confirmation (#1386).
+  - `CLAUDE.md` Bug-report triage section: rule that multi-reopen issues require a bit-exact runnable reproducer against the reporter's environment before "root cause confirmed" (#1389); `_framework_attrs` snapshot-order invariant note (#1393).
+  - `CLAUDE.md` Process Canon: filter-migration grep canon (when changing a filter convention, grep all call sites for the OLD pattern) (#1391); split-foundation soak-time guidance for solo-author case (no external consumers → soak optional) (#1385).
+  - `python/djust/live_view.py`: comment block on `_framework_attrs = frozenset(self.__dict__.keys())` documenting the BEFORE-snapshot vs AFTER-snapshot semantics (#1393).
+  - `docs/website/guides/authorization.md`: WS-communicator test pattern section showing how to test the per-event object-permission re-execution path (#1377).
 
 - **`scripts/check-test-coverage.py` now verifies Makefile and `pyproject.toml` testpaths bidirectionally (#1346, defense-in-depth on #1339).** The original one-directional check caught the case where the Makefile missed a path that pyproject.toml declared (#1339, the bug that left `python/djust/tests/` uncollected for months). The reverse direction — a path added to the Makefile but missing from pyproject.toml, or removed from pyproject and still in Makefile — would have gone unflagged. Now fails loud with a clear set diff in either direction.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,7 @@ When investigating an issue with a code-location citation:
    `self._framework_attrs = frozenset(self.__dict__.keys())` line based on
    whether it is framework state (reset on reconnect) or user state
    (persisted, change-tracked). See the comment block at
-   `python/djust/live_view.py:517` for the rule + examples.
+   `python/djust/live_view.py:518` for the rule + examples.
 
 6. **Multi-reopen issues require bit-exact runnable repro before "root
    cause confirmed" (#1389, PR #1086).** Theory-testing against synthetic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,22 @@ When investigating an issue with a code-location citation:
    TDD surfaced the real path; trying to fix the reporter-cited code would
    have been a no-op.
 
+5. **`_framework_attrs` snapshot-order invariant (#1393).** Any new attr
+   assigned in `LiveView.__init__` must be placed BEFORE or AFTER the
+   `self._framework_attrs = frozenset(self.__dict__.keys())` line based on
+   whether it is framework state (reset on reconnect) or user state
+   (persisted, change-tracked). See the comment block at
+   `python/djust/live_view.py:517` for the rule + examples.
+
+6. **Multi-reopen issues require bit-exact runnable repro before "root
+   cause confirmed" (#1389, PR #1086).** Theory-testing against synthetic
+   test cases is INSUFFICIENT — it confirms only that THE FRAMEWORK
+   behaves a certain way, not that THIS USER'S BUG matches the theory.
+   PR #1086 had 3 "root cause" comments based on framework-side theory
+   testing; all three were wrong. The actual fix landed only after
+   gaining direct project access to reproduce against the user's exact
+   environment.
+
 ## Common Pitfalls
 
 - **Ruff F509**: `%`-format strings containing CSS semicolons trigger false positives. Separate HTML (`%s` substitution) from CSS (static string) and concatenate.
@@ -720,6 +736,29 @@ Rules distilled from the v0.9.3-4 audit and process drain bucket.
   Action #180 (v0.9.1) already lists the single-script-transformation
   pattern as a safe alternative for parallel-agent safety; this rule
   extends it to single-agent bulk operations regardless of agent count.
+
+- **Filter-migration grep canon (#1391, v0.9.3-2 retro).** When changing a
+  filter convention (e.g., `k.startswith("_")` → `k in _framework_attrs`),
+  grep the codebase for the EXACT pre-fix expression text and verify all
+  matches are updated. Filters that operate on the same data type often
+  have parallel implementations (Python change-tracker, Rust differ,
+  push-commands path, identity snapshots). A migration that updates one
+  path and not the others creates a latent invariant violation that may
+  only surface in a future audit. Concrete check during Stage 4 planning:
+  for any PR that changes a filter expression, grep for the pre-fix text
+  and visually scan all hits.
+
+- **Split-foundation soak-time guidance (#1385, v0.9.5-1 retro).** When
+  an iteration ships a new public API surface AND the framework has
+  external consumers, soak the API for at least one release before
+  stacking the next iteration. When the framework owner is the only API
+  customer (no external production usage), soak is optional — proceed
+  directly. Document the soak decision explicitly in the milestone retro
+  for future reference. Empirical: v0.9.5-1's three iterations
+  (-1a/-1b/-1c) shipped in <3 hours with NO soak; iterations stacked
+  cleanly because there were no external consumers. Action #1122
+  (split-foundation pattern) primary value is API design lock-in, not
+  calendar soak.
 
 ## Additional Documentation
 

--- a/docs/website/guides/authorization.md
+++ b/docs/website/guides/authorization.md
@@ -252,6 +252,42 @@ The lifecycle is opt-in: views that don't override `get_object()` see ZERO overh
 
 Keep `get_object()` minimal — just the FK lookup. Expensive I/O in this method becomes per-mount overhead.
 
+## Testing the per-event check (the WS-communicator pattern)
+
+Unit tests of `check_object_permission(view, request)` cover mount-time enforcement. For the per-event re-execution path, tests must connect to the WS as an authenticated user and exchange real frames:
+
+```python
+from channels.testing import WebsocketCommunicator
+from django.contrib.auth.models import AnonymousUser
+import pytest
+
+@pytest.mark.asyncio
+async def test_per_event_denies_after_ownership_change():
+    """Per-event object-permission re-runs after the owner FK changes
+    mid-session, denying the formerly-authorized user."""
+    # Connect as user A who owns document 1.
+    communicator = WebsocketCommunicator(application, "/ws/documents/1/")
+    communicator.scope["user"] = user_a
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # Mount succeeds (user A owns the doc).
+    await communicator.send_json_to({"type": "mount", "kwargs": {"document_id": 1}})
+
+    # Reassign ownership to user B mid-session.
+    document.owner_id = user_b.pk
+    document.save()
+
+    # User A sends a write event.
+    await communicator.send_json_to({"type": "event", "name": "add_comment", "args": {"body": "x"}})
+
+    # Per-event check fires; denial frame returned, WS stays open.
+    response = await communicator.receive_json_from()
+    assert response == {"type": "error", "error": "Access denied for this object.", "code": "permission_denied"}
+```
+
+This pattern (real WS communicator + state mutation between mount and event) is the empirical proof that the per-event check fires correctly. Use it for any LiveView feature whose contract depends on between-frame state. (#1377, v0.9.5-1c retro.)
+
 ## Reference
 
 - ADR-017 (full design): `docs/adr/017-object-permission-lifecycle.md`

--- a/docs/website/guides/authorization.md
+++ b/docs/website/guides/authorization.md
@@ -257,12 +257,14 @@ Keep `get_object()` minimal — just the FK lookup. Expensive I/O in this method
 Unit tests of `check_object_permission(view, request)` cover mount-time enforcement. For the per-event re-execution path, tests must connect to the WS as an authenticated user and exchange real frames:
 
 ```python
+# Replace `application`, `user_a`, `user_b`, `document` with your test
+# fixtures. `application` is your project's ASGI application (typically
+# from your project's asgi.py or testing harness).
 from channels.testing import WebsocketCommunicator
-from django.contrib.auth.models import AnonymousUser
 import pytest
 
 @pytest.mark.asyncio
-async def test_per_event_denies_after_ownership_change():
+async def test_per_event_denies_after_ownership_change(user_a, user_b, document, application):
     """Per-event object-permission re-runs after the owner FK changes
     mid-session, denying the formerly-authorized user."""
     # Connect as user A who owns document 1.

--- a/python/djust/live_view.py
+++ b/python/djust/live_view.py
@@ -514,6 +514,15 @@ class LiveView(
 
         # Snapshot framework-set attrs so we can distinguish them from
         # user-defined _private attrs set in mount() or event handlers.
+        #
+        # _framework_attrs snapshot-order invariant (#1393):
+        #   BEFORE this snapshot → framework state (excluded from
+        #   user-private serialization, reset on reconnect). Examples:
+        #   self._object cache (v0.9.5-1a), self._async_pending.
+        #   AFTER this snapshot → user state (included in change tracking,
+        #   persisted across reconnects). Examples: self._action_state
+        #   (PR #1324), self._<user_attr>.
+        # Any new framework slot must be assigned BEFORE this line.
         self._framework_attrs: frozenset = frozenset(self.__dict__.keys())
 
         # v0.8.0 — @action server-action state. Initialized AFTER

--- a/python/djust/utils.py
+++ b/python/djust/utils.py
@@ -16,6 +16,39 @@ def is_model_list(value: Any) -> bool:
     return isinstance(value, list) and len(value) > 0 and isinstance(value[0], models.Model)
 
 
+def emit_one_shot_class_warning(cls: type, key: str, message: str, *args: Any) -> None:
+    """Emit a logger.warning at most once per class for the given key.
+
+    Reusable framework pattern for "framework can't help mechanically,
+    tell the developer loudly". Sets a class-level sentinel attr
+    ``_djust_warned_<key>`` so subsequent instances of the same class
+    don't repeat the warning. Subclasses get their own sentinel via
+    normal Python attribute lookup (each subclass is a distinct ``cls``),
+    and the sentinel survives module reload (HVR) because the class
+    object outlives the module reload.
+
+    Use cases: snapshot truncation thresholds, missing get_object()
+    on detail-view-shaped classes, deprecated decorator usage.
+
+    Pattern from PR #1326 (snapshot truncation), canonicalized #1392.
+
+    Args:
+        cls: The class to attach the sentinel to (typically
+            ``type(view_instance)``).
+        key: Short identifier for the warning category (used to build the
+            sentinel attr name); use ``snake_case`` and keep it stable.
+        message: A ``%s``-style log format string (per djust logging rules).
+        *args: Substitution args for the format string.
+    """
+    sentinel = f"_djust_warned_{key}"
+    # Use cls.__dict__ (not getattr) so subclasses get their own sentinel
+    # instead of inheriting the parent's "already warned" state.
+    if cls.__dict__.get(sentinel, False):
+        return
+    setattr(cls, sentinel, True)
+    logger.warning(message, *args)
+
+
 def get_csp_nonce(request: Any) -> str:
     """
     Extract the CSP nonce from a Django request, if one is set.

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -160,10 +160,6 @@ def _should_expose_timing() -> bool:
     )
 
 
-# Per-view-class set to suppress duplicate truncation warnings (#1285).
-_TRUNCATION_WARNED: set = set()
-
-
 def _snapshot_assigns(view_instance):
     """Fast identity+hash snapshot of public assigns for change detection.
 
@@ -212,36 +208,40 @@ def _snapshot_assigns(view_instance):
             else:
                 snapshot[k] = (vid, len(v))
                 if v and len(v) >= 100:
-                    _cls = type(view_instance).__qualname__
-                    if _cls not in _TRUNCATION_WARNED:
-                        _TRUNCATION_WARNED.add(_cls)
-                        logger.warning(
-                            "[djust] %s: list '%s' has %d items — content "
-                            "fingerprint truncated. In-place mutations inside "
-                            "list elements will NOT be detected by auto-diff. "
-                            "Use self.set_changed_keys({'%s'}) or assign a "
-                            "new list reference.",
-                            _cls,
-                            k,
-                            len(v),
-                            k,
-                        )
-        elif isinstance(v, dict):
-            snapshot[k] = (vid, len(v), tuple(v.keys()) if len(v) < 50 else len(v))
-            if len(v) >= 50:
-                _cls = type(view_instance).__qualname__
-                if _cls not in _TRUNCATION_WARNED:
-                    _TRUNCATION_WARNED.add(_cls)
-                    logger.warning(
-                        "[djust] %s: dict '%s' has %d keys — key fingerprint "
-                        "truncated. Key additions/removals will NOT be detected "
-                        "by auto-diff. Use self.set_changed_keys({'%s'}) or "
-                        "assign a new dict reference.",
+                    from .utils import emit_one_shot_class_warning
+
+                    _cls = type(view_instance)
+                    emit_one_shot_class_warning(
                         _cls,
+                        "snapshot_list_truncated",
+                        "[djust] %s: list '%s' has %d items — content "
+                        "fingerprint truncated. In-place mutations inside "
+                        "list elements will NOT be detected by auto-diff. "
+                        "Use self.set_changed_keys({'%s'}) or assign a "
+                        "new list reference.",
+                        _cls.__qualname__,
                         k,
                         len(v),
                         k,
                     )
+        elif isinstance(v, dict):
+            snapshot[k] = (vid, len(v), tuple(v.keys()) if len(v) < 50 else len(v))
+            if len(v) >= 50:
+                from .utils import emit_one_shot_class_warning
+
+                _cls = type(view_instance)
+                emit_one_shot_class_warning(
+                    _cls,
+                    "snapshot_dict_truncated",
+                    "[djust] %s: dict '%s' has %d keys — key fingerprint "
+                    "truncated. Key additions/removals will NOT be detected "
+                    "by auto-diff. Use self.set_changed_keys({'%s'}) or "
+                    "assign a new dict reference.",
+                    _cls.__qualname__,
+                    k,
+                    len(v),
+                    k,
+                )
         elif isinstance(v, set):
             snapshot[k] = (vid, len(v))
         elif isinstance(v, _IMMUTABLE_TYPES):

--- a/python/tests/test_snapshot_truncation_warning.py
+++ b/python/tests/test_snapshot_truncation_warning.py
@@ -12,7 +12,7 @@ developers that auto-diff won't detect mutations inside these containers.
 import logging
 
 from djust import LiveView
-from djust.websocket import _snapshot_assigns, _TRUNCATION_WARNED
+from djust.websocket import _snapshot_assigns
 
 
 class _ListView(LiveView):
@@ -23,11 +23,23 @@ class _DictView(LiveView):
     pass
 
 
+def _reset_truncation_sentinels(*classes):
+    """Clear the per-class one-shot warning sentinels set by
+    ``emit_one_shot_class_warning`` (#1392) so each test starts fresh."""
+    for cls in classes:
+        for attr in (
+            "_djust_warned_snapshot_list_truncated",
+            "_djust_warned_snapshot_dict_truncated",
+        ):
+            if attr in cls.__dict__:
+                delattr(cls, attr)
+
+
 class TestSnapshotTruncationWarning:
     """#1285: warning emitted on first truncation; suppressed on subsequent."""
 
     def setup_method(self):
-        _TRUNCATION_WARNED.clear()
+        _reset_truncation_sentinels(_ListView, _DictView)
 
     def test_list_truncation_emits_warning(self, caplog):
         view = _ListView()


### PR DESCRIPTION
## Summary

Final work unit of v0.9.5-2 drain. Bundles 8 retro-filed canon items + one small framework helper into a single PR.

## Closes

- Closes #1345 — Stage 4 plan template: verify cited cause for retro-filed issues
- Closes #1377 — WS-communicator test pattern documented in authorization guide
- Closes #1385 — split-foundation soak-time guidance for solo-author case
- Closes #1386 — Stage 7 self-review now requires disconfirming citations
- Closes #1389 — multi-reopen issues require bit-exact runnable repro
- Closes #1391 — filter-migration grep canon
- Closes #1392 — emit_one_shot_class_warning helper extracted; existing snapshot-truncation warning refactored to use it
- Closes #1393 — _framework_attrs snapshot-order invariant docstring + CLAUDE.md note

## What changed

- **`.pipeline-templates/bugfix-state.json`** — new Stage 4 mandatory item (#1345); new Stage 7 mandatory item (#1386)
- **`.pipeline-templates/feature-state.json`** — new Stage 7 mandatory item (#1386)
- **`python/djust/utils.py`** — new `emit_one_shot_class_warning(cls, key, message, *args)` helper (#1392)
- **`python/djust/websocket.py`** — refactored two `_TRUNCATION_WARNED: set` call sites in `_snapshot_assigns` to use the new helper; module-global sentinel removed
- **`python/tests/test_snapshot_truncation_warning.py`** — updated for the new sentinel scheme (per-class `_djust_warned_<key>` attrs)
- **`python/djust/live_view.py`** — snapshot-order invariant comment block above `_framework_attrs` snapshot (#1393)
- **`CLAUDE.md`** — three sections updated: Bug-report triage adds bit-exact-repro rule (#1389) + `_framework_attrs` invariant note (#1393); Process Canon adds filter-migration grep (#1391) + split-foundation soak guidance (#1385)
- **`docs/website/guides/authorization.md`** — appended WS-communicator test pattern section (#1377)

## Test plan

- [x] Pipeline templates parse as valid JSON
- [x] `emit_one_shot_class_warning` smoke-tested: same-class same-key suppresses; subclass gets independent sentinel; different keys independent
- [x] All 10 tests in `test_snapshot_truncation_warning.py` pass after sentinel-name update
- [x] Full pytest suite — no regressions
- [x] Pre-push hook caught the orphan `_TRUNCATION_WARNED` import (Action #122 working as designed); fixed in commit `a01f8995`

🤖 Generated with [Claude Code](https://claude.com/claude-code)