### PR TITLE
fix(security): sanitize_for_log cache_key on HTTP path (#1368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`sanitize_for_log` cache_key on HTTP cache-lookup debug log (#1368).** Pre-existing log-injection asymmetry between WebSocket and HTTP paths in `python/djust/mixins/rust_bridge.py`: the WS site at line 333 sanitized correctly; the HTTP site at line 363 did not. Since `cache_key` derives from `request.path` (user-controlled), an attacker-supplied path like `/page/\n[FAKE LOG ENTRY]` could inject newlines into the log stream. Mirrors the WS-path call to `sanitize_for_log(self._cache_key)` and adds the matching CodeQL annotation. Surfaced in PR #1367 Stage 11 SHOULD-FIX #3 (deferred per Action #1079).
+
 ## [0.9.5rc2] - 2026-05-06
 
 ### Added

--- a/python/djust/mixins/rust_bridge.py
+++ b/python/djust/mixins/rust_bridge.py
@@ -360,7 +360,11 @@ class RustBridgeMixin:
 
                 backend = get_backend()
                 self._cache_key = f"{session_key}_{view_key}{template_hash_slot}"
-                logger.debug("[LiveView] Cache lookup (HTTP): cache_key=%s", self._cache_key)
+                # codeql[py/log-injection] — cache_key may contain request.path; sanitize
+                logger.debug(
+                    "[LiveView] Cache lookup (HTTP): cache_key=%s",
+                    sanitize_for_log(self._cache_key),
+                )
 
                 cached = backend.get(self._cache_key)
                 if cached:


### PR DESCRIPTION
## Summary

Mirrors the WebSocket-path `sanitize_for_log(self._cache_key)` call at the HTTP site in `_initialize_rust_view`. Since `cache_key` derives from `request.path` (user-controlled), the unsanitized HTTP debug log was a CodeQL `py/log-injection` surface.

One-line fix matching the v0.9.5-2 #1391 canon (filter-migration grep): the WS sibling already sanitized; the HTTP sibling needed the same treatment.

## Closes

- Closes #1368

## Test plan

- [x] Full pytest — 4743 passed, 14 skipped (no regression)
- [x] CodeQL annotation matches the WS sibling at line 333
- [x] No new test required (defensive sanitization fix; no functional change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)