### PR TITLE
fix(templates): Node::Include round-trip no longer double-quotes path (#1396)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Node::Include` round-trip no longer double-quotes the template path (#1396).** Parser was preserving the outer quotes on `Include.template`; emitter `nodes_to_template_string` then wrapped again, producing `{% include ""partials/header.html"" %}` on round-trip. Surfaced during PR #1397's conversion of round-trip tests to drive from parser output (Action #158 working as designed). Fixed by aligning the parser to strip outer quotes (matching the existing `Extends`, `Static`, and `Now` contracts) — single source of truth, emitter unchanged. `test_nodes_to_template_string_include` un-ignored. Added `test_nodes_to_template_string_now` for defense-in-depth.
+
 ### Security
 
 - **`sanitize_for_log` cache_key on HTTP cache-lookup debug log (#1368).** Pre-existing log-injection asymmetry between WebSocket and HTTP paths in `python/djust/mixins/rust_bridge.py`: the WS site at line 333 sanitized correctly; the HTTP site at line 363 did not. Since `cache_key` derives from `request.path` (user-controlled), an attacker-supplied path like `/page/\n[FAKE LOG ENTRY]` could inject newlines into the log stream. Mirrors the WS-path call to `sanitize_for_log(self._cache_key)` and adds the matching CodeQL annotation. Surfaced in PR #1367 Stage 11 SHOULD-FIX #3 (deferred per Action #1079).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "0.9.5-rc.1"
+version = "0.9.5-rc.2"
 dependencies = [
  "ahash",
  "criterion",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "0.9.5-rc.1"
+version = "0.9.5-rc.2"
 dependencies = [
  "ahash",
  "criterion",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "0.9.5-rc.1"
+version = "0.9.5-rc.2"
 dependencies = [
  "bincode",
  "criterion",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "0.9.5-rc.1"
+version = "0.9.5-rc.2"
 dependencies = [
  "ahash",
  "chrono",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "0.9.5-rc.1"
+version = "0.9.5-rc.2"
 dependencies = [
  "ahash",
  "criterion",

--- a/crates/djust_templates/src/inheritance.rs
+++ b/crates/djust_templates/src/inheritance.rs
@@ -805,12 +805,23 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "real bug uncovered by #1388 — `Node::Include`'s `template` field is parser-stored with surrounding quotes; emitter double-wraps. Tracked as #1396 (out-of-scope per #1079 broader-sweep canon)."]
     fn test_nodes_to_template_string_include() {
-        // Drive from parser output (#1388). Currently fails — see #1396.
+        // Drive from parser output (#1388). Regression for #1396 — parser
+        // stored Include.template with surrounding quotes, emitter wrapped
+        // them in another pair, producing {% include ""partials/header.html"" %}.
         let nodes = parse_source("{% include \"partials/header.html\" %}");
         let result = nodes_to_template_string(&nodes);
         assert_eq!(result, "{% include \"partials/header.html\" %}");
+    }
+
+    #[test]
+    fn test_nodes_to_template_string_now() {
+        // Drive from parser output (#1388). Lock in Now round-trip
+        // (audited under #1396 — Now strips quotes correctly at parse,
+        // no double-wrap; defense-in-depth test against future regression).
+        let nodes = parse_source("{% now \"Y-m-d\" %}");
+        let result = nodes_to_template_string(&nodes);
+        assert_eq!(result, "{% now \"Y-m-d\" %}");
     }
 
     #[test]

--- a/crates/djust_templates/src/parser.rs
+++ b/crates/djust_templates/src/parser.rs
@@ -582,7 +582,12 @@ fn parse_token(tokens: &[Token], i: &mut usize) -> Result<Option<Node>> {
                             "Include tag requires a template name".to_string(),
                         ));
                     }
-                    let template = args[0].clone();
+                    // Strip surrounding quotes (#1396) so Include.template
+                    // shares the unquoted-field contract with Extends/Static/Now.
+                    // Without this strip, the inheritance emitter
+                    // (`nodes_to_template_string`) double-wraps the value,
+                    // producing `{% include ""x.html"" %}` on round-trip.
+                    let template = args[0].trim_matches(|c| c == '"' || c == '\'').to_string();
                     let mut with_vars = Vec::new();
                     let mut only = false;
 


### PR DESCRIPTION
## Summary

Surfaced during PR #1397's conversion of `test_nodes_to_template_string_include` to drive from parser output (#1388). Action #158 working as designed: the conversion immediately exposed a real bug masked by hand-built fixtures.

## What changed

- **Parser-side fix** (`crates/djust_templates/src/parser.rs:585`) — `Node::Include.template` now strips outer quotes at parse time, matching the existing contract for `Node::Extends`, `Node::Static`, and `Node::Now`. Single source of truth.
- **Emitter** (`crates/djust_templates/src/inheritance.rs:422`) — unchanged.
- **Tests** — un-ignored `test_nodes_to_template_string_include` (was marked `#[ignore]` in PR #1397 with pointer here); added `test_nodes_to_template_string_now` for defense-in-depth.

## Audit results

- `Node::Static.path` — already correctly strips quotes at `parser.rs:633` ✅
- `Node::Now.format` — already correctly strips quotes at `parser.rs:805` ✅
- `Node::Include.template` — was the outlier; now fixed ✅

## Closes

- Closes #1396

## Test plan

- [x] RED→GREEN: pre-fix the include test failed with `left: "{% include \"\"partials/header.html\"\" %}" right: "{% include \"partials/header.html\" %}"`; post-fix passes
- [x] Rust workspace — 745 → 747 active passing (1 → 0 ignored, +1 new Now test)
- [x] djust_templates: 284/284 green
- [x] Python pytest — 4743 passed, 14 skipped (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)