### PR TITLE
fix(state-backends): remove dead InMemoryStateBackend.get_and_update (#1356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **Dead `InMemoryStateBackend.get_and_update()` removed (#1356).** Method had zero callers and would re-introduce the #1353 shared-mutable-state race class if a future caller was added without auditing. PR #1355 fixed the sibling `get()` to clone via msgpack round-trip; `get_and_update()` was overlooked. Per the issue body's preferred-fix order, deletion was cleanest. Removes ~22 lines of dead code from `python/djust/state_backends/memory.py`. (Surfaced as PR #1355 Stage 13 Re-Review #1.)
+
 ### Fixed
 
 - **`Node::Include` round-trip no longer double-quotes the template path (#1396).** Parser was preserving the outer quotes on `Include.template`; emitter `nodes_to_template_string` then wrapped again, producing `{% include ""partials/header.html"" %}` on round-trip. Surfaced during PR #1397's conversion of round-trip tests to drive from parser output (Action #158 working as designed). Fixed by aligning the parser to strip outer quotes (matching the existing `Extends`, `Static`, and `Now` contracts) — single source of truth, emitter unchanged. `test_nodes_to_template_string_include` un-ignored. Added `test_nodes_to_template_string_now` for defense-in-depth.

--- a/python/djust/state_backends/memory.py
+++ b/python/djust/state_backends/memory.py
@@ -178,28 +178,6 @@ class InMemoryStateBackend(StateBackend):
                 if state_size > 0:
                     self._state_sizes[key] = state_size
 
-    def get_and_update(self, key: str) -> Optional[Tuple[RustLiveView, float]]:
-        """
-        Atomically retrieve and update timestamp (thread-safe).
-
-        This is useful for extending session TTL on access without
-        separate get/set calls that could race.
-
-        Args:
-            key: Session key
-
-        Returns:
-            Tuple of (RustLiveView, new_timestamp) if found, None otherwise
-        """
-        with self._lock:
-            cached = self._cache.get(key)
-            if cached:
-                view, _ = cached
-                new_timestamp = time.time()
-                self._cache[key] = (view, new_timestamp)
-                return (view, new_timestamp)
-            return None
-
     def delete(self, key: str) -> bool:
         """
         Remove from in-memory cache (thread-safe).


### PR DESCRIPTION
## Summary

Removes the dead `InMemoryStateBackend.get_and_update()` method per PR #1355 Stage 13 Re-Review #1.

The method returned a shared Python reference to the cached object — the same race class that #1353 fixed in the sibling `get()` (now does a serialize/deserialize clone). `get_and_update()` was overlooked in PR #1355. Confirmed via `grep -rn get_and_update python/`: definition only, no callers, no tests reference it.

Per the issue body's preferred-fix order, deletion was cleanest:
1. **Delete** if dead ✓
2. Make it clone too (consistent with `get()`)
3. Document the contract

## Closes

- Closes #1356

## Test plan

- [x] `grep -rn get_and_update python/` confirms no callers post-deletion
- [x] Full pytest — 4743 passed, 14 skipped (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)