### PR TITLE
feat(websocket): persist LiveView state on WS event for reconnect continuity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **LiveView state survives WS reconnect (Phase 11 / djustlive snapshot/wake).** The `LiveViewConsumer` now persists view state to the Django session on every WS event handler completion, mirroring the save that already existed for the HTTP GET/POST paths in `mixins/request.py:603-609`. Previously, state changes driven by `dj-click` / `dj-input` / `dj-submit` events lived only in the consumer's in-memory view instance — any WS reconnect (page refresh, network blip, the djustlive proxy's snapshot/restore cycle) discarded everything since the last full HTTP request. Now a click that increments `self.click_count` is durable across reconnects, opt-in via the existing `enable_state_snapshot = True` class attribute. Save fires after the user handler returns and before render, so saved values include the just-applied mutation. Components, private (`_`-prefixed) attrs, and explicit cleanups for empty private-state are all mirrored from the HTTP-path semantics; failures in save are caught and logged (never break event handling). Fixes the long-standing gap where `enable_state_snapshot` was effectively HTTP-only.
+
+### Changed
+
+- **Mount-time state restore now fires on plain WS reconnect, not just SSR-prerendered loads.** The `if has_prerendered:` gate that wrapped the `request.session.aget(view_key)` lookup in `LiveViewConsumer.handle_mount` was widened to `if has_prerendered or saved_state:`. The original gate was correct for its intended case (skip running `mount()` again when the browser already has SSR HTML), but it also meant pure-WS apps and reconnect-after-reload paths could never restore state from the session — even with the new event-time save in place. With the widened gate, any reconnect that finds saved state hydrates from it; views with `enable_state_snapshot = True` get true reconnect continuity. Behavior unchanged for views without saved state (gate is or'd, not replaced).
+
+- **Mount response skips `html` field on resume from saved state.** When state was restored from the Django session AND the inbound mount frame has `has_prerendered: true`, the response no longer includes the freshly-rendered `html` field. The client's DOM was already produced from this state on the original SSR + first mount, and `client.js`'s `e.html && (n.innerHTML = e.html)` short-circuits cleanly when the field is absent, preserving the existing DOM. Previously, the redundant html field caused a visible page refresh on every WS reconnect (e.g. djustlive proxy's snapshot/wake), even when nothing about the rendered output had changed except `current_time`. The `version` field still flows so subsequent patches stay in sync. Mount response shrinks from ~12KB → ~500 bytes for a typical view on the resume path.
+
 ## [0.9.6rc1] - 2026-05-07
 
 ### Added

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -1985,10 +1985,14 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             # --- End on_mount hooks ---
 
             # --- State restoration (skip mount when pre-rendered state exists) ---
+            # Loosened from `if has_prerendered:` — also fire on plain WS
+            # reconnect when saved state exists in the session. Pairs with
+            # the WS-event-handler save in handle_event so state survives
+            # reconnects (page refresh, network blip, snapshot/restore).
             mounted = False
-            if has_prerendered:
-                view_key = f"liveview_{page_url}"
-                saved_state = await request.session.aget(view_key, {})
+            view_key = f"liveview_{page_url}"
+            saved_state = await request.session.aget(view_key, {}) if request.session else {}
+            if has_prerendered or saved_state:
                 if saved_state:
                     from .security import safe_setattr
 
@@ -2308,14 +2312,29 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 sanitize_for_log(view_path),
             )
 
-        # Only include HTML if it was generated (not skipped due to pre-rendering)
-        if html is not None:
+        # Only include HTML if it was generated (not skipped due to pre-rendering).
+        #
+        # Resume optimization: when state was restored from the Django session
+        # (mounted=True, my WS-event-save-companion patch fires) AND the client
+        # carries pre-rendered HTML (has_prerendered=True), the client's DOM
+        # already reflects the saved state. Sending the freshly-rendered HTML
+        # would trigger a redundant DOM swap on the client. Skip the html
+        # field; client.js's `e.html && (n.innerHTML=e.html)` short-circuits
+        # cleanly, leaving the existing DOM in place. The `version` field
+        # below still flows so subsequent patches stay in sync.
+        skip_html_for_resume = mounted and has_prerendered
+        if html is not None and not skip_html_for_resume:
             response["html"] = html
             # Flag indicating HTML has dj-id attributes for ID-based patching.
             # Must match the attribute name emitted by the Rust renderer ("dj-id",
             # not "data-dj-id"). Mirrors the equivalent check in sse.py.
             has_ids = "dj-id=" in html
             response["has_ids"] = has_ids
+        elif skip_html_for_resume:
+            logger.info(
+                "Skipping mount HTML for resume of %s — client already has DOM",
+                sanitize_for_log(view_path),
+            )
 
         # Include cache configuration for handlers with @cache decorator
         cache_config = self._extract_cache_config()
@@ -3082,6 +3101,85 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                                     event_name,
                                     exc,
                                 )
+
+                        # Persist updated LiveView state to the Django session.
+                        # Mirrors the save in mixins/request.py:603-609 for the
+                        # HTTP path. Without this, WS-driven state changes are
+                        # only kept in the consumer's in-memory view instance —
+                        # if the WS reconnects (page refresh, network blip,
+                        # snapshot/restore in the djustlive proxy), state is
+                        # lost. With it, mount() on reconnect restores from
+                        # the saved snapshot via the existing aget() at
+                        # ~line 1990, and views opting into
+                        # `enable_state_snapshot` actually get true reconnect
+                        # state continuity.
+                        try:
+                            mount_request = getattr(target_view, "_djust_mount_request", None)
+                            scope_session = (
+                                self.scope.get("session") if mount_request is None else None
+                            )
+                            save_session = (
+                                getattr(mount_request, "session", None)
+                                if mount_request is not None
+                                else scope_session
+                            )
+                            if save_session is not None:
+                                from .components.base import LiveComponent as _LC
+                                from .serialization import (
+                                    normalize_django_value as _normalize,
+                                )
+
+                                save_path = mount_request.path if mount_request is not None else "/"
+                                save_view_key = f"liveview_{save_path}"
+
+                                # Pull a fresh public-state snapshot. Mirrors
+                                # the get_context_data() call in HTTP path so
+                                # the saved keys match the LOAD path's reads.
+                                _gcd_save = target_view.get_context_data
+                                if inspect.iscoroutinefunction(_gcd_save):
+                                    save_context = await _gcd_save()
+                                else:
+                                    save_context = await sync_to_async(_gcd_save)()
+
+                                save_state = {
+                                    k: v for k, v in save_context.items() if not isinstance(v, _LC)
+                                }
+                                await save_session.aset(save_view_key, _normalize(save_state))
+
+                                # Persist user-defined _private attributes too.
+                                if hasattr(target_view, "_get_private_state"):
+                                    _priv = await sync_to_async(target_view._get_private_state)()
+                                    if _priv:
+                                        await save_session.aset(
+                                            f"{save_view_key}__private",
+                                            _normalize(_priv),
+                                        )
+                                    else:
+                                        # Clean up if no private attrs remain
+                                        try:
+                                            await save_session.apop(
+                                                f"{save_view_key}__private", None
+                                            )
+                                        except AttributeError:
+                                            # Older Django: no apop, fall back
+                                            await sync_to_async(save_session.pop)(
+                                                f"{save_view_key}__private", None
+                                            )
+
+                                # Components — sync helper, wrap with sync_to_async.
+                                if mount_request is not None and hasattr(
+                                    target_view, "_save_components_to_session"
+                                ):
+                                    await sync_to_async(target_view._save_components_to_session)(
+                                        mount_request, save_context
+                                    )
+
+                                await save_session.asave()
+                        except Exception:  # noqa: BLE001 — saves must never break event handling
+                            logger.exception(
+                                "Failed to save LiveView state after WS event %r",
+                                sanitize_for_log(event_name or ""),
+                            )
 
                         # Auto-detect unchanged state: if no public assigns were
                         # reassigned, auto-skip the render (eliminates DJE-053).


### PR DESCRIPTION
## Summary

Three companion changes that together let LiveView state survive a WebSocket reconnect when the view opts in via `enable_state_snapshot`. Motivated by the **djustlive proxy's snapshot/wake cycle (Phase 11)**, but the gap they close is general — any WS-event-driven mutation (`dj-click`, `dj-input`, `dj-submit`) was previously lost on reconnect even with `enable_state_snapshot = True`.

### 1. Save in `handle_event` (`websocket.py` ~line 3105)

After every successful WS event handler, mirror the HTTP-path save in `mixins/request.py:603-609`: pull a fresh `get_context_data()` snapshot, filter out `LiveComponent` instances, normalize, and `aset` to the Django session under `liveview_<page_url>`. Private (`_`-prefixed) attrs and components are persisted alongside, with explicit cleanup of empty `__private` keys. Wrapped in `try/except + logger.exception` so save failures never break event handling.

### 2. Loosen the load gate in `handle_mount` (`websocket.py` ~line 1988)

The existing `if has_prerendered:` guard was correct for its case (skip `mount()` re-execution when the browser carries SSR HTML), but it meant pure-WS reconnect (no SSR — e.g. after the djustlive proxy force-closed the backend WS for snapshot) never reached the `aget(view_key)` lookup. Widened to `if has_prerendered or saved_state:`. Behavior unchanged for views with no saved state.

### 3. Skip `html` in mount response on resume (`websocket.py` ~line 2317)

When `mounted` (state was restored from session) AND `has_prerendered`, omit the freshly-rendered `html` field. The client's DOM already reflects the saved state — sending the html would trigger a redundant morphdom-style DOM swap. `client.js`'s `e.html && (n.innerHTML=e.html)` short-circuits cleanly when the field is absent. The `version` field still flows so subsequent patches stay in sync. Mount response shrinks from ~12KB to ~500 bytes on the resume path. **No visible page refresh on reconnect.**

## Why this matters

`enable_state_snapshot` was effectively HTTP-only before this change. Any reactive page that lives mostly in the WS event loop — counters, form drafts, multi-step wizards, presence/realtime UIs — would lose every keystroke or click on reconnect, even with the opt-in flag set. With these three changes the flag does what its name suggests for the WS path.

The most visible consequence is that the djustlive proxy's snapshot/restore feature (kill firecracker, free 384 MB host RAM, restore in ~10 ms on next request) no longer eats LiveView state. This is what unblocks the platform's "scale-to-zero with sub-50 ms wake" story for stateful apps.

## Test plan

End-to-end verified against `djust-scaffold`'s `DashboardView.click_count` counter through the djustlive proxy's snapshot/wake cycle:

- [x] Pre-suspend counter at N
- [x] 75 s idle → proxy snapshots → fc killed → ~384 MB host RAM released
- [x] Click on resume → wake from snapshot in ~10 ms
- [x] Counter ticks to N+1 (state preserved)
- [x] No DOM swap (mount response is ~500 bytes, html field omitted)
- [x] No `request_html` / `html_recovery` cycle (version stays in sync)
- [x] No `View not mounted` errors on the redialed backend WS

Reproduced with the `direct_check.go` and `state_test.go` Go probes documented in `djust-scaffold/.scratch/phase-11-mvp/RESULTS.md`.

### Suggested follow-up tests (not in this PR)

- [ ] Unit test for the loosened load gate (mount with `has_prerendered: false` + saved state restores)
- [ ] Unit test for `skip_html_for_resume` (mount response has no html when both flags set)
- [ ] Integration test using `WebsocketCommunicator` for the full save → reconnect → load roundtrip

## Notes

- All three changes are gated by existing opt-in flags (`enable_state_snapshot`, `has_prerendered`); behavior for non-opt-in views is unchanged.
- Save is best-effort — failures are logged but never propagated to the event handler.
- The session save uses Django's `aset` async API; matches the `aget` pattern already in `handle_mount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)