### PR TITLE
fix(state-backends/memory): discard corrupt entry on round-trip failure (#1410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`InMemoryStateBackend.get()` discards corrupt entries instead of returning the shared in-memory ref (#1410).** When `RustLiveView.deserialize_msgpack` raised — typically after a hot-swap struct change or msgpack schema drift — the previous fallback returned the cached object directly. Two concurrent connections to the same view then shared one `_rust_view`, and mutations from connection A leaked into connection B's render context. After a `cargo build` of `djust_vdom` + `.so` swap, fresh navigations could re-render with state from the prior session. Now the backend pops the corrupt entry from its in-memory dict and returns `None`; the caller's mount path treats the cache as cold and runs `mount()` cleanly. Discovered during the #1408 investigation.
+
 ## [0.9.6rc1] - 2026-05-07
 
 ### Added

--- a/python/djust/state_backends/memory.py
+++ b/python/djust/state_backends/memory.py
@@ -118,16 +118,25 @@ class InMemoryStateBackend(StateBackend):
                 serialized = view.serialize_msgpack()
                 clone = RustLiveView.deserialize_msgpack(serialized)
             except Exception:
-                # Defensive: if msgpack round-trip fails for any reason,
-                # fall back to returning the cached ref. The race window
-                # is preferable to an outright cache miss that destroys
-                # the diff baseline. Logged so this surfaces in dev.
+                # Round-trip failed (msgpack schema drift after a hot-swap,
+                # corrupt payload, etc). Returning the shared ref is
+                # silently corrupting — two concurrent connections to the
+                # same view would mutate the SAME `_rust_view` and leak
+                # state across each other (#1410). The strictly-safer
+                # alternative is to fail the cache-hit and let the caller
+                # treat this as uninitialized — `mount()` will run again
+                # and rebuild clean state.
+                #
+                # Discard the corrupt entry under the lock so the next
+                # caller doesn't re-trip the same exception.
+                with self._lock:
+                    self._cache.pop(key, None)
                 logger.exception(
                     "InMemoryStateBackend.get: serialize/deserialize round-trip "
-                    "failed for key '%s'; returning shared ref (race risk)",
+                    "failed for key '%s'; entry discarded — caller should remount",
                     key,
                 )
-                return (view, timestamp)
+                return None
             return (clone, timestamp)
 
     def set(

--- a/python/djust/state_backends/memory.py
+++ b/python/djust/state_backends/memory.py
@@ -128,9 +128,18 @@ class InMemoryStateBackend(StateBackend):
                 # and rebuild clean state.
                 #
                 # Discard the corrupt entry under the lock so the next
-                # caller doesn't re-trip the same exception.
+                # caller doesn't re-trip the same exception. Identity-
+                # guard the pop: between the unlock above and the
+                # re-lock here, a concurrent `set(key, new_view)` could
+                # have landed a fresh, valid entry — we must not delete
+                # the *new* one in place of the corrupt one we held.
+                # `cached`'s reference to `view` keeps the original
+                # alive, so `is` is sound.
                 with self._lock:
-                    self._cache.pop(key, None)
+                    current = self._cache.get(key)
+                    if current is not None and current[0] is view:
+                        self._cache.pop(key, None)
+                        self._state_sizes.pop(key, None)
                 logger.exception(
                     "InMemoryStateBackend.get: serialize/deserialize round-trip "
                     "failed for key '%s'; entry discarded — caller should remount",

--- a/tests/unit/test_state_backend.py
+++ b/tests/unit/test_state_backend.py
@@ -296,6 +296,51 @@ class TestInMemoryBackend:
         # doesn't re-trip the same exception cycle.
         assert backend.get("k") is None, "corrupt entry was not popped from cache"
 
+    def test_get_round_trip_failure_does_not_clobber_concurrent_set(self):
+        """#1410 TOCTOU regression: between the lock-release after the
+        failed round-trip and the lock-reacquire for the discard pop,
+        a concurrent `set(key, new_view)` can land a fresh valid entry.
+        The discard must NOT delete that fresh entry — only the corrupt
+        ref the round-trip was operating on. Identity-guard via `is`.
+        """
+        from unittest.mock import patch
+
+        backend = InMemoryStateBackend()
+        original = RustLiveView("<div>orig</div>")
+        backend.set("k", original)
+
+        replacement = RustLiveView("<div>replacement</div>")
+
+        # Simulate the concurrent set() landing INSIDE the failed
+        # round-trip handler — patch deserialize_msgpack to raise AND
+        # write a fresh entry as a side effect, mirroring the worst-case
+        # interleaving.
+        def raise_and_simulate_concurrent_set(*_args, **_kwargs):
+            backend.set("k", replacement)
+            raise ValueError("simulated msgpack schema drift")
+
+        with patch.object(
+            RustLiveView,
+            "deserialize_msgpack",
+            side_effect=raise_and_simulate_concurrent_set,
+        ):
+            result = backend.get("k")
+
+        # The failed get returns None as documented.
+        assert result is None
+
+        # But the fresh `replacement` entry from the concurrent set
+        # MUST still be there — the discard path identity-guards on
+        # the original view ref.
+        cached = backend.get("k")
+        assert cached is not None, (
+            "TOCTOU bug regression: the concurrent set() landed a fresh "
+            "entry, but the failed-round-trip discard popped it anyway. "
+            "Identity-guard (`is`) is missing or broken."
+        )
+        view, _ts = cached
+        assert view.render() == "<div>replacement</div>"
+
 
 class TestRedisBackend:
     """Test RedisStateBackend (requires Redis server)."""

--- a/tests/unit/test_state_backend.py
+++ b/tests/unit/test_state_backend.py
@@ -255,6 +255,47 @@ class TestInMemoryBackend:
         backend = InMemoryStateBackend()
         assert backend.delete_all() == 0
 
+    def test_get_discards_corrupt_entry_on_round_trip_failure(self):
+        """#1410: when serialize/deserialize round-trip fails (msgpack
+        schema drift after a hot-swap, corrupt state, etc.) `get()` must
+        DISCARD the entry and return None — never the shared in-memory
+        ref. Returning a shared ref would let two concurrent connections
+        mutate the same `_rust_view`, leaking state across sessions.
+
+        The strictly-safer alternative is to fail-the-cache-hit so the
+        caller's mount path treats it as uninitialized and runs `mount()`
+        again on a clean state.
+        """
+        from unittest.mock import patch
+
+        backend = InMemoryStateBackend()
+        view = RustLiveView("<div>orig</div>")
+        backend.set("k", view)
+
+        # Confirm baseline: a normal get() returns a (clone, ts) tuple.
+        assert backend.get("k") is not None
+
+        # Force the round-trip to fail. Patch deserialize_msgpack on the
+        # class so the next call inside `get()` raises.
+        with patch.object(
+            RustLiveView,
+            "deserialize_msgpack",
+            side_effect=ValueError("simulated msgpack schema drift"),
+        ):
+            result = backend.get("k")
+
+        # Must return None — NOT the shared ref. The previous shape was
+        # `return (view, timestamp)`, which is the silent-corruption path
+        # this fix closes.
+        assert result is None, (
+            f"expected None on round-trip failure, got {result!r} "
+            "(this means the shared-ref fallback is back — see #1410)"
+        )
+
+        # And the corrupt entry must be discarded so the next caller
+        # doesn't re-trip the same exception cycle.
+        assert backend.get("k") is None, "corrupt entry was not popped from cache"
+
 
 class TestRedisBackend:
     """Test RedisStateBackend (requires Redis server)."""


### PR DESCRIPTION
## Summary

Closes #1410.

`InMemoryStateBackend.get()` previously caught a serialize/deserialize round-trip exception (typically `RustLiveView.deserialize_msgpack` raising after a hot-swap struct change or msgpack schema drift) and fell back to returning the cached **shared ref**. Two concurrent connections to the same view then mutated the same `_rust_view` — a silent cross-session state leak.

The fix discards the corrupt entry from the in-memory dict and returns `None`. The caller's mount path treats it as uninitialized and runs `mount()` cleanly. Strictly safer than silent corruption.

Surfaced during the #1408 investigation: after `cargo build` of `djust_vdom` + `.so` swap, fresh navigations re-rendered with state from the prior session.

## Test plan

- [x] `tests/unit/test_state_backend.py::TestInMemoryBackend::test_get_discards_corrupt_entry_on_round_trip_failure` — patches `RustLiveView.deserialize_msgpack` to raise, asserts `get()` returns `None` and the entry is gone on the next call.
- [x] All 49 existing state-backend tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)