### PR TITLE
docs(template-cheatsheet): note Django {%-in-comment gotcha (#1423)

### DIFF
--- a/docs/website/guides/template-cheatsheet.md
+++ b/docs/website/guides/template-cheatsheet.md
@@ -841,3 +841,16 @@ Data passing:
   dj-value-*                      (extra value kwargs)
   dj-target="#selector"           (scoped DOM updates)
 ```
+
+## Gotchas
+
+### Don't put `{%` or `%}` inside `{# … #}` comments
+
+djust's Rust template engine handles this correctly — it treats `{# … #}` as opaque. **Django's stock template parser does not.** When a template flows through Django (e.g., the non-LiveView HTTP path, or any third-party tool that re-parses your templates), a comment that contains a partial tag string will trip Django's tokenizer:
+
+```django
+{# d-none (not {% if %}) so the VDOM ... #}        <!-- ❌ Django will choke -->
+{# d-none keeps the DOM stable so the VDOM ... #}  <!-- ✅ both engines OK -->
+```
+
+The Django error is `TemplateSyntaxError: Unexpected end of expression in if tag` from `django/template/smartif.py`. Workaround: rewrite the comment without `{%` / `%}`. (Reference: [#1423](https://github.com/djust-org/djust/issues/1423).)


### PR DESCRIPTION
## Summary

Closes #1423 as documentation-only.

The reporter hit a Django `TemplateSyntaxError` from a `{# d-none (not {% if %}) so the VDOM ... #}` comment. **Investigation finding**: djust's Rust template engine handles `{# … #}` correctly — the lexer at `crates/djust_templates/src/lexer.rs:289-304` skips opaquely until `#}` regardless of contents. Verified locally:

```python
>>> render_template('{# (not {% if %}) #}<div></div>', {})
'<div></div>'   # OK
```

The failure surfaces only when a template flows through **upstream Django**'s tokenizer (non-LiveView HTTP path, third-party doc tools that re-parse, etc.). djust can't fix Django's parser. Best we can do is warn about the trip wire.

This PR adds a Gotchas section to the template cheatsheet documenting:
- The failure mode (Django's `smartif.py: Unexpected end of expression in if tag`)
- A trivial workaround (rewrite the comment without `{%` / `%}`)
- Reference back to #1423

## Test plan

- [x] Read the rendered guide locally to verify formatting.
- [ ] Maintainer confirms the framing is right (i.e., we don't intend to "fix" Django).

🤖 Generated with [Claude Code](https://claude.com/claude-code)