### PR TITLE
feat(checks): D001 — psycopg3-required system check (#1433)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **System check `djust.D001` — warn when Postgres is configured but `psycopg[binary]>=3.2` is not installed (#1433).** djust's `db.notifications` (LISTEN/NOTIFY bridge) requires psycopg3. The 0.9.5 cycle hardened the runtime path to permanent-fail with a WARNING when `@notify_on_save` actually fires (#1357), but operators who deploy the misconfig without an active consumer wouldn't see the warning until much later. D001 surfaces it at `manage.py check` / `runserver` startup, before traffic. Fires only when the default DB engine is Postgres AND `psycopg2` is importable AND `psycopg` (3.x) is missing or at version < 3.2. Silenceable per-project via `SILENCED_SYSTEM_CHECKS = ['djust.D001']`.
+
 ### Fixed
 
 - **`InMemoryStateBackend.get()` discards corrupt entries instead of returning the shared in-memory ref (#1410).** When `RustLiveView.deserialize_msgpack` raised — typically after a hot-swap struct change or msgpack schema drift — the previous fallback returned the cached object directly. Two concurrent connections to the same view then shared one `_rust_view`, and mutations from connection A leaked into connection B's render context. After a `cargo build` of `djust_vdom` + `.so` swap, fresh navigations could re-render with state from the prior session. Now the backend pops the corrupt entry from its in-memory dict and returns `None`; the caller's mount path treats the cache as cold and runs `mount()` cleanly. Discovered during the #1408 investigation.

--- a/python/djust/checks.py
+++ b/python/djust/checks.py
@@ -2977,3 +2977,133 @@ def check_admin_widgets(app_configs, _admin_sites=None, **kwargs):
             )
 
     return results
+
+
+# ---------------------------------------------------------------------------
+# Database-driver checks (D0xx)
+# ---------------------------------------------------------------------------
+
+
+def _parse_psycopg_version(version_str: str) -> tuple:
+    """Parse a `major.minor[.patch[...]]` version string into a tuple of ints.
+
+    Returns ``(0, 0)`` on anything we can't parse — the caller treats
+    that as "couldn't determine version, don't make claims about it".
+    """
+    parts = []
+    for chunk in version_str.split(".")[:2]:
+        digits = ""
+        for ch in chunk:
+            if ch.isdigit():
+                digits += ch
+            else:
+                break
+        if not digits:
+            return (0, 0)
+        parts.append(int(digits))
+    while len(parts) < 2:
+        parts.append(0)
+    return tuple(parts[:2])
+
+
+@register("djust")
+def check_psycopg3_for_pg_notify(app_configs, **kwargs):
+    """djust.D001 — warn when Postgres is configured but psycopg3 is missing.
+
+    djust's ``db.notifications`` (LISTEN/NOTIFY bridge) requires
+    ``psycopg[binary]>=3.2``. The 0.9.5 cycle hardened the runtime path
+    to permanent-fail with a WARNING when ``@notify_on_save`` actually
+    fires (#1357), but operators who deploy the misconfig and don't have
+    any consumer running won't see that warning until much later.
+
+    This check surfaces the misconfig at ``manage.py check`` /
+    ``runserver`` startup, before traffic. It only emits when:
+
+      1. ``DATABASES['default']['ENGINE']`` is the Postgres backend.
+      2. The legacy ``psycopg2`` driver IS importable.
+      3. ``psycopg`` (3.x) is NOT importable, OR is at version < 3.2.
+
+    Scoped to ``"default"`` because that's where 99% of djust apps put
+    their primary DB; multi-database setups can silence per-project via
+    ``SILENCED_SYSTEM_CHECKS``.
+    """
+    results: list = []
+    if _is_check_suppressed("djust.D001"):
+        return results
+
+    try:
+        from django.conf import settings
+    except Exception:
+        return results
+
+    databases = getattr(settings, "DATABASES", {}) or {}
+    default = databases.get("default", {}) or {}
+    engine = default.get("ENGINE", "") or ""
+
+    # Only the postgres backend matters for LISTEN/NOTIFY.
+    if engine != "django.db.backends.postgresql":
+        return results
+
+    # If psycopg2 is NOT importable AND psycopg is NOT importable,
+    # Django itself raises an unrelated error — don't pile on.
+    try:
+        import psycopg2  # noqa: F401
+    except ImportError:
+        return results
+
+    psycopg2_version = ""
+    try:
+        psycopg2_version = getattr(psycopg2, "__version__", "")  # noqa: F821
+    except Exception:
+        pass
+
+    psycopg3_version: str | None = None
+    try:
+        import psycopg as _psycopg3
+
+        psycopg3_version = getattr(_psycopg3, "__version__", "0.0")
+    except ImportError:
+        psycopg3_version = None
+
+    needs_warning = False
+    if psycopg3_version is None:
+        needs_warning = True
+        detected_msg = "psycopg[binary]>=3.2 NOT installed"
+    else:
+        major_minor = _parse_psycopg_version(psycopg3_version)
+        if major_minor < (3, 2):
+            needs_warning = True
+            detected_msg = f"psycopg installed but at version {psycopg3_version} (need >= 3.2)"
+
+    if not needs_warning:
+        return results
+
+    psycopg2_label = (
+        f"psycopg2 (legacy driver) at version {psycopg2_version}"
+        if psycopg2_version
+        else "psycopg2 (legacy driver)"
+    )
+
+    results.append(
+        DjustWarning(
+            (
+                "Postgres LISTEN/NOTIFY (db.notifications) is unavailable because "
+                "psycopg[binary]>=3.2 is not installed.\n"
+                "  Detected: %s.\n"
+                "  Required: psycopg[binary] (psycopg3) at version >= 3.2.\n"
+                "  %s.\n"
+                "  Non-Postgres apps and apps that don't use @notify_on_save / "
+                "db.listen() are unaffected. Apps that DO use those features will "
+                "hit a permanent-failure WARNING at first NOTIFY attempt (#1357)."
+            )
+            % (psycopg2_label, detected_msg),
+            hint=(
+                "pip install 'psycopg[binary]>=3.2' — or silence with "
+                "SILENCED_SYSTEM_CHECKS = ['djust.D001'] if your app doesn't "
+                "use db.notifications."
+            ),
+            id="djust.D001",
+            fix_hint="pip install 'psycopg[binary]>=3.2'",
+        )
+    )
+    return results

--- a/python/tests/test_checks.py
+++ b/python/tests/test_checks.py
@@ -4276,3 +4276,99 @@ class TestA090DjustMarkdownCheck:
         assert len(a090) == 1
         # Message includes the total count (3).
         assert "3 location(s)" in a090[0].msg
+
+
+# ---------------------------------------------------------------------------
+# D001 -- psycopg2 installed but psycopg3 missing or too old
+# ---------------------------------------------------------------------------
+
+
+class TestD001PsycopgVersionCheck:
+    """djust.D001: warn when Postgres is configured but psycopg[binary]>=3.2 isn't installed."""
+
+    def _run(self):
+        from djust.checks import check_psycopg3_for_pg_notify
+
+        return check_psycopg3_for_pg_notify(None)
+
+    def test_no_warn_for_sqlite_engine(self, settings):
+        """Non-Postgres apps are unaffected."""
+        settings.DATABASES = {
+            "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}
+        }
+        results = self._run()
+        assert [r for r in results if r.id == "djust.D001"] == []
+
+    def test_no_warn_when_psycopg3_at_required_version(self, settings):
+        """Postgres + psycopg2 + psycopg3>=3.2 → no warning."""
+        settings.DATABASES = {"default": {"ENGINE": "django.db.backends.postgresql", "NAME": "x"}}
+        # Both modules must be importable. Patch what's likely missing
+        # in this environment via sys.modules surrogate.
+        import sys
+        import types
+
+        fake_psycopg2 = types.ModuleType("psycopg2")
+        fake_psycopg2.__version__ = "2.9.9"
+        fake_psycopg3 = types.ModuleType("psycopg")
+        fake_psycopg3.__version__ = "3.2.4"
+        with patch.dict(sys.modules, {"psycopg2": fake_psycopg2, "psycopg": fake_psycopg3}):
+            results = self._run()
+        assert [r for r in results if r.id == "djust.D001"] == []
+
+    def test_warns_when_psycopg3_missing(self, settings):
+        """Postgres + psycopg2 + no psycopg3 → D001 warning."""
+        settings.DATABASES = {"default": {"ENGINE": "django.db.backends.postgresql", "NAME": "x"}}
+        import sys
+        import types
+
+        fake_psycopg2 = types.ModuleType("psycopg2")
+        fake_psycopg2.__version__ = "2.9.9"
+        # Block psycopg3 import by putting None in sys.modules — that's
+        # the canonical way to cause `import psycopg` to raise ImportError.
+        with patch.dict(sys.modules, {"psycopg2": fake_psycopg2, "psycopg": None}):
+            results = self._run()
+        d001 = [r for r in results if r.id == "djust.D001"]
+        assert len(d001) == 1
+        assert "NOT installed" in d001[0].msg
+        assert "2.9.9" in d001[0].msg
+
+    def test_warns_when_psycopg3_too_old(self, settings):
+        """Postgres + psycopg2 + psycopg3<3.2 → D001 warning."""
+        settings.DATABASES = {"default": {"ENGINE": "django.db.backends.postgresql", "NAME": "x"}}
+        import sys
+        import types
+
+        fake_psycopg2 = types.ModuleType("psycopg2")
+        fake_psycopg2.__version__ = "2.9.9"
+        fake_psycopg3 = types.ModuleType("psycopg")
+        fake_psycopg3.__version__ = "3.1.18"
+        with patch.dict(sys.modules, {"psycopg2": fake_psycopg2, "psycopg": fake_psycopg3}):
+            results = self._run()
+        d001 = [r for r in results if r.id == "djust.D001"]
+        assert len(d001) == 1
+        assert "3.1.18" in d001[0].msg
+        assert "need >= 3.2" in d001[0].msg
+
+
+class TestParsePsycopgVersion:
+    """Internal: _parse_psycopg_version handles the common version-string shapes."""
+
+    def test_parses_standard_three_part(self):
+        from djust.checks import _parse_psycopg_version
+
+        assert _parse_psycopg_version("3.2.4") == (3, 2)
+
+    def test_parses_two_part(self):
+        from djust.checks import _parse_psycopg_version
+
+        assert _parse_psycopg_version("3.2") == (3, 2)
+
+    def test_parses_pre_release_tail(self):
+        from djust.checks import _parse_psycopg_version
+
+        assert _parse_psycopg_version("3.2.0rc1") == (3, 2)
+
+    def test_unparseable_returns_zeros(self):
+        from djust.checks import _parse_psycopg_version
+
+        assert _parse_psycopg_version("not-a-version") == (0, 0)


### PR DESCRIPTION
## Summary

Closes #1433.

New Django system check `djust.D001` (first in a new "D" / Database-driver category) that warns when:

1. `DATABASES['default']['ENGINE']` is `django.db.backends.postgresql`, AND
2. `psycopg2` (legacy driver) is importable, AND
3. `psycopg` (3.x) is NOT importable, OR is at version < 3.2

This complements the runtime permanent-fail-on-first-NOTIFY behaviour from #1357 — that stays as the last-line-of-defense, but D001 surfaces the misconfig at `manage.py check` / `runserver` startup so operators see the problem before traffic, even if no `@notify_on_save` consumer is currently running.

## Test plan

- [x] 8 new tests in `python/tests/test_checks.py`:
  - `TestD001PsycopgVersionCheck`: sqlite (no warn), pg+3.2 (no warn), pg+missing (warn), pg+too-old (warn).
  - `TestParsePsycopgVersion`: standard, two-part, pre-release-tail, unparseable inputs.
- [x] CHANGELOG `[Unreleased] ### Added` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)