### PR TITLE
perf(theming): cache theme_context output by ThemeState tuple (#1437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **`theme_context` now caches its rendered output by `ThemeState` tuple (#1437).** The Django context processor `djust.theming.context_processors.theme_context` previously ran the full CSS-generation + theme-switcher HTML pipeline on every templating request. Output is now `lru_cache(maxsize=512)`'d on `(theme, preset, pack, mode, resolved_mode, layout, presets_key)` — a pure function of state, no request data flows in. djust's catalog of ~60 presets × 2 modes × handful of packs fits comfortably under the cache size. Per-request cost: ~1-3 ms → ~5-10 µs post-warmup. New `djust.theming.context_processors.clear_theme_context_cache()` exposed for theme-pack hot-reload and tests.
 - **`TenantMiddleware` short-circuits when no resolver is configured (#1436).** When neither `DJUST_CONFIG['TENANT_RESOLVER']` nor `DJUST_TENANTS` is set, the middleware now bypasses the resolver call, the thread-local set/clear pair, and the required-tenant gate — switching `__call__` to a straight `get_response(request)` passthrough. Saves ~2-5% per-request CPU for consumers with `djust[tenants]` installed but no tenant opt-in (single-tenant deploys, scaffold starters, demo apps). Consumers who set either config keep the full path; `request.tenant` is still set to `None` on the no-op path so `getattr(request, "tenant", None)` callers see the same shape.
 
 ### Added

--- a/python/djust/tests/test_theming_context_cache.py
+++ b/python/djust/tests/test_theming_context_cache.py
@@ -1,0 +1,182 @@
+"""Tests for the theme_context per-process cache (#1437)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache_per_test():
+    """Each test starts with a clean cache so warm-state from a prior
+    test doesn't mask cold-path bugs."""
+    from djust.theming.context_processors import clear_theme_context_cache
+
+    clear_theme_context_cache()
+    yield
+    clear_theme_context_cache()
+
+
+def _make_manager(preset="default", mode="light", resolved_mode="light", pack=None, presets=None):
+    """Build a stub theme manager whose `get_state()` returns a
+    ThemeState with the given fields and `get_available_presets()`
+    returns the given preset list."""
+    from djust.theming.manager import ThemeState
+
+    state = ThemeState(
+        theme="default",
+        preset=preset,
+        mode=mode,
+        resolved_mode=resolved_mode,
+        pack=pack,
+    )
+    if presets is None:
+        presets = [
+            {"name": "default", "display_name": "Default", "is_active": preset == "default"},
+            {"name": "ocean", "display_name": "Ocean", "is_active": preset == "ocean"},
+        ]
+    mgr = MagicMock()
+    mgr.get_state.return_value = state
+    mgr.get_available_presets.return_value = presets
+    return mgr
+
+
+class TestThemeContextCache:
+    def test_two_identical_calls_render_once(self):
+        """Same (preset, pack, mode, resolved_mode, presets) on two
+        calls → CSS generation runs exactly once. Cache hit on the
+        second call."""
+        from djust.theming.context_processors import theme_context
+
+        mgr = _make_manager()
+        with (
+            patch("djust.theming.context_processors.get_theme_manager", return_value=mgr),
+            patch(
+                "djust.theming.context_processors.generate_css_for_state",
+                return_value=":root { --color: blue; }",
+            ) as mock_css,
+        ):
+            ctx1 = theme_context(MagicMock())
+            ctx2 = theme_context(MagicMock())
+        assert mock_css.call_count == 1, (
+            f"expected CSS generation to be called once (cache hit on 2nd), "
+            f"got {mock_css.call_count}"
+        )
+        # And the rendered HTML matches across both calls.
+        assert ctx1["theme_head"] == ctx2["theme_head"]
+        assert ctx1["theme_switcher"] == ctx2["theme_switcher"]
+
+    def test_different_preset_misses_cache(self):
+        """Different preset → fresh render (cache miss)."""
+        from djust.theming.context_processors import theme_context
+
+        mgr_a = _make_manager(preset="default")
+        mgr_b = _make_manager(preset="ocean")
+        with patch("djust.theming.context_processors.generate_css_for_state") as mock_css:
+            mock_css.side_effect = ["css-a", "css-b"]
+            with patch("djust.theming.context_processors.get_theme_manager", return_value=mgr_a):
+                ctx1 = theme_context(MagicMock())
+            with patch("djust.theming.context_processors.get_theme_manager", return_value=mgr_b):
+                ctx2 = theme_context(MagicMock())
+        assert mock_css.call_count == 2
+        assert "css-a" in ctx1["theme_head"]
+        assert "css-b" in ctx2["theme_head"]
+
+    def test_different_mode_misses_cache(self):
+        """Different mode (light vs dark) → fresh render."""
+        from djust.theming.context_processors import theme_context
+
+        mgr_light = _make_manager(mode="light", resolved_mode="light")
+        mgr_dark = _make_manager(mode="dark", resolved_mode="dark")
+        with patch(
+            "djust.theming.context_processors.generate_css_for_state", return_value="x"
+        ) as mock_css:
+            with patch(
+                "djust.theming.context_processors.get_theme_manager", return_value=mgr_light
+            ):
+                theme_context(MagicMock())
+            with patch("djust.theming.context_processors.get_theme_manager", return_value=mgr_dark):
+                theme_context(MagicMock())
+        assert mock_css.call_count == 2
+
+    def test_different_pack_misses_cache(self):
+        """Different pack → fresh render."""
+        from djust.theming.context_processors import theme_context
+
+        mgr_a = _make_manager(pack=None)
+        mgr_b = _make_manager(pack="shadcn-default")
+        with patch(
+            "djust.theming.context_processors.generate_css_for_state", return_value="x"
+        ) as mock_css:
+            with patch("djust.theming.context_processors.get_theme_manager", return_value=mgr_a):
+                theme_context(MagicMock())
+            with patch("djust.theming.context_processors.get_theme_manager", return_value=mgr_b):
+                theme_context(MagicMock())
+        assert mock_css.call_count == 2
+
+    def test_different_presets_list_misses_cache(self):
+        """Adding/removing a theme preset (e.g., a hot-reload of the
+        manifest) must invalidate the cache for that key. The presets
+        list is part of the cache key."""
+        from djust.theming.context_processors import theme_context
+
+        presets_a = [
+            {"name": "default", "display_name": "Default", "is_active": True},
+        ]
+        presets_b = [
+            {"name": "default", "display_name": "Default", "is_active": True},
+            {"name": "newly-added", "display_name": "New One", "is_active": False},
+        ]
+        mgr_a = _make_manager(presets=presets_a)
+        mgr_b = _make_manager(presets=presets_b)
+        with patch(
+            "djust.theming.context_processors.generate_css_for_state", return_value="x"
+        ) as mock_css:
+            with patch("djust.theming.context_processors.get_theme_manager", return_value=mgr_a):
+                theme_context(MagicMock())
+            with patch("djust.theming.context_processors.get_theme_manager", return_value=mgr_b):
+                theme_context(MagicMock())
+        assert mock_css.call_count == 2
+
+    def test_clear_cache_drops_warm_state(self):
+        """clear_theme_context_cache() forces a fresh render on next
+        call — used for theme-pack hot-reload."""
+        from djust.theming.context_processors import (
+            clear_theme_context_cache,
+            theme_context,
+        )
+
+        mgr = _make_manager()
+        with (
+            patch("djust.theming.context_processors.get_theme_manager", return_value=mgr),
+            patch(
+                "djust.theming.context_processors.generate_css_for_state", return_value="x"
+            ) as mock_css,
+        ):
+            theme_context(MagicMock())
+            clear_theme_context_cache()
+            theme_context(MagicMock())
+        assert mock_css.call_count == 2
+
+    def test_request_object_does_not_leak_into_cached_output(self):
+        """The cached function takes only the (preset, pack, mode,
+        resolved_mode, presets_key) tuple — nothing from request flows
+        in. Two requests with different `request.user`, `request.path`,
+        etc. but same theme state get the SAME bytes."""
+        from djust.theming.context_processors import theme_context
+
+        mgr = _make_manager()
+        with (
+            patch("djust.theming.context_processors.get_theme_manager", return_value=mgr),
+            patch("djust.theming.context_processors.generate_css_for_state", return_value="x"),
+        ):
+            req1 = MagicMock()
+            req1.user.id = 1
+            req1.path = "/a"
+            req2 = MagicMock()
+            req2.user.id = 999
+            req2.path = "/b/different"
+            ctx1 = theme_context(req1)
+            ctx2 = theme_context(req2)
+        # Identical bytes → no per-request leakage.
+        assert ctx1["theme_head"] == ctx2["theme_head"]
+        assert ctx1["theme_switcher"] == ctx2["theme_switcher"]

--- a/python/djust/theming/context_processors.py
+++ b/python/djust/theming/context_processors.py
@@ -4,10 +4,91 @@ Context processors for djust_theming.
 Adds theme CSS and state to template context.
 """
 
+from functools import lru_cache
+
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils.safestring import mark_safe
 
-from .manager import generate_css_for_state, get_css_prefix, get_theme_manager
+from .manager import (
+    ThemeState,
+    generate_css_for_state,
+    get_css_prefix,
+    get_theme_manager,
+)
+
+# Anti-FOUC script — static; defined at module load (NOT per-request).
+_ANTI_FOUC_SCRIPT = """<script>
+(function() {
+    var storageKey = 'djust-theme-mode';
+    var storedMode = localStorage.getItem(storageKey);
+    var mode = storedMode || 'system';
+    var resolvedMode = mode;
+    if (mode === 'system') {
+        resolvedMode = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    document.documentElement.setAttribute('data-theme', resolvedMode);
+    document.documentElement.setAttribute('data-theme-mode', mode);
+})();
+</script>"""
+
+
+@lru_cache(maxsize=512)
+def _render_theme_outputs(theme, preset, pack, mode, resolved_mode, layout, presets_key):
+    """Pure-function render of (theme_head_html, theme_switcher_html).
+
+    Cached because the output is byte-identical for the same theme
+    `(theme, preset, pack, mode, resolved_mode, layout)` tuple on a
+    given preset list. djust's whole catalog is ~60 presets × 2 modes
+    × handful of packs = a few hundred unique keys, well under
+    maxsize=512.
+
+    `presets_key` is a hashable digest of the available-presets list.
+    The list itself is unhashable (list of dicts), so the caller
+    passes a tuple-of-tuples representation as the cache key and the
+    rebuild reconstructs presets from that tuple.
+
+    Per #1437: ~1-3 ms per request → ~5-10 µs (dict lookup) post-warmup
+    on every template-rendering request. The cache is per-process;
+    that's fine because the function is genuinely a pure function —
+    no request data leaks in.
+    """
+    state = ThemeState(
+        theme=theme,
+        preset=preset,
+        mode=mode,
+        resolved_mode=resolved_mode,
+        pack=pack,
+        layout=layout,
+    )
+    css = generate_css_for_state(state, css_prefix=get_css_prefix())
+    js_url = staticfiles_storage.url("djust_theming/js/theme.js")
+    theme_head = (
+        f"{_ANTI_FOUC_SCRIPT}\n"
+        f"<style data-djust-theme>{css}</style>\n"
+        f'<script src="{js_url}" defer></script>'
+    )
+    presets = [dict(t) for t in presets_key]
+    theme_switcher = _render_theme_switcher(state, presets)
+    return theme_head, theme_switcher
+
+
+def _presets_to_cache_key(presets):
+    """Convert the available-presets list (list of dicts) into a
+    hashable tuple-of-tuples for use as an `lru_cache` key. Only the
+    fields actually consumed by `_render_theme_switcher` are kept."""
+    return tuple(
+        tuple(sorted((k, v) for k, v in p.items() if k in {"name", "display_name", "is_active"}))
+        for p in presets
+    )
+
+
+def clear_theme_context_cache():
+    """Drop the per-process render cache.
+
+    Call this on theme-pack reload, or in tests that mutate theme state
+    between assertions. Cheap; the cache rebuilds lazily.
+    """
+    _render_theme_outputs.cache_clear()
 
 
 def theme_context(request):
@@ -22,33 +103,18 @@ def theme_context(request):
     """
     manager = get_theme_manager(request)
     state = manager.get_state()
+    presets = manager.get_available_presets()
+    presets_key = _presets_to_cache_key(presets)
 
-    # Generate CSS - use pack generator if pack is set, otherwise use theme generator
-    css = generate_css_for_state(state, css_prefix=get_css_prefix())
-
-    # Anti-FOUC script
-    anti_fouc_script = """<script>
-(function() {
-    var storageKey = 'djust-theme-mode';
-    var storedMode = localStorage.getItem(storageKey);
-    var mode = storedMode || 'system';
-    var resolvedMode = mode;
-    if (mode === 'system') {
-        resolvedMode = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    document.documentElement.setAttribute('data-theme', resolvedMode);
-    document.documentElement.setAttribute('data-theme-mode', mode);
-})();
-</script>"""
-
-    # Complete theme head HTML
-    js_url = staticfiles_storage.url("djust_theming/js/theme.js")
-    theme_head = f"""{anti_fouc_script}
-<style data-djust-theme>{css}</style>
-<script src="{js_url}" defer></script>"""
-
-    # Theme switcher HTML
-    theme_switcher = _render_theme_switcher(state, manager.get_available_presets())
+    theme_head, theme_switcher = _render_theme_outputs(
+        state.theme,
+        state.preset,
+        state.pack,
+        state.mode,
+        state.resolved_mode,
+        state.layout,
+        presets_key,
+    )
 
     return {
         "theme_head": mark_safe(theme_head),
@@ -56,7 +122,7 @@ def theme_context(request):
         "theme_preset": state.preset,
         "theme_mode": state.mode,
         "theme_resolved_mode": state.resolved_mode,
-        "theme_presets": manager.get_available_presets(),
+        "theme_presets": presets,
     }
 
 


### PR DESCRIPTION
## Summary

Closes #1437.

`theme_context` ran the CSS-generation + theme-switcher HTML pipeline on every templating request. The output is byte-identical for a given `ThemeState` tuple — pure function of state, no request data flows in. Wrap with `@lru_cache(maxsize=512)`.

Per-request cost: ~1-3 ms → ~5-10 µs (dict lookup + tuple unpack) post-warmup. djust's whole catalog of ~60 presets × 2 modes × handful of packs fits well under the cache size.

## Cache key shape

`(theme, preset, pack, mode, resolved_mode, layout, presets_key)`

The available-presets list (unhashable list of dicts) is normalized to a sorted tuple-of-tuples via `_presets_to_cache_key`, keeping only the fields the switcher consumes (`name`, `display_name`, `is_active`).

## Invalidation

`djust.theming.context_processors.clear_theme_context_cache()` is exposed for:
- Theme-pack hot-reload (when the manifest changes)
- Tests that mutate theme state between assertions

## Test plan

- [x] 7 regression tests in `test_theming_context_cache.py`:
  - Repeat call → cache hit (CSS-generation runs once)
  - Different preset / mode / pack / presets list → cache miss
  - `clear_theme_context_cache()` drops warm state
  - **`request` object does NOT leak into cached output** — different `request.user`, `request.path` with same state → byte-identical bytes
- [x] All 42 existing theming tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)