### PR TITLE
docs(canon): v0.9.6-1 retro canon batch (#1445/#1446/#1447/#1450)

### DIFF
--- a/.pipeline-templates/bugfix-state.json
+++ b/.pipeline-templates/bugfix-state.json
@@ -431,6 +431,11 @@
       "subagent_prompt": "You are reviewing PR #{pr_number}. Project: {project_path}. PR targets {pr_target_branch}. BUDGET (#1211, v0.9.5 retro Action Tracker #192): cap your final review comment at 250 words. For security-related changes, enumerate at most the attack shapes the plan documented — do NOT spelunk for additional edge cases beyond that list. PR #1201's reviewer stalled at the 10-min watchdog mid-tangent on backslash-injection; tight scoped reviews find real gaps without watchdog risk. Step 0: Read .pipeline-state/*-plan.md for the original plan. Step 1: Run git diff {pr_target_branch}...HEAD, read changed files. Check docs/PULL_REQUEST_CHECKLIST.md if exists — use as review framework. Step 2: Cross-ref plan vs implementation — verify every planned deliverable was implemented. Step 2b: Cross-ref the plan's test list against actual test files — every test the plan specified must exist. Step 3: Review for correctness, security (XSS, injection, secrets exposure — only the shapes the plan documented), testing gaps, code quality (print vs logging, except:pass), docs, perf, architecture. Flag auto-reject triggers. Step 4: Run project test suite, report pass/fail. Step 5: Decide APPROVE/REQUEST_CHANGES/COMMENT. Step 6 MANDATORY: Post review to GitHub with gh pr review {pr_number} --comment --body '<formatted review under 250 words>'. If REQUEST_CHANGES use --request-changes. Save to pr/feedback/ if dir exists. Step 7: Output verdict.",
       "checklist": [
         {
+          "action": "Stage-11 stale-base check (#1450 / Action #250): run `git fetch origin && BEHIND=$(git rev-list --count HEAD..origin/{pr_target_branch})`. If BEHIND > 0, STOP. The branch is reviewing against a stale base; the merge applies on top of CURRENT main. Rebase (`git rebase origin/{pr_target_branch}`) BEFORE reviewing.",
+          "done": false,
+          "mandatory": true
+        },
+        {
           "action": "read .pipeline-state/<branch>-plan.md for plan compliance check",
           "done": false
         },

--- a/.pipeline-templates/feature-state.json
+++ b/.pipeline-templates/feature-state.json
@@ -421,6 +421,11 @@
       "subagent_prompt": "You are reviewing PR #{pr_number}. Project: {project_path}. PR targets {pr_target_branch}. BUDGET (#1211, v0.9.5 retro Action Tracker #192): cap your final review comment at 350 words. Feature PRs allow exploration of edge cases tied to the planned feature only — do NOT spelunk for additional edge cases beyond what the plan scope covers. For security-related changes, enumerate at most the attack shapes the plan documented. PR #1201's reviewer stalled at the 10-min watchdog mid-tangent on backslash-injection; tight scoped reviews find real gaps without watchdog risk. Step 0: Read .pipeline-state/*-plan.md for the original plan. Step 1: Run git diff {pr_target_branch}...HEAD, read changed files. Check docs/PULL_REQUEST_CHECKLIST.md if exists — use as review framework. Step 2: Cross-ref plan vs implementation — verify every planned deliverable was implemented. Step 2b: Cross-ref the plan's test list against actual test files — every test the plan specified must exist. Step 3: Review for correctness, security (XSS, injection, secrets exposure — only the shapes the plan documented), testing gaps, code quality (print vs logging, except:pass), docs, perf, architecture. Flag auto-reject triggers. Step 4: Run project test suite, report pass/fail. Step 5: Decide APPROVE/REQUEST_CHANGES/COMMENT. Step 6 MANDATORY: Post review to GitHub with gh pr review {pr_number} --comment --body '<formatted review under 350 words>'. If REQUEST_CHANGES use --request-changes. Save to pr/feedback/ if dir exists. Step 7: Output verdict.",
       "checklist": [
         {
+          "action": "Stage-11 stale-base check (#1450 / Action #250): run `git fetch origin && BEHIND=$(git rev-list --count HEAD..origin/{pr_target_branch})`. If BEHIND > 0, STOP. The branch is reviewing against a stale base; the merge applies on top of CURRENT main. Rebase (`git rebase origin/{pr_target_branch}`) BEFORE reviewing.",
+          "done": false,
+          "mandatory": true
+        },
+        {
           "action": "read .pipeline-state/<branch>-plan.md for plan compliance check",
           "done": false
         },

--- a/.pipeline-templates/ship-state.json
+++ b/.pipeline-templates/ship-state.json
@@ -250,6 +250,11 @@
       "subagent_prompt": "You are reviewing PR #{pr_number}. Project: {project_path}. PR targets {pr_target_branch}. Step 1: Run git diff {pr_target_branch}...HEAD, read changed files. Check docs/PULL_REQUEST_CHECKLIST.md if exists. Step 2: Review for correctness, security (XSS, injection, secrets exposure), testing gaps, code quality (print vs logging, except:pass), docs, perf, architecture. Flag auto-reject triggers. Step 3: Run project test suite, report pass/fail. Step 4: Decide APPROVE/REQUEST_CHANGES/COMMENT. Step 5 MANDATORY: Post review to GitHub with gh pr review {pr_number} --comment --body '<formatted review with checklist>'. If REQUEST_CHANGES use --request-changes. Step 6: Output verdict.",
       "checklist": [
         {
+          "action": "Stage-11 stale-base check (#1450 / Action #250): run `git fetch origin && BEHIND=$(git rev-list --count HEAD..origin/{pr_target_branch})`. If BEHIND > 0, STOP. The branch is reviewing against a stale base; the merge applies on top of CURRENT main. Rebase (`git rebase origin/{pr_target_branch}`) BEFORE reviewing.",
+          "done": false,
+          "mandatory": true
+        },
+        {
           "action": "git diff against target branch",
           "done": false
         },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -777,6 +777,31 @@ Rules distilled from the v0.9.3-4 audit and process drain bucket.
   (split-foundation pattern) primary value is API design lock-in, not
   calendar soak.
 
+## Process canonicalizations from v0.9.6-1 retro arc
+
+Five rules from the v0.9.6-1 retro tracker rows #245–#250 (PRs #1431, #1438, #1441, #1442, #1443, #1444). Canonicalized here so the next milestone doesn't repeat the failure modes.
+
+- **Lock-release/lock-reacquire TOCTOU rule (#245 / #1445).** When a code path acquires a lock, releases for unlocked work (CPU-only round-trips, network calls, async yields), then re-acquires the lock to mutate state, the entry it's mutating may have been replaced by a concurrent writer. Identity-guard the mutation (`current is original_ref`) or version-counter check at re-entry. Same class of failure as Action #1198 (`commit-or-rollback handler shape`) but for lock-windows rather than await-windows. Canonical case study: PR #1438's `python/djust/state_backends/memory.py:117-141` — the first-pass fail-closed pop did `lock → read → unlock → round-trip → relock → pop(key)` and a concurrent `set(key, new_view)` in the unlock window would have been clobbered. Identity-guarded with `current[0] is view`.
+
+- **Zero-cost-when-unused middleware/processor pattern (#246 / #1446).** Any middleware or context-processor for an optional djust extra (`tenants`, `theming`, `presence`, `streaming`, etc.) should detect "not opted in" once in `__init__` and switch the hot path to a no-op that just calls `get_response(request)`. Preserve attribute existence on `request` (e.g., `request.tenant = None`) so `getattr(request, "X", None)` callers see the same shape. Canonical case studies: PR #1441 (`TenantMiddleware` short-circuits when neither `DJUST_CONFIG['TENANT_RESOLVER']` nor `DJUST_TENANTS` is set) and PR #1443 (`theme_context` pre-rendering with fail-soft empty-string fallback). Saves ~2-5% per-request CPU when unused.
+
+- **Cache-by-struct: include all fields upfront, prune later (#247 / #1447).** When wrapping a function whose inputs are derived from a struct, the cache key MUST include every field of the struct. Pruning a field later (because profiling shows it doesn't matter) is a one-line change with a regression test. Adding a field later means cache-poisoning bugs in production — two callers with different field-N values get the same cached output. Canonical case study: PR #1442's `_render_theme_outputs` initially keyed on `(preset, pack, mode, resolved_mode, presets_key)` but missed `theme` and `layout`; test failure caught it pre-merge.
+
+- **Wire-protocol JSON pinning as a standard test class (#248 / #1448).** Any Rust↔JS or Python↔JS wire-format that's a `serde`/`json.dumps`-derived contract with a client gets a snapshot-test file. Existing tests verify *semantics* (`this input produces this output`); the new class pins the *JSON shape*. A field rename or `#[serde(skip_serializing_if = "Option::is_none")]` removal would silently break every deployed client running an older bundle. Canonical case study: PR #1444's `crates/djust_vdom/tests/wire_protocol_snapshot.rs` (16 literal-string assertions for every Patch variant + VNode struct + every optional-field permutation).
+
+- **Stage 11 must verify branch is not stale vs base BEFORE reviewing (#250 / #1450).** Any PR opened a non-trivial number of commits ago + not rebased gets a stale-base diff. The reviewer reviews against THAT base; the merge applies on top of CURRENT main. The two are different programs. Canonical case study: PR #1431 was 7 PRs behind main; the diff vs main *deleted* 5 CHANGELOG entries, the entire v0.9.6-1 retro, the wire-protocol snapshot test, and reverted the perf rewrites — merging would have silently undone v0.9.6-1. All 13 CI checks were green; the merge button looked safe. The reviewer subagent caught it via `git log main..HEAD --oneline` showing only 1 commit despite 7 on main since branch base. Mandatory Stage 11 check:
+
+```bash
+git fetch origin
+BEHIND=$(git rev-list --count HEAD..origin/<base>)
+if [ "$BEHIND" -gt 0 ]; then
+  echo "STOP: branch is $BEHIND commits behind origin/<base>. Rebase before reviewing."
+  exit 1
+fi
+```
+
+If BEHIND > 0, STOP. Rebase (`git rebase origin/<base>`) or merge base into branch BEFORE reviewing. Reviewing against a stale base reviews a different program than the merge will apply.
+
 ## Additional Documentation
 
 - `docs/PULL_REQUEST_CHECKLIST.md` — PR review checklist


### PR DESCRIPTION
## Summary

Closes #1445 #1446 #1447 #1450.

Canon-doc batch from the v0.9.6-1 retro. Five rules added to CLAUDE.md + Stage 11 stale-base check added to all three pipeline-state templates.

| Rule | Action # | Issue | Case study |
|---|---|---|---|
| Lock-release/lock-reacquire TOCTOU (generalize #1198 to lock-windows) | #245 | #1445 | PR #1438 |
| Zero-cost-when-unused middleware/processor pattern | #246 | #1446 | PR #1441, #1443 |
| Cache-by-struct: include all fields upfront | #247 | #1447 | PR #1442 |
| Wire-protocol JSON pinning standard test class | #248 | #1448 | PR #1444 (#1448 stays open for the other 5 contracts) |
| Stage 11 must verify branch is not stale vs base | #250 | #1450 | PR #1431 |

## Test plan

- [x] CLAUDE.md additions validate as markdown (no broken links).
- [x] Pipeline state templates parse as valid JSON.
- [x] Stage 11 stale-base check command works locally: `git fetch origin && git rev-list --count HEAD..origin/main` returns a number on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)