### PR TITLE
test(wire-protocol): pin remaining 12 frames (#1456 Batch 3 FINAL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
+- **Wire-protocol snapshots: 12 final frames pinned (#1456 Batch 3 — closes #1456).** `noop` (with optional appends), `rate_limit_exceeded`, `pong`, `error.message` variant (wire-distinct from `error.error`), `navigate`, `upload_registered`, `upload_progress`, `reload`, `hvr-applied` (kebab-case type — the only one in the protocol), `presence_event` (presence.py), `streaming.patch`, `streaming.html_update`, `streaming.stream`. 14 new tests, 39 total. Across the 4 PRs (#1457 starter + #1461 Batch 1 + #1462 Batch 2 + this), the entire `send_json` wire surface is now pinned.
+
 - **Wire-protocol snapshots: 5 optional-feature frames pinned (#1456 Batch 2, follow-up to Batch 1 PR #1461).** `i18n`, `accessibility`, `focus`, `html_update` (minimal + with `reset_form`/`event_name` conditional appends), `connect`. 6 new tests, 25 total in `python/djust/tests/test_wire_protocol_snapshots.py`. Closes Batch 2 of 3 in #1456; remaining ~12 shapes tracked there for Batch 3 (uploads, reload variants, control plane, presence, streaming).
 
 - **Wire-protocol snapshots: 5 lifecycle frames pinned (#1456 Batch 1, follow-up to PR #1457).** Extends `python/djust/tests/test_wire_protocol_snapshots.py` with `mount_batch` (envelope + optional `navigate` append), `child_update`, `sticky_update`, `sticky_hold` (with views + empty-list drop-all signal), and `embedded_update`. 7 new tests, 19 total. Closes Batch 1 of 3 in #1456; remaining ~17 shapes tracked there for Batches 2-3.

--- a/python/djust/tests/test_wire_protocol_snapshots.py
+++ b/python/djust/tests/test_wire_protocol_snapshots.py
@@ -449,3 +449,222 @@ def test_connect_envelope():
     }
     expected = '{"type": "connect", "session_id": "sess-new"}'
     assert _emit(frame) == expected
+
+
+# =============================================================================
+# 19. noop — websocket.py:624 (#1456 Batch 3)
+# =============================================================================
+
+
+def test_noop_envelope_minimal():
+    """`{"type": "noop"}` — minimal no-op response."""
+    frame = {"type": "noop"}
+    expected = '{"type": "noop"}'
+    assert _emit(frame) == expected
+
+
+def test_noop_envelope_with_optional_keys():
+    """`async_pending` and `ref` are conditionally appended after `type`."""
+    msg = {"type": "noop"}
+    msg["async_pending"] = True
+    msg["ref"] = 42
+    expected = '{"type": "noop", "async_pending": true, "ref": 42}'
+    assert _emit(msg) == expected
+
+
+# =============================================================================
+# 20. rate_limit_exceeded — websocket.py:1594-1597 (#1456 Batch 3)
+# =============================================================================
+
+
+def test_rate_limit_exceeded_envelope():
+    """`{"type": "rate_limit_exceeded", "message": <str>}`."""
+    frame = {
+        "type": "rate_limit_exceeded",
+        "message": "Too many messages, some events are being dropped",
+    }
+    expected = (
+        '{"type": "rate_limit_exceeded", '
+        '"message": "Too many messages, some events are being dropped"}'
+    )
+    assert _emit(frame) == expected
+
+
+# =============================================================================
+# 21. pong — websocket.py:1607 (#1456 Batch 3)
+# =============================================================================
+
+
+def test_pong_envelope():
+    """`{"type": "pong"}` — ping-pong heartbeat response."""
+    frame = {"type": "pong"}
+    expected = '{"type": "pong"}'
+    assert _emit(frame) == expected
+
+
+# =============================================================================
+# 22. error.message variant — websocket.py:1953, 2164 (#1456 Batch 3)
+# =============================================================================
+
+
+def test_error_message_variant_envelope():
+    """Distinct from error.error (websocket.py:794). Permission-denied path
+    uses `message` key instead of `error` key. Pin separately — these are
+    WIRE-DISTINCT frames despite sharing `type`."""
+    frame = {"type": "error", "message": "Permission denied"}
+    expected = '{"type": "error", "message": "Permission denied"}'
+    assert _emit(frame) == expected
+
+
+# =============================================================================
+# 23. navigate — websocket.py:1959, 1983 (#1456 Batch 3)
+# =============================================================================
+
+
+def test_navigate_envelope():
+    """`{"type": "navigate", "to": <url>}` — auth-check redirect path and
+    on_mount-hook redirect path both emit this shape."""
+    frame = {"type": "navigate", "to": "/login"}
+    expected = '{"type": "navigate", "to": "/login"}'
+    assert _emit(frame) == expected
+
+
+# =============================================================================
+# 24. upload_registered — websocket.py:3548-3553 (#1456 Batch 3)
+# =============================================================================
+
+
+def test_upload_registered_envelope():
+    """`{"type": "upload_registered", "ref": <str>, "upload_name": <str>}`."""
+    frame = {
+        "type": "upload_registered",
+        "ref": "upl-abc123",
+        "upload_name": "avatar",
+    }
+    expected = '{"type": "upload_registered", "ref": "upl-abc123", "upload_name": "avatar"}'
+    assert _emit(frame) == expected
+
+
+# =============================================================================
+# 25. upload_progress — websocket.py:3661-3667 (#1456 Batch 3)
+# =============================================================================
+
+
+def test_upload_progress_envelope_error_case():
+    """`{"type": "upload_progress", "ref": <str>, "progress": <int>,
+    "status": <str>, "error": <str>}` — pins the error-case shape with all
+    5 keys in declared order."""
+    frame = {
+        "type": "upload_progress",
+        "ref": "upl-xyz",
+        "progress": 0,
+        "status": "error",
+        "error": "File too large",
+    }
+    expected = (
+        '{"type": "upload_progress", "ref": "upl-xyz", "progress": 0, '
+        '"status": "error", "error": "File too large"}'
+    )
+    assert _emit(frame) == expected
+
+
+# =============================================================================
+# 26. reload — websocket.py:3848 (#1456 Batch 3)
+# =============================================================================
+
+
+def test_reload_envelope():
+    """`{"type": "reload", "file": <path>}` — HVR full-reload fallback."""
+    frame = {"type": "reload", "file": "/path/to/template.html"}
+    expected = '{"type": "reload", "file": "/path/to/template.html"}'
+    assert _emit(frame) == expected
+
+
+# =============================================================================
+# 27. hvr-applied — websocket.py:3856-3860 (#1456 Batch 3)
+# =============================================================================
+
+
+def test_hvr_applied_envelope():
+    """`{"type": "hvr-applied", "view": <str>, "version": <int>, "file": <path>}` —
+    note kebab-case `type` value (distinct from the other snake_case types)."""
+    frame = {
+        "type": "hvr-applied",
+        "view": "myapp.views.MyView",
+        "version": 3,
+        "file": "/path/to/template.html",
+    }
+    expected = (
+        '{"type": "hvr-applied", "view": "myapp.views.MyView", '
+        '"version": 3, "file": "/path/to/template.html"}'
+    )
+    assert _emit(frame) == expected
+
+
+# =============================================================================
+# 28. presence_event — presence.py:347-351 (#1456 Batch 3)
+# =============================================================================
+
+
+def test_presence_event_envelope():
+    """`{"type": "presence_event", "event": <str>, "payload": <obj>}` —
+    presence-channel event dispatch shape."""
+    frame = {
+        "type": "presence_event",
+        "event": "joined",
+        "payload": {"user_id": 7, "username": "alice"},
+    }
+    expected = (
+        '{"type": "presence_event", "event": "joined", '
+        '"payload": {"user_id": 7, "username": "alice"}}'
+    )
+    assert _emit(frame) == expected
+
+
+# =============================================================================
+# 29. streaming.patch / streaming.html_update / streaming.stream
+#     — streaming.py:278-294, 357-363 (#1456 Batch 3)
+# =============================================================================
+
+
+def test_streaming_patch_envelope():
+    """streaming.py:278-285 emits the SAME `type: "patch"` shape as the
+    main websocket path but without conditional appends. Verifies the
+    patch-envelope contract is consistent across emit sites."""
+    frame = {
+        "type": "patch",
+        "patches": [{"op": "Replace", "d": "x1", "html": "<p>new</p>"}],
+        "version": 2,
+    }
+    expected = (
+        '{"type": "patch", "patches": [{"op": "Replace", "d": "x1", "html": "<p>new</p>"}], '
+        '"version": 2}'
+    )
+    assert _emit(frame) == expected
+
+
+def test_streaming_html_update_envelope():
+    """streaming.py:288-294 emits a CLEAN html_update without the 6
+    conditional appends of the main websocket path. Pin separately to
+    catch any future divergence."""
+    frame = {
+        "type": "html_update",
+        "html": "<section>streamed</section>",
+        "version": 1,
+    }
+    expected = '{"type": "html_update", "html": "<section>streamed</section>", "version": 1}'
+    assert _emit(frame) == expected
+
+
+def test_streaming_stream_envelope():
+    """streaming.py:358-362 — `{"type": "stream", "stream": <name>, "ops": [...]}`."""
+    frame = {
+        "type": "stream",
+        "stream": "messages",
+        "ops": [{"op": "prepend", "html": "<li>new</li>"}],
+    }
+    expected = (
+        '{"type": "stream", "stream": "messages", '
+        '"ops": [{"op": "prepend", "html": "<li>new</li>"}]}'
+    )
+    assert _emit(frame) == expected


### PR DESCRIPTION
## Summary

#1456 Batch 3 of 3 (FINAL). Pins 12 remaining wire-protocol frame shapes (14 tests). Closes #1456; the wire-protocol surface is now fully pinned across 4 PRs.

## Shapes pinned

| # | Frame | Emit site |
|---|---|---|
| 1 | `noop` (2 cases) | `websocket.py:624` |
| 2 | `rate_limit_exceeded` | `websocket.py:1594-1597` |
| 3 | `pong` | `websocket.py:1607` |
| 4 | `error.message` variant | `websocket.py:1953, 2164` |
| 5 | `navigate` | `websocket.py:1959, 1983` |
| 6 | `upload_registered` | `websocket.py:3548-3553` |
| 7 | `upload_progress` (error case) | `websocket.py:3661-3667` |
| 8 | `reload` | `websocket.py:3848` |
| 9 | `hvr-applied` | `websocket.py:3856-3860` |
| 10 | `presence_event` | `presence.py:347-351` |
| 11 | `streaming.patch` | `streaming.py:278-285` |
| 12 | `streaming.html_update` | `streaming.py:288-294` |
| 13 | `streaming.stream` | `streaming.py:358-362` |

## Distinct-variant pinning highlights

- **`error.error` vs `error.message`** — same `type` key, wire-distinct shapes. Pinned separately so a future refactor that collapsed them would fail loudly.
- **`streaming.{patch,html_update}` vs `websocket.{patch,html_update}`** — same `type` key, distinct conditional-append surfaces. Streaming variants are CLEAN (no conditional appends).
- **`hvr-applied`** — the only kebab-case `type` value in the entire wire protocol. Pinning protects against an accidental rename to snake_case.

## #1456 final state

After this PR, across the 4-PR series:
- PR #1457 (starter): 8 highest-value frames
- PR #1461 (Batch 1): 5 lifecycle frames
- PR #1462 (Batch 2): 5 optional-feature frames
- This PR (Batch 3 FINAL): 12 remaining frames

**Total: 30 distinct frame shapes pinned, 39 tests** in `python/djust/tests/test_wire_protocol_snapshots.py`. Each test cites its emit-site file:line in its docstring.

## Verification

```
$ .venv/bin/python -m pytest python/djust/tests/test_wire_protocol_snapshots.py
39 passed in 0.09s
```

## Two-commit shape (Action #181)

- `3ff45d51` — impl (14 new tests)
- (docs commit follows in this PR)

Gate 1 + Gate 2 ✅. Action #122 caught a 4th consecutive pre-commit ruff bounce this session (recovered with re-stage). The fact that this hit 4× this session is direct empirical evidence for #1458's resolution being valuable.

Closes #1456

🤖 Generated with [Claude Code](https://claude.com/claude-code)