### PR TITLE
docs(canon): #1467 investigation closure + LiveComponent/sticky-child routing canon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -837,6 +837,24 @@ One rule from the v0.9.7-2 drain (PR #1466 — clean-redo of stale PR #1429 via 
 
   **Where this lives now**: `docs/PULL_REQUEST_CHECKLIST.md` Test Quality section as a one-bullet requirement. Out-of-repo follow-up: the implementer-subagent prompt template in the pipeline-run skill repository should add a Verification-section step calling this out explicitly.
 
+## Process canonicalizations from v0.9.7-3 retro arc
+
+One rule from the v0.9.7-3 drain (PRs #1469, #1470 + the #1467 investigation).
+
+- **LiveComponent vs sticky-child LiveView event-routing distinction (#1467 investigation).** Two distinct mechanisms exist for embedded children in a djust page; they look similar from a template/user perspective but route events through different code paths and have different persistence semantics:
+
+  1. **LiveComponents** (`python/djust/components/base.py` `LiveComponent`): assigned as parent attributes (`self.foo = MyComponent(...)`); routed via `component_id` param; resolved at `python/djust/websocket.py:2856` via `self.view_instance._components.get(component_id)`; persisted via `_save_components_to_session` walking parent's `get_context_data()`.
+
+  2. **Sticky-child LiveViews** (`{% live_render %}`-embedded full `LiveView` subclasses): registered via `StickyChildRegistry._register_child`; routed via `view_id` param; resolved at `python/djust/websocket.py:2689-2696` via `self.view_instance._get_all_child_views()`; NOT persisted (gap; tracked at #1471).
+
+  **Implication for save-block work**: when the `handle_event` save block gates on `target_view is self.view_instance`, only sticky-child events are skipped (LiveComponent events pass the gate because `target_view` stays as parent — `component_id` routing doesn't reassign `target_view`). PR #1466's gate was originally written about "child LiveComponent views" but the actual path it gates is sticky-children. Future readers should not conflate these.
+
+  **Investigation cost saved**: ~1 hour of code-path tracing at Stage 4 of #1467. The issue body and #1466's gate comment both used "LiveComponent" loosely to mean "embedded child"; tracing the routing showed LiveComponents already persist via the existing parent-save path, and only sticky-child LiveViews need new architectural work.
+
+  **Where this lives now**: this CLAUDE.md section + the #1467 close comment + the #1471 follow-up issue body.
+
+  **Generalized rule for child-routing PRs**: when working on `handle_event`-adjacent code, explicitly state whether the change targets LiveComponents (`component_id`), sticky-child LiveViews (`view_id`), or both. Test the routing path you claim to affect — a `component_id`-routed test does NOT exercise the sticky-child path, and vice versa.
+
 ## Additional Documentation
 
 - `docs/PULL_REQUEST_CHECKLIST.md` — PR review checklist

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -385,7 +385,7 @@ The bug class is: *the only object-level auth surface djust offers (`check_permi
 |---|---|---|---|---|
 | 1 | #1468 | Implementer-subagent prompt must mandate gate-the-change-off tautology self-test before reporting tests passing. One-bullet PR-checklist addition + CLAUDE.md case study from PR #1466 (4/7 first-pass tautology rate caught by Stage 11). Lowest-risk, highest-leverage of the three | P2 docs/canon | ~30-45 min |
 | 2 | #1464 | Pre-commit ruff auto-restage IMPLEMENTATION (#1458 investigation closed with 3 options). Empirical case: 5 ruff-bounces caught by Action #122 across PRs #1454/#1457/#1462/#1463/#1466 this session. Recommend Option A (wrapper script `scripts/git-commit-with-precommit.sh`) as lowest-risk first step | P2 tooling | ~1-1.5 hr |
-| 3 | #1467 | WS-event save for child LiveComponent views. PR #1466's gate skips child views entirely (conservative); this issue picks one of 3 design options (propagate `_djust_mount_request` to children at construction / new identity scheme / declare out-of-scope) and ships | P2 feature | ~2-3 hr |
+| 3 | ~~#1467~~ | ~~WS-event save for child LiveComponent views.~~ **Closed Option C (out-of-scope)** — investigation revealed LiveComponent embedded children already persist via parent's `_save_components_to_session` (no gap). Sticky-child `LiveView` persistence is a separate architectural problem (LOAD-time discovery) tracked at #1471 for v0.10.0+ | P2 → closed | investigation-only |
 
 #### Sequencing strategy
 


### PR DESCRIPTION
Closes #1467 (as Option C — out-of-scope, with investigation finding).

## Summary

After Stage 4 code-path tracing of the #1467 issue body, the premise needed refinement:

- The issue body uses "child LiveComponent views" loosely; the actual code path it cites (`websocket.py:2689-2696`) is the sticky-child `LiveView` path (`view_id` routing), not the LiveComponent path (`component_id` routing).
- **LiveComponent embedded children already persist** across WS reconnect via the existing `_save_components_to_session` call in PR #1466's save block. `target_view` stays as `self.view_instance` for component events, so PR #1466's gate passes and the components dict is serialized to `liveview_<parent_path>_components`.
- **Sticky-child `LiveView`s** are the actual gap. They route via `view_id`, fail the gate, and their state is dropped. Same is true on the HTTP path — neither saves sticky-child state today.

Closing the sticky-child gap requires architectural work (SAVE side + LOAD-time discovery + sticky-id index) that doesn't fit a single 2-3 hr PR. Filed as #1471 for v0.10.0+.

## What changed

- `CLAUDE.md` — adds a "Process canonicalizations from v0.9.7-3 retro arc" section documenting the LiveComponent vs sticky-child routing distinction. Saves ~1hr of code-path tracing for future readers.
- `ROADMAP.md` — marks #1467 closed with the investigation outcome.

Investigation comment posted to #1467: https://github.com/djust-org/djust/issues/1467#issuecomment-4435650564

Follow-up issue: #1471 (Sticky-child LiveView state persistence across WS reconnect).

## Test plan

- [x] Docs-only PR — no code change. `python/djust/websocket.py` is unchanged on this branch (diff against `main` is `CLAUDE.md` + `ROADMAP.md` only).
- [x] No CHANGELOG entry needed — no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)