### PR TITLE
docs(checklist): NUL-delimited reads bullet for shell tools (#1473)

### DIFF
--- a/docs/PULL_REQUEST_CHECKLIST.md
+++ b/docs/PULL_REQUEST_CHECKLIST.md
@@ -72,6 +72,25 @@ This document outlines the mandatory checks that must be evaluated when reviewin
 - [ ] **Memory safety** - No unsafe code without justification
 - [ ] **Performance implications** considered for VDOM-affecting changes
 
+### Shell Scripts Processing Git Output
+
+<!-- shell-git-output-safety -->
+
+- [ ] **NUL-delimited reads for git path output** — Any shell script that processes paths from `git diff --name-only`, `git ls-files`, `git status --porcelain`, etc. must read NUL-delimited (`-z` flag) into a bash array, then pass via quoted array expansion + `--` separator. Filenames with spaces or glob metacharacters (`*`, `?`, `[`) silently corrupt under newline-split + word-split. Reference: PR #1470 first-pass shipped `git add $STAGED` inside a wrapper specifically written to prevent ruff-bounce friction — Stage 11 caught it before merge. Pattern (macOS bash 3.2 compatible):
+
+  ```bash
+  STAGED=()
+  while IFS= read -r -d '' f; do
+      STAGED+=("$f")
+  done < <(git diff --cached -z --name-only --diff-filter=ACMR)
+
+  # Consume via quoted array expansion + `--` separator:
+  git add -- "${STAGED[@]}"
+  uvx pre-commit run --files "${STAGED[@]}"
+  ```
+
+  AVOID: `STAGED=$(git diff --cached --name-only)` + `git add $STAGED`. Source: Action Tracker #256 / #1473.
+
 ### JavaScript Code Standards
 
 - [ ] **ESLint rules** pass - Code follows project style guide


### PR DESCRIPTION
Closes #1473. Lands the v0.9.7-3 retro Action Tracker #256 follow-up.

## Summary

Adds a Stage 7 self-review bullet to `docs/PULL_REQUEST_CHECKLIST.md` requiring NUL-delimited reads (`git diff -z` + bash array + quoted expansion) for any shell script processing git path output.

Motivated by PR #1470's first-pass shipping `git add \$STAGED` inside the very wrapper that was written to prevent ruff-bounce friction. Filenames with spaces or glob metacharacters would silently corrupt under the unquoted word-split. Stage 11 caught it; the rule locks the pattern as a Stage 7 self-review item going forward.

## Test plan

- [x] Docs-only PR. No CHANGELOG needed (internal contributor checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)