### PR TITLE
docs(roadmap): scope the v1.0.0 milestone (strategy session 2026-05-17)

### DIFF
--- a/RETRO.md
+++ b/RETRO.md
@@ -299,6 +299,11 @@ issue or be explicitly closed with a reason.
 
 ## v0.9.7-3 — Canon + tooling follow-ups + investigation-class close (PRs #1469, #1470, #1472)
 
+> **Forward-link:** the v0.9.x bake closed here. Strategy session 2026-05-17
+> (`docs/strategy-sessions/2026-05-17-v1.0.0-readiness.md`) scoped the next
+> milestone — **v1.0.0 — Release Readiness** (Path 3: Accessibility-in,
+> Dead-View-out). See `ROADMAP.md` §"Next: v1.0.0".
+
 **Date**: 2026-05-12
 **Scope**: 3 PRs merged + 1 issue closed Option C (out-of-scope, investigation-only). Two canon PRs (#1469 gate-off self-test, #1472 LiveComponent vs sticky-child routing distinction), one tooling PR (#1470 pre-commit auto-restage wrapper), one investigation that pivoted scope (#1467 → #1471 follow-up). All three v0.9.7-2 retro tracker rows resolved this milestone.
 **Tests at close**: 2800 Python + 9 new in `test_git_commit_with_precommit.py` (PR #1470) + 39 wire-protocol snapshots + 272 djust_vdom Rust + 1564 JS. No regression at close.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # djust Roadmap
 
-> Current version: **0.9.7** (released 2026-05-16) — Last roadmap refresh: 2026-05-17 (roadmap audit: 50 stale matrix entries struck, v0.9.3–0.9.5 state labels corrected).
+> Current version: **0.9.7** (released 2026-05-16) — Last roadmap refresh: 2026-05-17 (v1.0.0 milestone scoped via `/pipeline-strategy` deep session — Path 3: Accessibility-in, Dead-View-out).
 
 This roadmap outlines what has been built, what is actively being worked on, and where djust is headed. Priorities are shaped by real-world usage across [djust.org](https://djust.org) and [djustlive](https://djustlive.com), and by feature parity goals with Phoenix LiveView 1.0 and React 19-level interactivity.
 
@@ -18,6 +18,44 @@ Two name shapes appear in this roadmap, with distinct meanings:
 **Historical note**: ROADMAP entries `v0.9.1` through `v0.9.5` (already shipped) were drain buckets under the old naming; they are equivalent to `v0.9.1-1` through `v0.9.1-5` under the new convention. They are NOT being retroactively renamed (would invalidate cross-references in 50+ PRs, retro files, and CHANGELOG entries). The convention applies forward-only.
 
 **Released**: `v0.9.1` cut 2026-04-30 (tag `v0.9.1`, GitHub Release published, PyPI live). Bundles 8 drain buckets + post-cleanup. Retro: RETRO.md §v0.9.1. Tracker carryovers (#1234, #1235, #1236) and the post-release SSE bug bundle (#1237) move into `v0.9.2-1` below.
+
+## Next: v1.0.0 — Release Readiness
+
+> Scoped 2026-05-17 by a `/pipeline-strategy` deep session — see `docs/strategy-sessions/2026-05-17-v1.0.0-readiness.md`.
+
+*Goal:* Promote djust from the v0.9.x bake (7 stable releases of audit-driven hardening since the v0.9.0 "feature wave before 1.0 testing") to a 1.0 SemVer stability commitment. The strategy session compared three paths and chose **Path 3 — Accessibility-in, Dead-View-out**: ship the correctness/stability gate plus framework-wide Accessibility; defer Dead View / Progressive Enhancement to post-1.0 as an additive capability that does not break the 1.0 API contract.
+
+**Scope** (~3 weeks, 6 work units):
+
+| # | Work unit | Theme | Priority | Effort |
+|---|---|---|---|---|
+| 1 | Fix Rust template `is None` / `is not None` operator bug (#1483) | Correctness gate | P0 | S |
+| 2 | 1.0 API-stability + deprecation policy | Stability gate | P0 | M |
+| 3 | Pre-1.0 security sweep (`djust_audit` + CodeQL + dependency ceilings) | Stability gate | P1 | S–M |
+| 4 | Framework-wide Accessibility (ARIA/WCAG) — finish the PARTIAL theming-only state | 1.0 feature | P1 | L |
+| 5 | ADR status reconciliation (008/013/014/016/017 → Accepted; AI arc → post-1.0) | Polish | P2 | S |
+| 6 | 1.0 documentation pass (Getting Started, upgrade guide, CHANGELOG release narrative) | Polish | P1 | M |
+
+**Sequencing:** #1483 first (pre-req correctness bug, smallest, design-novel). API-stability policy second — it is foundational and gates what the docs pass (unit 6) documents. Security sweep (3) and Accessibility (4) run in parallel after. ADR reconciliation (5) + docs (6) ship last, once the API-stability policy is settled.
+
+**Deferred to post-1.0** (recorded so future strategy sessions don't re-litigate):
+- **Dead View / Progressive Enhancement** — additive; does not break the 1.0 API contract. Re-scoped from `v1.0.0` to `post-1.0` in the Priority Matrix.
+- **Free-threaded-safe declaration (#1432)**, **sticky-child WS-reconnect persistence (#1471)** — borderline; revisit for v1.0.x / v1.1.
+- **AI / server-driven arc** (ADR-002 phases 4–5, ADR-003/004/005/006) — already roadmap-committed post-1.0.
+
+**Acceptance for v1.0.0:**
+- [ ] #1483 fixed with a regression test (Rust + Python template-engine parity).
+- [ ] API-stability + deprecation policy published; public surface audited for experimental/provisional markers.
+- [ ] Pre-1.0 security sweep clean.
+- [ ] Accessibility: framework-wide ARIA/WCAG markup pass + system check(s); theming color-contrast validation already shipped.
+- [ ] ADRs 008/013/014/016/017 marked Accepted; AI arc explicitly marked post-1.0.
+- [ ] 1.0 docs complete (Getting Started, upgrade guide, CHANGELOG release narrative).
+- [ ] Then: cut `v1.0.0rc1` via `/djust-release`.
+
+**Pipeline runner notes:**
+- `/pipeline-run --milestone v1.0.0` picks the next unit by priority + dependency order.
+- Drain buckets toward this release use the `v1.0.0-N` naming (see convention above).
+- First task: **#1483** — bugfix pipeline.
 
 ## Released: v0.9.1 (2026-04-30)
 
@@ -1204,8 +1242,8 @@ Single grouped PR (`feat/v0.9.2-2-template-canon` or similar). Both items edit `
 | ~~**P2**~~ | ~~Server Actions (`@action` decorator)~~ ✅ Shipped — `python/djust/decorators.py:233` (`@action` with auto-tracked `_action_state[name] = {pending, error, result}`) | ~~React 19 parity; standardized pending/error/success for mutations~~ | ~~v0.8.0~~ |
 | ~~**P2**~~ | ~~Async Streams~~ ✅ Shipped — `python/djust/streaming.py` `StreamingMixin` (token-by-token DOM updates via `stream_to(...)` + LLM streaming primitives) | ~~Phoenix 1.0 parity; infinite scroll and real-time feeds at scale~~ | ~~v0.8.0~~ |
 | **P2** | Connection multiplexing | Pages with 5+ live sections need this to not waste connections | v0.6.0 |
-| **P2** | Dead View / Progressive Enhancement | 1.0 requirement for government/accessibility projects | v1.0.0 |
-| **P2** | Accessibility (ARIA/WCAG) — _Partial: WCAG color-contrast validation shipped (`python/djust/theming/accessibility.py`); framework-wide ARIA/WCAG markup audit still pending._ | 1.0 requirement; Phoenix was criticized for shipping without this | v1.0.0 |
+| **P2** | Dead View / Progressive Enhancement — _deferred to post-1.0 (strategy 2026-05-17): additive capability, does not break the 1.0 API contract_ | 1.0 requirement for government/accessibility projects | post-1.0 |
+| **P1** | Accessibility (ARIA/WCAG) — _Partial: WCAG color-contrast validation shipped (`python/djust/theming/accessibility.py`); framework-wide ARIA/WCAG markup audit is unit 4 of the v1.0.0 milestone (strategy 2026-05-17)._ | 1.0 requirement; Phoenix was criticized for shipping without this | v1.0.0 |
 | ~~**P2**~~ | ~~Type-safe template validation~~ ✅ Shipped in v0.5.1 (`manage.py djust_typecheck`) | ~~Catch template variable typos at CI — unique differentiator vs all competitors~~ | ~~v0.5.1~~ |
 | ~~**P2**~~ | ~~Keep-Alive / `dj-activity`~~ ✅ Shipped — `static/djust/src/49-activity.js` + `templatetags/live_tags.py` `{% dj_activity %}` (React 19.2 `<Activity>` parity, server-canonical visibility) | ~~Pre-render hidden routes, preserve state — React 19.2 parity~~ | ~~v0.7.0~~ |
 | ~~**P2**~~ | ~~Streaming markdown renderer~~ ✅ Shipped in v0.7.0 (`{% djust_markdown %}` + `djust.render_markdown`, pulldown-cmark backend, provisional-line splitter) | ~~Incremental markdown for LLM output — strongest AI vertical signal~~ | ~~v0.7.0~~ |

--- a/docs/strategy-sessions/2026-05-17-v1.0.0-readiness.md
+++ b/docs/strategy-sessions/2026-05-17-v1.0.0-readiness.md
@@ -1,0 +1,73 @@
+# Strategy Session — v1.0.0 Release Readiness
+
+**Date:** 2026-05-17
+**Trigger:** milestone-boundary (user goal: "prepare for 1.0 release using pipeline-skills")
+**Mode:** deep
+**State file:** `.pipeline-state/strategy-2026-05-17-v1.0.0-readiness.json`
+**Skill:** `/pipeline-strategy`
+
+## Context
+
+djust shipped **v0.9.7 stable** on 2026-05-16 with 4,002 test functions and only 8
+open issues (mostly tech-debt + 4 out-of-repo pipeline-skill chores). The v0.9.0
+milestone was explicitly titled *"Full feature wave before 1.0 testing"*;
+v0.9.1–v0.9.7 — 7 stable releases of audit-driven hardening — constitute the bake.
+
+A `/pipeline-roadmap-audit` run earlier the same day (PR #1484, merged) struck 50
+stale Priority-Matrix entries and pinned the concrete 1.0 gate.
+
+## Survey findings
+
+- **Three 1.0 gates:** template-engine correctness bug #1483 (`is None` / `is not
+  None` silently returns false); Dead View / Progressive Enhancement (v1.0.0-tagged,
+  NOT SHIPPED); Accessibility / ARIA/WCAG (v1.0.0-tagged, PARTIAL — theming
+  color-contrast validation shipped, framework-wide markup a11y pending).
+- **No v1.0.0 milestone** existed in ROADMAP — it jumped from v0.9.x drains to
+  v0.10.0 "Rust Polish" and post-1.0 buckets.
+- **ADR status drift:** ADRs 008/013/014/016/017 describe already-shipped features
+  but still read "Proposed".
+- **AI / server-driven arc** (ADR-002 ph4–5, ADR-003/004/005/006) genuinely unbuilt;
+  ROADMAP already marks the arc post-1.0.
+
+## Candidates (9) → Clusters (4)
+
+| Cluster | Candidates | Effort |
+|---|---|---|
+| **A — correctness + stability gate** | #1483 template fix · API-stability policy · security sweep | ~1 week |
+| **B — 1.0 feature requirements** | Dead View · Accessibility (ARIA/WCAG) | ~3–4 weeks |
+| **C — polish + docs** | ADR reconciliation · 1.0 documentation pass | ~3–4 days |
+| **D — deferred-gap closers** | #1432 free-threaded · #1471 sticky-child WS | ~3 days (not 1.0-blocking) |
+
+## Paths considered
+
+| Path | Clusters | Effort | Risk |
+|---|---|---|---|
+| **1 — Lean 1.0** | A + C | ~1.5–2 wks | Ships 1.0 with no accessibility — repeats the criticism the ROADMAP cites Phoenix for. |
+| **2 — Complete the contract** | A + B + C | ~5–6 wks | Bundles two large features into a consolidation release; long runway; scope creep. |
+| **3 — Accessibility-in, Dead-View-out** ⭐ | A + C + Accessibility | ~3 wks | Still a multi-week a11y effort; Dead View deferred (acceptable — additive). |
+
+## Recommendation & Decision
+
+**Recommended:** Path 3. A 1.0 release is fundamentally a SemVer stability
+commitment, so Clusters A and C are non-negotiable in every path; the only real
+decision is Cluster B. Path 2 pushes the release out 5–6 weeks and bundles two
+large features into what should be a consolidation release. Path 1 ships 1.0
+missing accessibility — the precise mistake the ROADMAP cites Phoenix for — and
+a11y is hard to bolt on credibly after the API freezes. Path 3 keeps Accessibility
+(already PARTIAL, so finishing is cheaper than starting, and it is reputationally
+load-bearing) while re-scoping Dead View to post-1.0, where it sits naturally as
+an additive capability.
+
+**Decision (deep mode, user-confirmed):** Path 3. Chosen == recommended.
+
+**Directional change:** none. No active ADR is overridden — the AI/server-driven
+arc is already roadmap-marked post-1.0; deferring Dead View refines an un-ADR'd
+Priority-Matrix row. No new ADR required.
+
+## Captured artifacts
+
+- `ROADMAP.md` — new `## Next: v1.0.0 — Release Readiness` milestone (6 work units);
+  Dead View re-scoped `v1.0.0` → `post-1.0`; Accessibility row repointed to unit 4.
+- This document.
+- Forward-link appended to `RETRO.md` §v0.9.7-3.
+- Execution begins: `/pipeline-next --milestone v1.0.0` → first task #1483.


### PR DESCRIPTION
## Summary

`/pipeline-strategy` deep session that scopes the **v1.0.0 — Release Readiness** milestone. Follows the roadmap audit (#1484, merged) — djust has shipped v0.9.7 stable and the v0.9.0→v0.9.7 bake is complete.

## Decision

Compared 3 distinct paths; **Path 3 — Accessibility-in, Dead-View-out** chosen (user-confirmed, deep mode).

| Path | Scope | Effort | |
|---|---|---|---|
| 1 — Lean 1.0 | gate only | ~1.5-2 wks | ships without a11y |
| 2 — Complete contract | gate + both features | ~5-6 wks | long runway |
| **3 — A11y in, Dead View out** ⭐ | gate + Accessibility | **~3 wks** | **chosen** |

## v1.0.0 milestone (6 work units)

1. Fix template `is None`/`is not None` bug (#1483) — P0
2. 1.0 API-stability + deprecation policy — P0
3. Pre-1.0 security sweep — P1
4. Framework-wide Accessibility (ARIA/WCAG) — P1
5. ADR status reconciliation — P2
6. 1.0 documentation pass — P1

**Deferred to post-1.0:** Dead View / Progressive Enhancement (additive — doesn't break the 1.0 API contract), #1432, #1471, the AI/server-driven ADR arc.

## Changes

- `ROADMAP.md` — new `## Next: v1.0.0` milestone section; Dead View row re-scoped `v1.0.0` → `post-1.0`; Accessibility row repointed.
- `docs/strategy-sessions/2026-05-17-v1.0.0-readiness.md` — full session record.
- `RETRO.md` — forward-link from v0.9.7-3 (bake close) to the session.

No directional change — no ADR overridden.

## Next

After merge: `/pipeline-run --milestone v1.0.0` → first task **#1483**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)