### PR TITLE
fix(templates): support Django `is` / `is not` identity operators (#1483)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Rust template renderer now supports Django's `is` / `is not` identity operators in `{% if %}` conditions (#1483).** `{% if x is None %}` and `{% if x is not None %}` previously fell through every operator branch in `evaluate_condition` to the default `Ok(false)`, so they silently evaluated false for *all* values — templates using this Django-standard syntax always took the `{% else %}` branch even when the condition was true. The renderer now implements `is` / `is not` with Python identity semantics: identity holds only for the singletons `None`, `True`, and `False`; arbitrary equal values (`5 is 5`, `"a" is "a"`) are NOT treated as identical (CPython interning is an implementation detail templates must not rely on). Templates that previously fell through to the `{% else %}` branch — e.g. `{% if some_value is not None %}` for a non-`None` value — will now correctly take the `{% if %}` branch. This brings the Rust template engine to parity with the Django (Python) engine, which has supported `is` / `is not` natively since Django 4.0. Regression coverage in `TestIsIdentityOperators` (`python/tests/test_template_conditions.py`) plus Rust unit tests in `crates/djust_templates/src/renderer.rs`.
+
 ## [0.9.7] - 2026-05-16
 
 Stable release. No code changes since v0.9.7rc3 (2026-05-12) — RC3 soaked for 4 days with djustlive on the pinned wheel and zero regressions reported. See the rc1, rc2, rc3 entries below for the full v0.9.7 changeset:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "0.9.7-rc.3"
+version = "0.9.7"
 dependencies = [
  "ahash",
  "criterion",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "0.9.7-rc.3"
+version = "0.9.7"
 dependencies = [
  "ahash",
  "criterion",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "0.9.7-rc.3"
+version = "0.9.7"
 dependencies = [
  "bincode",
  "criterion",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "0.9.7-rc.3"
+version = "0.9.7"
 dependencies = [
  "ahash",
  "chrono",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "0.9.7-rc.3"
+version = "0.9.7"
 dependencies = [
  "ahash",
  "criterion",

--- a/crates/djust_templates/src/renderer.rs
+++ b/crates/djust_templates/src/renderer.rs
@@ -1658,6 +1658,21 @@ fn evaluate_condition(condition: &str, context: &Context) -> Result<bool> {
         }
     }
 
+    // Handle Django identity operators "is" / "is not" (Django 4.0+).
+    // " is not " MUST be checked before " is " because the former
+    // contains the latter as a substring. Space-padded markers avoid
+    // matching variable names that merely contain "is" (e.g. "analysis").
+    if let Some(pos) = condition.find(" is not ") {
+        let left = get_value(condition[..pos].trim(), context)?;
+        let right = get_value(condition[pos + 8..].trim(), context)?;
+        return Ok(!values_identity(&left, &right));
+    }
+    if let Some(pos) = condition.find(" is ") {
+        let left = get_value(condition[..pos].trim(), context)?;
+        let right = get_value(condition[pos + 4..].trim(), context)?;
+        return Ok(values_identity(&left, &right));
+    }
+
     // Handle >= (must be before > to avoid false match)
     if condition.contains(">=") {
         let parts: Vec<&str> = condition.split(">=").map(|s| s.trim()).collect();
@@ -1808,6 +1823,23 @@ fn values_equal(a: &Value, b: &Value) -> bool {
         (Value::Integer(a), Value::Integer(b)) => a == b,
         (Value::Float(a), Value::Float(b)) => (a - b).abs() < f64::EPSILON,
         (Value::String(a), Value::String(b)) => a == b,
+        _ => false,
+    }
+}
+
+/// Django identity comparison for the `is` / `is not` template operators.
+///
+/// Mirrors Python's `is`: identity holds only for the singletons
+/// `None`, `True`, and `False`. Arbitrary equal values (`5 is 5`,
+/// `"a" is "a"`) are NOT contractually identical — CPython interning is
+/// an implementation detail templates must not rely on — so non-singleton
+/// types always return false. This is intentionally stricter than
+/// [`values_equal`].
+fn values_identity(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::Null, Value::Null) => true,
+        (Value::Bool(a), Value::Bool(b)) => a == b,
+        // Non-singletons: Python `is` is not identity-stable; treat as false.
         _ => false,
     }
 }
@@ -3018,5 +3050,145 @@ mod tests {
         context.set("True".to_string(), Value::String("not a bool".to_string()));
         let val = get_value("True", &context).unwrap();
         assert_eq!(val.to_string(), "not a bool");
+    }
+
+    // ----- #1483: `is` / `is not` identity operators -----
+
+    fn render_if(template: &str, vars: Vec<(&str, Value)>) -> String {
+        let tokens = tokenize(template).unwrap();
+        let nodes = parse(&tokens).unwrap();
+        let mut context = Context::new();
+        for (k, v) in vars {
+            context.set(k.to_string(), v);
+        }
+        render_nodes(&nodes, &context).unwrap()
+    }
+
+    #[test]
+    fn test_values_identity() {
+        // Null/Null -> true (Python `None is None`)
+        assert!(values_identity(&Value::Null, &Value::Null));
+        // Bool/Bool -> matches value (Python `True is True`, `False is False`)
+        assert!(values_identity(&Value::Bool(true), &Value::Bool(true)));
+        assert!(values_identity(&Value::Bool(false), &Value::Bool(false)));
+        assert!(!values_identity(&Value::Bool(true), &Value::Bool(false)));
+        // Mismatched singletons -> false
+        assert!(!values_identity(&Value::Null, &Value::Bool(false)));
+        assert!(!values_identity(&Value::Bool(true), &Value::Null));
+        // Non-singletons -> always false (CPython interning is not contractual)
+        assert!(!values_identity(&Value::Integer(5), &Value::Integer(5)));
+        assert!(!values_identity(&Value::Float(1.0), &Value::Float(1.0)));
+        assert!(!values_identity(
+            &Value::String("a".to_string()),
+            &Value::String("a".to_string())
+        ));
+    }
+
+    #[test]
+    fn test_if_is_none_true() {
+        let result = render_if(
+            "{% if val is None %}empty{% else %}filled{% endif %}",
+            vec![("val", Value::Null)],
+        );
+        assert_eq!(result, "empty");
+    }
+
+    #[test]
+    fn test_if_is_none_false() {
+        // 0 is not None — identity, not truthiness
+        let result = render_if(
+            "{% if val is None %}empty{% else %}filled{% endif %}",
+            vec![("val", Value::Integer(0))],
+        );
+        assert_eq!(result, "filled");
+    }
+
+    #[test]
+    fn test_if_is_not_none_true() {
+        let result = render_if(
+            "{% if some_float is not None %}set{% else %}unset{% endif %}",
+            vec![("some_float", Value::Float(12.3))],
+        );
+        assert_eq!(result, "set");
+    }
+
+    #[test]
+    fn test_if_is_not_none_false() {
+        let result = render_if(
+            "{% if val is not None %}set{% else %}unset{% endif %}",
+            vec![("val", Value::Null)],
+        );
+        assert_eq!(result, "unset");
+    }
+
+    #[test]
+    fn test_if_is_true_singleton() {
+        let result = render_if(
+            "{% if flag is True %}yes{% else %}no{% endif %}",
+            vec![("flag", Value::Bool(true))],
+        );
+        assert_eq!(result, "yes");
+    }
+
+    #[test]
+    fn test_if_is_false_singleton() {
+        let result = render_if(
+            "{% if flag is False %}off{% else %}on{% endif %}",
+            vec![("flag", Value::Bool(false))],
+        );
+        assert_eq!(result, "off");
+    }
+
+    #[test]
+    fn test_if_is_not_true() {
+        let result = render_if(
+            "{% if flag is not True %}not-true{% else %}true{% endif %}",
+            vec![("flag", Value::Bool(false))],
+        );
+        assert_eq!(result, "not-true");
+    }
+
+    #[test]
+    fn test_if_is_non_singleton_not_identical() {
+        // Python identity semantics: `5 is 5` does NOT contractually hold.
+        let result = render_if(
+            "{% if a is b %}same{% else %}diff{% endif %}",
+            vec![("a", Value::Integer(5)), ("b", Value::Integer(5))],
+        );
+        assert_eq!(result, "diff");
+    }
+
+    #[test]
+    fn test_if_is_combined_with_and() {
+        // `is` / `is not` compose with the lower-precedence `and`.
+        let result = render_if(
+            "{% if a is not None and b is None %}match{% else %}nomatch{% endif %}",
+            vec![("a", Value::Integer(7)), ("b", Value::Null)],
+        );
+        assert_eq!(result, "match");
+    }
+
+    #[test]
+    fn test_if_is_not_checked_before_is() {
+        // Substring-ordering invariant: `x is not None` must be parsed as
+        // `x  (is not)  None`, NOT `x  (is)  (not None)`. With val set to a
+        // non-None value, `is not None` -> true. If " is " matched first,
+        // the right operand would be "not None" and resolve incorrectly.
+        let result = render_if(
+            "{% if val is not None %}set{% else %}unset{% endif %}",
+            vec![("val", Value::Integer(1))],
+        );
+        assert_eq!(result, "set");
+    }
+
+    #[test]
+    fn test_if_variable_named_with_is_substring_no_false_match() {
+        // A variable named "analysis" contains "is" but must not false-match
+        // the operator branch — space-padding guards against this.
+        let result = render_if(
+            "{% if analysis %}has-analysis{% else %}none{% endif %}",
+            vec![("analysis", Value::Bool(true))],
+        );
+        assert_eq!(result, "has-analysis");
     }
 }

--- a/docs/RUST_TEMPLATE_API.md
+++ b/docs/RUST_TEMPLATE_API.md
@@ -623,7 +623,9 @@ pub enum Node {
 
 **Condition operators**: The `If` node supports comparison operators:
 - Equality: `==`, `!=`
+- Identity: `is`, `is not` (Django identity semantics — true only for the `None`, `True`, `False` singletons)
 - Comparison: `>`, `<`, `>=`, `<=`
+- Membership: `in`
 - Boolean: `and`, `or`, `not`
 - Branching: `{% elif %}` is supported (converted to nested `If` nodes)
 

--- a/docs/TEMPLATE_BACKEND.md
+++ b/docs/TEMPLATE_BACKEND.md
@@ -135,6 +135,7 @@ def my_view(request):
 - Filters: `{{ variable|filter }}` (including `urlencode`)
 - Tags: `{% if %}`, `{% elif %}`, `{% else %}`, `{% for %}`, `{% extends %}`, `{% block %}`, `{% url %}`, `{% include %}`
 - Comparison operators: `>`, `<`, `>=`, `<=` in `{% if %}` tags
+- Identity operators: `is`, `is not` in `{% if %}` tags (e.g. `{% if x is None %}`)
 - Comments: `{# comment #}`
 
 ✅ **Template Loading**

--- a/python/tests/test_template_conditions.py
+++ b/python/tests/test_template_conditions.py
@@ -342,5 +342,76 @@ class TestElifInHtmlAttribute:
         assert 'class=""' in result
 
 
+class TestIsIdentityOperators:
+    """#1483: Django 4.0+ `is` / `is not` identity-test operators.
+
+    Identity semantics follow Python: `is` is true only for the
+    None/True/False singletons (`None is None` -> true, `5 is 5` -> false).
+    """
+
+    def test_is_not_none_with_non_none_value(self):
+        """#1483 repro: `is not None` must render the true branch for a set float value."""
+        template = (
+            "{% if some_float is not None %}rendered: {{ some_float }}"
+            "{% else %}fallthrough{% endif %}"
+        )
+        result = render_template(template, {"some_float": 12.3})
+        assert result == "rendered: 12.3"
+
+    def test_is_not_none_with_none_value(self):
+        """#1483: `is not None` must render the false branch when the value is None."""
+        template = "{% if val is not None %}set{% else %}unset{% endif %}"
+        result = render_template(template, {"val": None})
+        assert result == "unset"
+
+    def test_is_none_with_none_value(self):
+        """#1483: `is None` must render the true branch when the value is None."""
+        template = "{% if val is None %}empty{% else %}filled{% endif %}"
+        result = render_template(template, {"val": None})
+        assert result == "empty"
+
+    def test_is_none_with_non_none_value(self):
+        """#1483: `is None` must render the false branch for a set value."""
+        template = "{% if val is None %}empty{% else %}filled{% endif %}"
+        result = render_template(template, {"val": 0})
+        assert result == "filled"
+
+    def test_is_none_with_zero_value(self):
+        """#1483: `is None` is identity, not truthiness — 0 is not None."""
+        template = "{% if count is not None %}has-count{% else %}no-count{% endif %}"
+        result = render_template(template, {"count": 0})
+        assert result == "has-count"
+
+    def test_is_true_singleton(self):
+        """#1483: `is True` is true for the True singleton."""
+        template = "{% if flag is True %}yes{% else %}no{% endif %}"
+        result = render_template(template, {"flag": True})
+        assert result == "yes"
+
+    def test_is_false_singleton(self):
+        """#1483: `is False` is true for the False singleton."""
+        template = "{% if flag is False %}off{% else %}on{% endif %}"
+        result = render_template(template, {"flag": False})
+        assert result == "off"
+
+    def test_is_not_true_with_false(self):
+        """#1483: `is not True` is true when the value is False."""
+        template = "{% if flag is not True %}not-true{% else %}true{% endif %}"
+        result = render_template(template, {"flag": False})
+        assert result == "not-true"
+
+    def test_is_non_singleton_values_are_not_identical(self):
+        """#1483: Python identity semantics — `5 is 5` style equality does NOT hold."""
+        template = "{% if a is b %}same{% else %}diff{% endif %}"
+        result = render_template(template, {"a": 5, "b": 5})
+        assert result == "diff"
+
+    def test_is_none_combined_with_and(self):
+        """#1483: `is`/`is not` must compose with `and` (lower precedence)."""
+        template = "{% if a is not None and b is None %}match{% else %}nomatch{% endif %}"
+        result = render_template(template, {"a": 7, "b": None})
+        assert result == "match"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Closes #1483. **v1.0.0 milestone unit 1** (correctness gate). The Rust template renderer's `evaluate_condition` had no branch for Django's `is` / `is not` identity operators — `{% if x is None %}` and `{% if x is not None %}` fell through to the default `Ok(false)` and silently evaluated false for **all** values, always taking the `{% else %}` branch.

## The fix

`crates/djust_templates/src/renderer.rs`:
- New `values_identity` helper — Python identity semantics: true only for matching `None` / `True` / `False` singletons; `5 is 5` / `"a" is "a"` are **false** (CPython interning is not contractual).
- New `is` / `is not` dispatch branch in `evaluate_condition`, placed with the comparison-tier operators. `" is not "` is matched before `" is "` (substring containment); space-padded markers prevent false-matching variable names that contain "is".

Brings the Rust engine to parity with the Django (Python) engine, which has supported `is` / `is not` since Django 4.0. No Python-side change needed.

## Tests

- 12 Rust unit tests in `renderer.rs` (helper coverage, both operators, singleton/non-singleton, precedence, substring-no-false-match).
- `TestIsIdentityOperators` — 10 cases in `python/tests/test_template_conditions.py` (the Stage-4 reproducer; 7 fail pre-fix, all 10 pass post-fix). Gate-off self-test verified.
- Full suite green: 4290 Python pass, all Rust pass, 1572 JS pass.

## Note on `Cargo.lock`

The committed `Cargo.lock` had stale workspace versions (`0.9.7-rc.3`) vs `Cargo.toml` (`0.9.7`) on main; any `cargo` invocation regenerates it, so the `cargo-clippy` pre-commit hook bounced every commit until corrected. The one-line-per-crate `0.9.7-rc.3` → `0.9.7` correction is included in commit 1.

## Pipeline

Bugfix pipeline (state: `.pipeline-state/fix-template-is-none-operator-1483.json`). Two-commit shape: impl+tests, then docs+CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)