### PR TITLE
docs(adr): reconcile ADR statuses against shipped reality (v1.0.0 unit 5)

### DIFF
--- a/docs/adr/002-backend-driven-ui-automation.md
+++ b/docs/adr/002-backend-driven-ui-automation.md
@@ -1,6 +1,6 @@
 # ADR-002: Backend-Driven UI Automation
 
-**Status**: Proposed
+**Status**: Partially Accepted — Phases 1a-1c (push_commands, wait_for_event, TutorialMixin) shipped 2026-04-13 in v0.4.2; Phases 4-5 (broadcast_commands, AssistantMixin) deferred post-1.0
 **Date**: 2026-04-11
 **Deciders**: Project maintainers
 **Target version**: v0.4.2 (MVP), v0.5.x (full surface)

--- a/docs/adr/003-llm-provider-abstraction.md
+++ b/docs/adr/003-llm-provider-abstraction.md
@@ -1,6 +1,6 @@
 # ADR-003: LLM Provider Abstraction for AssistantMixin
 
-**Status**: Proposed
+**Status**: Deferred — post-1.0 (AI/server-driven arc; roadmap-committed)
 **Date**: 2026-04-11
 **Deciders**: Project maintainers
 **Target version**: v0.5.x (lands with `AssistantMixin`)

--- a/docs/adr/004-undo-for-llm-driven-actions.md
+++ b/docs/adr/004-undo-for-llm-driven-actions.md
@@ -1,6 +1,6 @@
 # ADR-004: Undo for LLM-Driven Actions
 
-**Status**: Proposed
+**Status**: Deferred — post-1.0 (AI/server-driven arc; roadmap-committed)
 **Date**: 2026-04-11
 **Deciders**: Project maintainers
 **Target version**: v0.5.x (lands with `AssistantMixin`)

--- a/docs/adr/005-consent-envelope-for-remote-control.md
+++ b/docs/adr/005-consent-envelope-for-remote-control.md
@@ -1,6 +1,6 @@
 # ADR-005: Consent Envelope for Remote Control
 
-**Status**: Proposed
+**Status**: Deferred — post-1.0 (AI/server-driven arc; roadmap-committed)
 **Date**: 2026-04-11
 **Deciders**: Project maintainers
 **Target version**: v0.5.x (lands with multi-user `broadcast_commands`)

--- a/docs/adr/006-ai-generated-uis-with-capture-and-promote.md
+++ b/docs/adr/006-ai-generated-uis-with-capture-and-promote.md
@@ -1,6 +1,6 @@
 # ADR-006: AI-Generated UIs with Capture-and-Promote
 
-**Status**: Proposed
+**Status**: Deferred — post-1.0 (AI/server-driven arc, issue #1044; roadmap-committed)
 **Date**: 2026-04-11
 **Deciders**: Project maintainers
 **Target version**: v0.6.x (lands after AssistantMixin, Phase 5 of ADR-002)

--- a/docs/adr/008-auto-generated-http-api-from-event-handlers.md
+++ b/docs/adr/008-auto-generated-http-api-from-event-handlers.md
@@ -1,6 +1,6 @@
 # ADR-008: Auto-Generated HTTP API from `@event_handler`
 
-**Status**: Proposed
+**Status**: Accepted — shipped 2026-04-21 in v0.5.1 (PR #835)
 **Date**: 2026-04-20
 **Deciders**: Project maintainers
 **Target version**: v0.7.0 (candidate; could merge with ADR-N "Server Actions" in v0.8.0 if scope allows)

--- a/docs/adr/013-view-transitions-api-integration.md
+++ b/docs/adr/013-view-transitions-api-integration.md
@@ -1,6 +1,6 @@
 # ADR-013: View Transitions API Integration in `applyPatches`
 
-**Status**: Proposed
+**Status**: Accepted — async foundation (PR-A #1099) shipped v0.8.5; opt-in wrap (PR-B #1113) shipped v0.8.6
 **Date**: 2026-04-26
 **Deciders**: Project maintainers
 **Target version**: v0.8.5 candidate

--- a/docs/adr/014-sticky-liveview-autodetect.md
+++ b/docs/adr/014-sticky-liveview-autodetect.md
@@ -1,6 +1,6 @@
 # ADR-014: `{% live_render %}` Auto-Detection of Preserved Stickies
 
-**Status**: Proposed
+**Status**: Accepted — shipped 2026-04-27 in v0.9.0 (PR #1128, closes #1032)
 **Date**: 2026-04-26
 **Deciders**: Project maintainers
 **Target version**: v0.9.0 (P1, 1.0-blocker)

--- a/docs/adr/016-transport-runtime-interface.md
+++ b/docs/adr/016-transport-runtime-interface.md
@@ -1,6 +1,6 @@
 # ADR-016: Transport Runtime Interface
 
-**Status**: Proposed
+**Status**: Accepted — ViewRuntime + Transport interface shipped 2026-04-30 in v0.9.2 (PR #1239, closes #1237); subsequent transport-migration PRs are non-blocking follow-ups
 **Date**: 2026-04-30
 **Target version**: v0.9.2-1 (PR-A: minimal extraction); subsequent PRs migrate the rest
 **Related**: #1237 (3 SSE bugs that motivate the refactor),

--- a/docs/adr/017-object-permission-lifecycle.md
+++ b/docs/adr/017-object-permission-lifecycle.md
@@ -1,6 +1,6 @@
 # ADR-017: Object-Level Authorization Lifecycle (`get_object` + `has_object_permission`)
 
-**Status**: Proposed
+**Status**: Accepted — shipped 2026-05-06 in v0.9.5 (PR #1374, closes #1373)
 **Date**: 2026-05-06
 **Deciders**: Project maintainers
 **Target version**: v0.9.5 (P0, security)


### PR DESCRIPTION
## Summary

**v1.0.0 milestone unit 5.** Ten ADRs in `docs/adr/` read `Status: Proposed` although the feature shipped (or was deliberately deferred). Before the 1.0 release, the decision record should be truthful. Each status was **verified against the codebase + git history** before updating (Action #1345 — don't trust the survey blindly).

## Updates

**Accepted — feature shipped:**
| ADR | Feature | Shipped |
|---|---|---|
| 008 | auto-generated HTTP API (`expose_api=`) | v0.5.1, PR #835 |
| 013 | View Transitions API | v0.8.5 PR #1099 / v0.8.6 PR #1113 |
| 014 | sticky-LiveView autodetect | v0.9.0, PR #1128 |
| 016 | transport-runtime interface (`ViewRuntime`) | v0.9.2, PR #1239 |
| 017 | object-permission lifecycle | v0.9.5, PR #1374 |

**Partially Accepted:**
- ADR-002 backend-driven UI — Phases 1a–1c shipped v0.4.2; Phases 4–5 deferred post-1.0.

**Deferred post-1.0** (the AI/server-driven arc, roadmap-committed):
- ADR-003 (LLM provider abstraction), ADR-004 (undo for LLM actions), ADR-005 (consent envelope), ADR-006 (AI-generated UIs).

All PR/version citations are grep/`gh`-verified — no hallucinated numbers (Action #1071). Docs-only; no CHANGELOG entry (internal decision-record change, not a user-facing feat/fix).

## Pipeline

Docs-only pipeline — test/review/security stages skipped per `DOCS_ONLY`. State: `.pipeline-state/docs-v1-adr-status-reconciliation.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)