### PR TITLE
docs(v1.0.0): 1.0 documentation pass (milestone unit 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+**v1.0.0 — the stability milestone.** After the v0.9.x audit-driven bake,
+djust 1.0 makes its SemVer commitment: code written against the public API
+keeps working across every 1.x release. 1.0 is a *consolidation* release —
+there are **no breaking changes from 0.9.7**; an app that runs on 0.9.7 runs
+on 1.0 unchanged. The milestone shipped in six units: the Rust template-engine
+`is` / `is not` fix, the published API-stability + deprecation policy, a
+pre-1.0 dependency security sweep, framework-wide accessibility (the new `Y`
+system-check category plus built-in component ARIA), an ADR reconciliation
+pass, and this 1.0 documentation pass.
+
 ### Added
 
 - **API-stability + deprecation policy published — `docs/API_STABILITY.md` (v1.0.0 milestone, unit 2).** The canonical, authoritative statement of djust's 1.0 SemVer commitment. Defines the **public API surface** SemVer covers (top-level `djust` exports, the `djust.decorators` decorators, public `LiveView` / `LiveComponent` / `Component` methods, the mixins re-exported from the top-level package, registered template tags/filters, documented config keys, and the snapshot-pinned WebSocket wire protocol) and what is explicitly **not** covered (underscore-prefixed names, `djust.mixins.*` internal-composition mixins, Rust crate internals, debug/dev-server/hot-reload internals). Documents the deprecation process — `DeprecationWarning` announcement, `.. deprecated::` docstring marker, `### Deprecated` CHANGELOG entry, mandatory migration path — and the support window: a symbol deprecated in `1.Y` is removed no earlier than `2.0.0`, with a `>= 1.1.0` removal floor for the three pre-1.0 legacy symbols (`@event`, `LiveViewForm`, the `_legacy` theming module). A user-facing companion guide ships at `docs/website/guides/api-stability.md`, linked from the docs-site nav. This is unit 2 of the 6-unit v1.0.0 (Release Readiness) milestone — the policy is foundational and gates what the 1.0 docs pass documents.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ djust brings Phoenix LiveView-style reactive components to Django, with performa
 [![CI](https://github.com/djust-org/djust/actions/workflows/test.yml/badge.svg)](https://github.com/djust-org/djust/actions/workflows/test.yml)
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![Django 3.2+](https://img.shields.io/badge/django-3.2+-green.svg)](https://www.djangoproject.com/)
+[![Django 4.2+](https://img.shields.io/badge/django-4.2+-green.svg)](https://www.djangoproject.com/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/djust.svg)](https://pypi.org/project/djust/)
 
 ## ✨ Features
@@ -20,7 +20,7 @@ djust brings Phoenix LiveView-style reactive components to Django, with performa
 - ⚡ **10-100x Faster** - Rust-powered template engine and Virtual DOM diffing
 - 🔄 **Reactive Components** - Phoenix LiveView-style server-side reactivity
 - 🔌 **Django Compatible** - Works with existing Django templates and components
-- 📦 **Zero Build Step** - ~29KB gzipped client JavaScript, no bundling needed
+- 📦 **Zero Build Step** - ~53 KB gzipped minified client JavaScript, no bundling needed
 - 🌐 **WebSocket Updates** - Real-time DOM patches over WebSocket (with HTTP fallback)
 - 🎯 **Minimal Client Code** - Smart diffing sends only what changed
 - 🔒 **Type Safe** - Rust guarantees for core performance-critical code
@@ -70,7 +70,7 @@ djust uses a Rust-powered Virtual DOM (VDOM) to diff server-rendered HTML and se
 <!DOCTYPE html>
 <html>
 <head>
-    {% djust_scripts %}              {# Loads ~5KB client JavaScript #}
+    {% djust_scripts %}              {# Loads the client runtime #}
 </head>
 <body dj-view="{{ dj_view_id }}">   {# Identifies the WebSocket session #}
     <div dj-root>                    {# Reactive boundary — only this is diffed #}
@@ -191,7 +191,7 @@ from django.urls import path
 from myapp.views import CounterView
 
 urlpatterns = [
-    path('counter/', CounterView.as_live_view(), name='counter'),
+    path('counter/', CounterView.as_view(), name='counter'),
 ]
 ```
 
@@ -270,7 +270,7 @@ python benchmark.py
 
 - Python 3.10+
 - Rust 1.70+ (for building from source)
-- Django 3.2+
+- Django 4.2+
 
 ### Install from PyPI
 
@@ -578,7 +578,7 @@ class Button(Component):
     @event_handler
     def on_click(self):
         self.clicks += 1
-        print(f"Clicked {self.clicks} times!")
+        # self.clicks is auto-exposed to the template (public attribute)
 ```
 
 ### Decorators
@@ -702,7 +702,7 @@ class ProductSearchView(LiveView):
 
 - ✅ **Zero JavaScript Required** - Common patterns work without writing any JS
 - ✅ **87% Code Reduction** - Decorators replace hundreds of lines of manual JavaScript
-- ✅ **Lightweight Bundle** - ~29KB gzipped client.js (vs Livewire ~50KB)
+- ✅ **Lightweight Bundle** - ~53 KB gzipped minified client.js, no npm dependencies
 - ✅ **Competitive DX** - Matches Phoenix LiveView and Laravel Livewire developer experience
 
 #### Available Decorators
@@ -945,7 +945,7 @@ def search(self, query: str = "", **kwargs):
 ```
 ┌─────────────────────────────────────────────┐
 │  Browser                                    │
-│  ├── Client.js (~29KB gz) - Events & DOM   │
+│  ├── Client.js (~53 KB gz) - Events & DOM  │
 │  └── WebSocket Connection                   │
 └─────────────────────────────────────────────┘
            ↕️ WebSocket (Binary/JSON)
@@ -1063,7 +1063,7 @@ Areas we'd love help with:
 - [x] Reusable component library (`djust_components` crate)
 - [x] JIT pipeline improvements and stale-closure fixes
 - [x] Authentication & authorization (view-level + handler-level)
-- [ ] File upload handling
+- [x] File upload handling
 - [x] Server-sent events (SSE) fallback
 - [ ] React/Vue component compatibility
 - [x] TypeScript definitions (`djust.d.ts` shipped with the package)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,10 @@ This directory contains comprehensive documentation for djust organized by topic
 - **[Template Requirements](guides/template-requirements.md)** - Required template attributes (dj-view, dj-root)
 - **[Working with External Services](guides/services.md)** - AWS, REST APIs, Redis integration patterns
 - **[Error Code Reference](guides/error-codes.md)** - Complete error code guide with fixes
-- **[System Checks Reference](system-checks.md)** - All 37 check IDs (C/V/S/T/Q), severities, suppression patterns, and false positives
+- **[System Checks Reference](system-checks.md)** - Check IDs across the C/V/S/T/Q/Y categories, severities, suppression patterns, and false positives
 - **[API Stability & Deprecation Policy](API_STABILITY.md)** - What the djust 1.0 SemVer commitment covers, the deprecation process, and the support window
+- **[Upgrading to djust 1.0](website/guides/upgrade-to-1.0.md)** - What the 1.0 SemVer commitment means for a 0.9.x app, the deprecated symbols, and the new accessibility checks
+- **[Accessibility (ARIA / WCAG)](website/guides/accessibility.md)** - Built-in component ARIA, the `Y` accessibility system checks, and theming color-contrast WCAG validation
 - **[Scaffolding Generator](guides/scaffolding.md)** - Generate CRUD LiveView scaffolds from model definitions
 
 ### 🔌 Real-Time Features

--- a/docs/website/_config.yaml
+++ b/docs/website/_config.yaml
@@ -286,6 +286,11 @@ navigation:
         file: guides/api-stability.md
         order: 18
         level: reference
+      - title: Upgrading to djust 1.0
+        slug: upgrade-to-1.0
+        file: guides/upgrade-to-1.0.md
+        order: 18.2
+        level: reference
       - title: Accessibility (ARIA / WCAG)
         slug: accessibility
         file: guides/accessibility.md

--- a/docs/website/guides/upgrade-to-1.0.md
+++ b/docs/website/guides/upgrade-to-1.0.md
@@ -1,0 +1,83 @@
+---
+title: "Upgrading to djust 1.0"
+slug: upgrade-to-1.0
+section: guides
+order: 18.2
+level: reference
+description: "What the djust 1.0 SemVer commitment means for a 0.9.x app, the deprecated symbols, and the new accessibility checks. 1.0 is a consolidation release with no breaking changes from 0.9.7."
+---
+
+# Upgrading to djust 1.0
+
+**TL;DR:** djust 1.0 is a **consolidation release**. There are **no breaking
+changes from 0.9.7** — if your app runs on 0.9.7, it runs on 1.0 unchanged.
+The headline of 1.0 is a *promise*, not a migration: starting at 1.0.0, code
+written against djust's public API keeps working across every 1.x release.
+
+## 1.0 is a consolidation release
+
+There is nothing to migrate. 1.0 caps the v0.9.x audit-driven bake — an
+API-stability policy, a framework-wide accessibility pass, and a pre-1.0
+security sweep — without changing any public behavior. Bump your dependency
+and run your test suite; that is the whole upgrade.
+
+## What 1.0 means: the SemVer commitment
+
+The 0.x series carried **no** stability guarantee — per SemVer, pre-1.0
+versions make no promise, and djust used that latitude. The commitment takes
+effect at **1.0.0**:
+
+- A symbol in djust's **public API surface** is never removed or changed
+  incompatibly in a MINOR or PATCH release. Breaking a public symbol is a
+  MAJOR-only change.
+- New public symbols may be added in any MINOR release (additive changes are
+  backward-compatible).
+- Anything underscore-prefixed, or reachable only by reaching into a
+  submodule, is **internal** and may change at any time.
+
+For the full definition of the public API surface, see
+[`docs/API_STABILITY.md`](https://github.com/johnrtipton/djust/blob/main/docs/API_STABILITY.md)
+and the [API Stability & Deprecations guide](api-stability.md).
+
+## Deprecated symbols
+
+Three symbols are deprecated as of 0.9.7. **All three still work in the 1.x
+line** — each carries the 0.x carve-out removal floor of **`>= 1.1.0`**, so
+nothing is removed in 1.0 itself.
+
+| Symbol | Use instead | Removed no earlier than |
+| --- | --- | --- |
+| `@event` decorator | `@event_handler` | 1.1.0 |
+| `LiveViewForm` | `django.forms.Form` (form reactivity comes from `FormMixin` on the `LiveView`) | 1.1.0 |
+| `_legacy` theming module (`THEMES`, `get_theme()`, `list_themes()`) | `DESIGN_SYSTEMS` / `get_design_system` / `get_all_design_systems` from `djust.theming.theme_packs` | 1.1.0 |
+
+Each migration is mechanical — see
+[`docs/API_STABILITY.md` § "Currently Deprecated Symbols"](https://github.com/johnrtipton/djust/blob/main/docs/API_STABILITY.md#currently-deprecated-symbols)
+for before/after code for every symbol.
+
+## New in the 1.0 line: accessibility system checks
+
+djust 1.0 ships the `Y` (accessibility) category of Django system checks
+(`Y001`, `Y002`). When you run `manage.py check`, they scan your templates for
+common accessibility gaps.
+
+- They emit **warnings only** — they never fail `manage.py check`.
+- They are **suppressible** like any Django check (via `SILENCED_SYSTEM_CHECKS`).
+
+See the [Accessibility guide](accessibility.md) for the full check list and
+remediation guidance.
+
+## Action items
+
+1. Bump your `djust` dependency to `1.0.x` and run your test suite — nothing
+   should change.
+2. Surface any deprecated-symbol usage before the 1.1 line removes it:
+
+   ```bash
+   python -W error::DeprecationWarning manage.py check
+   ```
+
+   This turns djust's deprecation warnings into errors, making every `@event`
+   / `LiveViewForm` / `_legacy` theming call site visible.
+3. Migrate any flagged symbols at your own pace — they keep working through
+   the entire 1.x line.

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -177,6 +177,7 @@ Rust powers the core rendering engine:
 
 ## Migrating
 
+- **[Upgrading to djust 1.0](guides/upgrade-to-1.0.md)** — what the 1.0 SemVer commitment means, the deprecated symbols, and the new accessibility checks. 1.0 is a consolidation release — no breaking changes from 0.9.7.
 - **[From standalone djust packages](guides/migration-from-standalone-packages.md)** — moving from `pip install djust-auth` / `djust-tenants` / `djust-theming` / `djust-components` / `djust-admin`? Replace with `djust[auth]` / `djust[tenants]` / etc. extras. Mechanical sed script + FAQ included. ([ADR-007](../adr/007-package-taxonomy-and-consolidation.md) Phase 4 — sunset as of v0.6.0.)
 
 ---


### PR DESCRIPTION
## Summary

**v1.0.0 milestone unit 6 — the final unit.** Gets djust's docs release-ready for the 1.0 stability commitment.

## What's in it

**`README.md`:**
- **P0 fix** — the Getting Started walkthrough used `CounterView.as_live_view()`, which doesn't exist (`live_view.py` defines `as_view()`). Every new user copy-pasting the README hit an `AttributeError`. Fixed.
- "Django 3.2+" → "Django 4.2+" (matches `pyproject.toml`).
- Dropped a `print(f"...")` anti-pattern from the custom-component example (djust's own rules forbid it).
- Corrected stale client-JS size claims (~29 KB → ~53 KB gzipped minified — measured).
- Marked the shipped "File upload handling" roadmap item done.

**New `docs/website/guides/upgrade-to-1.0.md`** — concise 0.9.x → 1.0 upgrade guide: the SemVer-1.0 stability commitment (cross-refs `API_STABILITY.md`), the 3 deprecated symbols (`@event`, `LiveViewForm`, `_legacy` theming), the new `Y` accessibility checks, and that 1.0 is a **consolidation release — no breaking changes from 0.9.7**. Nav-linked from `_config.yaml` + the guides index.

**`docs/README.md`** — stale check-count reference fixed (the `Y` category was added).

**`CHANGELOG.md`** — a narrative lead-in framing `[Unreleased]` as the v1.0.0 stability milestone (units 1-6). No dated `[1.0.0]` heading — that's the release cut's job.

## Milestone status

With this PR, **all 6 units of the v1.0.0 milestone are complete** (#1486, #1488, #1490, #1491, #1492, this). v1.0.0rc1 can be cut next.

## Pipeline

Docs-only pipeline — test/review/security stages skipped per `DOCS_ONLY`. State: `.pipeline-state/docs-v1-documentation-pass.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)