### PR TITLE
deps: migrate to markup5ever_rcdom + html5ever 0.39 (supersedes #1427)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,16 +437,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,9 +589,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "html5ever"
-version = "0.36.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
  "markup5ever",
@@ -723,16 +713,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "markup5ever"
-version = "0.36.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril",
@@ -741,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "markup5ever_rcdom"
-version = "0.36.0+unofficial"
+version = "0.39.0+unofficial"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5fc8802e8797c0dfdd2ce5c21aa0aee21abbc7b3b18559100651b3352a7b63"
+checksum = "3ac010f19d6c4af81eeb4018a39d7a115de9d285af45c126a4ac02e6fc5716b7"
 dependencies = [
  "html5ever",
  "markup5ever",
@@ -1380,6 +1364,7 @@ dependencies = [
  "parking_lot",
  "phf_shared",
  "precomputed-hash",
+ "serde",
 ]
 
 [[package]]
@@ -1426,12 +1411,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
- "futf",
- "mac",
+ "new_debug_unreachable",
  "utf-8",
 ]
 
@@ -1974,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "xml5ever"
-version = "0.36.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f57dd51b88a4b9f99f9b55b136abb86210629d61c48117ddb87f567e51e66be7"
+checksum = "5ab627f34ff61b80d756180d556f9c68801d836d271b3b8c094504ceca69d221"
 dependencies = [
  "log",
  "markup5ever",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ regex = "1.12"
 once_cell = "1.21"
 thiserror = "2.0"
 quick-xml = "0.36"
-html5ever = "0.36"
-markup5ever_rcdom = "0.36"
+html5ever = "0.39"
+markup5ever_rcdom = "0.39"
 chrono = "0.4"  # DateTime handling for timesince filter
 
 # Actor system dependencies


### PR DESCRIPTION
## Summary

Supersedes dependabot **#1427**, which bumped `markup5ever_rcdom` 0.36→0.39 alone and failed 8 CI checks.

## Root cause

Bumping `markup5ever_rcdom` without `html5ever` left **two `markup5ever` versions** in the dependency graph. `RcDom` (rcdom 0.39) implements `markup5ever 0.39::TreeSink`, but `parse_document` / `parse_fragment` resolved from `html5ever 0.36`, which expects `markup5ever 0.36::TreeSink` — a distinct type. Result: `the trait bound RcDom: TreeSink is not satisfied` ×6.

## Fix

Bump **both** `markup5ever_rcdom` **and** `html5ever` to 0.39 in the workspace `Cargo.toml`. The 0.39 API (`RcDom`, `Handle`, `NodeData`, `parse_document`, `parse_fragment`, `from_utf8`) is byte-identical to 0.36 — verified against the 0.39 crate sources — so `crates/djust_vdom/src/parser.rs`, the only consumer, needs **zero source change**.

`Cargo.lock` regenerated: html5ever / markup5ever / markup5ever_rcdom / xml5ever → 0.39, tendril → 0.5.0; transitive `futf` + `mac` dropped (leaner tree).

## Verification

- `djust_vdom`'s **272 tests** pass (HTML parsing, torture round-trip, SVG attrs, dj-if markers, wire-protocol snapshots) — parsed output is **byte-stable** across the bump.
- Full suite: 4290 Python, 805 Rust, 1572 JS — all green.
- `cargo audit` clean — no advisory on any 0.39 crate.

## Pipeline

Bugfix pipeline. State: `.pipeline-state/deps-markup5ever-rcdom-0.39.json`. After merge, #1427 will be closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)