### PR TITLE
fix(templates): preprocess multi-line {# ... #} comments for Django classical (#1551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Multi-line `{# ... #}` comments containing template-tag syntax no longer crash Django classical (#1551).** djust ships two template renderers: the Rust engine (`crates/djust_templates/src/lexer.rs:289-305`) treats `{# ... #}` as opaque even across newlines, but Django's classical tokenizer (`django.template.base.Lexer`) uses a non-DOTALL regex — multi-line `{# ... #}` was NOT recognized as a single comment, so a `{% if %}` inside the comment body parsed as a real tag and raised `TemplateSyntaxError`. The mismatch was silent: templates rendered fine via the LiveView WebSocket path (Rust) and crashed via `client.get()` in pytest, Django's debug error renderer, or any view using `render()` directly. Follow-up to #1423. Fix: new `djust.template.loaders.FilesystemLoader` and `djust.template.loaders.AppDirectoriesLoader` — drop-in replacements for the standard Django loaders that preprocess `{# ... #}` blocks out of the template source before Django classical's tokenizer sees them. Single-line comments are stripped too (Django strips them anyway). Projects opt in by replacing the default loaders in `TEMPLATES['OPTIONS']['loaders']`. Performance: one regex pass per template load (<1ms); loaded templates are cached so this runs once per template, not per render. Covered by 10 regression cases in `python/djust/tests/test_multiline_comment_parity_1551.py`, including a control that pins the bug shape in vanilla Django classical.
+
 ## [1.0.0rc6] - 2026-05-19
 
 ### Security

--- a/python/djust/template/loaders.py
+++ b/python/djust/template/loaders.py
@@ -1,0 +1,130 @@
+"""
+Django template Loader subclasses that normalize comment handling
+between djust's Rust template engine and Django's classical engine.
+
+## The problem (#1551)
+
+djust ships two template renderers:
+
+1. The Rust engine (``djust._rust.render_template_with_dirs``) — used for
+   LiveView WebSocket responses and production page renders. Its lexer
+   at ``crates/djust_templates/src/lexer.rs:289-305`` treats ``{# ... #}``
+   as opaque even across newlines.
+
+2. Django's classical engine — used by ``client.get()`` in pytest, by
+   Django's debug error-page renderer, and by any view that uses
+   ``render()`` directly. Its tokenizer (``django.template.base.Lexer``)
+   uses a non-DOTALL regex; multi-line ``{# ... #}`` is NOT recognized
+   as a single comment. A ``{% if %}`` inside the comment body gets
+   parsed as a real tag → ``TemplateSyntaxError``.
+
+The mismatch is silent: a template renders fine on the dev server
+(Rust path) and crashes in CI or on error paths (classical path).
+
+## The fix
+
+These Loader subclasses preprocess ``{# ... #}`` blocks out of the
+template source BEFORE Django classical's tokenizer sees them.
+Single-line comments are also stripped — Django strips them anyway,
+so doing it ourselves is uniform and safe.
+
+## Usage
+
+Replace the default Django loaders in your ``TEMPLATES`` setting::
+
+    TEMPLATES = [
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "DIRS": [...],
+            "APP_DIRS": False,  # explicit loaders shape required
+            "OPTIONS": {
+                "loaders": [
+                    "djust.template.loaders.FilesystemLoader",
+                    "djust.template.loaders.AppDirectoriesLoader",
+                ],
+                ...,
+            },
+        },
+    ]
+
+Or, equivalent and slightly more flexible, with the cached wrapper::
+
+    "loaders": [
+        ("django.template.loaders.cached.Loader", [
+            "djust.template.loaders.FilesystemLoader",
+            "djust.template.loaders.AppDirectoriesLoader",
+        ]),
+    ],
+
+The preprocessing is a single regex pass and adds < 1 ms overhead per
+template load. Loaded templates are cached by Django, so this runs once
+per template, not per render.
+"""
+
+from __future__ import annotations
+
+import re
+
+from django.template.loaders.app_directories import (
+    Loader as DjangoAppDirectoriesLoader,
+)
+from django.template.loaders.filesystem import Loader as DjangoFilesystemLoader
+
+__all__ = [
+    "AppDirectoriesLoader",
+    "FilesystemLoader",
+    "strip_multiline_comments",
+]
+
+
+# Match `{# ... #}` non-greedily, across newlines (re.DOTALL).
+#
+# Non-greedy is load-bearing: `{# A #} text {# B #}` must produce ` text `,
+# not `` (greedy would consume across both comments).
+_MULTILINE_COMMENT_RE = re.compile(r"\{#.*?#\}", re.DOTALL)
+
+
+def strip_multiline_comments(source: str) -> str:
+    """Strip all ``{# ... #}`` blocks from a template source string.
+
+    Both single-line and multi-line comments are removed; Django classical
+    strips single-line comments anyway, so doing it ourselves is uniform
+    and safe.
+
+    Args:
+        source: Template source code.
+
+    Returns:
+        Source with all ``{# ... #}`` blocks removed.
+
+    Example:
+        >>> strip_multiline_comments("{# hi #}<p>x</p>")
+        '<p>x</p>'
+        >>> strip_multiline_comments("{# A #} text {# B #}")
+        ' text '
+    """
+    return _MULTILINE_COMMENT_RE.sub("", source)
+
+
+class FilesystemLoader(DjangoFilesystemLoader):
+    """Drop-in replacement for ``django.template.loaders.filesystem.Loader``
+    that preprocesses multi-line ``{# ... #}`` comments out of the source
+    before Django's tokenizer sees them.
+
+    See module docstring for the asymmetry this fixes (#1551).
+    """
+
+    def get_contents(self, origin):
+        source = super().get_contents(origin)
+        return strip_multiline_comments(source)
+
+
+class AppDirectoriesLoader(DjangoAppDirectoriesLoader):
+    """Drop-in replacement for
+    ``django.template.loaders.app_directories.Loader`` with the same
+    ``{# ... #}`` preprocessing as :class:`FilesystemLoader`.
+    """
+
+    def get_contents(self, origin):
+        source = super().get_contents(origin)
+        return strip_multiline_comments(source)

--- a/python/djust/tests/test_multiline_comment_parity_1551.py
+++ b/python/djust/tests/test_multiline_comment_parity_1551.py
@@ -1,0 +1,200 @@
+"""
+Regression tests for #1551 — Multi-line `{# ... #}` comment handling
+asymmetry between the Rust template renderer and Django classical.
+
+## The bug
+
+The Rust lexer at `crates/djust_templates/src/lexer.rs:289-305` treats
+`{# ... #}` as opaque even across newlines — it consumes until `#}` without
+caring what's between. Django classical's tokenizer uses a non-DOTALL regex
+in `django.template.base.Lexer`, so multi-line `{# ... #}` is NOT recognized
+as a comment. Any `{% ... %}` syntax inside a multi-line comment body is
+parsed as a real tag, raising `TemplateSyntaxError`.
+
+This is asymmetric: a template renders fine via the LiveView WS path (Rust)
+but crashes via `client.get()` (Django classical), Django's debug error
+renderer, or any view that uses `render()` directly. The mismatch is silent
+— projects ship templates that work on the dev server and break in CI or on
+error paths.
+
+Follow-up to #1423 (which fixed the Rust side but didn't normalize behavior
+with classical). Reporter: NYC Comptroller Claims project (private).
+
+## Fix
+
+`djust.template.loaders` provides a `FilesystemLoader` + `AppDirectoriesLoader`
+subclass that preprocesses multi-line `{# ... #}` blocks out of the template
+source before Django classical sees it. The preprocessing matches both
+single-line and multi-line comments uniformly (Django ALSO strips
+single-line comments — the only difference is multi-line — so preprocessing
+all of them yields identical output).
+
+Projects opt in by replacing their classical Django loader entries in
+`TEMPLATES`:
+
+    'OPTIONS': {
+        'loaders': [
+            'djust.template.loaders.FilesystemLoader',
+            'djust.template.loaders.AppDirectoriesLoader',
+        ],
+    },
+"""
+
+from __future__ import annotations
+
+
+import pytest
+from django.template import engines
+from django.template.exceptions import TemplateSyntaxError
+
+
+# ---------------------------------------------------------------------------
+# The bug — Django classical crashes on multi-line {# ... %} ... #}
+# ---------------------------------------------------------------------------
+
+
+_PROBLEMATIC_TEMPLATE = """\
+{# d-none (not {% if %}) so the VDOM
+   toggles a class attribute, not a subtree.
+   See djust #1550. #}
+<div class="foo {% if x %}d-none{% endif %}"></div>
+"""
+
+_SINGLELINE_OK_TEMPLATE = """\
+{# d-none keeps the DOM stable #}
+<div class="foo {% if x %}d-none{% endif %}"></div>
+"""
+
+
+def test_django_classical_crashes_on_multiline_comment_with_tag_syntax():
+    """The bug: Django classical raises TemplateSyntaxError on multi-line
+    {# ... %} ... #} comments containing partial tag syntax."""
+    django_engine = engines["django"]
+    with pytest.raises(TemplateSyntaxError, match="Unexpected end of expression"):
+        django_engine.from_string(_PROBLEMATIC_TEMPLATE).render({"x": True})
+
+
+def test_django_classical_single_line_comment_works():
+    """Control: single-line {# ... #} comments are NOT broken in Django
+    classical even when they contain template-tag-like syntax.
+
+    Wait — actually they ARE broken when the body contains `{% %}`. Single-
+    line comments work for plain prose; the `{% %}`-in-comment behavior is
+    the cross-cutting Django bug. This control verifies the bug shape.
+    """
+    django_engine = engines["django"]
+    # Plain single-line comment (no embedded tag syntax) — works.
+    out = django_engine.from_string("{# just a comment #}\n<div>x</div>").render({})
+    assert "<div>x</div>" in out
+    assert "just a comment" not in out
+
+
+# ---------------------------------------------------------------------------
+# The fix — djust.template.loaders strip multi-line {# ... #} preprocessing
+# ---------------------------------------------------------------------------
+
+
+def test_strip_multiline_comments_removes_problematic_block():
+    """The preprocessing helper strips multi-line {# ... #} comments."""
+    from djust.template.loaders import strip_multiline_comments
+
+    out = strip_multiline_comments(_PROBLEMATIC_TEMPLATE)
+    assert "d-none (not" not in out
+    assert "{% if %}" not in out  # the prose-tag-text is stripped
+    # The actual template tags outside the comment remain.
+    assert "{% if x %}d-none{% endif %}" in out
+    assert '<div class="foo' in out
+
+
+def test_strip_multiline_comments_handles_single_line():
+    """The preprocessing also handles single-line comments — Django strips
+    them anyway, so doing it ourselves is safe and uniform."""
+    from djust.template.loaders import strip_multiline_comments
+
+    src = "{# single-line #}<p>hello</p>"
+    assert strip_multiline_comments(src) == "<p>hello</p>"
+
+
+def test_strip_multiline_comments_preserves_template_tags():
+    """The preprocessing MUST NOT strip {% ... %} or {{ ... }} — only
+    {# ... #}."""
+    from djust.template.loaders import strip_multiline_comments
+
+    src = "{% if x %}{{ y }}{% endif %}{# comment #}"
+    assert "{% if x %}{{ y }}{% endif %}" in strip_multiline_comments(src)
+
+
+def test_strip_multiline_comments_handles_nested_braces():
+    """A comment body can contain `{` and `}` chars (e.g. JSON examples).
+    The matcher must terminate on `#}`, not on bare `}`."""
+    from djust.template.loaders import strip_multiline_comments
+
+    src = '{# example: {"key": "value"} #}<p>x</p>'
+    assert strip_multiline_comments(src) == "<p>x</p>"
+
+
+def test_strip_multiline_comments_multiple_comments():
+    """Multiple non-overlapping comments are stripped independently."""
+    from djust.template.loaders import strip_multiline_comments
+
+    src = "{# A #}<p>x</p>{# B\nspans lines #}<p>y</p>"
+    out = strip_multiline_comments(src)
+    assert "A" not in out and "B" not in out
+    assert "<p>x</p>" in out and "<p>y</p>" in out
+
+
+def test_strip_multiline_comments_non_greedy():
+    """The matcher must be non-greedy — `{# A #} text {# B #}` must produce
+    ' text ', not '' (greedy would consume across both comments)."""
+    from djust.template.loaders import strip_multiline_comments
+
+    src = "{# A #} text {# B #}"
+    assert strip_multiline_comments(src) == " text "
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via the Loader subclass — Django can parse the template now
+# ---------------------------------------------------------------------------
+
+
+def test_loader_preprocesses_problematic_template(tmp_path, settings):
+    """When the FilesystemLoader is used, a template that previously crashed
+    Django classical now renders cleanly."""
+    from django.template import Engine
+
+    # Write the problematic template to a temp dir.
+    (tmp_path / "test.html").write_text(_PROBLEMATIC_TEMPLATE)
+
+    # Use the djust FilesystemLoader directly — no settings mutation.
+    engine = Engine(
+        dirs=[str(tmp_path)],
+        loaders=[
+            ("djust.template.loaders.FilesystemLoader", [str(tmp_path)]),
+        ],
+    )
+    tpl = engine.get_template("test.html")
+    out = tpl.render(
+        engine.template_context_processors_func.__self__
+        if False
+        else __import__("django").template.Context({"x": True})
+    )
+    assert "d-none" in out
+    assert '<div class="foo d-none">' in out
+
+
+def test_loader_does_not_mutate_loaded_source_for_non_comment_content(tmp_path):
+    """The Loader subclass only strips comments — actual template content
+    (tags, text, variables) must pass through unchanged."""
+    from django.template import Engine, Context
+
+    src = "Hello {{ name }} — count: {% if n %}{{ n }}{% endif %}"
+    (tmp_path / "no_comments.html").write_text(src)
+    engine = Engine(
+        dirs=[str(tmp_path)],
+        loaders=[
+            ("djust.template.loaders.FilesystemLoader", [str(tmp_path)]),
+        ],
+    )
+    tpl = engine.get_template("no_comments.html")
+    out = tpl.render(Context({"name": "world", "n": 3}))
+    assert out == "Hello world — count: 3"


### PR DESCRIPTION
Closes #1551. Follow-up to #1423.

## TL;DR
djust ships two template renderers and they disagreed on multi-line `{# ... #}` handling. The Rust engine treats them as opaque across newlines; Django classical's tokenizer doesn't (non-DOTALL regex), so a `{% if %}` inside a multi-line comment body parsed as a real tag and crashed with `TemplateSyntaxError`.

**Silent footgun:** templates rendered fine via the LiveView WebSocket path (Rust) and crashed via `client.get()` in pytest, Django's debug error renderer, or any view using `render()` directly. Reporter (NYC Comptroller Claims) hit it twice in 90 minutes after explicitly documenting the gotcha.

## Fix

Per issue body option 1: new `djust.template.loaders.FilesystemLoader` and `djust.template.loaders.AppDirectoriesLoader` — drop-in replacements for the standard Django loaders that preprocess `{# ... #}` blocks out of the template source before Django classical's tokenizer sees them.

```python
TEMPLATES = [{
    'BACKEND': 'django.template.backends.django.DjangoTemplates',
    'DIRS': [...],
    'APP_DIRS': False,  # explicit loaders shape required
    'OPTIONS': {
        'loaders': [
            'djust.template.loaders.FilesystemLoader',
            'djust.template.loaders.AppDirectoriesLoader',
        ],
    },
}]
```

Single-line comments are stripped too — Django strips them anyway, so doing it uniformly is safe and symmetric.

## Coverage

10 regression tests in `python/djust/tests/test_multiline_comment_parity_1551.py`:

- `test_django_classical_crashes_on_multiline_comment_with_tag_syntax` — control; pins the bug shape in vanilla Django classical
- 6 `strip_multiline_comments()` unit tests — basic, single-line, preserves-tags, nested-braces, multiple, non-greedy
- 2 loader-level E2E tests through Django `Engine` — confirms problematic template now renders + non-comment content passes through untouched
- `test_django_classical_single_line_comment_works` — controls the comparison

## Verification

- Full Python regression: **7,311 passed, 0 failed.**
- New tests: **10/10 passing.**
- Performance: one regex pass per template load (~1 ms or less); loaded templates are cached so this runs once per template, not per render.

## Two-commit shape (#1173)
- `107322b8` — implementation (`loaders.py` + 10 tests)
- `8dbfdd85` — CHANGELOG only

## Adoption recommendation
Recommend documenting in the Getting Started guide and the migration guide from older djust versions. Not a default-on change (don't silently mutate users' loaders) — opt-in via settings is the right balance per #1551's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)