### PR TITLE
feat(renderers): Renderer Protocol + HtmlRenderer — LVN-I PR-1 (#1577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`djust.renderers` package — pluggable `Renderer` Protocol + default `HtmlRenderer` (LVN-I PR-1; ADR-019; #1577).** Foundation iteration of the LiveView Native track. Introduces a structurally narrow `Renderer` Protocol (`@runtime_checkable`; `output_format: str`; `render_with_diff(...) -> tuple[str, Optional[str], int]`) so the server-side reactive lifecycle can dispatch to non-HTML targets (SwiftUI, Compose — LVN-II onward in #1578). `HtmlRenderer` wraps the existing Django-template + Rust VDOM pipeline; behavior is byte-identical to the pre-refactor inline call. `TemplateMixin.render_with_diff` at `python/djust/mixins/template.py:942` now dispatches through `HtmlRenderer(self).render_with_diff(...)` instead of inlining `self._rust_view.render_with_diff()`. **What's explicitly NOT in this PR**: `ViewRuntime` plumbing (PR-2 of LVN-I) and `?platform=` handshake parsing (PR-3); `NativeRenderer` + widget vocabulary (LVN-II / #1578); `crates/djust_vdom` (wire format unchanged); `static/djust/client.js` (browser client byte-identical). New tests: `python/djust/tests/test_renderer_protocol.py` (11 cases covering package imports, Protocol shape, `HtmlRenderer` conformance via `@runtime_checkable` isinstance, delegation to `_rust_view`, and the dispatch gate that the mixin routes through `HtmlRenderer` instead of the inline call). Full djust test suite: 2991 pass / 3 skipped / 0 fail (no regression). Prior art: ADR-016 (`ViewRuntime` + `Transport` — this is the third pluggability axis on the same refactor).
+
 ## [1.0.0rc9] - 2026-05-22
 
 ### Fixed

--- a/python/djust/mixins/template.py
+++ b/python/djust/mixins/template.py
@@ -939,7 +939,18 @@ Object.assign(window.handlerMetadata, {json.dumps(metadata)});
             )
         self._sync_done_this_cycle = False  # Reset for next cycle
 
-        result = self._rust_view.render_with_diff()
+        # ADR-019: dispatch through the renderer abstraction. HtmlRenderer
+        # is the default; future PR-3 of LVN-I will let the connection
+        # handshake pick a different renderer. Local import — renderers
+        # has no djust deps, but the local form matches the file's
+        # existing convention for cycle-safe imports.
+        from ..renderers import HtmlRenderer
+
+        result = HtmlRenderer(self).render_with_diff(
+            request=None,
+            extract_liveview_root=False,
+            preloaded_context=None,
+        )
         html, patches_json, version = result
 
         # Capture per-phase Rust timing (render, parse, diff, serialize)

--- a/python/djust/renderers/__init__.py
+++ b/python/djust/renderers/__init__.py
@@ -1,0 +1,23 @@
+"""Renderer abstraction for djust LiveView.
+
+Iteration I of ADR-019 (LiveView Native): introduces a pluggable
+``Renderer`` Protocol so the existing server-side reactive lifecycle
+can drive non-HTML targets. This PR ships the Protocol + the default
+``HtmlRenderer`` only; ``NativeRenderer`` and runtime threading land
+in subsequent PRs of LVN-I.
+
+The Protocol is intentionally narrow — one method, ``render_with_diff``,
+returning the same ``(html, patches_json, version)`` triple
+``TemplateMixin.render_with_diff`` returns today. The Protocol exists so
+future renderers (SwiftUI, Compose, terminal) can wrap an alternative
+template + diff pipeline behind the same Python-side contract.
+
+See also:
+- ADR-019 §"What changes in djust core"
+- ADR-016 §"ViewRuntime" (prior pluggability axis)
+"""
+
+from .base import Renderer
+from .html import HtmlRenderer
+
+__all__ = ["Renderer", "HtmlRenderer"]

--- a/python/djust/renderers/base.py
+++ b/python/djust/renderers/base.py
@@ -1,0 +1,50 @@
+"""Renderer Protocol — the contract every output backend implements.
+
+See ADR-019 §"Three layers" §1 for the full design rationale.
+
+This module is intentionally tiny and import-light: it defines the
+Protocol and nothing else. Implementations live in sibling modules
+(``html.py``, future ``native.py``) and are re-exported from
+``renderers/__init__.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Protocol, Tuple, runtime_checkable
+
+__all__ = ["Renderer"]
+
+
+@runtime_checkable
+class Renderer(Protocol):
+    """Output-format-pluggable renderer for a mounted LiveView.
+
+    Implementations wrap an output-specific render + diff pipeline. The
+    default :class:`HtmlRenderer` wraps the existing Django-template +
+    Rust-parse + Rust-diff path; future implementations will produce
+    widget-shaped trees for SwiftUI / Compose clients (LVN-II onward).
+
+    The ``output_format`` attribute identifies the renderer choice at
+    handshake time (PR-3 of LVN-I). ``"html"`` for the default;
+    ``"swiftui"``, ``"compose"`` for native renderers (not in this PR).
+
+    ``@runtime_checkable`` allows ``isinstance(obj, Renderer)`` to assert
+    structural conformance at test time without forcing subclassing.
+    """
+
+    output_format: str
+
+    def render_with_diff(
+        self,
+        request: Any = None,
+        extract_liveview_root: bool = False,
+        preloaded_context: Optional[dict] = None,
+    ) -> Tuple[str, Optional[str], int]:
+        """Render the current view state and compute the diff.
+
+        Returns the same triple ``TemplateMixin.render_with_diff`` returns
+        today: ``(html, patches_json, version)``. The ``patches_json`` is
+        the Rust VDOM differ's output (msgpack/JSON envelope is added by
+        the transport, NOT by the renderer).
+        """
+        ...

--- a/python/djust/renderers/html.py
+++ b/python/djust/renderers/html.py
@@ -1,0 +1,59 @@
+"""Default HTML renderer — wraps the existing Django template + Rust VDOM pipeline.
+
+This module is the smallest possible refactor of the inline render path
+in :meth:`TemplateMixin.render_with_diff`. It does NOT change ANY
+behavior — it is a structural extraction so the dispatch site has a
+named seam to which future ``NativeRenderer`` etc. can plug in
+(LVN-II onward; ADR-019).
+
+The renderer wraps the view instance (not just template + context)
+because the existing call site does more than render: it caches a
+per-view ``RustLiveView``, syncs Django context into Rust state, and
+tracks ``_sync_done_this_cycle`` to avoid double-sync. Reproducing all
+of that from a renderer that only knows ``(template_name, context)``
+would either duplicate state or break the existing fast paths.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Tuple
+
+__all__ = ["HtmlRenderer"]
+
+
+class HtmlRenderer:
+    """Default renderer — emits HTML via the existing Rust VDOM pipeline.
+
+    Conforms to :class:`djust.renderers.Renderer` Protocol. Behavior is
+    identical to the pre-refactor inline call at
+    ``mixins/template.py:942``: invokes ``self.view._rust_view.render_with_diff()``
+    and returns the result unchanged.
+    """
+
+    output_format: str = "html"
+
+    def __init__(self, view: Any) -> None:
+        """Bind the renderer to a LiveView instance.
+
+        The caller (currently ``TemplateMixin.render_with_diff``) is
+        responsible for ``_initialize_rust_view`` and state sync — the
+        renderer assumes ``view._rust_view`` is ready.
+        """
+        self.view = view
+
+    def render_with_diff(
+        self,
+        request: Any = None,
+        extract_liveview_root: bool = False,
+        preloaded_context: Optional[dict] = None,
+    ) -> Tuple[str, Optional[str], int]:
+        """Run the Rust VDOM differ and return ``(html, patches_json, version)``.
+
+        The ``request``, ``extract_liveview_root``, and ``preloaded_context``
+        parameters are on the Protocol surface but not consumed here; the
+        wrapping ``TemplateMixin.render_with_diff`` handles them around
+        this call. They are accepted so the Protocol shape is consistent
+        across renderers (LVN-II's ``NativeRenderer`` will need
+        ``request`` for per-platform variant resolution).
+        """
+        return self.view._rust_view.render_with_diff()

--- a/python/djust/tests/test_renderer_protocol.py
+++ b/python/djust/tests/test_renderer_protocol.py
@@ -1,0 +1,171 @@
+"""LVN-I PR-1 gate test: Renderer Protocol + HtmlRenderer shape.
+
+Tests for ADR-019 Iteration I, PR-1 — the renderer abstraction
+foundation. Asserts the Protocol exists with the documented shape, that
+``HtmlRenderer`` conforms to it, and that ``TemplateMixin.render_with_diff``
+dispatches through the renderer instead of calling ``_rust_view``
+directly.
+
+The test that gates the entire PR is
+:meth:`TestRendererDispatch.test_mixin_dispatches_through_html_renderer`
+— it goes RED until the ``mixins/template.py`` edit lands.
+
+See:
+- ``docs/adr/019-liveview-native.md`` §"Three layers" §1
+- ``python/djust/renderers/`` (this PR introduces the package)
+- ``python/djust/tests/test_runtime.py`` for the analogous test shape
+  used for ``ViewRuntime`` / ``Transport`` Protocol verification
+"""
+
+from __future__ import annotations
+
+import django
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": ":memory:",
+            }
+        },
+        INSTALLED_APPS=[
+            "django.contrib.contenttypes",
+            "django.contrib.auth",
+            "django.contrib.sessions",
+        ],
+        SECRET_KEY="test-secret-key-renderer-protocol",
+        SESSION_ENGINE="django.contrib.sessions.backends.db",
+        USE_TZ=True,
+        DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+    )
+    django.setup()
+
+from unittest.mock import MagicMock, patch
+
+
+class TestRendererPackageImports:
+    """The Protocol and default implementation must be importable from
+    the top-level ``djust.renderers`` package per ADR-019 layout.
+    """
+
+    def test_import_renderer_from_package(self):
+        from djust.renderers import Renderer  # noqa: F401
+
+    def test_import_html_renderer_from_package(self):
+        from djust.renderers import HtmlRenderer  # noqa: F401
+
+    def test_package_exports_match_all(self):
+        import djust.renderers as renderers
+
+        assert "Renderer" in renderers.__all__
+        assert "HtmlRenderer" in renderers.__all__
+
+
+class TestRendererProtocolShape:
+    """Renderer is a runtime-checkable Protocol with the documented
+    attributes: ``output_format: str`` and ``render_with_diff(...)``.
+    """
+
+    def test_renderer_is_a_protocol(self):
+        from djust.renderers import Renderer
+
+        assert getattr(Renderer, "_is_protocol", False) is True
+
+    def test_renderer_has_output_format_attribute(self):
+        from djust.renderers import Renderer
+
+        # ``from __future__ import annotations`` stores annotations as
+        # strings; check the string form OR resolve via get_type_hints.
+        assert "output_format" in Renderer.__annotations__
+        assert Renderer.__annotations__["output_format"] == "str"
+
+    def test_renderer_has_render_with_diff_method(self):
+        from djust.renderers import Renderer
+
+        assert hasattr(Renderer, "render_with_diff")
+        assert callable(Renderer.render_with_diff)
+
+
+class TestHtmlRendererConformance:
+    def test_html_renderer_declares_output_format(self):
+        from djust.renderers import HtmlRenderer
+
+        assert HtmlRenderer.output_format == "html"
+
+    def test_html_renderer_instance_conforms_to_protocol(self):
+        from djust.renderers import HtmlRenderer, Renderer
+
+        renderer = HtmlRenderer(view=MagicMock())
+        assert isinstance(renderer, Renderer)
+
+    def test_html_renderer_binds_view_on_init(self):
+        from djust.renderers import HtmlRenderer
+
+        view = MagicMock()
+        renderer = HtmlRenderer(view)
+        assert renderer.view is view
+
+    def test_html_renderer_delegates_to_rust_view(self):
+        """``HtmlRenderer.render_with_diff`` must call through to the
+        bound view's ``_rust_view.render_with_diff()`` and return its
+        result verbatim — this is the wire-format invariant that keeps
+        the browser client byte-identical.
+        """
+        from djust.renderers import HtmlRenderer
+
+        view = MagicMock()
+        view._rust_view.render_with_diff.return_value = (
+            "<div>html</div>",
+            '[{"type":"SetText","text":"x"}]',
+            42,
+        )
+
+        renderer = HtmlRenderer(view)
+        result = renderer.render_with_diff()
+
+        view._rust_view.render_with_diff.assert_called_once_with()
+        assert result == (
+            "<div>html</div>",
+            '[{"type":"SetText","text":"x"}]',
+            42,
+        )
+
+
+class TestRendererDispatch:
+    """The PR-1 gate: ``TemplateMixin.render_with_diff`` no longer calls
+    ``self._rust_view.render_with_diff()`` directly; it constructs an
+    ``HtmlRenderer`` and dispatches through it.
+
+    This is the test that goes RED until the ``mixins/template.py`` edit
+    lands and GREEN immediately after — the structural seam the rest of
+    LVN-I builds on.
+    """
+
+    def test_mixin_dispatches_through_html_renderer(self):
+        from djust.mixins.template import TemplateMixin
+
+        # Plain MagicMock (no spec) — render_with_diff calls many helpers
+        # from sibling mixins (_initialize_rust_view from rust_bridge,
+        # _sync_state_to_rust, etc.) that aren't on TemplateMixin's own
+        # surface. MagicMock without spec auto-stubs all of them.
+        view = MagicMock()
+        view._rust_view.render_with_diff.return_value = ("<div>x</div>", None, 1)
+        view._rust_view.get_render_timing.return_value = {}
+        view._sync_done_this_cycle = False
+        view._force_full_html = False
+        view._current_html_size = None
+        view.__class__ = type("StubView", (), {})  # avoid 'template' property check
+
+        with patch(
+            "djust.renderers.html.HtmlRenderer.render_with_diff",
+            return_value=("<div>x</div>", None, 1),
+        ) as patched_render:
+            TemplateMixin.render_with_diff(view)
+
+        assert patched_render.called, (
+            "TemplateMixin.render_with_diff did not dispatch through "
+            "HtmlRenderer — the renderer-abstraction seam is missing. "
+            "See ADR-019 §'Three layers' §1."
+        )


### PR DESCRIPTION
## Summary

Foundation iteration of [ADR-019 LiveView Native](docs/adr/019-liveview-native.md). Tracking issue: #1577 (LVN-I). Targets `1.1` per the [project-local pipeline templates](.pipeline-templates/README.md).

## What's in this PR

- **NEW**: `python/djust/renderers/` package
  - `base.py` — `Renderer` Protocol (`@runtime_checkable`; `output_format: str`; `render_with_diff(...) -> tuple[str, Optional[str], int]`)
  - `html.py` — `HtmlRenderer` (binds to a LiveView, delegates `render_with_diff()` to `view._rust_view.render_with_diff()`)
  - `__init__.py` — re-exports
- **EDIT**: `python/djust/mixins/template.py:942` — one-line surgical replacement. The inline `self._rust_view.render_with_diff()` becomes `HtmlRenderer(self).render_with_diff(...)`. Surrounding state-sync / timing / extraction logic unchanged.
- **NEW**: `python/djust/tests/test_renderer_protocol.py` (11 tests) — covers package imports, Protocol shape, `HtmlRenderer` conformance, delegation to `_rust_view`, and the dispatch gate.

## What this PR explicitly does NOT do

- `ViewRuntime` plumbing → PR-2 of LVN-I (separate PR)
- `?platform=` handshake parsing → PR-3 of LVN-I
- `NativeRenderer` + widget vocabulary → LVN-II (#1578)
- `crates/djust_vdom` untouched — wire format unchanged
- `static/djust/client.js` untouched — browser client byte-identical

## Two-commit shape

Per [#1173 canon](docs/adr/). Commit 1: implementation only (no CHANGELOG). Commit 2: CHANGELOG only.

## Verification

- `pytest python/djust/tests/test_renderer_protocol.py` → 11/11 pass
- `pytest python/djust/tests/` (full djust suite) → 2991 pass, 3 skipped, 0 fail (same counts as pre-PR — no regression)
- Gate test `test_mixin_dispatches_through_html_renderer` was RED before the `mixins/template.py:942` edit (`ModuleNotFoundError: djust.renderers`) and GREEN after — proving the dispatch seam is live (satisfies #1210 verify-artifact-before-planning gate).

## Plan + ADR references

- ADR: [`docs/adr/019-liveview-native.md`](docs/adr/019-liveview-native.md) §"Three layers" §1
- Plan: [`.pipeline-state/feat-lvn-1-renderer-abstraction-plan.md`](.pipeline-state/feat-lvn-1-renderer-abstraction-plan.md) (gitignored — local artifact)
- Prior art: [ADR-016](docs/adr/016-transport-runtime-interface.md) — `ViewRuntime` + `Transport`; this is the third pluggability axis on the same refactor.
- Tracking: [#1577](https://github.com/djust-org/djust/issues/1577)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via /pipeline-run