### PR TITLE
feat(renderers): NativeRenderer POC walker emits real widget VNodes

### DIFF
--- a/python/djust/renderers/native.py
+++ b/python/djust/renderers/native.py
@@ -1,68 +1,138 @@
-"""NativeRenderer scaffold — emits widget-shaped VNodes for native clients.
+"""NativeRenderer — emits widget-shaped VNodes for native clients.
 
-LVN-II PR-2 of [ADR-019](../../../docs/adr/019-liveview-native.md). This
-module is the **scaffold** that establishes the structural seam between
-the renderer pipeline and the widget-shaped output path. The full
-Django-template walker that translates ``<Stack>`` / ``<Text>`` / etc.
-template syntax into widget VNodes is deferred to LVN-II PR-3 (template
-loader) and LVN-II PR-4 (reference variant + stub-client integration
-test).
+LVN-II POC (djust-org/djust#1578 follow-up): the structural scaffold
+from LVN-II PR-2 now has a working render path. Renders the resolved
+``.swiftui.html`` / ``.compose.html`` template variant through Django,
+parses the result with the stdlib HTML parser into a VNode tree, and
+emits a single ``Replace`` patch (no diffing — full re-render per
+tick is fine for POC; real diffing reuses ``djust_vdom`` later).
 
-Current behavior: ``NativeRenderer`` is registered in the ``RENDERERS``
-dict so the LiveViewConsumer handshake (LVN-I PR-3) successfully routes
-``?platform=swiftui`` / ``?platform=compose`` requests through this
-renderer; today the render path raises ``NotImplementedError`` with a
-clear pointer to the tracking issue, so a native client connecting
-prematurely sees a defined error rather than silent HTML fallback.
+The output format is JSON (matches djust's WS default
+``use_binary = False`` at ``websocket.py:393``). Wire shape matches
+``HtmlRenderer``'s `(html, patches_json, version)` triple so the
+transport layer is unchanged.
 
-The ``output_format`` attribute carries the platform key the handshake
-selected (``"swiftui"`` or ``"compose"``) so a future template-walker
-can pick a per-platform variant. Both platforms share the widget
-vocabulary; differences live in style / event-attr handling on the
-client side.
+Why the stdlib HTMLParser and not ``crates/djust_vdom``: the Rust
+parser is HTML-tag-aware in subtle ways (`<br/>` self-close, attr
+escaping). For a POC that emits widget tags (`<Stack>`, `<Text>`),
+stdlib is enough and avoids touching the Rust extension. Later
+optimization can route the widget templates through the Rust parser
+with no client-visible change.
 """
 
 from __future__ import annotations
 
+import json
+from html.parser import HTMLParser
 from typing import Any, Optional, Tuple
+
+from django.template.loader import render_to_string
 
 __all__ = ["NativeRenderer", "SwiftUIRenderer", "ComposeRenderer"]
 
 
+# Base62 djust-id generator — matches the format the Rust counter
+# produces (``crates/djust_vdom/src/lib.rs:55-114``) just enough for
+# the native clients' identity-tracking; the actual integer space is
+# different but the alphabet matches so the wire shape is consistent.
+_BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+
+def _to_base62(n: int) -> str:
+    if n == 0:
+        return "0"
+    out = []
+    while n:
+        n, r = divmod(n, 62)
+        out.append(_BASE62[r])
+    return "".join(reversed(out))
+
+
+class _VNodeBuilder(HTMLParser):
+    """Build a VNode dict tree from native-template HTML output."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.root: Optional[dict] = None
+        self.stack: list[dict] = []
+        self.id_counter = 0
+
+    def _next_id(self) -> str:
+        self.id_counter += 1
+        return _to_base62(self.id_counter)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+        node = {
+            "id": self._next_id(),
+            "tag": tag,
+            "attrs": {k: (v if v is not None else "") for k, v in attrs},
+            "text": "",
+            "children": [],
+        }
+        if self.stack:
+            self.stack[-1]["children"].append(node)
+        elif self.root is None:
+            self.root = node
+        self.stack.append(node)
+
+    def handle_endtag(self, tag: str) -> None:
+        # Tolerant close: pop until we find a matching tag (handles
+        # malformed templates without crashing the render path).
+        for i in range(len(self.stack) - 1, -1, -1):
+            if self.stack[i]["tag"] == tag:
+                del self.stack[i:]
+                return
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+        # Self-closing tag like <Spacer/> — no children, no need to push.
+        node = {
+            "id": self._next_id(),
+            "tag": tag,
+            "attrs": {k: (v if v is not None else "") for k, v in attrs},
+            "text": "",
+            "children": [],
+        }
+        if self.stack:
+            self.stack[-1]["children"].append(node)
+        elif self.root is None:
+            self.root = node
+
+    def handle_data(self, data: str) -> None:
+        stripped = data.strip()
+        if not stripped:
+            return
+        if self.stack:
+            # Append to the current node's text. Multiple text runs get
+            # joined by a space — fine for widget templates that don't
+            # mix structure and prose like web HTML does.
+            cur = self.stack[-1]
+            cur["text"] = (cur["text"] + " " + stripped).strip() if cur["text"] else stripped
+
+
 class NativeRenderer:
-    """Scaffold for the native-widget renderer (LVN-II PR-2).
+    """POC native widget renderer for djust LiveView.
 
-    Conforms to :class:`djust.renderers.Renderer` Protocol but raises
-    ``NotImplementedError`` from ``render_with_diff`` — the widget-tree
-    walker lands in LVN-II PR-3. Subclassed by :class:`SwiftUIRenderer`
-    and :class:`ComposeRenderer` to fix the ``output_format`` per
-    platform; both classes are registered in
+    Conforms to :class:`djust.renderers.Renderer` Protocol. Renders the
+    per-platform template variant resolved by :func:`resolve_template`,
+    parses the result into a VNode tree, and emits a single ``Replace``
+    patch covering the whole tree (no incremental diffing in this
+    iteration — added later).
+
+    Subclasses :class:`SwiftUIRenderer` and :class:`ComposeRenderer`
+    fix the ``output_format`` per platform and are registered in
     ``djust.renderers.RENDERERS``.
-
-    The scaffold exists so:
-    - LVN-I PR-3's handshake successfully routes native ``?platform=``
-      values (the alternative — keeping native out of the registry —
-      means the handshake silently falls back to HTML, which masks
-      misconfigurations).
-    - LVN-II PR-3 / PR-4 have a defined class to plug into rather than
-      birthing one mid-PR.
-    - LVN-III / LVN-IV client developers have a known server-side
-      target to write integration tests against, even if the body is
-      a clear NotImplementedError today.
     """
 
     output_format: str = "native"
 
     def __init__(self, view: Any) -> None:
         self.view = view
+        # Monotonic version per renderer instance. Native clients
+        # enforce this in their PatchApplicator (the version-regression
+        # gate from djust-native-{ios,android} PR-3).
+        self._version = 0
 
     def resolve_template(self, base: str) -> str:
-        """Pick the platform variant of ``base`` for this renderer.
-
-        Wraps :func:`template_resolver.resolve_variant` with this
-        renderer's ``output_format`` so callers don't have to plumb
-        the format separately.
-        """
         from .template_resolver import resolve_variant
 
         return resolve_variant(base, self.output_format)
@@ -73,32 +143,57 @@ class NativeRenderer:
         extract_liveview_root: bool = False,
         preloaded_context: Optional[dict] = None,
     ) -> Tuple[str, Optional[str], int]:
-        """Emit a widget-VNode-shaped diff.
+        """Render the platform variant and emit a Replace-only patch.
 
-        Today: raises ``NotImplementedError`` — the widget-tree walker is
-        the remaining LVN-II work (the renderer scaffold + vocabulary +
-        template resolver are in place; gluing them together via a real
-        Rust-side widget VDOM differ is the substantial piece).
-
-        The error includes the resolved template variant so a client
-        developer who hits it knows EXACTLY which template the resolver
-        picked — invaluable for debugging "why is my native variant not
-        loading?" before the walker is implemented.
-
-        See: https://github.com/djust-org/djust/issues/1578
+        Returns ``(html, patches_json, version)``. The ``html`` field is
+        empty for the native path (no HTML payload — the wire is
+        patches-only). The ``patches_json`` is a single-element list
+        containing a Replace patch with the full VNode tree, JSON-encoded.
         """
-        base_template = getattr(self.view, "template_name", "<unknown>")
-        resolved = (
-            self.resolve_template(base_template) if base_template != "<unknown>" else "<unknown>"
-        )
-        raise NotImplementedError(
-            f"NativeRenderer.render_with_diff (output_format={self.output_format!r}) "
-            f"is awaiting the widget-tree walker. The platform variant resolver "
-            f"picked '{resolved}' (from base '{base_template}'). See "
-            f"djust-org/djust#1578 for the remaining implementation. To unblock "
-            f"client development today, run the WS without ?platform= and the "
-            f"handshake falls through to HtmlRenderer."
-        )
+        base_template = getattr(self.view, "template_name", None)
+        if base_template is None:
+            raise RuntimeError(
+                "NativeRenderer: view has no template_name. The native "
+                "render path requires a Django template (and a per-platform "
+                "variant like foo.swiftui.html alongside foo.html). See "
+                "docs/native-author-guide.md."
+            )
+
+        template_name = self.resolve_template(base_template)
+
+        # Use the LiveView's preloaded_context if the runtime supplied it;
+        # otherwise pull it from get_context_data() like the HTML path.
+        if preloaded_context is not None:
+            context = preloaded_context
+        else:
+            context = self.view.get_context_data()
+
+        # Hoisted-import call site so tests can patch
+        # djust.renderers.native.render_to_string.
+        html_text = render_to_string(template_name, context)
+
+        builder = _VNodeBuilder()
+        builder.feed(html_text)
+        builder.close()
+
+        if builder.root is None:
+            raise RuntimeError(
+                f"NativeRenderer: template {template_name!r} produced no "
+                f"VNode root. Make sure the template starts with a widget "
+                f"tag like <Stack>...</Stack>."
+            )
+
+        patches = [
+            {
+                "type": "replace",
+                "path": [],
+                "djId": None,
+                "node": builder.root,
+            }
+        ]
+        patches_json = json.dumps(patches)
+        self._version += 1
+        return "", patches_json, self._version
 
 
 class SwiftUIRenderer(NativeRenderer):

--- a/python/djust/tests/test_native_renderer_poc.py
+++ b/python/djust/tests/test_native_renderer_poc.py
@@ -1,0 +1,131 @@
+"""LVN-II POC gate test: NativeRenderer actually renders.
+
+Replaces the scaffold's `NotImplementedError` with a real render path
+that walks a Django template and emits widget VNodes. Tests mock
+``render_to_string`` so they're independent of Django settings setup.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import django
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}},
+        INSTALLED_APPS=["django.contrib.contenttypes", "django.contrib.auth"],
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "DIRS": [],
+                "APP_DIRS": True,
+                "OPTIONS": {},
+            }
+        ],
+        SECRET_KEY="test-secret",
+        USE_TZ=True,
+    )
+    django.setup()
+
+
+def _make_view(template_name="home.html"):
+    view = MagicMock()
+    view.template_name = template_name
+    view.get_context_data.return_value = {}
+    return view
+
+
+class TestNativeRendererRenders:
+    def test_renders_widget_vnode_tree(self):
+        from djust.renderers import ComposeRenderer
+
+        view = _make_view()
+        r = ComposeRenderer(view)
+
+        rendered_html = (
+            "<Stack spacing='12' padding='16'>"
+            "<Text font='title'>Hello, Margaret</Text>"
+            "<Button dj-tap='dismiss_alert'>Dismiss</Button>"
+            "</Stack>"
+        )
+        with (
+            patch.object(r, "resolve_template", return_value="home.compose.html"),
+            patch("djust.renderers.native.render_to_string", return_value=rendered_html),
+        ):
+            html, patches_json, version = r.render_with_diff()
+
+        assert html == ""
+        assert version == 1
+        patches = json.loads(patches_json)
+        assert len(patches) == 1
+        assert patches[0]["type"] == "replace"
+        assert patches[0]["path"] == []
+
+        root = patches[0]["node"]
+        assert root["tag"] == "stack"  # HTMLParser lowercases
+        assert root["attrs"]["spacing"] == "12"
+        assert root["attrs"]["padding"] == "16"
+        assert "id" in root
+        assert len(root["children"]) == 2
+
+        text_node, button_node = root["children"]
+        assert text_node["tag"] == "text"
+        assert text_node["text"] == "Hello, Margaret"
+        assert text_node["attrs"]["font"] == "title"
+        assert button_node["tag"] == "button"
+        assert button_node["attrs"]["dj-tap"] == "dismiss_alert"
+        assert button_node["text"] == "Dismiss"
+
+    def test_version_monotonically_increases(self):
+        from djust.renderers import ComposeRenderer
+
+        r = ComposeRenderer(_make_view())
+        with (
+            patch.object(r, "resolve_template", return_value="home.compose.html"),
+            patch("djust.renderers.native.render_to_string", return_value="<Stack></Stack>"),
+        ):
+            _, _, v1 = r.render_with_diff()
+            _, _, v2 = r.render_with_diff()
+            _, _, v3 = r.render_with_diff()
+        assert (v1, v2, v3) == (1, 2, 3)
+
+    def test_self_closing_widget(self):
+        from djust.renderers import ComposeRenderer
+
+        r = ComposeRenderer(_make_view())
+        with (
+            patch.object(r, "resolve_template", return_value="home.compose.html"),
+            patch(
+                "djust.renderers.native.render_to_string",
+                return_value="<Stack><Spacer/><Text>a</Text></Stack>",
+            ),
+        ):
+            _, patches_json, _ = r.render_with_diff()
+        root = json.loads(patches_json)[0]["node"]
+        assert [c["tag"] for c in root["children"]] == ["spacer", "text"]
+
+    def test_no_template_name_raises_clearly(self):
+        from djust.renderers import ComposeRenderer
+
+        view = MagicMock(spec=[])  # no template_name attr
+        r = ComposeRenderer(view)
+        import pytest
+
+        with pytest.raises(RuntimeError, match="template_name"):
+            r.render_with_diff()
+
+    def test_empty_template_raises_clearly(self):
+        from djust.renderers import ComposeRenderer
+
+        r = ComposeRenderer(_make_view())
+        with (
+            patch.object(r, "resolve_template", return_value="empty.compose.html"),
+            patch("djust.renderers.native.render_to_string", return_value="   "),
+        ):
+            import pytest
+
+            with pytest.raises(RuntimeError, match="no.*VNode root"):
+                r.render_with_diff()

--- a/python/djust/tests/test_native_renderer_scaffold.py
+++ b/python/djust/tests/test_native_renderer_scaffold.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
-
 
 class TestRegistryHasNativeEntries:
     def test_swiftui_registered(self):
@@ -55,28 +53,6 @@ class TestNativeRendererConformance:
         assert ComposeRenderer.output_format == "compose"
 
 
-class TestScaffoldRaises:
-    """The scaffold raises with a clear pointer to the tracking issue."""
-
-    def test_swiftui_render_with_diff_raises_with_clear_message(self):
-        from djust.renderers import SwiftUIRenderer
-
-        r = SwiftUIRenderer(view=MagicMock())
-        with pytest.raises(NotImplementedError) as exc_info:
-            r.render_with_diff()
-        msg = str(exc_info.value)
-        assert "walker" in msg
-        assert "1578" in msg
-        assert "swiftui" in msg
-
-    def test_compose_render_with_diff_raises(self):
-        from djust.renderers import ComposeRenderer
-
-        r = ComposeRenderer(view=MagicMock())
-        with pytest.raises(NotImplementedError):
-            r.render_with_diff()
-
-
 class TestNativeRendererResolverWiring:
     """LVN-II PR-4: NativeRenderer wires the template variant resolver."""
 
@@ -89,16 +65,15 @@ class TestNativeRendererResolverWiring:
         assert r.resolve_template("definitely-not-real.html") == "definitely-not-real.html"
 
     def test_error_message_includes_resolved_template_name(self):
+        # POC superseded: NativeRenderer no longer raises NotImplementedError;
+        # it actually renders. See test_native_renderer_poc.py for the
+        # current render behavior; resolve_template is still tested above.
         from unittest.mock import MagicMock
         from djust.renderers import SwiftUIRenderer
 
         view = MagicMock()
         view.template_name = "medicare/home.html"
         r = SwiftUIRenderer(view=view)
-        try:
-            r.render_with_diff()
-        except NotImplementedError as exc:
-            msg = str(exc)
-            # Resolver picked the base (variant doesn't exist in test loaders)
-            assert "medicare/home.html" in msg
-            assert "swiftui" in msg
+        # Test now only confirms resolve_template's fallback shape; the
+        # render path itself is exercised in test_native_renderer_poc.py.
+        assert r.resolve_template("medicare/home.html") == "medicare/home.html"


### PR DESCRIPTION
POC server-side walker for Android-simulator integration test. Replaces NativeRenderer NotImplementedError with actual Django template walk + HTMLParser-based VNode tree + Replace-only JSON patches. 5 new tests, 3027 full suite pass.