### PR TITLE
fix(theming): make presets.get_preset() consult runtime registry first (closes #1595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Theming registry/static-dict divergence — runtime-registered presets now reach the CSS generator (#1595).** `register_preset()` adds to a runtime `Registry._presets` dict that the theme manager, theme switcher, and introspection APIs all consult; but `presets.get_preset()` — the function the CSS generator path ultimately calls to render `--primary` etc. into `:root` — read only from the static `THEME_PRESETS` module dict, blind to runtime registration. Result: any consumer following the documented `register_preset()` API in `AppConfig.ready()` got their custom palette silently replaced with the default slate-black `THEME_PRESETS["default"]` in the actual rendered CSS, while the manager/switcher/`gh-pr-checks`-style introspection correctly reported the registered preset as active — exactly the kind of API-says-X-but-renderer-uses-Y divergence that costs an hour of debugging. Fix mirrors the registry-first-OR-static-fallback dispatch already established in `theme_packs.get_theme_pack()` (`python/djust/theming/theme_packs.py:1216-1222`): `get_preset()` now consults `get_registry().get_preset(name)` first, then falls back to `THEME_PRESETS.get(name, DEFAULT_THEME)`. Same shape, same `import .registry` inside the function to avoid the circular import that bites if registry imports back from presets. Covered by 3 new regression tests in `python/djust/tests/test_theming_presets.py` (`test_get_preset_consults_runtime_registry_first_1595` + 2 companions locking in the second half of the contract: static-dict fallback for built-in names + `DEFAULT_THEME` fallback for unknown names). Gate-the-fix-off self-test passes (Action #1200/#1468): with the fix reverted, exactly 1 of the 3 new tests fails — the registry-first regression case — and the other 2 pass, confirming no tautology. Removes the need for the documented workaround (`_presets.THEME_PRESETS[name] = preset`) — consumers can now use the public `register_preset()` API alone.
+
 ## [1.0.0rc9] - 2026-05-22
 
 ### Fixed

--- a/python/djust/tests/test_theming_presets.py
+++ b/python/djust/tests/test_theming_presets.py
@@ -57,5 +57,79 @@ def test_invalid_preset():
     assert preset is None
 
 
+def test_get_preset_consults_runtime_registry_first_1595():
+    """Regression for #1595 — `presets.get_preset()` must consult the runtime
+    registry first so user-registered presets actually reach the CSS generator.
+
+    Before the fix: `get_preset()` read from the static `THEME_PRESETS` module
+    dict only, so a preset added via `register_preset()` was visible to the
+    manager / theme switcher / introspection (which consult the registry) but
+    INVISIBLE to the renderer (which goes through this function). The user's
+    `--primary` was silently replaced with the default slate-black palette.
+
+    Mirrors the registry-first dispatch in `theme_packs.get_theme_pack()`
+    (`python/djust/theming/theme_packs.py:1216-1222`).
+    """
+    from djust.theming import presets
+    from djust.theming.registry import get_registry, register_preset
+
+    sentinel_name = "_regression_1595_runtime_only"
+    sentinel = ThemePreset(
+        name=sentinel_name,
+        display_name="1595 sentinel",
+        description="present in runtime registry, NOT in static THEME_PRESETS",
+        light=THEME_PRESETS["default"].light,
+        dark=THEME_PRESETS["default"].dark,
+    )
+
+    # Pre-condition: not present in the static dict.
+    assert sentinel_name not in THEME_PRESETS, (
+        "test setup invariant violated — sentinel name must not exist statically"
+    )
+
+    register_preset(sentinel_name, sentinel)
+    try:
+        # The registry sees it.
+        assert get_registry().get_preset(sentinel_name) is sentinel
+
+        # The bug-of-record: presets.get_preset() must ALSO see it.
+        # Pre-fix this returns DEFAULT_THEME instead of `sentinel`.
+        result = presets.get_preset(sentinel_name)
+        assert result is sentinel, (
+            f"#1595: presets.get_preset({sentinel_name!r}) returned "
+            f"{result.name!r} instead of the runtime-registered preset. "
+            "Registry/static-dict divergence — the CSS generator would render "
+            "the wrong palette."
+        )
+    finally:
+        # Clean up so subsequent tests don't see the sentinel.
+        get_registry()._presets.pop(sentinel_name, None)
+
+
+def test_get_preset_static_dict_fallback_when_registry_lacks_name():
+    """Companion to #1595: static dict fallback must still work for built-in
+    presets that the runtime registry doesn't know about.
+
+    Locks in the second half of the registry-first-OR-static-fallback contract.
+    """
+    from djust.theming import presets
+
+    # "blue" is in the static dict; no test setup registers it at runtime.
+    result = presets.get_preset("blue")
+    assert result.name == "blue", f"static-dict fallback broke: got {result.name!r} for 'blue'"
+
+
+def test_get_preset_unknown_name_returns_default():
+    """Companion to #1595: when neither the registry nor the static dict has
+    the name, `get_preset()` falls back to DEFAULT_THEME (existing behavior).
+    """
+    from djust.theming import presets
+
+    result = presets.get_preset("definitely_does_not_exist_anywhere_1595")
+    assert result is presets.DEFAULT_THEME, (
+        f"unknown-name fallback broke: got {result.name!r} instead of DEFAULT_THEME"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/python/djust/theming/presets.py
+++ b/python/djust/theming/presets.py
@@ -156,8 +156,21 @@ THEME_PRESETS: dict[str, ThemePreset] = {
 
 
 def get_preset(name: str) -> ThemePreset:
-    """Get a theme preset by name, with fallback to default."""
-    return THEME_PRESETS.get(name, DEFAULT_THEME)
+    """Get a theme preset by name.
+
+    Resolution order, matching ``theme_packs.get_theme_pack()``:
+
+    1. Runtime registry (presets added via ``register_preset()``).
+    2. Built-in static ``THEME_PRESETS`` dict.
+    3. ``DEFAULT_THEME`` fallback.
+
+    Before #1595 only step 2 + 3 ran, so user-registered presets were visible
+    to the manager/registry/introspection but invisible to the CSS generator
+    that ultimately renders ``--primary`` etc. into ``:root``.
+    """
+    from .registry import get_registry
+
+    return get_registry().get_preset(name) or THEME_PRESETS.get(name, DEFAULT_THEME)
 
 
 def list_presets() -> list[dict]:


### PR DESCRIPTION
## Summary

Fixes #1595 — `register_preset()` adds to the runtime registry, but `presets.get_preset()` (the function the CSS generator path ultimately calls) reads from the static `THEME_PRESETS` module dict only. Result: user-registered presets are visible to manager/registry/introspection but **invisible to the renderer**, silently replaced with the default slate-black palette in `:root`.

## Fix

Mirror the registry-first-OR-static-fallback dispatch already in `theme_packs.get_theme_pack()` (line 1216-1222):

```python
def get_preset(name: str) -> ThemePreset:
    from .registry import get_registry
    return get_registry().get_preset(name) or THEME_PRESETS.get(name, DEFAULT_THEME)
```

Same shape as the theme-pack dispatch, with the same `import .registry` inside the function to avoid the circular import that bites if `registry` imports back from `presets`.

Removes the need for the documented workaround (`_presets.THEME_PRESETS[name] = preset`) — consumers can now use the public `register_preset()` API alone.

## TDD verification

- **Red phase**: wrote `test_get_preset_consults_runtime_registry_first_1595` first, ran against main → FAILED with `presets.get_preset(sentinel) returned 'default' instead of the runtime-registered preset` (the exact symptom the issue describes).
- **Green phase**: applied the fix → test passes.
- **Gate-the-fix-off self-test (Action #1200/#1468)**: stashed the fix → exactly 1 of 3 new tests fails (the regression case); other 2 pass (no tautology). Fix restored, all 3 green.

## Tests

3 new regression tests in `python/djust/tests/test_theming_presets.py`:

1. `test_get_preset_consults_runtime_registry_first_1595` — the load-bearing assertion (registered preset is visible via registry AND via `get_preset()`)
2. `test_get_preset_static_dict_fallback_when_registry_lacks_name` — locks in the second half of the dispatch contract
3. `test_get_preset_unknown_name_returns_default` — final fallback to `DEFAULT_THEME` unchanged

Full suite results:
- All 8 tests in `test_theming_presets.py` pass
- All 1811 theming tests pass (`pytest python/djust/tests/test_theming_*.py tests/unit/test_theming_*.py -q`)
- Full project suite: 4390 py + 1609 js + Rust — all green

## Two-commit shape

- `8a4d2d8e` fix + tests (no CHANGELOG) — Gate 1 verified
- `357439a2` CHANGELOG only — Gate 2 verified

## Refs

- Closes #1595
- Mirrors `theme_packs.get_theme_pack()` (`python/djust/theming/theme_packs.py:1216`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)