### PR TITLE
ci: rust-cache + PR matrix trim + security-scan shift (~15-20 min/PR)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,16 +36,13 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: Cache Rust dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      # Swatinem/rust-cache keys on rustc version + Cargo.lock + the job
+      # context (so rust-tests and python-tests don't poison each other's
+      # caches — python-tests builds the PyO3 cdylib, rust-tests builds
+      # the workspace libs). Already in use in release.yml:102. Previously
+      # this was a hand-rolled actions/cache keyed only on Cargo.lock,
+      # which suffered cache misses on rustc bumps and dependency changes.
+      - uses: Swatinem/rust-cache@v2
 
       - name: Set up Python (for PyO3)
         uses: actions/setup-python@v6
@@ -104,16 +101,10 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Cache Rust dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      # Matrix-aware: Swatinem/rust-cache automatically scopes the cache
+      # to the python-version matrix dimension, so 3.12 / 3.13 / 3.14
+      # builds keep separate caches and don't invalidate each other.
+      - uses: Swatinem/rust-cache@v2
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -319,9 +319,23 @@ jobs:
             rm examples/demo_project/server.pid
           fi
 
-  # Security scanning job - runs in parallel
+  # Security scanning job — bandit + safety + cargo-audit + npm-audit.
+  # Runs on push to main, schedule, and manual dispatch; SKIPPED on PRs.
+  #
+  # Rationale: this job duplicates the heavier audit that
+  # ``pre-release-security-audit.yml`` runs on every tag push — at PR time
+  # it was the single longest job in the workflow (~8 min observed) and
+  # produced findings ``security-tests`` (pytest-cov) had already gated.
+  # Keeping it on push-to-main catches main-branch regressions in
+  # security-relevant dependencies the moment they land, without paying
+  # the cost on every dependabot rebase / fixup commit.
+  #
+  # ``security-tests`` (further down) stays on the PR path — it is the
+  # pytest-cov leg with the ``--cov-fail-under=75`` gate, which is a real
+  # PR-time signal we don't want to drop.
   security-scan:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v6
 
@@ -476,7 +490,10 @@ jobs:
             if [ "${{ needs.playwright-tests.result }}" != "success" ]; then
               echo "WARNING: Playwright tests failed (optional, not blocking)"
             fi
-            if [ "${{ needs.security-scan.result }}" != "success" ]; then
+            # ``skipped`` is the expected result on PR runs (security-scan
+            # is push/schedule/dispatch only) — only warn on a true failure.
+            if [ "${{ needs.security-scan.result }}" != "success" ] && \
+               [ "${{ needs.security-scan.result }}" != "skipped" ]; then
               echo "WARNING: Security scan had warnings (review recommended)"
             fi
             exit 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,12 +85,20 @@ jobs:
         run: cargo fmt --check
 
   # Python tests - runs in parallel with pytest-xdist
+  #
+  # Matrix-on-PR is the project's #1 minute sink (3 cells × ~10 min each).
+  # On PR we run only the canonical interpreter (3.12); on push to main
+  # we run the full matrix (3.12/3.13/3.14). 3.13 / 3.14 regressions are
+  # caught on the merge commit instead of at PR time — one merge later,
+  # not "never". Historical evidence the matrix has value: PRs #450 / #452
+  # shipped real 3.14-support fixes. Tradeoff accepted because the absolute
+  # cost (~8 min/PR × dependabot volume) outweighed the latency.
   python-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12', '3.13', '3.14']
+        python-version: ${{ github.event_name == 'push' && fromJSON('["3.12","3.13","3.14"]') || fromJSON('["3.12"]') }}
     name: python-tests (py${{ matrix.python-version }})
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Three independent ``test.yml`` changes — one commit each — targeting the next-tier cost levers identified after #1633 shipped. Estimated combined savings: **~15-20 min/PR** on a typical dependabot rebase. Each commit is independently revertable.

| Commit | Lever | Expected savings | Risk |
|---|---|---|---|
| ``b45e86d`` | Swatinem/rust-cache for cargo target/ | ~4-8 min/run (4 Rust-using jobs) | Low — same action ``release.yml:102`` already uses |
| ``4c8f90a`` | Trim PR Python matrix to 3.12; full matrix on push to main | ~8 min/PR | Medium — see tradeoff below |
| ``5879...`` | Shift security-scan off PR path | ~5 min/PR | Low — security-tests stays on PRs; pre-release-security-audit.yml stays on tags |

## 1. ``Swatinem/rust-cache@v2`` (commit ``b45e86d``)

Replaces hand-rolled ``actions/cache@v5`` blocks in ``rust-tests`` and ``python-tests``. The old key (``${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}``) ignored rustc version and the workspace member set. Swatinem's action — already trusted in this repo at ``release.yml:102`` — keys on rustc + Cargo.lock + job context, which both increases hit rate (target dir reuse across Cargo.toml-only changes) and prevents cross-job cache poisoning between the workspace-libs build (``rust-tests``) and the PyO3 cdylib build (``python-tests``).

## 2. PR-only Python matrix trim (commit ``4c8f90a``)

On PR: run python-tests on **3.12 only**. On push to main: full matrix (3.12 / 3.13 / 3.14).

**Tradeoff this PR accepts**: 3.13 / 3.14 regressions move from \"blocked at PR time\" to \"caught on the merge commit.\" The full matrix runs immediately on merge to main, so a 3.14-specific break is caught the same day and rolls back as a normal revert.

**Why this is OK**: 3.14 issues have historically been rare but real — PRs #450 and #452 (Mar 2026) shipped 3.14-support fixes. The matrix has clear value at *some* frequency; the question is whether to pay the cost on every dependabot rebase. At ~8 min/PR × dependabot's volume in our May 2026 burn breakdown, the latency tradeoff is worth it.

**Revert path**: replace the ``fromJSON`` conditional at the matrix line with the literal list. The job name template is unchanged, so any branch protection / required check rule pinned to ``python-tests (py3.12)`` keeps working.

## 3. Shift ``security-scan`` off PR path (commit ``5879…``)

``security-scan`` (bandit + safety + cargo-audit + npm-audit + ESLint-security) was the **single longest job** on push-to-main runs (~8 min observed) and duplicates the deeper ``pre-release-security-audit.yml`` audit that runs on every tag push. Moving it to push/schedule/dispatch only.

**What stays where after this PR:**
- PR time: ``security-tests`` (pytest-cov against ``test_security_*.py``, ``--cov-fail-under=75``) → unchanged gate.
- Push to main: full ``security-scan`` → catches main-branch regressions in security-relevant deps immediately on land.
- Tag time: ``pre-release-security-audit.yml`` → deepest full audit pre-release.

``test-summary`` is also updated to treat ``security-scan.result == 'skipped'`` as expected (the PR-run case) instead of warning. The hard pass/fail gate at lines 472–475 was already insensitive to ``security-scan``.

## Test plan

- [x] YAML structure validated (Swatinem invocations, fromJSON conditional, security-scan ``if:``, test-summary skipped tolerance — all confirmed in diff)
- [ ] After merge: confirm PR runs of test.yml show ``security-scan`` as Skipped and ``python-tests`` as 1 matrix cell
- [ ] After merge: confirm push-to-main run shows full matrix + security-scan running
- [ ] After 2-3 PR runs: check ``rust-cache`` hit-rate annotations in the action's log lines

## Order of confidence (if a partial revert is needed)

- Commit ``b45e86d`` (rust-cache) is the safest — keep first.
- Commit ``5879…`` (security shift) is policy more than risk — revert if your security model wants PR-time alerts.
- Commit ``4c8f90a`` (matrix trim) carries the documented 3.14-latency tradeoff — revert first if a 3.14 regression slips through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)