### PR TITLE
fix(websocket): refresh recovery baseline after start_async completion (#1636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`start_async` completion now refreshes the VDOM recovery baseline (#1636).** When a client VDOM patch fails (e.g. an `{% if %}` block that adds a sibling), the client requests `html_recovery` and the server serves — then clears — `_recovery_html` (one-time use). `LiveViewConsumer._run_async_work` re-renders and sends patches when a `start_async` background callback completes, but — unlike `handle_event` and `server_push` (the #1202 fix) — it never updated `_recovery_html` / `_recovery_version`. After a recovery had consumed the baseline, an async-triggered patch that also failed on the client found `_recovery_html=None`, got back "Recovery HTML unavailable", and the view froze at the transitional state (e.g. `Status: fetching`) even though the backend pipeline had advanced. `_run_async_work` now sets the recovery baseline after `render_with_diff()` in both the patches branch and the full-HTML fallback branch, mirroring the other two render paths, so async-callback state pushes keep reaching the client across patch-failure/recovery cycles.
+
 ## [1.0.0rc13] - 2026-05-28
 
 ### Added

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -929,6 +929,15 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
 
             if patches is not None:
                 patch_list = fast_json_loads(patches) if patches else []
+                # Refresh the recovery baseline so a later request_html (e.g.
+                # an async-triggered patch that fails on the client) has fresh
+                # HTML to serve. Mirrors handle_event and server_push (#1202).
+                # Without this, an html_recovery that already consumed
+                # _recovery_html leaves it None, the next request_html returns
+                # "Recovery HTML unavailable", and the client freezes at the
+                # transitional state even though the backend advanced (#1636).
+                self._recovery_html = html
+                self._recovery_version = version
                 await self._send_update(
                     patches=patch_list,
                     version=version,
@@ -945,6 +954,10 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         ),
                     )
                 )(html)
+                # The fallback sends the full render to the client, so the
+                # recovery baseline must track it too (#1636).
+                self._recovery_html = html
+                self._recovery_version = version
                 await self._send_update(
                     html=html_content,
                     version=version,

--- a/tests/unit/test_async_recovery_html_1636.py
+++ b/tests/unit/test_async_recovery_html_1636.py
@@ -1,0 +1,157 @@
+"""Regression: ``start_async`` completion must refresh the recovery baseline (#1636).
+
+The bug
+-------
+
+When a client VDOM patch fails (e.g. an ``{% if %}`` block that adds a sibling),
+the client sends ``request_html`` and the server serves ``_recovery_html`` —
+then clears it (one-time use, ``handle_request_html`` at ``websocket.py:4520``).
+
+``LiveViewConsumer._run_async_work`` re-renders + sends patches when a
+``start_async`` background callback completes, but — unlike ``handle_event``
+(``websocket.py:3633``) and ``server_push`` (``websocket.py:4990``, the #1202
+fix) — it never updated ``_recovery_html`` / ``_recovery_version``. So after a
+recovery consumed the baseline, the next ``request_html`` (triggered by a
+re-failing async patch) found ``_recovery_html=None``, returned
+"Recovery HTML unavailable", and the client froze at the transitional state
+even though the backend had advanced.
+
+This is the reporter's stated "most painful" half of #1636: after one
+``{% if %}`` patch failure, async-callback state pushes stop reaching the
+client.
+
+The fix
+-------
+
+``_run_async_work`` sets ``self._recovery_html = html`` and
+``self._recovery_version = version`` after ``render_with_diff()``, in BOTH the
+patches branch and the full-HTML fallback branch — mirroring ``handle_event`` /
+``server_push``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from djust.websocket import LiveViewConsumer
+
+
+def _make_consumer(render_return):
+    """Minimal consumer wired to drive ``_run_async_work`` deterministically."""
+    consumer = LiveViewConsumer()
+    consumer.view_instance = MagicMock()
+    consumer.view_instance._skip_render = False
+    consumer.view_instance._sync_state_to_rust = MagicMock()
+    # No cancellation / no handle_async_result hooks for the happy path.
+    del consumer.view_instance._async_cancelled
+    del consumer.view_instance.handle_async_result
+    consumer.view_instance.render_with_diff = MagicMock(return_value=render_return)
+    consumer.view_instance._strip_comments_and_whitespace = MagicMock(side_effect=lambda h: h)
+    consumer.view_instance._extract_liveview_content = MagicMock(side_effect=lambda h: h)
+    consumer.use_binary = False
+    consumer.send = AsyncMock()
+    consumer._send_update = AsyncMock()
+    # Flush helpers are no-ops here.
+    for name in (
+        "_flush_push_events",
+        "_flush_flash",
+        "_flush_page_metadata",
+        "_flush_pending_layout",
+        "_flush_deferred",
+    ):
+        setattr(consumer, name, AsyncMock())
+    return consumer
+
+
+async def _run(consumer):
+    await consumer._run_async_work(
+        task_name="t",
+        callback=lambda: None,
+        args=(),
+        kwargs={},
+        event_name="pick",
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_render_stores_recovery_html():
+    """After an async-completion render with patches, the recovery baseline
+    must be refreshed so a later ``request_html`` has fresh HTML to serve."""
+    consumer = _make_consumer(("<div>after-async</div>", '[{"type":"SetText"}]', 42))
+
+    await _run(consumer)
+
+    consumer._send_update.assert_awaited_once()
+    assert consumer._recovery_html == "<div>after-async</div>"
+    assert consumer._recovery_version == 42
+
+
+@pytest.mark.asyncio
+async def test_recovery_html_refreshed_across_multiple_async_renders():
+    """Consecutive async renders must each refresh the recovery baseline so a
+    stale earlier render is never served on a later recovery."""
+    consumer = _make_consumer(None)
+    consumer.view_instance.render_with_diff = MagicMock(
+        side_effect=[
+            ("<div>first</div>", '[{"type":"SetText","v":1}]', 1),
+            ("<div>second</div>", '[{"type":"SetText","v":2}]', 2),
+            ("<div>third</div>", '[{"type":"SetText","v":3}]', 3),
+        ]
+    )
+
+    for _ in range(3):
+        await _run(consumer)
+
+    assert consumer._recovery_html == "<div>third</div>"
+    assert consumer._recovery_version == 3
+
+
+@pytest.mark.asyncio
+async def test_async_full_html_fallback_stores_recovery_html():
+    """The full-HTML fallback branch (``patches is None``) sends full HTML to
+    the client, so the recovery baseline must track that HTML too."""
+    consumer = _make_consumer(("<div>full-html-fallback</div>", None, 7))
+
+    await _run(consumer)
+
+    consumer._send_update.assert_awaited_once()
+    # The async else-branch sends full HTML; recovery baseline must match it.
+    assert consumer._recovery_html == "<div>full-html-fallback</div>"
+    assert consumer._recovery_version == 7
+
+
+@pytest.mark.asyncio
+async def test_request_html_after_async_completion_serves_fresh_html():
+    """End-to-end continuity (the load-bearing test): a recovery that consumed
+    ``_recovery_html`` must be re-armed by a subsequent async completion, so the
+    NEXT ``request_html`` serves the advanced state instead of failing.
+
+    Mirrors the reporter's sequence: event → patch fails → request_html (clears
+    baseline) → start_async completes → patch fails again → request_html must
+    succeed (not "Recovery HTML unavailable")."""
+    consumer = _make_consumer(("<div>routed</div>", '[{"type":"SetText"}]', 99))
+
+    # Simulate the first recovery having already consumed the baseline.
+    consumer._recovery_html = None
+    consumer._recovery_version = 0
+
+    # Async work completes and re-renders the advanced (routed) state.
+    await _run(consumer)
+
+    # A subsequent request_html now has fresh HTML to serve.
+    await consumer.handle_request_html({})
+
+    sent = consumer.send.await_args
+    # handle_request_html uses self.send_json -> self.send; assert it served
+    # the routed HTML rather than an error envelope.
+    payload = (
+        sent.kwargs.get("text_data")
+        if sent and sent.kwargs
+        else (sent.args[0] if sent and sent.args else "")
+    )
+    assert "routed" in str(payload), (
+        f"request_html after async completion must serve the advanced HTML; got: {payload!r}"
+    )
+    assert "unavailable" not in str(payload).lower()


### PR DESCRIPTION
## Summary

Fixes the production-impacting half of #1636: after a client VDOM patch fails and `html_recovery` runs, subsequent state pushes from a `start_async` background callback stop reaching the client and the view freezes at the transitional state (e.g. `Status: fetching`) even though the backend pipeline advanced.

## Root cause (reproducer-first)

`LiveViewConsumer._run_async_work` (`python/djust/websocket.py`) re-renders and sends patches when a `start_async` callback completes, but — unlike `handle_event` (`websocket.py:3633`) and `server_push` (`websocket.py:4990`, the #1202 fix) — it never updated `self._recovery_html` / `self._recovery_version`.

`handle_request_html` consumes the recovery baseline and clears it (`_recovery_html = None`, one-time use). So the sequence the reporter hit was:

1. `pick` renders the transitional state; `handle_event` arms `_recovery_html`.
2. A client patch fails → client sends `request_html` → server serves the HTML and sets `_recovery_html = None`.
3. `start_async` `_run` completes → `_run_async_work` renders the advanced state and sends patches **but leaves `_recovery_html` None**.
4. That async patch also fails on the client → the next `request_html` finds `_recovery_html=None` → returns **"Recovery HTML unavailable"** → the client can't recover and freezes.

## Fix

`_run_async_work` now sets `_recovery_html` / `_recovery_version` after `render_with_diff()` in **both** the patches branch and the full-HTML fallback branch, mirroring `handle_event` / `server_push`. Recovery stays armed across patch-failure/recovery cycles, so async-callback state pushes keep reaching the client.

## Tests

`tests/unit/test_async_recovery_html_1636.py` (4 cases, mirror `test_server_push.py::TestServerPushHandler`):
- async render with patches arms the recovery baseline
- baseline refreshed across consecutive async renders
- full-HTML fallback branch arms it too
- **end-to-end continuity**: recovery consumes the baseline → async completes → a subsequent `request_html` serves the advanced HTML instead of the "Recovery HTML unavailable" error (this test reproduces the exact pre-fix error string).

Gate-off self-test (#254): all 4 fail with the two assignments reverted. Full suite: 5100 passed, 0 failed.

## Scope (per scope-discipline)

This PR fixes the reporter's explicitly-stated "most painful" half (async pushes stopping after recovery), which reproduces deterministically. Two findings surfaced during investigation are filed as follow-ups rather than bundled here:

1. **Why the specific client patch fails 1/N in the reporter's full page.** A faithful real-engine reconstruction of the reporter's 5-patch shape (`InsertChild` + the dj-if-marker subtree + the SetAttr/SetText siblings) applies cleanly (0/5 fail) — so the client-side trigger lives in template specifics not present in the `djbug1` blob. Needs a bit-exact public repro (CLAUDE.md #1086/#1389). Follow-up: #1641.
2. **Comment-filter inconsistency**: `getSignificantChildren` counts all comments (`12-vdom-patch.js:1145`) while `getNodeByPath` counts only dj-if comments (`:216`). Real latent index-mismatch bug, but only triggers with a *regular* HTML comment among siblings (Rust VDOM drops non-dj-if comments) — not #1636's trigger. Follow-up: #1640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
