### PR TITLE
refactor(websocket): consolidate recovery-baseline arming into _arm_recovery (#1645)

### DIFF
--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -955,8 +955,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 # _recovery_html leaves it None, the next request_html returns
                 # "Recovery HTML unavailable", and the client freezes at the
                 # transitional state even though the backend advanced (#1636).
-                self._recovery_html = html
-                self._recovery_version = version
+                self._arm_recovery(html, version)
                 await self._send_update(
                     patches=patch_list,
                     version=version,
@@ -975,8 +974,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 )(html)
                 # The fallback sends the full render to the client, so the
                 # recovery baseline must track it too (#1636).
-                self._recovery_html = html
-                self._recovery_version = version
+                self._arm_recovery(html, version)
                 await self._send_update(
                     html=html_content,
                     version=version,
@@ -1037,6 +1035,21 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                     logger.exception(
                         "[djust] Error in handle_async_result for task '%s'", task_name
                     )
+
+    def _arm_recovery(self, html: str, version: int) -> None:
+        """Arm the on-demand VDOM recovery baseline.
+
+        Single source of truth for the ``request_html`` recovery state
+        (``_recovery_html`` / ``_recovery_version``). Every render-send path —
+        ``handle_event``, ``server_push``, ``_run_async_work`` — calls this after
+        rendering so the baseline can never drift between paths. Hand-copying the
+        two-line assignment is exactly how the async path was missed in #1639;
+        centralizing it here (#1645) makes a new send path inherit correct arming
+        by calling one method. The one-time clear (``_recovery_html = None`` in
+        ``handle_request_html``) is the only other writer.
+        """
+        self._recovery_html = html
+        self._recovery_version = version
 
     async def _send_update(
         self,
@@ -3630,8 +3643,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         # Store rendered HTML for on-demand recovery.
                         # Client sends request_html when applyPatches() fails
                         # (e.g., {% if %} blocks shifting DOM structure).
-                        self._recovery_html = html
-                        self._recovery_version = version
+                        self._arm_recovery(html, version)
 
                         await self._send_update(
                             patches=patch_list,
@@ -4983,8 +4995,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                     # handle_event. Without this, request_html after a failed
                     # broadcast-triggered patch finds _recovery_html=None and
                     # forces a page reload. See #1202.
-                    self._recovery_html = html
-                    self._recovery_version = version
+                    self._arm_recovery(html, version)
                     await self._send_update(
                         patches=patches,
                         version=version,

--- a/tests/unit/test_arm_recovery_helper_1645.py
+++ b/tests/unit/test_arm_recovery_helper_1645.py
@@ -1,0 +1,54 @@
+"""Regression/consolidation: a single _arm_recovery() helper is the source of
+truth for VDOM recovery-baseline arming, so no send path can drift (#1645).
+
+`_recovery_html` / `_recovery_version` were armed by a hand-copied two-line
+assignment at every send path (handle_event, server_push, _run_async_work). That
+is exactly the drift that caused #1639 — the async path was added without the
+arming. This pins the consolidation: the assignment lives in one helper, and
+every render-send path routes through it.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+import djust.websocket as ws_mod
+from djust.websocket import LiveViewConsumer
+
+
+def test_arm_recovery_sets_both_fields():
+    consumer = LiveViewConsumer()
+    consumer._arm_recovery("<div>x</div>", 7)
+    assert consumer._recovery_html == "<div>x</div>"
+    assert consumer._recovery_version == 7
+
+
+def test_arm_recovery_is_the_only_arming_mechanism():
+    """No method other than _arm_recovery (and the one-time clear in
+    handle_request_html) may assign _recovery_html directly — otherwise a new
+    send path could arm inconsistently or forget a field."""
+    src = inspect.getsource(ws_mod)
+    # All `self._recovery_html = ...` assignments in the module.
+    assigns = re.findall(r"self\._recovery_html\s*=\s*(.+)", src)
+    # Allowed: the helper's own assignment, and the one-time clear (= None).
+    disallowed = [rhs.strip() for rhs in assigns if rhs.strip() not in ("html", "None")]
+    assert disallowed == [], (
+        "_recovery_html must only be assigned inside _arm_recovery (rhs 'html') "
+        f"or cleared (= None); found stray assignments: {disallowed}"
+    )
+
+
+def test_render_send_paths_route_through_arm_recovery():
+    """Each render-send path must call _arm_recovery rather than hand-assign."""
+    for name in ("handle_event", "server_push", "_run_async_work"):
+        method_src = inspect.getsource(getattr(LiveViewConsumer, name))
+        assert "_arm_recovery(" in method_src, (
+            f"{name} must arm the recovery baseline via self._arm_recovery(...) "
+            f"so it can't drift from the other send paths (#1645)."
+        )
+        # And must NOT hand-assign _recovery_html directly anymore.
+        assert "_recovery_html =" not in method_src, (
+            f"{name} still hand-assigns _recovery_html; route it through "
+            f"_arm_recovery instead (#1645)."
+        )


### PR DESCRIPTION
## Summary
Fixes #1645 (tech-debt follow-up from the #1644 retro). `_recovery_html` / `_recovery_version` were armed by a hand-copied two-line assignment at every render-send path (`handle_event`, `server_push`, `_run_async_work`). That duplication is exactly the drift that caused #1639 — the `start_async` path was added *without* the arming, freezing the view after a `request_html` recovery.

## Fix
Introduce a single `_arm_recovery(html, version)` helper as the one source of truth; every send path routes through it. The only other writer is the one-time clear (`= None`) in `handle_request_html`. **Pure refactor — no behavior change.**

## Tests
`tests/unit/test_arm_recovery_helper_1645.py`:
- helper sets both fields
- a regex guard asserting NO method other than `_arm_recovery` (rhs `html`) or the clear (`= None`) assigns `_recovery_html` — so a future send path can't arm inconsistently
- each send path routes through `_arm_recovery` and no longer hand-assigns (RED pre-refactor)

Existing recovery/navigation behavior tests (#1636, #1643, `server_push`) stay green; broad websocket/recovery/async sweep: 506 passed.

No CHANGELOG entry — internal refactor, no behavior change (`feat:`/`fix:` only per convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)