### PR TITLE
fix(websocket): resolve live_redirect target view from URL, not client (#1647)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`live_redirect` to a different view now mounts the correct target (#1647).** The client's `resolveViewPath()` falls back to the current container's `dj-view` — the **source** view — when `window.djust._routeMap` is empty, which is the default for apps using plain Django `path()` URLconfs (no `live_session()`). The server trusted that client-supplied class in the `live_redirect_mount` frame, instantiated the *source* view against the destination URL's request, and raised "Failed to load view. Please refresh the page." `handle_live_redirect_mount` now resolves the destination view server-side from the URL via Django's URL dispatcher and overrides the client-supplied `view` when the URL maps to a djust `LiveView` (falling back to the client value otherwise, so `live_session()` route maps are unaffected). **`live_session()` is no longer a hidden prerequisite for `live_redirect` across plain `path()` URLconfs.**
+
 ## [1.0.0rc14] - 2026-05-28
 
 ### Added

--- a/python/djust/tests/test_live_redirect_mount_resolve_1647.py
+++ b/python/djust/tests/test_live_redirect_mount_resolve_1647.py
@@ -1,0 +1,102 @@
+"""Regression: live_redirect_mount must resolve the TARGET view server-side
+from the URL, not trust the client-supplied (source) view (#1647).
+
+The client's `resolveViewPath()` falls back to the current container's `dj-view`
+— the SOURCE view — when its route map is empty (the default for plain Django
+`path()` URLconfs with no `live_session()`). The server then instantiated the
+source class against the new URL's request and raised "Failed to load view".
+
+`LiveViewConsumer._resolve_view_path_from_url(url)` resolves the destination URL
+to its djust LiveView via Django's URL dispatcher, and `handle_live_redirect_mount`
+overrides `data["view"]` with it (falling back to the client value when the URL
+doesn't map to a LiveView).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from django.test import override_settings
+
+from djust.websocket import LiveViewConsumer
+
+URLCONF = "tests.redirect_mount_test_urls"
+SOURCE = "tests.redirect_mount_test_urls.RedirectSourceView"
+TARGET = "tests.redirect_mount_test_urls.RedirectTargetView"
+
+
+@override_settings(ROOT_URLCONF=URLCONF)
+def test_resolve_view_path_from_url_returns_target():
+    consumer = LiveViewConsumer()
+    assert consumer._resolve_view_path_from_url("/redirect-target/") == TARGET
+
+
+@override_settings(ROOT_URLCONF=URLCONF)
+def test_resolve_returns_none_for_unmapped_url():
+    consumer = LiveViewConsumer()
+    assert consumer._resolve_view_path_from_url("/no-such-url/") is None
+
+
+@override_settings(ROOT_URLCONF=URLCONF)
+def test_resolve_returns_none_for_non_liveview():
+    consumer = LiveViewConsumer()
+    # A plain Django view must NOT be overridden — caller keeps the client value.
+    assert consumer._resolve_view_path_from_url("/plain/") is None
+
+
+@override_settings(ROOT_URLCONF=URLCONF)
+def test_resolve_returns_none_for_empty_url():
+    consumer = LiveViewConsumer()
+    assert consumer._resolve_view_path_from_url("") is None
+
+
+@pytest.mark.asyncio
+@override_settings(ROOT_URLCONF=URLCONF)
+async def test_handle_live_redirect_mount_overrides_source_view():
+    """The end-to-end fix: client ships the SOURCE view + the TARGET url; the
+    server must mount the TARGET (resolved from the url), not the source."""
+    consumer = LiveViewConsumer()
+    consumer.scope = {"session": None, "user": None}
+    consumer.view_instance = None  # no old view → no sticky staging
+    consumer._sticky_auto_reattached = set()
+    consumer._sticky_preserved = {}
+
+    captured = {}
+
+    async def _fake_handle_mount(data, **kwargs):
+        captured["view"] = data.get("view")
+
+    with patch.object(consumer, "handle_mount", new=AsyncMock(side_effect=_fake_handle_mount)):
+        await consumer.handle_live_redirect_mount(
+            {"view": SOURCE, "url": "/redirect-target/", "params": {}}
+        )
+
+    assert captured.get("view") == TARGET, (
+        "handle_live_redirect_mount must override the client-supplied SOURCE view "
+        f"with the URL-resolved TARGET view; handle_mount received {captured.get('view')!r}"
+    )
+
+
+@pytest.mark.asyncio
+@override_settings(ROOT_URLCONF=URLCONF)
+async def test_handle_live_redirect_mount_keeps_client_view_when_url_unresolvable():
+    """Control: when the URL doesn't map to a LiveView, the client-supplied view
+    is preserved (the live_session route-map path is unaffected)."""
+    consumer = LiveViewConsumer()
+    consumer.scope = {"session": None, "user": None}
+    consumer.view_instance = None
+    consumer._sticky_auto_reattached = set()
+    consumer._sticky_preserved = {}
+
+    captured = {}
+
+    async def _fake_handle_mount(data, **kwargs):
+        captured["view"] = data.get("view")
+
+    with patch.object(consumer, "handle_mount", new=AsyncMock(side_effect=_fake_handle_mount)):
+        await consumer.handle_live_redirect_mount(
+            {"view": SOURCE, "url": "/no-such-url/", "params": {}}
+        )
+
+    assert captured.get("view") == SOURCE

--- a/python/djust/tests/test_live_redirect_mount_resolve_1647.py
+++ b/python/djust/tests/test_live_redirect_mount_resolve_1647.py
@@ -100,3 +100,39 @@ async def test_handle_live_redirect_mount_keeps_client_view_when_url_unresolvabl
         )
 
     assert captured.get("view") == SOURCE
+
+
+@pytest.mark.asyncio
+@override_settings(ROOT_URLCONF=URLCONF)
+async def test_back_nav_state_snapshot_view_not_overridden():
+    """Back-nav guard: when a `state_snapshot` is present it carries the
+    authoritative view, and its `url` may be generic and resolve to an
+    unrelated view. The URL-override must NOT fire — otherwise back-nav restores
+    the wrong view (regression caught by the pre-push suite during #1647)."""
+    consumer = LiveViewConsumer()
+    consumer.scope = {"session": None, "user": None}
+    consumer.view_instance = None
+    consumer._sticky_auto_reattached = set()
+    consumer._sticky_preserved = {}
+
+    captured = {}
+
+    async def _fake_handle_mount(data, **kwargs):
+        captured["view"] = data.get("view")
+
+    # url="/redirect-target/" WOULD resolve to TARGET, but the snapshot's view
+    # (SOURCE here) must win because a snapshot is present.
+    with patch.object(consumer, "handle_mount", new=AsyncMock(side_effect=_fake_handle_mount)):
+        await consumer.handle_live_redirect_mount(
+            {
+                "view": SOURCE,
+                "url": "/redirect-target/",
+                "params": {},
+                "state_snapshot": {"view_slug": SOURCE, "state_json": "{}", "ts": 0},
+            }
+        )
+
+    assert captured.get("view") == SOURCE, (
+        "a live_redirect_mount carrying a state_snapshot must NOT have its view "
+        f"overridden from the URL; handle_mount received {captured.get('view')!r}"
+    )

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -4412,7 +4412,17 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
         # request raises. Resolve the target view server-side from the URL; only
         # override when it maps to a djust LiveView, so the live_session
         # route-map path (client resolved correctly) is unaffected.
-        resolved_view = self._resolve_view_path_from_url(data.get("url", ""))
+        #
+        # NOT for back-navigation: a `state_snapshot` carries the authoritative
+        # `view_slug` for the restored view, and its `url` may be generic (e.g.
+        # "/") and resolve to an unrelated view. Skip the URL-override whenever a
+        # snapshot is present so back-nav restores the snapshot's view, not
+        # whatever the URL happens to map to.
+        resolved_view = (
+            None
+            if data.get("state_snapshot")
+            else self._resolve_view_path_from_url(data.get("url", ""))
+        )
         if resolved_view and resolved_view != data.get("view"):
             logger.debug(
                 "live_redirect_mount: server-resolved target view %s from URL %s (client sent %s)",

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -4403,6 +4403,24 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
         # mutates ``self._sticky_preserved`` to the final survivor set
         # after the slot scan; if it raises mid-flight we drain any
         # staged children so their background tasks don't leak.
+        #
+        # #1647: trust the DESTINATION URL over the client-supplied `view`.
+        # The client's resolveViewPath() falls back to the current container's
+        # dj-view (the SOURCE view) when its route map is empty — which is the
+        # default for apps using plain Django path() URLconfs (no
+        # live_session()). Mounting the source class against the new URL's
+        # request raises. Resolve the target view server-side from the URL; only
+        # override when it maps to a djust LiveView, so the live_session
+        # route-map path (client resolved correctly) is unaffected.
+        resolved_view = self._resolve_view_path_from_url(data.get("url", ""))
+        if resolved_view and resolved_view != data.get("view"):
+            logger.debug(
+                "live_redirect_mount: server-resolved target view %s from URL %s (client sent %s)",
+                resolved_view,
+                sanitize_for_log(data.get("url", "")),
+                sanitize_for_log(str(data.get("view"))),
+            )
+            data = {**data, "view": resolved_view}
         try:
             await self.handle_mount(
                 data,
@@ -4426,6 +4444,36 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         )
             self._sticky_preserved = {}
             raise
+
+    def _resolve_view_path_from_url(self, url: str) -> Optional[str]:
+        """Resolve a ``live_redirect`` destination URL to its djust LiveView
+        dotted path, server-side, via Django's URL resolver (#1647).
+
+        Returns the ``module.QualName`` of the view class wired to ``url`` in the
+        URLconf when (and only when) it is a :class:`djust.LiveView` subclass.
+        Returns ``None`` when the URL doesn't resolve, or maps to a non-LiveView
+        (e.g. a plain Django view) — the caller then keeps the client-supplied
+        ``view`` (preserving the ``live_session`` route-map path, where the
+        client already resolved the target correctly).
+        """
+        if not url:
+            return None
+        from django.urls import Resolver404, resolve
+
+        from .live_view import LiveView
+
+        try:
+            match = resolve(url)
+        except Resolver404:
+            return None
+        except Exception:  # noqa: BLE001 — never let URL resolution break mount
+            logger.debug("live_redirect view resolution raised for %s", sanitize_for_log(url))
+            return None
+        # View.as_view() stamps the class onto the returned callable.
+        view_class = getattr(match.func, "view_class", None)
+        if not (isinstance(view_class, type) and issubclass(view_class, LiveView)):
+            return None
+        return f"{view_class.__module__}.{view_class.__qualname__}"
 
     def _build_live_redirect_request(self, data: Dict[str, Any]):
         """Reconstruct a minimal Django request for the live_redirect target.

--- a/tests/redirect_mount_test_urls.py
+++ b/tests/redirect_mount_test_urls.py
@@ -1,0 +1,42 @@
+"""URL configuration for #1647 live_redirect_mount view-resolution tests.
+
+Maps two djust LiveViews and one plain Django view so the server-side
+``_resolve_view_path_from_url`` helper can be exercised against real URLconf
+entries. Referenced via ``@override_settings(ROOT_URLCONF=...)``.
+"""
+
+from __future__ import annotations
+
+from django.http import HttpResponse
+from django.urls import path
+
+from djust import LiveView
+
+
+class RedirectSourceView(LiveView):
+    template = (
+        '<div dj-root dj-view="tests.redirect_mount_test_urls.RedirectSourceView">source</div>'
+    )
+
+    def mount(self, request, **kwargs):
+        self.where = "source"
+
+
+class RedirectTargetView(LiveView):
+    template = (
+        '<div dj-root dj-view="tests.redirect_mount_test_urls.RedirectTargetView">target</div>'
+    )
+
+    def mount(self, request, **kwargs):
+        self.where = "target"
+
+
+def plain_django_view(request):  # not a LiveView — helper must return None for this
+    return HttpResponse("plain")
+
+
+urlpatterns = [
+    path("redirect-source/", RedirectSourceView.as_view(), name="redirect-source"),
+    path("redirect-target/", RedirectTargetView.as_view(), name="redirect-target"),
+    path("plain/", plain_django_view, name="plain"),
+]


### PR DESCRIPTION
## Summary
Fixes #1647. `live_redirect` to a *different* view failed with "Failed to load view. Please refresh the page." for apps using plain Django `path()` URLconfs.

## Root cause
The client's `resolveViewPath()` falls back to the current container's `dj-view` — the **source** view — when `window.djust._routeMap` is empty (the default without `live_session()`). The server trusted that client-supplied class in `live_redirect_mount` and instantiated the *source* view against the destination URL's request → mount raised.

## Fix (server is canonical)
`handle_live_redirect_mount` resolves the destination view server-side from `data["url"]` via Django's URL dispatcher (new `_resolve_view_path_from_url`: `resolve(url).func.view_class`) and overrides the client-supplied `view` when it maps to a djust `LiveView`. Falls back to the client value when the URL doesn't resolve to a LiveView (preserves `live_session()` route maps). **Removes the hidden `live_session()` prerequisite for plain `path()` URLconfs.**

**Back-nav guard:** the override is skipped when a `state_snapshot` is present — back-navigation carries the authoritative `view_slug` and its `url` may be generic (e.g. `/`) and resolve to an unrelated view. (This regression was caught by the pre-push suite and is pinned by a regression test.)

## Tests
`python/djust/tests/test_live_redirect_mount_resolve_1647.py` (7) + a test urlconf: helper resolves target / returns None for unmapped/non-LiveView/empty; `handle_live_redirect_mount` overrides SOURCE→TARGET (RED pre-fix, gate-off verified), keeps the client view when unresolvable, and does NOT override when a `state_snapshot` is present. Full pre-push suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)