### PR TITLE
fix(theming): break cyclic-import SCC via leaf _config module (CodeQL #2351, #2357-#2362)

### DIFF
--- a/python/djust/tests/test_theming_no_cyclic_import.py
+++ b/python/djust/tests/test_theming_no_cyclic_import.py
@@ -135,3 +135,111 @@ class TestThemingNoCyclicImport:
         assert get_preset("blue").name == "blue"
         # Unknown name falls back to DEFAULT_THEME (resolution step 3)
         assert get_preset("definitely-not-a-real-theme-xyz").name == "default"
+
+
+class TestConfigReaderIsLeaf:
+    """Gate the #2351/#2357-#2362 cycle-break: ``get_theme_config`` lives in the
+    leaf ``_config`` module and NO theming module imports it from ``manager``.
+
+    The earlier fix (#2352) broke the *eager* SCC by making cross-module imports
+    lazy, but CodeQL's ``py/cyclic-import`` counts lazy edges too — so the
+    ``→ manager.get_theme_config`` edges from registry / css_generator /
+    theme_css_generator / pack_css_generator / component_css_generator / checks /
+    components kept the SCC alive in CodeQL's view. Extracting ``get_theme_config``
+    to the leaf ``_config`` removed every one of those edges. These tests gate
+    the static import graph (lazy + eager) so the cycle can't silently return.
+    """
+
+    def test_config_module_is_a_leaf(self):
+        """``_config`` must import NOTHING from the cycle modules — it's the leaf
+        registry/css_generator read instead of manager."""
+        import ast
+
+        src = (THEMING_DIR / "_config.py").read_text()
+        cycle_mods = {
+            "presets",
+            "registry",
+            "manager",
+            "css_generator",
+            "theme_css_generator",
+            "pack_css_generator",
+            "component_css_generator",
+        }
+        for node in ast.walk(ast.parse(src)):
+            if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module:
+                base = node.module.split(".")[0]
+                assert base not in cycle_mods, (
+                    f"_config.py must stay a leaf but imports .{base} — "
+                    "that would re-create the cyclic-import SCC (#2351)."
+                )
+
+    def test_no_theming_module_imports_get_theme_config_from_manager(self):
+        """Every reader of ``get_theme_config`` must import it from ``._config``,
+        not ``.manager`` — importing from manager re-creates the
+        manager-centered cycles CodeQL flagged (#2357-#2362)."""
+        import ast
+
+        offenders = []
+        for path in THEMING_DIR.glob("*.py"):
+            if path.name == "manager.py":
+                continue  # manager legitimately re-exports it from _config
+            for node in ast.walk(ast.parse(path.read_text())):
+                if (
+                    isinstance(node, ast.ImportFrom)
+                    and node.level == 1
+                    and node.module
+                    and node.module.split(".")[0] == "manager"
+                    and any(alias.name == "get_theme_config" for alias in node.names)
+                ):
+                    offenders.append(f"{path.name}:{node.lineno}")
+        assert offenders == [], (
+            "these modules import get_theme_config from .manager (re-creates the "
+            f"cyclic-import SCC #2357-#2362); import from ._config instead: {offenders}"
+        )
+
+    def test_manager_reexports_get_theme_config_for_backcompat(self):
+        """``from djust.theming.manager import get_theme_config`` must keep
+        working (back-compat) and be the SAME object as the _config source."""
+        from djust.theming._config import get_theme_config as cfg_src
+        from djust.theming.manager import get_theme_config as mgr_reexport
+
+        assert mgr_reexport is cfg_src
+
+    def test_flagged_modules_are_outside_every_import_scc(self):
+        """presets / manager / css_generator (the files CodeQL flagged) must not
+        be in ANY strongly-connected component of the theming import graph
+        (lazy + eager). The pre-existing registry↔theme_packs / registry↔manifest
+        SCC is allowed — it's separate and was never flagged — but the flagged
+        modules must be outside it."""
+        import ast
+
+        mods = {p.stem for p in THEMING_DIR.glob("*.py") if p.stem != "__init__"}
+        edges = {}
+        for m in mods:
+            deps = set()
+            for node in ast.walk(ast.parse((THEMING_DIR / f"{m}.py").read_text())):
+                if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module:
+                    base = node.module.split(".")[0]
+                    if base in mods:
+                        deps.add(base)
+            edges[m] = deps
+
+        # Tarjan-free reachability SCC test: m is in an SCC iff it can reach
+        # itself through >=1 edge.
+        def reaches(start, target):
+            seen, stack = set(), [start]
+            while stack:
+                u = stack.pop()
+                for v in edges.get(u, ()):
+                    if v == target:
+                        return True
+                    if v not in seen:
+                        seen.add(v)
+                        stack.append(v)
+            return False
+
+        for m in ("presets", "manager", "css_generator"):
+            assert not reaches(m, m), (
+                f"{m} is in an import cycle (CodeQL py/cyclic-import #2351/"
+                f"#2357-#2362 would re-open). Edges from {m}: {sorted(edges[m])}"
+            )

--- a/python/djust/theming/_config.py
+++ b/python/djust/theming/_config.py
@@ -1,0 +1,76 @@
+"""Theme configuration reader — leaf module (CodeQL py/cyclic-import #2351, #2357–#2362).
+
+Holds ``DEFAULT_CONFIG`` + ``get_theme_config()`` + cookie-namespace validation,
+extracted from ``manager.py``. This module imports ONLY Django + stdlib — never
+``.presets`` / ``.registry`` / ``.manager`` / ``.css_generator`` — so that
+``registry.py`` and ``css_generator.py`` can read the theme config WITHOUT
+importing ``manager`` (the edge that closed the ``presets ↔ registry ↔ manager``
+and ``manager ↔ theme_css_generator ↔ css_generator`` import cycles).
+
+``manager`` re-exports ``get_theme_config`` / ``DEFAULT_CONFIG`` for back-compat,
+so ``from djust.theming.manager import get_theme_config`` keeps working.
+"""
+
+from __future__ import annotations
+
+import re
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+# Cookie names may only contain ASCII letters, digits, underscores, hyphens.
+COOKIE_NAMESPACE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+# Default configuration
+DEFAULT_CONFIG = {
+    "theme": "material",  # Design system theme
+    "preset": "default",  # Color preset
+    "default_mode": "system",
+    "persist_in_session": True,
+    "session_key": "djust_theme",
+    "enable_dark_mode": True,
+    "css_prefix": "",  # Namespace prefix for component CSS classes (e.g. "dj-")
+    "use_css_layers": True,  # Wrap generated CSS in @layer declarations
+    "css_layer_order": "base, tokens, components, djust-components, theme",  # Layer priority order
+    "critical_css": True,  # Split CSS into critical (inlined) and deferred (async-loaded)
+    "themes_dir": "themes/",  # User theme directory, relative to BASE_DIR
+    "direction": "auto",  # Text direction: "ltr", "rtl", or "auto" (detect from LANGUAGE_CODE)
+}
+
+
+def _validate_cookie_namespace(value):
+    """Validate ``LIVEVIEW_CONFIG['theme']['cookie_namespace']`` (#1169(b)).
+
+    The value is interpolated directly into cookie names; characters
+    illegal in cookie names (whitespace, ``=``, ``;``, non-ASCII)
+    silently produce malformed Set-Cookie headers. Validate at
+    config-load so the failure mode is a loud
+    :class:`~django.core.exceptions.ImproperlyConfigured` at startup
+    instead of broken cookies in production.
+
+    ``None`` and empty string are accepted as "no namespace configured".
+    """
+    if value is None or value == "":
+        return value
+    if not isinstance(value, str) or not COOKIE_NAMESPACE_RE.match(value):
+        raise ImproperlyConfigured(
+            f"LIVEVIEW_CONFIG['theme']['cookie_namespace']={value!r} contains "
+            f"characters illegal in cookie names. Use only ASCII letters, "
+            f"digits, underscores, and hyphens."
+        )
+    return value
+
+
+def get_theme_config() -> dict:
+    """Get theme configuration from Django settings.
+
+    Raises:
+        ImproperlyConfigured: if ``cookie_namespace`` contains characters
+            illegal in cookie names (#1169(b)).
+    """
+    liveview_config = getattr(settings, "LIVEVIEW_CONFIG", {})
+    theme_config = liveview_config.get("theme", {})
+    merged = {**DEFAULT_CONFIG, **theme_config}
+    # Validate cookie_namespace at config-load (#1169(b)).
+    _validate_cookie_namespace(merged.get("cookie_namespace"))
+    return merged

--- a/python/djust/theming/checks.py
+++ b/python/djust/theming/checks.py
@@ -3,7 +3,7 @@
 from django.conf import settings
 from django.core.checks import Error, Warning, register, Tags
 
-from .manager import get_theme_config
+from ._config import get_theme_config
 from .accessibility import AccessibilityValidator
 from .registry import get_registry
 

--- a/python/djust/theming/component_css_generator.py
+++ b/python/djust/theming/component_css_generator.py
@@ -120,7 +120,7 @@ def generate_component_css(prefix: str = "") -> str:
     Returns:
         Complete component CSS string.
     """
-    from .manager import get_theme_config
+    from ._config import get_theme_config
 
     css = _read_static_css()
     css = _apply_prefix(css, prefix)

--- a/python/djust/theming/components.py
+++ b/python/djust/theming/components.py
@@ -9,7 +9,8 @@ from dataclasses import dataclass
 from django.template.loader import select_template
 from django.utils.safestring import mark_safe
 
-from .manager import ThemeManager, get_theme_config
+from ._config import get_theme_config
+from .manager import ThemeManager
 from .template_resolver import _get_component_candidates, _get_theme_template_candidates
 
 

--- a/python/djust/theming/css_generator.py
+++ b/python/djust/theming/css_generator.py
@@ -541,7 +541,7 @@ pre code {
 
     def generate_css(self) -> str:
         """Generate complete CSS for the theme."""
-        from .manager import get_theme_config
+        from ._config import get_theme_config
 
         config = get_theme_config()
         use_layers = config.get("use_css_layers", True)
@@ -613,7 +613,7 @@ pre code {
         Returns:
             CSS string suitable for inlining in a <style> tag.
         """
-        from .manager import get_theme_config
+        from ._config import get_theme_config
 
         config = get_theme_config()
         use_layers = config.get("use_css_layers", True)
@@ -658,7 +658,7 @@ pre code {
         Returns:
             CSS string suitable for serving from a <link> tag.
         """
-        from .manager import get_theme_config
+        from ._config import get_theme_config
 
         config = get_theme_config()
         use_layers = config.get("use_css_layers", True)

--- a/python/djust/theming/manager.py
+++ b/python/djust/theming/manager.py
@@ -4,29 +4,30 @@ Theme state management for djust.
 Manages theme preset and mode preferences, with session persistence.
 """
 
-import re
 from dataclasses import dataclass
 from typing import Literal
 
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
 
 from ._types import ThemePreset
+
+# Theme config reader lives in the leaf ._config module so registry.py and
+# css_generator.py can read it without importing manager (the edge that closed
+# the presets↔registry↔manager and manager↔theme_css_generator↔css_generator
+# cyclic-import SCCs — CodeQL #2351/#2357-#2362). Re-exported here for
+# back-compat: ``from djust.theming.manager import get_theme_config`` still works.
+from ._config import (  # noqa: F401 — re-exported for back-compat
+    COOKIE_NAMESPACE_RE,
+    DEFAULT_CONFIG,
+    _validate_cookie_namespace,
+    get_theme_config,
+)
 
 # NOTE: ``get_preset`` is imported lazily inside ``ThemeManager.get_preset``
 # (the only call site) to avoid the
 # ``presets → registry → manager → presets`` cyclic-import SCC that
 # CodeQL flagged in alert #2352.
-
-# #1169(b) — cookie_namespace is interpolated directly into cookie names. RFC
-# 6265 forbids whitespace, control chars, '=' and ';' inside cookie names;
-# non-ASCII is implementation-defined and unsafe in practice. Restrict to
-# ASCII alphanumerics + underscore + hyphen (a strict subset of RFC 6265
-# token chars) so misconfiguration fails loudly at config-load instead of
-# silently emitting malformed Set-Cookie headers that browsers reject or
-# split into multiple cookies.
-COOKIE_NAMESPACE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 ThemeMode = Literal["light", "dark", "system"]
 
@@ -46,60 +47,6 @@ RTL_LANGUAGES = frozenset(
         "ug",  # Uyghur
     }
 )
-
-# Default configuration
-DEFAULT_CONFIG = {
-    "theme": "material",  # Design system theme
-    "preset": "default",  # Color preset
-    "default_mode": "system",
-    "persist_in_session": True,
-    "session_key": "djust_theme",
-    "enable_dark_mode": True,
-    "css_prefix": "",  # Namespace prefix for component CSS classes (e.g. "dj-")
-    "use_css_layers": True,  # Wrap generated CSS in @layer declarations
-    "css_layer_order": "base, tokens, components, djust-components, theme",  # Layer priority order
-    "critical_css": True,  # Split CSS into critical (inlined) and deferred (async-loaded)
-    "themes_dir": "themes/",  # User theme directory, relative to BASE_DIR
-    "direction": "auto",  # Text direction: "ltr", "rtl", or "auto" (detect from LANGUAGE_CODE)
-}
-
-
-def _validate_cookie_namespace(value):
-    """Validate ``LIVEVIEW_CONFIG['theme']['cookie_namespace']`` (#1169(b)).
-
-    The value is interpolated directly into cookie names; characters
-    illegal in cookie names (whitespace, ``=``, ``;``, non-ASCII)
-    silently produce malformed Set-Cookie headers. Validate at
-    config-load so the failure mode is a loud
-    :class:`~django.core.exceptions.ImproperlyConfigured` at startup
-    instead of broken cookies in production.
-
-    ``None`` and empty string are accepted as "no namespace configured".
-    """
-    if value is None or value == "":
-        return value
-    if not isinstance(value, str) or not COOKIE_NAMESPACE_RE.match(value):
-        raise ImproperlyConfigured(
-            f"LIVEVIEW_CONFIG['theme']['cookie_namespace']={value!r} contains "
-            f"characters illegal in cookie names. Use only ASCII letters, "
-            f"digits, underscores, and hyphens."
-        )
-    return value
-
-
-def get_theme_config() -> dict:
-    """Get theme configuration from Django settings.
-
-    Raises:
-        ImproperlyConfigured: if ``cookie_namespace`` contains characters
-            illegal in cookie names (#1169(b)).
-    """
-    liveview_config = getattr(settings, "LIVEVIEW_CONFIG", {})
-    theme_config = liveview_config.get("theme", {})
-    merged = {**DEFAULT_CONFIG, **theme_config}
-    # Validate cookie_namespace at config-load (#1169(b)).
-    _validate_cookie_namespace(merged.get("cookie_namespace"))
-    return merged
 
 
 @dataclass

--- a/python/djust/theming/pack_css_generator.py
+++ b/python/djust/theming/pack_css_generator.py
@@ -8,7 +8,7 @@ framework-aware component overrides, and all other styling dimensions from a The
 from functools import lru_cache
 
 from ..config import config as djust_config
-from .manager import get_theme_config
+from ._config import get_theme_config
 from .theme_packs import get_theme_pack, get_design_system
 from .theme_css_generator import CompleteThemeCSSGenerator
 

--- a/python/djust/theming/registry.py
+++ b/python/djust/theming/registry.py
@@ -200,7 +200,7 @@ class ThemeRegistry:
         """Load theme.toml manifests from configured themes_dir."""
         from django.conf import settings
 
-        from .manager import get_theme_config
+        from ._config import get_theme_config
 
         config = get_theme_config()
         themes_dir_rel = config.get("themes_dir", "themes/")

--- a/python/djust/theming/theme_css_generator.py
+++ b/python/djust/theming/theme_css_generator.py
@@ -14,7 +14,7 @@ Sources design data from DesignSystem objects in theme_packs.py.
 
 from functools import lru_cache
 
-from .manager import get_theme_config
+from ._config import get_theme_config
 from .theme_packs import DesignSystem, get_design_system
 from .css_generator import ThemeCSSGenerator as ColorCSSGenerator
 


### PR DESCRIPTION
## Summary
Resolves the 7 open CodeQL `py/cyclic-import` alerts in `djust.theming`: **#2351** (presets.py:42), **#2357–#2361** (css_generator.py:45/544/616/661/707), **#2362** (manager.py:518).

## Root cause
The prior fix (#2352) broke the *eager* import cycle by making cross-module imports lazy, and `test_theming_no_cyclic_import.py` gates the module-**top-level** graph (deliberately ignoring lazy imports). But CodeQL's `py/cyclic-import` counts **lazy edges too**, so the `→ manager.get_theme_config` edges (from registry, css_generator, theme_css_generator, pack/component_css_generator) plus the `presets → registry → manager → presets` loop kept the SCC alive in CodeQL's view — re-surfacing as these 7 alerts.

## Fix
Extract `get_theme_config` + `DEFAULT_CONFIG` + `_validate_cookie_namespace` (+ `COOKIE_NAMESPACE_RE`) from `manager.py` into a new **leaf** `_config.py` (imports only Django + stdlib). Every reader now imports the config from `._config` instead of `.manager`, removing all manager-ward edges from the generator/registry modules. `manager` **re-exports** `get_theme_config`/`DEFAULT_CONFIG`, so `from djust.theming.manager import get_theme_config` keeps working — **no behavior change, no public-API change.**

Result: `presets` / `manager` / `css_generator` are now outside every import SCC (verified by a reachability test). The **pre-existing, unflagged** `registry↔theme_packs` / `registry↔manifest` SCC is left as-is (separate concern, never flagged) — staying scoped to the 7 reported alerts.

## Tests
4 new gates in `test_theming_no_cyclic_import.py`: `_config` stays a leaf; no module imports `get_theme_config` from `.manager`; the manager re-export is the same object; and the flagged modules are outside every SCC (so the alerts can't silently regress). 1844 theming tests green; full pre-push suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)