### PR TITLE
fix(vdom): emit InsertChild.ref_d=None — positional guess mis-inserts under reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **VDOM `InsertChild.ref_d` no longer mis-inserts under sibling reorder.** The differ populated `ref_d` with a positional guess (`old.get(new_index).djust_id`) — the dj-id of whatever old node *happened* to sit at the new node's index. The client (`12-vdom-patch.js`) **honors** `ref_d` (it does `insertBefore(node, querySelector(':scope > [dj-id=ref_d]'))` and only falls back to the index when `ref_d` is absent), so under a reorder that guess is the wrong reference and the new node lands in the wrong position. The differ now emits `ref_d: None` and relies on the index: `InsertChild` is applied **last** in the client's phase order (after `RemoveSubtree`/`InsertSubtree`/`RemoveChild`/`MoveChild`), so the index is resolved against the settled new-frame and is reliable. A client-faithful differential harness measured ~18 mis-inserts per 6000 adversarial re-renders before the fix, 0 after. The `#1408` invariant is preserved (a `ref_d`, when present, must resolve in the OLD tree). Regression-pinned by `keyed_insert_ref_d_is_safe_not_a_wrong_guess` in `crates/djust_vdom/tests/test_diff_robustness_gaps.rs`.
+
 ## [1.0.0rc15] - 2026-05-28
 
 ### Fixed

--- a/crates/djust_vdom/src/diff.rs
+++ b/crates/djust_vdom/src/diff.rs
@@ -345,39 +345,25 @@ fn diff_children(
         .map(|(i, n)| (new_off + i, n))
         .collect();
 
-    reconcile_siblings(&old_nb, &new_nb, old, new_off, ppath, pid, out);
+    reconcile_siblings(&old_nb, &new_nb, ppath, pid, out);
 }
 
 /// Reconcile two lists of non-boundary siblings (each carrying its parent-
 /// absolute index). Chooses keyed reconciliation if any NEW sibling is keyed,
 /// otherwise positional/indexed.
-#[allow(clippy::too_many_arguments)]
 fn reconcile_siblings(
     old_nb: &[(usize, &VNode)],
     new_nb: &[(usize, &VNode)],
-    old_slice: &[VNode],
-    new_off: usize,
     ppath: &[usize],
     pid: Option<&str>,
     out: &mut Vec<Patch>,
 ) {
     let any_new_keyed = new_nb.iter().any(|(_, n)| n.key.is_some());
     if any_new_keyed {
-        reconcile_keyed(old_nb, new_nb, old_slice, new_off, ppath, pid, out);
+        reconcile_keyed(old_nb, new_nb, ppath, pid, out);
     } else {
-        reconcile_indexed(old_nb, new_nb, old_slice, new_off, ppath, pid, out);
+        reconcile_indexed(old_nb, new_nb, ppath, pid, out);
     }
-}
-
-/// `ref_d` heuristic: the djust_id of the OLD node occupying the new node's
-/// local slot — the reference sibling the client `insertBefore`s. Always
-/// resolves to a node present in the OLD tree (or is `None`), honoring the
-/// #1408 invariant. Mirrors the original's `old.get(new_idx)`.
-fn ref_d_for(old_slice: &[VNode], new_abs: usize, new_off: usize) -> Option<String> {
-    new_abs
-        .checked_sub(new_off)
-        .and_then(|local| old_slice.get(local))
-        .and_then(|n| n.djust_id.clone())
 }
 
 /// Positional reconciliation: pair the i-th old non-boundary sibling with the
@@ -385,12 +371,9 @@ fn ref_d_for(old_slice: &[VNode], new_abs: usize, new_off: usize) -> Option<Stri
 /// comment-vs-noncomment pair is remove+insert; surplus old -> RemoveChild,
 /// surplus new -> InsertChild. Used for fully-unkeyed lists; intentionally
 /// positional (no moves) — matches the original's indexed-diff behavior.
-#[allow(clippy::too_many_arguments)]
 fn reconcile_indexed(
     old_nb: &[(usize, &VNode)],
     new_nb: &[(usize, &VNode)],
-    old_slice: &[VNode],
-    new_off: usize,
     ppath: &[usize],
     pid: Option<&str>,
     out: &mut Vec<Patch>,
@@ -406,14 +389,7 @@ fn reconcile_indexed(
         } else {
             // Incompatible kind: remove old, insert new.
             push_remove_child(old_abs, old_node, ppath, pid, out);
-            push_insert_child(
-                new_abs,
-                new_node,
-                ppath,
-                pid,
-                ref_d_for(old_slice, new_abs, new_off),
-                out,
-            );
+            push_insert_child(new_abs, new_node, ppath, pid, out);
         }
     }
     // Surplus old -> remove (descending order so apply-index fallback is safe).
@@ -423,14 +399,7 @@ fn reconcile_indexed(
     }
     // Surplus new -> insert (ascending order).
     for &(new_abs, new_node) in new_nb.iter().skip(common) {
-        push_insert_child(
-            new_abs,
-            new_node,
-            ppath,
-            pid,
-            ref_d_for(old_slice, new_abs, new_off),
-            out,
-        );
+        push_insert_child(new_abs, new_node, ppath, pid, out);
     }
 }
 
@@ -445,12 +414,9 @@ fn reconcile_indexed(
 ///   MoveChild (#1260) — AND every effectively-unkeyed sibling that carries a
 ///   djust_id and changed absolute position also gets a MoveChild, so it is not
 ///   stranded by the keyed reorder.
-#[allow(clippy::too_many_arguments)]
 fn reconcile_keyed(
     old_nb: &[(usize, &VNode)],
     new_nb: &[(usize, &VNode)],
-    old_slice: &[VNode],
-    new_off: usize,
     ppath: &[usize],
     pid: Option<&str>,
     out: &mut Vec<Patch>,
@@ -541,14 +507,7 @@ fn reconcile_keyed(
             diff_node_into(old_node, new_node, &child_path, out);
         } else {
             push_remove_child(old_abs, old_node, ppath, pid, out);
-            push_insert_child(
-                new_abs,
-                new_node,
-                ppath,
-                pid,
-                ref_d_for(old_slice, new_abs, new_off),
-                out,
-            );
+            push_insert_child(new_abs, new_node, ppath, pid, out);
         }
     }
     for i in (common..old_pos.len()).rev() {
@@ -556,14 +515,7 @@ fn reconcile_keyed(
         push_remove_child(old_abs, old_node, ppath, pid, out);
     }
     for &(new_abs, new_node) in new_pos.iter().skip(common) {
-        push_insert_child(
-            new_abs,
-            new_node,
-            ppath,
-            pid,
-            ref_d_for(old_slice, new_abs, new_off),
-            out,
-        );
+        push_insert_child(new_abs, new_node, ppath, pid, out);
     }
 
     // 3) Recurse into matched effective-keyed pairs.
@@ -579,14 +531,7 @@ fn reconcile_keyed(
     for (new_abs, new_node) in new_nb.iter() {
         if let Some(k) = eff_key(new_node) {
             if !old_eff.contains_key(&k) {
-                push_insert_child(
-                    *new_abs,
-                    new_node,
-                    ppath,
-                    pid,
-                    ref_d_for(old_slice, *new_abs, new_off),
-                    out,
-                );
+                push_insert_child(*new_abs, new_node, ppath, pid, out);
             }
         }
     }
@@ -670,7 +615,6 @@ fn push_insert_child(
     new_node: &VNode,
     ppath: &[usize],
     pid: Option<&str>,
-    ref_d: Option<String>,
     out: &mut Vec<Patch>,
 ) {
     out.push(Patch::InsertChild {
@@ -678,7 +622,7 @@ fn push_insert_child(
         d: pid.map(|s| s.to_string()),
         index: new_abs,
         node: new_node.clone(),
-        ref_d,
+        ref_d: None,
     });
 }
 

--- a/crates/djust_vdom/tests/test_diff_robustness_gaps.rs
+++ b/crates/djust_vdom/tests/test_diff_robustness_gaps.rs
@@ -198,11 +198,21 @@ fn mixed_three_way_reorder_round_trip() {
 // =============================================================================
 
 #[test]
-fn keyed_insert_populates_resolvable_ref_d() {
-    // Insert a fresh keyed child BEFORE an existing keyed sibling. The
-    // InsertChild for the new node must carry a ref_d that is the djust_id of
-    // an existing OLD-tree node (so the client can insertBefore by id, and the
-    // #1408 invariant holds).
+fn keyed_insert_ref_d_is_safe_not_a_wrong_guess() {
+    // Insert a fresh keyed child BEFORE an existing keyed sibling.
+    //
+    // The client (12-vdom-patch.js) HONORS InsertChild.ref_d — it does
+    // `insertBefore(node, querySelector(':scope > [dj-id=ref_d]'))` — and only
+    // falls back to the index when ref_d is absent/unresolved. InsertChild is
+    // applied LAST (after removes/moves/subtrees settle the structure), so the
+    // index fallback is in the new-frame and is reliable.
+    //
+    // Therefore the diff must NOT emit a *positional guess* for ref_d: a wrong
+    // ref_d (e.g. `old.get(new_idx)`) is the wrong insert-before reference under
+    // reorder and mis-inserts on the real client. The safe contract is: ref_d is
+    // either None (rely on the reliable index) OR a djust_id present in the OLD
+    // tree that is genuinely the following sibling — never a fresh/new-only id.
+    // See scratch/vdom-rebuild/ANALYSIS_REPORT.md §10.
     let old = el("ul", "root").with_children(vec![el_text("li", "B", "b").with_key("kb")]);
     let new = el("ul", "root").with_children(vec![
         el_text("li", "A", "a").with_key("ka"),
@@ -210,7 +220,7 @@ fn keyed_insert_populates_resolvable_ref_d() {
     ]);
 
     let patches = diff_nodes(&old, &new, &[]);
-    let insert = patches
+    let ref_d = patches
         .iter()
         .find_map(|p| match p {
             Patch::InsertChild { node, ref_d, .. } if node.key.as_deref() == Some("ka") => {
@@ -219,16 +229,20 @@ fn keyed_insert_populates_resolvable_ref_d() {
             _ => None,
         })
         .expect("expected an InsertChild for the new keyed <li key=ka>");
-    let ref_d = insert
-        .expect("InsertChild.ref_d must be populated for an insert before an existing sibling");
-    assert!(
-        find_by_id(&old, &ref_d).is_some(),
-        "ref_d {:?} must resolve to a node present in the OLD tree (#1408), patches: {:#?}",
-        ref_d,
-        patches
-    );
 
-    // And the whole thing must still round-trip.
+    // INVARIANT (#1408): if ref_d is set it must resolve in the OLD tree —
+    // never a fresh new-only id. (Currently the diff emits None and relies on
+    // the index, which the client applies last; this guards either choice.)
+    if let Some(rid) = &ref_d {
+        assert!(
+            find_by_id(&old, rid).is_some(),
+            "ref_d {:?} must resolve to a node present in the OLD tree (#1408), patches: {:#?}",
+            rid,
+            patches
+        );
+    }
+
+    // And the whole thing must round-trip.
     let applied = round_trip(&old, &new);
     assert!(
         structurally_equal(&applied, &new),


### PR DESCRIPTION
## Summary

The VDOM differ populated `InsertChild.ref_d` with a **positional guess** — `old.get(new_index).djust_id`, i.e. the dj-id of whatever old node happened to sit at the new node's index. The client (`python/djust/static/djust/src/12-vdom-patch.js`, ~line 1756) **honors** `ref_d`:

```js
if (patch.ref_d) {
    insertRefChild = node.querySelector(`:scope > [dj-id="${CSS.escape(patch.ref_d)}"]`);
}
if (!insertRefChild) { insertRefChild = getSignificantChildren(node)[patch.index]; }  // fallback
```

So under a **sibling reorder**, that guess is the *wrong* reference node and the inserted child lands in the wrong slot. The index is only a fallback when `ref_d` is absent.

## Fix

Emit `ref_d: None` and rely on the index. `InsertChild` is applied **last** in the client's phase order (`RemoveSubtree → InsertSubtree → RemoveChild → MoveChild → InsertChild`), so by the time it runs the structure is settled and the index resolves against the new-frame reliably. Removes the now-dead `ref_d_for` helper and its `old_slice`/`new_off` threading (net −38 lines).

## How it was found

A **client-faithful differential harness** (a Rust applier mirroring `12-vdom-patch.js`'s phased, id-aware, `ref_d`-honoring apply) run over 6000 adversarial random re-renders measured:

| `ref_d` | mis-inserts / 6000 |
|---|---|
| positional heuristic (before) | 40 |
| `None` (after) | 22 |

i.e. the heuristic *caused* ~18 of the failures. (The remaining 22 are unrelated: ~15 the matched-boundary-reposition limitation tracked in #1666, ~7 a deep-tree long tail.)

This was masked because the in-tree test appliers (`patch::apply_patches`, `tests/common/apply_all`) resolve `InsertChild` by **index** and ignore `ref_d` entirely — so a wrong `ref_d` was invisible to the suite. (Recommendation, separate: add a client-faithful round-trip oracle to the suite; noted on #1666.)

## Invariants & tests

- The **#1408 invariant** is preserved: `ref_d`, when present, must resolve in the OLD tree.
- `keyed_insert_ref_d_is_safe_not_a_wrong_guess` (revised from the prior gap test) now asserts that safety invariant + round-trip, instead of requiring `ref_d` to be a (possibly wrong) `Some`.
- 265 crate tests pass; clippy + fmt clean.

Note: the same positional-`ref_d` shape exists in the prior/original differ, so this is a latent-bug fix, not solely a rebuild regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)