### PR TITLE
ci: promote demo djust_check dogfood to a blocking demo-checks job (#1713)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -276,31 +276,10 @@ jobs:
           uv run python manage.py migrate --noinput
           cd ../..
 
-      # Dogfood djust_check against the demo project (#1708, enforces
-      # CLAUDE.md #1060). #1683 shipped dead @click buttons to 1.0 GA because
-      # the demo templates were never run through djust_check in CI.
-      #
-      # The helper wraps `manage.py djust_check --json` (which itself always
-      # exits 0) and sets a real exit code. It fails ONLY on error-severity
-      # checks and the deprecated-attribute classes T001/T014/T015 (the exact
-      # #1683 bug class) — NOT on the demo's intentional warnings (public-view
-      # auth notices, partial-fragment templates).
-      #
-      # NOTE: this step inherits the job's `continue-on-error: true`, so it is
-      # NON-BLOCKING on its first runner iterations (rc4 retro finding #3: a new
-      # CI check exercising an env the dev machine can't fully mirror needs >=1
-      # runner-only iteration budgeted). Once it has shipped green on the
-      # runner, promote it to a blocking gate — either move it to a dedicated
-      # `demo-checks` job without continue-on-error, or wire it into the
-      # test-summary aggregate gate.
-      - name: Dogfood djust_check against the demo (non-blocking until green)
-        run: |
-          cd examples/demo_project
-          PYTHONPATH=../.. uv run python ../../scripts/ci_djust_check_demo.py
-          cd ../..
-        env:
-          PYTHONPATH: .
-
+      # NOTE: the djust_check demo dogfood used to live here as a
+      # `continue-on-error` step (#1708). It shipped green on the runner and
+      # was promoted (#1713) to its own BLOCKING `demo-checks` job below, so
+      # the dogfood is decoupled from playwright (which stays non-blocking).
       - name: Start development server
         run: |
           cd examples/demo_project
@@ -498,10 +477,66 @@ jobs:
           name: security-coverage-report
           path: coverage-security.json
 
+  # Demo djust_check dogfood — BLOCKING dedicated job (#1713, enforces
+  # CLAUDE.md #1060). #1683 shipped dead @click buttons to 1.0 GA because
+  # the demo templates were never run through djust_check in CI. The dogfood
+  # first shipped as a `continue-on-error` step inside playwright-tests
+  # (#1708); now that it has shipped green on the runner (rc4 retro finding
+  # #3: a new CI check exercising an env the dev machine can't fully mirror
+  # needs >=1 runner-only iteration budgeted), it is promoted to this
+  # dedicated BLOCKING job (no continue-on-error) and wired into the
+  # test-summary aggregate gate, so a re-introduced dead @click / legacy
+  # attribute (the #1683 bug class) red-bars the PR.
+  #
+  # The helper wraps `manage.py djust_check --json` (which itself always
+  # exits 0) and sets a real exit code. It fails ONLY on error-severity
+  # checks and the deprecated-attribute classes T001/T014/T015 (the exact
+  # #1683 bug class) — NOT on the demo's intentional warnings (public-view
+  # auth notices, partial-fragment templates).
+  demo-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: ${{ runner.os }}-python-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-python-
+
+      - name: Install Python dependencies
+        run: uv sync --extra dev
+
+      - name: Run Django migrations (demo)
+        run: |
+          cd examples/demo_project
+          uv run python manage.py migrate --noinput
+          cd ../..
+
+      - name: Dogfood djust_check against the demo (BLOCKING)
+        run: |
+          cd examples/demo_project
+          PYTHONPATH=../.. uv run python ../../scripts/ci_djust_check_demo.py
+          cd ../..
+        env:
+          PYTHONPATH: .
+
   # Summary job - waits for all test jobs
   test-summary:
     runs-on: ubuntu-latest
-    needs: [rust-tests, python-tests, javascript-tests, playwright-tests, security-scan, security-tests]
+    needs: [rust-tests, python-tests, javascript-tests, playwright-tests, security-scan, security-tests, demo-checks]
     if: always()
     steps:
       - name: Check test results
@@ -513,13 +548,16 @@ jobs:
           echo "  Playwright tests: ${{ needs.playwright-tests.result }} (optional)"
           echo "  Security scan: ${{ needs.security-scan.result }}"
           echo "  Security tests: ${{ needs.security-tests.result }}"
+          echo "  Demo checks: ${{ needs.demo-checks.result }}"
 
-          # Core tests must pass (Rust, Python, JavaScript, Security tests)
-          # Playwright tests and security scan are informational (not blocking)
+          # Core tests must pass (Rust, Python, JavaScript, Security tests,
+          # Demo checks). Playwright tests and security scan are informational
+          # (not blocking).
           if [ "${{ needs.rust-tests.result }}" == "success" ] && \
              [ "${{ needs.python-tests.result }}" == "success" ] && \
              [ "${{ needs.javascript-tests.result }}" == "success" ] && \
-             [ "${{ needs.security-tests.result }}" == "success" ]; then
+             [ "${{ needs.security-tests.result }}" == "success" ] && \
+             [ "${{ needs.demo-checks.result }}" == "success" ]; then
             echo "All core tests passed!"
             if [ "${{ needs.playwright-tests.result }}" != "success" ]; then
               echo "WARNING: Playwright tests failed (optional, not blocking)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI promotes the demo `djust_check` dogfood to a BLOCKING `demo-checks` job (#1713, CI infra — completes #1708, applies CLAUDE.md rc4 retro finding #3).** The dogfood added in #1708 ran as a `continue-on-error` step inside the non-blocking `playwright-tests` job, so a re-introduced dead `@click` / legacy attribute (the #1683 bug class) could NOT red-bar a PR. Now that the step has shipped green on the runner (the budgeted ≥1 runner-only iteration), it is extracted into a dedicated `demo-checks` job WITHOUT `continue-on-error` and wired into the `test-summary` aggregate gate (added to `needs:` and the blocking success condition alongside rust/python/js/security-tests). The dogfood step is removed from `playwright-tests`, which stays non-blocking and decoupled from the demo check (its own `migrate` step is retained for the dev server it starts). The wrapper `scripts/ci_djust_check_demo.py` is refactored to extract an importable `evaluate(parsed_json)` decision function (CLI behavior of `main()` unchanged), and a new unit test (`tests/test_ci_djust_check_demo.py`) feeds SYNTHETIC `djust_check --json` payloads through it to exercise BOTH gate arms end-to-end — the error-severity arm (never hit by the live 0-error demo, the Stage-11 note) and the deprecated-attr `T001`/`T014`/`T015` ID-set arm — the #252 empirical canary, with a clean-payload tautology guard (#254 gate-off verified: neutering the blocking arm makes all four blocking cases fail). No framework behavior change — CI config + test only.
+
 ### Security
 
 - Bump starlette 1.0.0 → 1.2.1 (CVE-2026-48710 host-header validation; transitive via mcp).

--- a/scripts/ci_djust_check_demo.py
+++ b/scripts/ci_djust_check_demo.py
@@ -65,35 +65,18 @@ def _extract_json(stdout):
     raise ValueError("no JSON object found in djust_check output")
 
 
-def main(argv=None):
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--demo-dir",
-        default=".",
-        help="Demo project directory containing manage.py (default: cwd)",
-    )
-    args = parser.parse_args(argv)
+def evaluate(data):
+    """Apply the CI gate to a parsed ``djust_check --json`` payload.
 
-    proc = subprocess.run(
-        [sys.executable, "manage.py", "djust_check", "--json"],
-        cwd=args.demo_dir,
-        capture_output=True,
-        text=True,
-    )
-    if proc.returncode != 0:
-        # djust_check itself errored (e.g. import/config failure) — surface it.
-        print("ERROR: `manage.py djust_check --json` exited %d" % proc.returncode)
-        print(proc.stdout)
-        print(proc.stderr, file=sys.stderr)
-        return 1
+    ``data`` is the dict produced by ``manage.py djust_check --json`` —
+    ``{"checks": [{"id", "severity", "message", ...}], "summary": {...}}``.
 
-    try:
-        data = _extract_json(proc.stdout)
-    except (ValueError, json.JSONDecodeError) as exc:
-        print("ERROR: could not parse djust_check JSON output: %s" % exc)
-        print(proc.stdout)
-        return 1
-
+    Returns ``0`` when the demo is clean (no error-severity checks and no
+    deprecated-attribute findings T001/T014/T015) and ``1`` otherwise. This
+    is the single decision point shared by ``main()`` and the unit tests so
+    both gate arms (error-severity and deprecated-attr ID-set) are exercised
+    end-to-end without spawning a subprocess (#1713, #252 empirical canary).
+    """
     checks = data.get("checks", [])
     summary = data.get("summary", {})
 
@@ -125,6 +108,38 @@ def main(argv=None):
 
     print("OK: no errors and no deprecated-attribute findings (T001/T014/T015).")
     return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--demo-dir",
+        default=".",
+        help="Demo project directory containing manage.py (default: cwd)",
+    )
+    args = parser.parse_args(argv)
+
+    proc = subprocess.run(
+        [sys.executable, "manage.py", "djust_check", "--json"],
+        cwd=args.demo_dir,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        # djust_check itself errored (e.g. import/config failure) — surface it.
+        print("ERROR: `manage.py djust_check --json` exited %d" % proc.returncode)
+        print(proc.stdout)
+        print(proc.stderr, file=sys.stderr)
+        return 1
+
+    try:
+        data = _extract_json(proc.stdout)
+    except (ValueError, json.JSONDecodeError) as exc:
+        print("ERROR: could not parse djust_check JSON output: %s" % exc)
+        print(proc.stdout)
+        return 1
+
+    return evaluate(data)
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_djust_check_demo.py
+++ b/tests/test_ci_djust_check_demo.py
@@ -1,0 +1,122 @@
+"""Tests for scripts/ci_djust_check_demo.py — #1713.
+
+The live dogfood (examples/demo_project) currently has 0 error-severity
+findings, so the ``severity == "error"`` arm of the gate is never exercised
+on the runner (rc4 retro finding #3 / Stage-11 note). These tests feed
+SYNTHETIC ``djust_check --json`` payloads straight into the extracted
+``evaluate()`` decision function so BOTH gate arms run end-to-end:
+
+  * error-severity finding            -> exit 1 (error arm)
+  * deprecated-attr T001/T014/T015    -> exit 1 (deprecated-attr ID-set arm)
+  * clean (benign warnings/info only) -> exit 0
+
+This synthetic-error-trigger IS the empirical canary (#252) for the
+wrapper's gate arms: each ``_blocks`` test is tautology-guarded (Action
+#1200 / #254) by also asserting a clean payload returns 0, so the gate
+cannot pass by always-returning-1 for an unrelated reason.
+
+The synthetic payloads match the EXACT shape ``djust_check --json`` emits
+(``_output_json`` in python/djust/management/commands/djust_check.py):
+``{"checks": [{"id", "severity", "category", "message", "hint"}],
+   "summary": {"total", "errors", "warnings", "info"}}`` with severity
+lowercased ("error" / "warning" / "info") and IDs like "djust.T001".
+"""
+
+import importlib.util
+import pathlib
+
+_SELF = pathlib.Path(__file__).resolve()
+_SCRIPT = _SELF.parents[1] / "scripts" / "ci_djust_check_demo.py"
+
+_spec = importlib.util.spec_from_file_location("ci_djust_check_demo", _SCRIPT)
+ci_djust_check_demo = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ci_djust_check_demo)
+
+evaluate = ci_djust_check_demo.evaluate
+
+
+def _check(check_id, severity, message="synthetic finding"):
+    """Build one check dict in the exact --json shape."""
+    return {
+        "id": check_id,
+        "severity": severity,
+        "category": "templates",
+        "message": message,
+        "hint": "",
+    }
+
+
+def _payload(checks):
+    """Wrap checks with a matching summary block (mirrors _output_json)."""
+    return {
+        "checks": checks,
+        "summary": {
+            "total": len(checks),
+            "errors": sum(1 for c in checks if c["severity"] == "error"),
+            "warnings": sum(1 for c in checks if c["severity"] == "warning"),
+            "info": sum(1 for c in checks if c["severity"] == "info"),
+        },
+    }
+
+
+def test_error_severity_blocks():
+    """An error-severity finding fails the gate (error arm)."""
+    payload = _payload(
+        [
+            _check("djust.S001", "error", "an error-severity finding"),
+            _check("djust.V004", "info", "benign info"),
+        ]
+    )
+    assert evaluate(payload) == 1
+
+
+def test_deprecated_t001_blocks():
+    """A T001 deprecated-@click finding at warning severity fails (ID-set arm)."""
+    payload = _payload(
+        [
+            _check("djust.T001", "warning", "deprecated @click attribute"),
+        ]
+    )
+    assert evaluate(payload) == 1
+
+
+def test_deprecated_t014_blocks():
+    """A T014 deprecated-data-dj-id finding at warning severity fails (ID-set arm)."""
+    payload = _payload(
+        [
+            _check("djust.T014", "warning", "deprecated data-dj-id attribute"),
+        ]
+    )
+    assert evaluate(payload) == 1
+
+
+def test_deprecated_t015_blocks():
+    """A T015 legacy-root-attribute finding at warning severity fails (ID-set arm)."""
+    payload = _payload(
+        [
+            _check("djust.T015", "warning", "legacy root attribute"),
+        ]
+    )
+    assert evaluate(payload) == 1
+
+
+def test_clean_payload_passes():
+    """Errors-free + no deprecated-attr findings -> exit 0 (tautology guard).
+
+    Includes benign warning/info findings the demo legitimately carries
+    (S005 public-view-without-auth, T012 partial fragments, V004 info) to
+    prove the gate does NOT fail on intentional demo states.
+    """
+    payload = _payload(
+        [
+            _check("djust.S005", "warning", "public view without auth (intentional)"),
+            _check("djust.T012", "warning", "partial fragment template"),
+            _check("djust.V004", "info", "informational"),
+        ]
+    )
+    assert evaluate(payload) == 0
+
+
+def test_empty_payload_passes():
+    """No checks at all -> exit 0."""
+    assert evaluate(_payload([])) == 0


### PR DESCRIPTION
## Summary

Promotes the demo `djust_check` dogfood (added in #1708) from a **non-blocking step** inside `playwright-tests` (which has `continue-on-error: true`) to a **dedicated BLOCKING `demo-checks` job**, so a re-introduced dead `@click` / legacy attribute (the #1683 bug class) now red-bars a PR. The step has shipped green on the runner, so per the rc4 retro finding #3 canon it is promoted to enforcing.

Closes #1713.

## The 4 changes

1. **New `demo-checks` job** (`.github/workflows/test.yml`) WITHOUT `continue-on-error`: `actions/checkout@v6` + `actions/setup-python@v6` (3.12) + `astral-sh/setup-uv@v7` + the uv dependency cache (mirrors the other jobs) + `uv sync --extra dev` + demo migrations (`cd examples/demo_project && uv run python manage.py migrate --noinput`) + the dogfood (`PYTHONPATH=../.. uv run python ../../scripts/ci_djust_check_demo.py`, env `PYTHONPATH: .` — mirrors the old step exactly). Comment updated to say it is now a BLOCKING dedicated job.
2. **Removed the dogfood step from `playwright-tests`** so playwright stays non-blocking and decoupled. Its own `migrate` step is retained (the dev server it starts still needs it).
3. **Wired `demo-checks` into `test-summary`**: added to `needs:`, echoed in the summary, and added to the BLOCKING success condition alongside rust/python/js/security-tests (NOT informational like playwright/security-scan).
4. **Unit test** (`tests/test_ci_djust_check_demo.py`): minimally refactored `scripts/ci_djust_check_demo.py` to extract an importable `evaluate(parsed_json)` decision function (CLI behavior of `main()` unchanged); the test feeds SYNTHETIC `djust_check --json` payloads to exercise both gate arms — error-severity (never hit by the live 0-error demo) and deprecated-attr `T001`/`T014`/`T015` — plus a clean tautology guard.

## Empirical canary (#252) + gate-off (#254)

The synthetic-error trigger IS the empirical canary for the wrapper's gate arms. Gate-off verified: neutering the blocking arm (`blocking = []`) makes all four blocking cases FAIL while the two clean cases still pass (non-tautological).

Synthetic payload schema matches `djust_check --json` (`_output_json` in `python/djust/management/commands/djust_check.py`) exactly: `{"checks": [{"id", "severity", "category", "message", "hint"}], "summary": {"total", "errors", "warnings", "info"}}`, severity lowercased, IDs like `djust.T001`.

## Local evidence

- `pytest tests/test_ci_djust_check_demo.py` → 6 passed.
- Gate-off: 4 blocking tests fail, 2 clean pass; restore → 6 pass.
- Live dogfood against the real demo: `104 total, 0 error(s)` → exit 0.
- YAML parses (venv PyYAML); `demo-checks` present, no `continue-on-error`, in `test-summary` needs.
- ruff clean on changed Python files.

## rc4 note

This is a CI-environment change the dev machine can't fully run. Per the rc4 cross-environment-CI rule, the new `demo-checks` job may need ≥1 runner-only iteration — that's expected, not a process failure.
