### PR TITLE
fix(render): match real dj-root/dj-view attribute, not substring, when picking VDOM source (#1746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`render_full_template` double-rendered the whole page when a child template merely *mentioned* `dj-root`/`dj-view` as text** (#1746). `get_template()` picked the VDOM source with a naive substring check (`"dj-root" in template_source or "dj-view" in template_source`). When the real `<div dj-root>` lived in the BASE template and the child only displayed the tokens in text (e.g. a `<code>` example) — or as a substring of another word (`adj-view`) — the check wrongly selected the child as the VDOM source, so `render_full_template` nested the entire page (two `<!DOCTYPE>`/two `<footer>`, truncated inline `<script>`, broken `dj-navigate` morphs). Replaced the substring check with the anchored-attribute regexes `_DJ_ROOT_RE`/`_DJ_VIEW_RE` already used elsewhere in the module, which require a real `<div ... dj-root/dj-view ...>` tag.
+
 ## [1.0.2] - 2026-06-06
 
 ### Added

--- a/python/djust/mixins/template.py
+++ b/python/djust/mixins/template.py
@@ -158,9 +158,23 @@ class TemplateMixin:
                     # the dj-root block directly without base template surrounding HTML,
                     # making extraction simpler and immune to Issue #365 miscount.
                     # Fall back to resolved if dj-root is only in the base template.
+                    #
+                    # Use the anchored-attribute regexes (NOT a naive substring): a
+                    # naive ``"dj-root" in template_source`` matches the token ANYWHERE
+                    # — including documentation/example code that merely *displays*
+                    # ``dj-root``/``dj-view`` as text, or another word containing it as
+                    # a substring (``adj-view``). When the real ``<div dj-root>`` lives
+                    # in the BASE template and the child only mentions the tokens in
+                    # text, the substring check wrongly picks the child as the VDOM
+                    # source → extraction finds no real dj-root → render_full_template
+                    # nests the whole page (two <!DOCTYPE>/two <footer>). The regexes
+                    # require a REAL ``<div ... dj-root/dj-view ...>`` tag (#1746).
                     vdom_source = (
                         template_source
-                        if ("dj-root" in template_source or "dj-view" in template_source)
+                        if (
+                            _DJ_ROOT_RE.search(template_source)
+                            or _DJ_VIEW_RE.search(template_source)
+                        )
                         else resolved
                     )
                     vdom_template = self._extract_liveview_root_with_wrapper(vdom_source)

--- a/python/djust/tests/test_render_full_template_djroot_substring_1746.py
+++ b/python/djust/tests/test_render_full_template_djroot_substring_1746.py
@@ -1,0 +1,189 @@
+"""Regression tests for #1746 — render_full_template must NOT double-render the
+whole page when a LiveView's CHILD template merely *mentions* the literal text
+``dj-root`` / ``dj-view`` (e.g. inside a ``<code>`` example) while the real
+``<div dj-root>`` lives in the BASE template.
+
+Root cause (#1746)
+------------------
+``python/djust/mixins/template.py`` ``get_template()`` chose the VDOM source
+with a NAIVE substring check::
+
+    vdom_source = (
+        template_source
+        if ("dj-root" in template_source or "dj-view" in template_source)
+        else resolved
+    )
+
+``"dj-root" in template_source`` matches the token ANYWHERE — including
+documentation/example code that merely *displays* ``dj-root`` / ``dj-view`` as
+text, or even another word containing it as a substring (``adj-view``). When
+the real ``<div dj-root>`` lives in the BASE template (a common layout) and the
+child only mentions the tokens in text, this wrongly picks the child as
+``vdom_source``; ``_extract_liveview_root_with_wrapper`` finds no real dj-root
+there → the VDOM template is wrong → ``render_full_template``'s shell/dj-root
+replacement nests the whole page (two ``<!DOCTYPE>`` / two ``<footer>``).
+
+Fix
+---
+Replace the substring check with the anchored-attribute regexes the rest of the
+module already uses (``_DJ_ROOT_RE`` / ``_DJ_VIEW_RE``), which require a REAL
+``<div ... dj-root ...>`` tag — so a child that merely displays the token in
+text won't match.
+
+This file pins the variant repro table from the issue:
+
+| child content                                  | <!DOCTYPE> count |
+|------------------------------------------------|------------------|
+| ``<p>hello</p>``                               | 1 (control)      |
+| ``<p>dj-view</p>`` (plain text)                | 1 (was 2)        |
+| ``<p>dj-root</p>`` (plain text)                | 1 (was 2)        |
+| ``<p><code>dj-view</code> <code>dj-root</code>`` | 1 (was 2)      |
+| ``<p>adj-view</p>`` (substring)                | 1 (was 2)        |
+| ``<p>dj-click</p>`` (other dj-* attr)          | 1 (control)      |
+
+Plus a control proving the GOOD path still works: a child that DOES declare its
+own real ``<div dj-root>`` must still render exactly one ``<!DOCTYPE>`` /
+``<footer>`` — the fix must not break the legitimate "child declares dj-root"
+case the original heuristic was written for.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+from django.test import override_settings
+
+from djust import LiveView
+from djust.utils import clear_template_dirs_cache
+
+
+class _TemplateHarness:
+    """Write a base + child template pair to a tmp dir and wire it into the
+    Django + Rust template search paths for the duration of a test."""
+
+    def __init__(self, base_src: str, child_src: str):
+        self._tmpdir = Path(tempfile.mkdtemp())
+        (self._tmpdir / "base_1746.html").write_text(base_src)
+        (self._tmpdir / "child_1746.html").write_text(child_src)
+        self._override = None
+
+    def __enter__(self):
+        from django.conf import settings
+
+        templates = [dict(t) for t in settings.TEMPLATES]
+        templates[0] = dict(templates[0])
+        templates[0]["DIRS"] = [str(self._tmpdir), *templates[0].get("DIRS", [])]
+        self._override = override_settings(TEMPLATES=templates)
+        self._override.enable()
+        clear_template_dirs_cache()
+        return self
+
+    def __exit__(self, *exc):
+        if self._override is not None:
+            self._override.disable()
+        clear_template_dirs_cache()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        return False
+
+
+def _make_view_class(name: str):
+    """Build a fresh LiveView subclass per test (avoids class-level state
+    leaking across tests, per the dynamic-subclass discipline #1109)."""
+
+    return type(
+        name,
+        (LiveView,),
+        {
+            "template_name": "child_1746.html",
+            "mount": lambda self, request, **kwargs: None,
+            "get_context_data": lambda self, **kwargs: {},
+        },
+    )
+
+
+# BASE template owns the real reactive root (<div dj-root> in the BASE);
+# single <footer>; single <!DOCTYPE>.
+_BASE = (
+    "<!DOCTYPE html>\n<html>\n<head><title>T</title></head>\n"
+    "<body>\n<nav>NAV</nav>\n"
+    "<main><div dj-root>{% block content %}{% endblock %}</div></main>\n"
+    "<footer>F</footer>\n</body>\n</html>"
+)
+
+
+def _doctype_and_footer_counts(child_block: str):
+    """Render render_full_template(None) for a child that {% extends %} _BASE
+    with the given content block, returning (doctype_count, footer_count)."""
+    child = (
+        '{% extends "base_1746.html" %}\n{% block content %}\n' + child_block + "\n{% endblock %}\n"
+    )
+    with _TemplateHarness(_BASE, child):
+        cls = _make_view_class("View1746")
+        v = cls()
+        v.mount(None)
+        v.get_template()  # sets _full_template (mirrors RequestMixin GET path)
+        html = v.render_full_template(None)
+    return (html.upper().count("<!DOCTYPE"), html.lower().count("<footer"))
+
+
+class TestRenderFullTemplateDoesNotDoubleRender:
+    """render_full_template must emit exactly ONE <!DOCTYPE>/<footer> regardless
+    of whether the child template merely *mentions* dj-root/dj-view as text."""
+
+    @pytest.mark.parametrize(
+        "label,child_block",
+        [
+            ("control_plain", "<p>hello</p>"),
+            ("dj_view_text", "<p>dj-view</p>"),
+            ("dj_root_text", "<p>dj-root</p>"),
+            ("dj_root_view_code", "<p><code>dj-view</code> and <code>dj-root</code></p>"),
+            ("substring_adj_view", "<p>adj-view</p>"),
+            ("control_dj_click", "<p>dj-click</p>"),
+        ],
+    )
+    def test_single_doctype_and_footer(self, label, child_block):
+        doctypes, footers = _doctype_and_footer_counts(child_block)
+        assert doctypes == 1, (
+            "child=%s: expected exactly ONE <!DOCTYPE> but got %d — the page "
+            "was double-rendered because the VDOM source was mis-selected "
+            "(#1746)." % (label, doctypes)
+        )
+        assert footers == 1, "child=%s: expected exactly ONE <footer> but got %d (#1746)." % (
+            label,
+            footers,
+        )
+
+    def test_child_declaring_its_own_real_dj_root_still_works(self):
+        """The GOOD path the original heuristic was written for: a child that
+        DOES declare its own real ``<div dj-root>`` must still render exactly
+        one <!DOCTYPE>/<footer>. The fix must pick ``template_source`` for this
+        case (the child has a REAL dj-root)."""
+        # Base here has NO dj-root; the child owns the real reactive root.
+        base_no_root = (
+            "<!DOCTYPE html>\n<html>\n<head><title>T</title></head>\n"
+            "<body>\n<nav>NAV</nav>\n{% block content %}{% endblock %}\n"
+            "<footer>F</footer>\n</body>\n</html>"
+        )
+        child = (
+            '{% extends "base_1746.html" %}\n'
+            "{% block content %}\n"
+            "<div dj-root><p>hello {{ nothing }}</p></div>\n"
+            "{% endblock %}\n"
+        )
+        with _TemplateHarness(base_no_root, child):
+            cls = _make_view_class("ViewOwnRoot1746")
+            v = cls()
+            v.mount(None)
+            v.get_template()
+            html = v.render_full_template(None)
+        assert html.upper().count("<!DOCTYPE") == 1, (
+            "child declaring its own real <div dj-root> regressed: expected "
+            "ONE <!DOCTYPE>, got %d." % html.upper().count("<!DOCTYPE")
+        )
+        assert html.lower().count("<footer") == 1, (
+            "child declaring its own real <div dj-root> regressed: expected "
+            "ONE <footer>, got %d." % html.lower().count("<footer")
+        )


### PR DESCRIPTION
## Root cause

`python/djust/mixins/template.py:161-165` (`get_template()`) chose the VDOM source with a **naive substring** check:

```python
vdom_source = (
    template_source                                   # the CHILD template
    if ("dj-root" in template_source or "dj-view" in template_source)
    else resolved                                     # the full resolved (base+child) template
)
```

`"dj-root" in template_source` matches the token **anywhere** — including documentation/example code that merely *displays* `dj-root`/`dj-view`, or another word containing it as a substring (`adj-view`). When the real `<div dj-root>` lives in the **base** template (a common layout) and the child only mentions the tokens in text, this wrongly picks the child as `vdom_source`; `_extract_liveview_root_with_wrapper` finds no real dj-root there → wrong VDOM template → `render_full_template`'s shell/dj-root replacement nests the whole page (two `<!DOCTYPE>`/two `<footer>`, truncated `<script>`, broken `dj-navigate`).

## Fix

Replace the substring check with the anchored-attribute regexes already defined in the module (`_DJ_ROOT_RE` / `_DJ_VIEW_RE`), which require a REAL `<div ... dj-root/dj-view ...>` tag:

```python
vdom_source = (
    template_source
    if (_DJ_ROOT_RE.search(template_source) or _DJ_VIEW_RE.search(template_source))
    else resolved
)
```

Both regexes are module-level and already in scope at line 161. A child that merely displays the token in text no longer matches; the legitimate "child declares its own real `<div dj-root>`" case (the reason the heuristic exists) still picks `template_source`.

## Variant repro table (regression test `test_render_full_template_djroot_substring_1746.py`)

| child content | `<!DOCTYPE>` before | after |
|---|---|---|
| `<p>hello</p>` (control) | 1 | 1 |
| `<p>dj-view</p>` (plain text) | **2** | 1 |
| `<p>dj-root</p>` (plain text) | **2** | 1 |
| `<p><code>dj-view</code> and <code>dj-root</code></p>` | **2** | 1 |
| `<p>adj-view</p>` (substring) | **2** | 1 |
| `<p>dj-click</p>` (other dj-* attr, control) | 1 | 1 |

Plus a control proving the **good path** still works: a child that DOES declare its own real `<div dj-root>` still renders exactly one `<!DOCTYPE>`/`<footer>`.

## Gate-off (#254)

Reverting the predicate to the naive substring (`if ("dj-root" in ... or "dj-view" in ...)`) makes the 4 behavior-meaningful cases (`dj-view`/`dj-root`/code/`adj-view`) fail again (2 DOCTYPEs); restoring the regex makes them pass. The 3 control cases pass either way — confirming the 4 are non-tautological.

## Symbol-migration grep (canon)

`grep -rn '"dj-root" in\|"dj-view" in' python/djust/` found one other production instance: `python/djust/checks.py:3341-3342` (`_check_view_root_same_element`, T005). It is **legitimately fine** — it operates on text already matched to be inside an HTML tag (`tag_re` extracts `<...>` tags first, then checks substring within each tag), so it cannot match displayed text the way the render path did. Not in scope (#1079). The remaining matches are test assertions (`test_mcp.py`).

## Test results

- New regression file: 7/7 pass (RED→GREEN confirmed).
- `test_ssr_render_normalization_1737.py` + `test_template_inheritance.py` + `test_context_processors_in_includes_1722.py` + `test_model_fk_rendering.py`: **30/30 pass** (the #1737 parity tests stay green).
- `python/djust/tests/`: **3099 passed, 3 skipped**.
- `python/tests/` + `tests/unit/`: 4206 passed; 4 pre-existing cross-dir-ordering pollution failures in `tests/unit/test_demo_views.py` (urlconf registration) — verified pre-existing (pass in isolation, and fail identically on a clean `origin/main` tree with my changes stashed). Unrelated to this fix.

Closes #1746
