### PR TITLE
Refs #1745 -- Harden nav/hooks regression guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,6 +265,9 @@ jobs:
       - name: Install Python dependencies
         run: uv sync --extra dev
 
+      - name: Build package
+        run: uv run maturin develop --release
+
       - name: Install Playwright
         run: |
           uv pip install playwright
@@ -326,6 +329,79 @@ jobs:
           name: playwright-server-logs
           path: examples/demo_project/server.log
 
+      - name: Stop server
+        if: always()
+        run: |
+          if [ -f examples/demo_project/server.pid ]; then
+            kill $(cat examples/demo_project/server.pid) || true
+            rm examples/demo_project/server.pid
+          fi
+
+  nav-hooks-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Cache Python dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: ${{ runner.os }}-python-nav-hooks-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-python-nav-hooks-
+            ${{ runner.os }}-python-
+      - name: Install Python dependencies
+        run: uv sync --extra dev
+      - name: Install Playwright
+        run: |
+          uv pip install playwright
+          .venv/bin/playwright install chromium
+      - name: Run Django migrations
+        run: |
+          cd examples/demo_project
+          uv run python manage.py migrate --noinput
+          cd ../..
+      - name: Start development server
+        run: |
+          cd examples/demo_project
+          nohup uv run python -m uvicorn demo_project.asgi:application \
+            --host 0.0.0.0 \
+            --port 8002 \
+            --log-level info \
+            > server.log 2>&1 &
+          echo $! > server.pid
+          cd ../..
+        env:
+          PYTHONPATH: .
+      - name: Wait for server to be ready
+        run: |
+          echo "Waiting for server to start..."
+          for i in {1..30}; do
+            if curl -s http://localhost:8002/ > /dev/null; then
+              echo "Server is ready!"
+              exit 0
+            fi
+            echo "Attempt $i/30: Server not ready yet..."
+            sleep 1
+          done
+          echo "Server failed to start"
+          cat examples/demo_project/server.log
+          exit 1
+      - name: Run nav + dj-hook regression guard
+        run: .venv/bin/python tests/playwright/test_nav_hooks.py
+      - name: Upload server logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nav-hooks-server-logs
+          path: examples/demo_project/server.log
       - name: Stop server
         if: always()
         run: |
@@ -538,7 +614,7 @@ jobs:
   # Summary job - waits for all test jobs
   test-summary:
     runs-on: ubuntu-latest
-    needs: [rust-tests, python-tests, javascript-tests, playwright-tests, security-scan, security-tests, demo-checks]
+    needs: [rust-tests, python-tests, javascript-tests, playwright-tests, nav-hooks-guard, security-scan, security-tests, demo-checks]
     if: always()
     steps:
       - name: Check test results
@@ -548,6 +624,7 @@ jobs:
           echo "  Python tests: ${{ needs.python-tests.result }}"
           echo "  JavaScript tests: ${{ needs.javascript-tests.result }}"
           echo "  Playwright tests: ${{ needs.playwright-tests.result }} (optional)"
+          echo "  Nav/hooks guard: ${{ needs.nav-hooks-guard.result }}"
           echo "  Security scan: ${{ needs.security-scan.result }}"
           echo "  Security tests: ${{ needs.security-tests.result }}"
           echo "  Demo checks: ${{ needs.demo-checks.result }}"
@@ -558,6 +635,7 @@ jobs:
           if [ "${{ needs.rust-tests.result }}" == "success" ] && \
              [ "${{ needs.python-tests.result }}" == "success" ] && \
              [ "${{ needs.javascript-tests.result }}" == "success" ] && \
+             [ "${{ needs.nav-hooks-guard.result }}" == "success" ] && \
              [ "${{ needs.security-tests.result }}" == "success" ] && \
              [ "${{ needs.demo-checks.result }}" == "success" ]; then
             echo "All core tests passed!"

--- a/tests/playwright/test_nav_hooks.py
+++ b/tests/playwright/test_nav_hooks.py
@@ -43,24 +43,24 @@ async def test_nav_hooks():
         failures = []
 
         print(f"📄 Loading Nav Demo Page A: {PAGE_A}")
-        await page.goto(PAGE_A)
 
-        # Install a MutationObserver on the [dj-view] root BEFORE the LiveView
-        # finishes hydrating, recording any remove+re-add of direct children
-        # (the #1737 hydration-flash symptom). Also set a window sentinel that
-        # a full page reload would wipe.
-        await page.evaluate(
+        # Install the observer before navigation so it can catch early hydration churn.
+        await page.add_init_script(
             """
-            () => {
+            (() => {
                 window.__nav_sentinel = Date.now();
                 window.__hydration_child_churn = 0;
-                const root = document.querySelector('[dj-view]');
-                if (root) {
+                window.__nav_observed_root = false;
+
+                const observeRoot = () => {
+                    const root = document.querySelector('[dj-view]');
+                    if (!root || window.__nav_obs) {
+                        return;
+                    }
+
                     window.__nav_observed_root = true;
                     const obs = new MutationObserver((records) => {
                         for (const r of records) {
-                            // Count only direct-child add/remove on the root —
-                            // the wholesale-replacement symptom of #1737.
                             if (r.target === root &&
                                 (r.removedNodes.length > 0 || r.addedNodes.length > 0)) {
                                 window.__hydration_child_churn += 1;
@@ -69,16 +69,51 @@ async def test_nav_hooks():
                     });
                     obs.observe(root, { childList: true });
                     window.__nav_obs = obs;
-                } else {
-                    window.__nav_observed_root = false;
-                }
-            }
+                };
+
+                observeRoot();
+
+                const installDocumentObserver = () => {
+                    if (!document.documentElement || window.__nav_doc_obs) {
+                        return;
+                    }
+
+                    const docObs = new MutationObserver(() => observeRoot());
+                    docObs.observe(document.documentElement, {
+                        childList: true,
+                        subtree: true,
+                    });
+                    window.__nav_doc_obs = docObs;
+                };
+
+                installDocumentObserver();
+
+                document.addEventListener("DOMContentLoaded", () => {
+                    observeRoot();
+                    installDocumentObserver();
+                });
+            })();
             """
         )
 
-        # Let the WebSocket connect + hooks mount + any (mis)hydration settle.
-        print("⏳ Waiting for hydration + hook mount (~1.5s)...")
-        await asyncio.sleep(1.5)
+        await page.goto(PAGE_A)
+
+        # Wait for the WebSocket connect + hooks mount + hydration observer.
+        print("⏳ Waiting for hydration + hook mount...")
+        try:
+            await page.wait_for_function(
+                """
+                () => window.__nav_observed_root === true &&
+                    window.__demoWidgetMounted === true &&
+                    (window.__demoWidgetMountCount || 0) >= 1 &&
+                    !!document.querySelector('#demo-widget-a')?.dataset.djustHookMounted
+                """,
+                timeout=8000,
+            )
+        except Exception:
+            failures.append(
+                "#1738/#1737: timed out waiting for Page A hydration observer and hook mount"
+            )
 
         # --- #1738: DemoWidget hook mounted on Page A ---
         mounted_a = await page.evaluate(
@@ -118,14 +153,18 @@ async def test_nav_hooks():
         # Wait for the SPA mount frame to arrive + new view to render.
         try:
             await page.wait_for_function(
-                "() => window.location.pathname === '/demos/nav-b/'",
+                """
+                (mountCountBefore) => window.location.pathname === '/demos/nav-b/' &&
+                                    (window.__demoWidgetMountCount || 0) > mountCountBefore &&
+                                    !!document.querySelector('#demo-widget-b')?.dataset.djustHookMounted
+                """,
+                arg=mount_count_before,
                 timeout=8000,
             )
         except Exception:
             failures.append(
-                "#1733: pathname did not change to /demos/nav-b/ after dj-navigate click"
+                "#1733/#1738: timed out waiting for Page B SPA nav and hook mount"
             )
-        await asyncio.sleep(1.0)
 
         path_after = await page.evaluate("() => window.location.pathname")
         sentinel_after = await page.evaluate("() => window.__nav_sentinel")


### PR DESCRIPTION
This PR hardens the nav/hooks regression guard.

Changes:
- installs the hydration MutationObserver before the initial navigation using add_init_script.
- replaces fixed asyncio.sleep waits with condition-based Playwright waits.
- adds a dedicated nav-hooks-guard CI job so this regression guard is blocking while the broader Playwright job remains optional.

Tested locally:
- .venv\Scripts\python tests\playwright\test_nav_hooks.py
- git diff --check