### PR TITLE
fix(render): count multi-line <div> opening tags in dj-root boundary scan (#1749)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`render_full_template` ejected page content outside `[dj-root]` for multi-line `<div>` tags, leaking it across `dj-navigate` (#1749).** The `dj-root` region's closing `</div>` was located by counting `<div>` depth, but the opening-tag check only matched the exact forms `"<div "` and `"<div>"` — a multi-line opening tag (`<div\n  class=...>` / `<div\t...>`) was not counted. Each missed open under-counted depth, so a later `</div>` closed the `dj-root` region early; the full rendered view was then spliced in place of the truncated region, leaving the tail of the page **outside** `<div dj-root>` (and duplicated). Because `dj-navigate` swaps only the `[dj-root]` subtree, that ejected content was never cleared on navigation (it leaked onto the next page — observed on a page authored with multi-line `<div>` sections, reached via a fresh GET). Fix: match `<div` followed by any tag-boundary char (whitespace, `>`, `/`). Same family as #1746.
+
 ## [1.0.3rc1] - 2026-06-06
 
 ### Fixed

--- a/python/djust/mixins/template.py
+++ b/python/djust/mixins/template.py
@@ -979,7 +979,20 @@ Object.assign(window.handlerMetadata, {json.dumps(metadata)});
                 depth = 1
                 i = after_open
                 while i < len(shell_html) and depth > 0:
-                    if shell_html[i : i + 5] == "<div " or shell_html[i : i + 5] == "<div>":
+                    # Opening <div ...>: match "<div" followed by a tag-boundary
+                    # char (whitespace, '>' or '/'). The previous check only
+                    # recognized the exact forms "<div " and "<div>", so a
+                    # MULTI-LINE opening tag ("<div\n  class=...>" / "<div\t...")
+                    # was not counted as an open. Each missed open under-counted
+                    # depth, so a later "</div>" drove depth to 0 EARLY — the
+                    # dj-root region was closed before its real end and all
+                    # subsequent page content rendered OUTSIDE [dj-root]. Because
+                    # dj-navigate only swaps the [dj-root] subtree, that ejected
+                    # content was never cleared on navigation (leaked onto the
+                    # next page). Matching any tag-boundary char fixes the count.
+                    if shell_html[i : i + 4] == "<div" and (
+                        i + 4 >= len(shell_html) or shell_html[i + 4] in " \t\r\n>/"
+                    ):
                         depth += 1
                     elif shell_html[i : i + 6] == "</div>":
                         depth -= 1

--- a/python/djust/tests/test_render_full_template_multiline_div_boundary.py
+++ b/python/djust/tests/test_render_full_template_multiline_div_boundary.py
@@ -1,0 +1,191 @@
+"""Regression tests for the dj-root boundary depth-counter in
+``render_full_template`` — multi-line ``<div`` opening tags must be counted (#1749).
+
+Root cause
+----------
+``python/djust/mixins/template.py`` ``render_full_template`` locates the
+``dj-root`` region's matching ``</div>`` by walking the rendered shell and
+counting ``<div>`` depth. The opening-tag check originally only recognized two
+EXACT byte forms::
+
+    if shell_html[i : i + 5] == "<div " or shell_html[i : i + 5] == "<div>":
+        depth += 1
+
+A MULTI-LINE opening tag — ``<div\n  class="...">`` or ``<div\t...>`` — was not
+matched, so it was NOT counted as an open. Each missed open under-counted depth,
+so a later ``</div>`` drove depth to 0 EARLY: the ``dj-root`` region was closed
+before its real end. ``render_full_template`` then spliced the (correct,
+full) ``self._rust_view.render()`` output in place of the *truncated* region,
+leaving the tail of the original shell content OUTSIDE ``<div dj-root>`` — so
+that tail rendered both inside the root (from the rust output) AND as a sibling
+after it (the leftover shell). Two consequences:
+
+1. The tail content is DUPLICATED in the initial GET HTML.
+2. Because ``dj-navigate`` swaps only the ``[dj-root]`` subtree on navigation,
+   the ejected sibling copy is never cleared — it "leaks" onto the next page.
+
+Observed downstream: djust.org ``/examples/`` (demo sections authored as
+``<div\n class="demo-section">``) ejected every demo after the first outside
+``dj-root``; navigating examples→home left the demos on the home page.
+
+Fix
+---
+Match ``<div`` followed by ANY tag-boundary char (whitespace, ``>`` or ``/``),
+not just the exact ``"<div "`` / ``"<div>"`` forms.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from html.parser import HTMLParser
+from pathlib import Path
+
+from django.test import override_settings
+
+from djust import LiveView
+from djust.utils import clear_template_dirs_cache
+
+
+class _TemplateHarness:
+    def __init__(self, base_src: str, child_src: str):
+        self._tmpdir = Path(tempfile.mkdtemp())
+        (self._tmpdir / "base_mlb.html").write_text(base_src)
+        (self._tmpdir / "child_mlb.html").write_text(child_src)
+        self._override = None
+
+    def __enter__(self):
+        from django.conf import settings
+
+        templates = [dict(t) for t in settings.TEMPLATES]
+        templates[0] = dict(templates[0])
+        templates[0]["DIRS"] = [str(self._tmpdir), *templates[0].get("DIRS", [])]
+        self._override = override_settings(TEMPLATES=templates)
+        self._override.enable()
+        clear_template_dirs_cache()
+        return self
+
+    def __exit__(self, *exc):
+        if self._override is not None:
+            self._override.disable()
+        clear_template_dirs_cache()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        return False
+
+
+def _make_view_class(name: str):
+    return type(
+        name,
+        (LiveView,),
+        {
+            "template_name": "child_mlb.html",
+            "mount": lambda self, request, **kwargs: None,
+            "get_context_data": lambda self, **kwargs: {},
+        },
+    )
+
+
+# BASE owns the real reactive root; single <footer>/<!DOCTYPE>.
+_BASE = (
+    "<!DOCTYPE html>\n<html>\n<head><title>T</title></head>\n"
+    "<body>\n<nav>NAV</nav>\n"
+    "<main><div dj-root>{% block content %}{% endblock %}</div></main>\n"
+    "<footer>F</footer>\n</body>\n</html>"
+)
+
+# Child content authored with MULTI-LINE <div tags (the trigger). The TAIL
+# marker sits after several multi-line divs — with the buggy counter it ejects
+# (and duplicates) outside dj-root; with the fix it stays inside, once.
+_CHILD_MULTILINE = (
+    '{% extends "base_mlb.html" %}\n'
+    "{% block content %}\n"
+    '<div\n  class="card">CARD_ONE</div>\n'
+    '<div\n  class="card">CARD_TWO</div>\n'
+    '<div\n  class="card">TAIL_MARKER_XYZ</div>\n'
+    "{% endblock %}\n"
+)
+
+
+def _render(child_src: str) -> str:
+    with _TemplateHarness(_BASE, child_src):
+        cls = _make_view_class("ViewMLB")
+        v = cls()
+        v.mount(None)
+        v.get_template()  # sets _full_template (mirrors the GET path)
+        return v.render_full_template(None)
+
+
+class _RootContainmentParser(HTMLParser):
+    """Track whether a given marker text appears inside <div dj-root> and
+    whether any element is a SIBLING of dj-root inside <main>."""
+
+    def __init__(self):
+        super().__init__()
+        self.stack = []
+        self.dj_root_depth = None
+        self.tail_inside = 0
+        self.tail_outside = 0
+        self._pending_marker = None
+
+    def handle_starttag(self, tag, attrs):
+        ad = dict(attrs)
+        self.stack.append(tag)
+        if tag == "div" and "dj-root" in ad:
+            self.dj_root_depth = len(self.stack)
+
+    def handle_endtag(self, tag):
+        if self.stack and self.stack[-1] == tag:
+            self.stack.pop()
+        elif tag in self.stack:
+            while self.stack and self.stack.pop() != tag:
+                pass
+        if self.dj_root_depth is not None and len(self.stack) < self.dj_root_depth:
+            self.dj_root_depth = None
+
+    def handle_data(self, data):
+        if "TAIL_MARKER_XYZ" in data:
+            if self.dj_root_depth is not None:
+                self.tail_inside += 1
+            else:
+                self.tail_outside += 1
+
+
+class TestMultilineDivBoundary:
+    def test_tail_after_multiline_divs_stays_inside_dj_root(self):
+        html = _render(_CHILD_MULTILINE)
+
+        # The marker must appear EXACTLY ONCE in the output — the boundary bug
+        # duplicated it (once inside the rust output, once as leftover shell).
+        assert html.count("TAIL_MARKER_XYZ") == 1, (
+            "TAIL_MARKER_XYZ appears %d times — content after multi-line <div> "
+            "tags was ejected/duplicated outside dj-root by the boundary "
+            "depth-counter." % html.count("TAIL_MARKER_XYZ")
+        )
+
+        # Structurally: the marker must be INSIDE <div dj-root>, never a sibling.
+        p = _RootContainmentParser()
+        p.feed(html)
+        assert p.tail_inside == 1 and p.tail_outside == 0, (
+            "TAIL_MARKER_XYZ containment wrong: inside=%d outside=%d — content "
+            "rendered OUTSIDE dj-root will leak on dj-navigate." % (p.tail_inside, p.tail_outside)
+        )
+
+        # And exactly one document shell (no double-render).
+        assert html.upper().count("<!DOCTYPE") == 1
+        assert html.lower().count("<footer") == 1
+
+    def test_single_line_divs_unaffected(self):
+        """Control: single-line <div ...> content was always handled — keep it
+        green so the fix didn't regress the common case."""
+        child = (
+            '{% extends "base_mlb.html" %}\n'
+            "{% block content %}\n"
+            '<div class="card">CARD_ONE</div>\n'
+            '<div class="card">TAIL_MARKER_XYZ</div>\n'
+            "{% endblock %}\n"
+        )
+        html = _render(child)
+        assert html.count("TAIL_MARKER_XYZ") == 1
+        p = _RootContainmentParser()
+        p.feed(html)
+        assert p.tail_inside == 1 and p.tail_outside == 0


### PR DESCRIPTION
Closes #1749.

## Problem
`render_full_template` finds the `dj-root` region's closing `</div>` by counting `<div>` depth, but the opening-tag check only matched the exact byte forms `"<div "` and `"<div>"`. A **multi-line opening tag** — `<div\n  class="...">` / `<div\t...>` — was not counted as an open. Each missed open under-counted depth, so a later `</div>` drove depth to 0 **early**: the `dj-root` region closed before its real end, the full rendered view was spliced in place of the *truncated* region, and the tail of the page rendered **outside** `<div dj-root>` (and duplicated).

Because `dj-navigate` swaps only the `[dj-root]` subtree on SPA navigation, that ejected content was never cleared → **it leaked onto the next page**. Reproduced on djust.org `/examples/` (demo sections authored as `<div\n class="demo-section">`): navigating examples→home left all demos on the home page. Single-line `<div ` content (e.g. home) was unaffected; only triggers on a fresh GET (the SPA-mount path puts content cleanly inside `dj-root`). Same family as #1746.

## Fix
Match `<div` followed by any tag-boundary char (whitespace, `>`, `/`) — one predicate in `render_full_template`'s boundary scan (`python/djust/mixins/template.py`).

## Verification
- Empirically on djust.org `/examples/`: 484 real `<div` opens, only 481 counted (3 `<div\n` missed) → demos ejected. After fix: all 17 demos inside `dj-root`; examples→home navigation clean (no leak, correct title/`dj-view`).
- New `test_render_full_template_multiline_div_boundary.py` (2 cases) with **gate-off proof**: reverting the predicate makes the tail marker appear 2× (ejected/duplicated) → test fails; with the fix it appears once, inside `dj-root`. Control: single-line `<div>` content stays green.
- Full Python suite: +2 passing tests; the 17 `test_theme_tags_rust_engine_1721` failures in `make test-python` are **pre-existing** test-ordering pollution (identical on clean `origin/main`; pass in isolation; CI runs tests in separate jobs).

## Follow-up (separate, not in this PR)
`dj-navigate` SPA nav doesn't update page chrome outside `dj-root` (active-nav highlight, `document.title`, the `dj-root` `dj-view` attribute). Tracking separately — relates to ADR-021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)