### PR TITLE
ci(test): build Rust extension in nav-hooks-guard before running the guard (#1752)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -359,6 +359,13 @@ jobs:
             ${{ runner.os }}-python-
       - name: Install Python dependencies
         run: uv sync --extra dev
+      - name: Build package
+        # Force a fresh Rust-extension build so this BLOCKING render guard never
+        # tests a stale cached extension. The uv/.venv cache key is keyed on
+        # pyproject.toml/uv.lock only, so a PR that changes just crates/*.rs would
+        # otherwise restore a previously-built djust and exercise old rendering.
+        # Mirrors the python-tests / playwright-tests jobs. (#1752)
+        run: uv run maturin develop --release
       - name: Install Playwright
         run: |
           uv pip install playwright


### PR DESCRIPTION
Closes #1752 (item 1).

## Problem
`nav-hooks-guard` (added in #1748, now a **blocking** CI gate) was the only Rust-extension-dependent job without a `maturin develop` build step. Its `uv`/`.venv` cache key is `hashFiles('**/pyproject.toml','**/uv.lock')`, so a PR that changes only `crates/*.rs` (no Python-dep change) restores a **previously-built djust** and the guard exercises **old rendering behavior** — a blocking render guard that can pass (or fail) against a stale extension.

## Fix
Add `uv run maturin develop --release` after `uv sync --extra dev`, mirroring the `python-tests` and `playwright-tests` jobs, so the guard always tests freshly-built code.

```yaml
- name: Install Python dependencies
  run: uv sync --extra dev
+ - name: Build package
+   run: uv run maturin develop --release
- name: Install Playwright
```

## Verification
- YAML parses; step order correct (Install deps → Build package → Install Playwright); build command byte-identical to the sibling `playwright-tests` job.
- The empirical proof is this PR's own CI run: `nav-hooks-guard` must stay green **with** the build step (confirms the step works and doesn't break the job).

## Follow-ups (remain in #1752)
- Item 2: blocking-vs-`continue-on-error` soak for the Playwright-based guard.
- Item 3: extract a reusable workflow to de-duplicate the ~80% shared server harness between `nav-hooks-guard` and `playwright-tests` (would prevent exactly this kind of copy-paste drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)