### PR TITLE
ci: extract shared Playwright-server harness into a composite action (#1752)

### DIFF
--- a/.github/actions/djust-playwright-server/action.yml
+++ b/.github/actions/djust-playwright-server/action.yml
@@ -1,0 +1,85 @@
+name: 'djust Playwright server'
+description: >-
+  Set up Python + uv, build the djust Rust extension, install Playwright
+  (chromium), run Django migrations, and start the demo project's dev server
+  on :8002, waiting until it answers. Shared by the playwright-tests and
+  nav-hooks-guard jobs (#1752). The caller must `actions/checkout` first
+  (this is a local action) and is responsible for running its own test step,
+  uploading server.log on failure, and stopping the server.
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Cache Python dependencies
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cache/uv
+          .venv
+        key: ${{ runner.os }}-python-playwright-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-python-playwright-
+          ${{ runner.os }}-python-
+
+    - name: Install Python dependencies
+      shell: bash
+      run: uv sync --extra dev
+
+    - name: Build package
+      # Force a fresh Rust-extension build so render-behavior guards never test a
+      # stale cached extension. The uv/.venv cache key is keyed on
+      # pyproject.toml/uv.lock only, so a crates/*.rs-only change would otherwise
+      # restore a previously-built djust. (#1752)
+      shell: bash
+      run: uv run maturin develop --release
+
+    - name: Install Playwright
+      shell: bash
+      run: |
+        uv pip install playwright
+        .venv/bin/playwright install chromium
+
+    - name: Run Django migrations
+      shell: bash
+      run: |
+        cd examples/demo_project
+        uv run python manage.py migrate --noinput
+        cd ../..
+
+    - name: Start development server
+      shell: bash
+      env:
+        PYTHONPATH: .
+      run: |
+        cd examples/demo_project
+        nohup uv run python -m uvicorn demo_project.asgi:application \
+          --host 0.0.0.0 \
+          --port 8002 \
+          --log-level info \
+          > server.log 2>&1 &
+        echo $! > server.pid
+        cd ../..
+
+    - name: Wait for server to be ready
+      shell: bash
+      run: |
+        echo "Waiting for server to start..."
+        for i in {1..30}; do
+          if curl -s http://localhost:8002/ > /dev/null; then
+            echo "Server is ready!"
+            exit 0
+          fi
+          echo "Attempt $i/30: Server not ready yet..."
+          sleep 1
+        done
+        echo "Server failed to start"
+        cat examples/demo_project/server.log
+        exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,72 +244,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Cache Python dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/uv
-            .venv
-          key: ${{ runner.os }}-python-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-python-
-
-      - name: Install Python dependencies
-        run: uv sync --extra dev
-
-      - name: Build package
-        run: uv run maturin develop --release
-
-      - name: Install Playwright
-        run: |
-          uv pip install playwright
-          .venv/bin/playwright install chromium
-
-      - name: Run Django migrations
-        run: |
-          cd examples/demo_project
-          uv run python manage.py migrate --noinput
-          cd ../..
-
-      # NOTE: the djust_check demo dogfood used to live here as a
-      # `continue-on-error` step (#1708). It shipped green on the runner and
-      # was promoted (#1713) to its own BLOCKING `demo-checks` job below, so
-      # the dogfood is decoupled from playwright (which stays non-blocking).
-      - name: Start development server
-        run: |
-          cd examples/demo_project
-          nohup uv run python -m uvicorn demo_project.asgi:application \
-            --host 0.0.0.0 \
-            --port 8002 \
-            --log-level info \
-            > server.log 2>&1 &
-          echo $! > server.pid
-          cd ../..
-        env:
-          PYTHONPATH: .
-
-      - name: Wait for server to be ready
-        run: |
-          echo "Waiting for server to start..."
-          for i in {1..30}; do
-            if curl -s http://localhost:8002/ > /dev/null; then
-              echo "Server is ready!"
-              exit 0
-            fi
-            echo "Attempt $i/30: Server not ready yet..."
-            sleep 1
-          done
-          echo "Server failed to start"
-          cat examples/demo_project/server.log
-          exit 1
+      # Shared harness: setup + build + playwright + migrate + start demo on
+      # :8002. The djust_check demo dogfood was promoted out of here to its own
+      # BLOCKING `demo-checks` job (#1708/#1713); playwright stays non-blocking.
+      - name: Set up Playwright server
+        uses: ./.github/actions/djust-playwright-server
 
       - name: Run Playwright tests
         run: |
@@ -341,66 +280,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-      - name: Cache Python dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/uv
-            .venv
-          key: ${{ runner.os }}-python-nav-hooks-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-python-nav-hooks-
-            ${{ runner.os }}-python-
-      - name: Install Python dependencies
-        run: uv sync --extra dev
-      - name: Build package
-        # Force a fresh Rust-extension build so this BLOCKING render guard never
-        # tests a stale cached extension. The uv/.venv cache key is keyed on
-        # pyproject.toml/uv.lock only, so a PR that changes just crates/*.rs would
-        # otherwise restore a previously-built djust and exercise old rendering.
-        # Mirrors the python-tests / playwright-tests jobs. (#1752)
-        run: uv run maturin develop --release
-      - name: Install Playwright
-        run: |
-          uv pip install playwright
-          .venv/bin/playwright install chromium
-      - name: Run Django migrations
-        run: |
-          cd examples/demo_project
-          uv run python manage.py migrate --noinput
-          cd ../..
-      - name: Start development server
-        run: |
-          cd examples/demo_project
-          nohup uv run python -m uvicorn demo_project.asgi:application \
-            --host 0.0.0.0 \
-            --port 8002 \
-            --log-level info \
-            > server.log 2>&1 &
-          echo $! > server.pid
-          cd ../..
-        env:
-          PYTHONPATH: .
-      - name: Wait for server to be ready
-        run: |
-          echo "Waiting for server to start..."
-          for i in {1..30}; do
-            if curl -s http://localhost:8002/ > /dev/null; then
-              echo "Server is ready!"
-              exit 0
-            fi
-            echo "Attempt $i/30: Server not ready yet..."
-            sleep 1
-          done
-          echo "Server failed to start"
-          cat examples/demo_project/server.log
-          exit 1
+      # Shared harness (setup + build + playwright + migrate + start demo on
+      # :8002), identical to playwright-tests — the composite keeps the build
+      # step from drifting out of one job (#1752 items 1+3).
+      - name: Set up Playwright server
+        uses: ./.github/actions/djust-playwright-server
       - name: Run nav + dj-hook regression guard
         run: .venv/bin/python tests/playwright/test_nav_hooks.py
       - name: Upload server logs on failure


### PR DESCRIPTION
Closes #1752.

## Problem
`nav-hooks-guard` and `playwright-tests` duplicated ~9 setup steps (Python/uv/cache/`uv sync`/maturin build/Playwright install/migrate/start server/wait). #1753 had to patch the missing `maturin develop` step into `nav-hooks-guard` *specifically because* the copy had drifted out of sync — textbook parallel-path drift (#1646).

## Fix (item 3)
Extract the shared harness into a composite action `.github/actions/djust-playwright-server`. Both jobs now `actions/checkout` → `uses: ./.github/actions/djust-playwright-server` → run their own test step → upload `server.log` on failure → stop server.

- **One definition** can't drift a step out of one job.
- Jobs keep their identity: `playwright-tests` stays `continue-on-error: true` (optional), `nav-hooks-guard` stays blocking; `test-summary` `needs`/AND-condition unchanged.
- Net −31 lines (`+95/−126`).

## Items 1 & 2
- **Item 1** (maturin build) shipped in #1753 — now lives in the composite, so it can't drift again.
- **Item 2** (blocking-vs-soak) resolved **by decision**: keep `nav-hooks-guard` blocking. The soak concern (#1534) is retroactively satisfied — it has run green across #1748, #1753, and #1754, and the condition-based waits (#1748) reduce flake.

## Verification
- Local: both YAML files parse; every composite `run` step declares `shell: bash`; both jobs preserve checkout→composite ordering + their stop/upload steps + `continue-on-error` settings.
- **The empirical proof is this PR's own CI**: both `playwright-tests` and `nav-hooks-guard` must run green *through the composite* (a new runner-only path; per #1534, ≥1 runner iteration may be expected for composite-action quirks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)