### PR TITLE
fix(deploy): respect .gitignore in deploy tarball + warn on oversized uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`djust deploy` now respects `.gitignore` when building the deploy tarball, and warns before oversized uploads (#1759).** `_create_tarball` previously walked the source tree using a hardcoded `EXCLUDE_*` list, ignoring the project's `.gitignore`. Non-standard names — a `.venv-dev/` virtualenv carrying a 115 MB Playwright `node` binary, `scratch/` screenshots, `mobile-app/wheels/` — slipped straight in, producing a 152 MB tarball that the server's ingress rejected with a raw 413. Fix: when the source is a git work tree, `_create_tarball` takes its file list from `git ls-files --cached --others --exclude-standard` (tracked ∪ untracked, minus ignored), so the project's `.gitignore` is the source of truth. Non-git directories fall back to the existing `os.walk` path unchanged. The `EXCLUDE_*` security net (`EXCLUDE_DIR_NAMES`, `EXCLUDE_FILENAMES`, `EXCLUDE_FILE_SUFFIXES`, `EXCLUDE_FILENAME_STEMS`) still applies on the git path so credentials and live databases are dropped even if the user forgot to gitignore them (#1505 intent preserved). A new `_tarball_size_warning` prints an actionable warning to stderr before upload when the packed tarball exceeds 50 MB, listing the largest included files so the user can identify what to add to `.gitignore` instead of hitting a raw nginx 413 page. 6 new regression cases in `python/tests/test_deploy_cli.py`.
+
 ## [1.0.3] - 2026-06-07
 
 ### Added

--- a/python/djust/deploy_cli.py
+++ b/python/djust/deploy_cli.py
@@ -93,6 +93,13 @@ EXCLUDE_FILENAMES = frozenset({".DS_Store", "Thumbs.db"})
 # ``.environment`` is NOT a stem variant of ``.env`` and stays included.
 EXCLUDE_FILENAME_STEMS = frozenset({".env", "db.sqlite3"})
 
+# Above this packed size, ``deploy_dir`` warns before uploading and points at
+# the largest included files. A clean djust app tarball is a few MB; anything
+# this large is almost always build artifacts or local data that belongs in
+# .gitignore — and the djustlive ingress 413s uploads past its body-size cap,
+# so surfacing it here turns a raw nginx error into an actionable message.
+TARBALL_WARN_BYTES = 50 * 1024 * 1024
+
 
 # ---------------------------------------------------------------------------
 # Credential helpers
@@ -1032,47 +1039,121 @@ def status(ctx: click.Context, project: Optional[str]) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _is_excluded_dirname(name: str) -> bool:
+    """A directory basename is excluded iff it exactly equals an
+    EXCLUDE_DIR_NAMES entry or ends with an EXCLUDE_DIR_SUFFIXES entry."""
+    return name in EXCLUDE_DIR_NAMES or name.endswith(EXCLUDE_DIR_SUFFIXES)
+
+
+def _is_excluded_filename(name: str) -> bool:
+    """A file basename is excluded iff it equals an EXCLUDE_FILENAMES entry,
+    ends with an EXCLUDE_FILE_SUFFIXES entry, or is a stem-variant of an
+    EXCLUDE_FILENAME_STEMS entry (``stem``, ``stem + "."*`` or ``stem + "-"*``
+    — e.g. ``.env.production``, ``db.sqlite3-wal``). The ``.`` / ``-``
+    discriminator keeps ``.environment`` in (not a ``.env`` variant; #1505)."""
+    if name in EXCLUDE_FILENAMES or name.endswith(EXCLUDE_FILE_SUFFIXES):
+        return True
+    return any(
+        name == stem or name.startswith(stem + ".") or name.startswith(stem + "-")
+        for stem in EXCLUDE_FILENAME_STEMS
+    )
+
+
+def _is_excluded_relpath(relative: str) -> bool:
+    """Apply the EXCLUDE_* rules to a POSIX relative path (as emitted by
+    ``git ls-files``): excluded iff any directory segment is an excluded
+    dirname OR the final segment is an excluded filename. This is the security
+    net that keeps credentials / live DBs / bytecode out of the tarball even
+    when the user has not gitignored them."""
+    segments = relative.split("/")
+    *dir_parts, base = segments
+    if any(_is_excluded_dirname(d) for d in dir_parts):
+        return True
+    return _is_excluded_filename(base)
+
+
+def _git_tracked_files(source_dir: Path) -> Optional[list]:
+    """Return the working-tree files of ``source_dir`` minus gitignored paths,
+    as POSIX relative paths, or ``None`` if ``source_dir`` is not a usable git
+    work tree.
+
+    ``git ls-files --cached --others --exclude-standard`` is exactly "tracked
+    files ∪ untracked files, minus everything matched by .gitignore / global
+    excludes" — i.e. the working tree as the user sees it, minus the junk they
+    already told git to ignore. No commit is required (``--others`` reports
+    untracked files directly), so a freshly-``git init``'d project works too.
+
+    The presence of ``.git`` (a directory in a normal clone, a file in a
+    worktree) gates this: a plain non-git directory returns ``None`` so the
+    caller falls back to the os.walk path. Any git failure (git absent, bad
+    repo) also falls back rather than aborting the deploy.
+    """
+    if not (source_dir / ".git").exists():
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+            cwd=str(source_dir),
+            capture_output=True,
+            check=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return [
+        chunk.decode("utf-8", "surrogateescape") for chunk in result.stdout.split(b"\0") if chunk
+    ]
+
+
 def _create_tarball(source_dir: Path, output_path: Path) -> None:
     """
     Create a tarball of source_dir excluding unwanted patterns.
 
-    Exclusion is path-segment / basename anchored (NOT substring-matched):
-    a directory is excluded iff its basename equals an entry in
-    EXCLUDE_DIR_NAMES or ends with an EXCLUDE_DIR_SUFFIXES entry; a file is
-    excluded iff its name equals an EXCLUDE_FILENAMES entry, ends with an
-    EXCLUDE_FILE_SUFFIXES entry, or is a stem-variant of an
-    EXCLUDE_FILENAME_STEMS entry (``stem``, ``stem + "."*`` or
-    ``stem + "-"*`` — e.g. ``.env.production``, ``db.sqlite3-wal``). This
-    prevents over-exclusion such as a ``venv`` token wrongly dropping
-    ``venvironment.py`` (#1505), while still excluding suffixed credential /
-    live-database files such as ``.env.production`` and ``db.sqlite3-wal``.
+    When ``source_dir`` is a git work tree, the file set comes from
+    ``git ls-files`` (see :func:`_git_tracked_files`), so the user's existing
+    ``.gitignore`` is the source of truth — a ``.venv-dev`` virtualenv, a
+    ``scratch/`` build dir, or locally-built wheels they already ignore stay
+    out of the tarball even though their names are not in EXCLUDE_DIR_NAMES.
+    Otherwise (a non-git directory, or git unavailable) it falls back to an
+    ``os.walk`` of the tree.
+
+    In BOTH paths the EXCLUDE_* rules are applied as a security net via
+    :func:`_is_excluded_dirname` / :func:`_is_excluded_filename`: exclusion is
+    path-segment / basename anchored (NOT substring-matched), so credential /
+    live-database files such as ``.env.production`` and ``db.sqlite3-wal`` are
+    dropped even if the user forgot to gitignore them, while lookalikes such as
+    ``venvironment.py`` and ``.environment`` are kept (#1505).
 
     Args:
         source_dir: Directory to tar
         output_path: Where to write the tarball
     """
+    git_files = _git_tracked_files(source_dir)
+
     with tarfile.open(output_path, "w:gz") as tar:
+        if git_files is not None:
+            for relative in git_files:
+                # Security net: EXCLUDE_* still applies to git-listed paths.
+                if _is_excluded_relpath(relative):
+                    continue
+                file_path = source_dir / relative
+                # Skip gitlinks (submodules), broken symlinks, and anything
+                # git lists that is not a regular file on disk.
+                if not file_path.is_file():
+                    continue
+                try:
+                    tar.add(file_path, arcname=relative)
+                except Exception as e:
+                    logger.debug("Failed to add %s to tarball: %s", file_path, e)
+            return
+
         for root, dirs, files in os.walk(source_dir):
             # Prune excluded directories in-place so os.walk does not descend
             # into them. Matched by exact basename or basename suffix.
-            dirs[:] = [
-                d
-                for d in dirs
-                if d not in EXCLUDE_DIR_NAMES and not d.endswith(EXCLUDE_DIR_SUFFIXES)
-            ]
+            dirs[:] = [d for d in dirs if not _is_excluded_dirname(d)]
 
             for file in files:
-                # Skip excluded files — exact basename or basename suffix.
-                if file in EXCLUDE_FILENAMES or file.endswith(EXCLUDE_FILE_SUFFIXES):
-                    continue
-                # Skip stem-variants of sensitive filenames: the file equals
-                # the stem, or starts with ``stem + "."`` / ``stem + "-"``.
-                # The ``.`` / ``-`` discriminator keeps ``.environment`` in
-                # (it is not a ``.env`` variant) — see #1505.
-                if any(
-                    file == stem or file.startswith(stem + ".") or file.startswith(stem + "-")
-                    for stem in EXCLUDE_FILENAME_STEMS
-                ):
+                if _is_excluded_filename(file):
                     continue
 
                 file_path = Path(root) / file
@@ -1082,6 +1163,45 @@ def _create_tarball(source_dir: Path, output_path: Path) -> None:
                     tar.add(file_path, arcname=str(relative))
                 except Exception as e:
                     logger.debug("Failed to add %s to tarball: %s", file_path, e)
+
+
+def _tarball_size_warning(tarball_path: Path, threshold: Optional[int] = None) -> Optional[str]:
+    """Return a human-readable warning if ``tarball_path`` is suspiciously
+    large, else ``None``.
+
+    "Large" means larger than ``threshold`` bytes (default
+    :data:`TARBALL_WARN_BYTES`). The message reports the packed size and the
+    largest included files (by uncompressed size) so the user can see exactly
+    what to add to ``.gitignore``. Surfaced before upload so an oversized
+    tarball produces an actionable hint instead of a raw nginx 413 page.
+    """
+    if threshold is None:
+        threshold = TARBALL_WARN_BYTES
+    size = tarball_path.stat().st_size
+    if size <= threshold:
+        return None
+
+    try:
+        with tarfile.open(tarball_path, "r:gz") as tar:
+            largest = sorted(
+                ((m.size, m.name) for m in tar.getmembers() if m.isfile()),
+                reverse=True,
+            )[:5]
+    except (OSError, tarfile.TarError):
+        largest = []
+
+    lines = [
+        f"Warning: deploy tarball is {size / 1_048_576:.1f} MB — unusually large "
+        "and may exceed the server's upload limit.",
+    ]
+    if largest:
+        lines.append("Largest files included:")
+        lines.extend(f"  {sz / 1_048_576:6.1f} MB  {name}" for sz, name in largest)
+    lines.append(
+        "If any are build artifacts or local data, add them to .gitignore "
+        "(the deploy honors it) and re-run."
+    )
+    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
@@ -1210,6 +1330,10 @@ def deploy_dir(
     try:
         _create_tarball(Path(source_dir), tarball_path)
         click.echo(f"Tarball created: {tarball_path.stat().st_size} bytes")
+
+        size_warning = _tarball_size_warning(tarball_path)
+        if size_warning:
+            click.echo(size_warning, err=True)
 
         url = f"{server}/api/v1/projects/{project_slug}/deploy/directory/"
 

--- a/python/tests/test_deploy_cli.py
+++ b/python/tests/test_deploy_cli.py
@@ -1422,3 +1422,166 @@ class TestCreateTarball:
         assert "keep.py" in names
         assert "dist" in names
         assert "logs" in names
+
+
+class TestCreateTarballGitignore:
+    """`_create_tarball` honors ``.gitignore`` when the source dir is a git repo.
+
+    The hardcoded EXCLUDE_* list only knows a fixed set of dir/file names, so
+    project-specific bloat with non-standard names (a ``.venv-dev`` virtualenv,
+    a ``scratch/`` dir, locally-built wheels) sailed straight into the tarball
+    even though the user had already gitignored it — producing a 152 MB upload
+    that the server's 50 MB ingress cap 413'd. When the source is a git work
+    tree, the file set is taken from ``git ls-files --cached --others
+    --exclude-standard`` (the working tree minus ignored paths), so the user's
+    existing ``.gitignore`` is the source of truth. The EXCLUDE_* rules still
+    apply as a security net so credentials / live DBs never ship even if the
+    user forgot to ignore them.
+    """
+
+    def _git_repo(self, tmp_path, layout, gitignore=""):
+        """Create a git repo (no commit needed) with files + a .gitignore.
+
+        ``git ls-files --others --exclude-standard`` reports untracked,
+        non-ignored files without any commit, so the repo stays uncommitted.
+        """
+        import subprocess
+
+        src = tmp_path / "repo"
+        src.mkdir()
+        if gitignore:
+            (src / ".gitignore").write_text(gitignore)
+        for rel in layout:
+            target = src / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("x")
+        subprocess.run(["git", "init", "-q"], cwd=src, check=True)
+        return src
+
+    def test_gitignored_paths_excluded(self, tmp_path):
+        """Paths matched by .gitignore are dropped; app code is kept. This is
+        the max-companion case: ``.venv-dev`` and ``scratch`` are gitignored but
+        NOT in EXCLUDE_DIR_NAMES, so only .gitignore-respect drops them."""
+        import tarfile
+
+        from djust.deploy_cli import _create_tarball
+
+        src = self._git_repo(
+            tmp_path,
+            layout=[
+                "app.py",
+                "pkg/mod.py",
+                ".venv-dev/lib/python3.12/site-packages/playwright/node",
+                "scratch/shot.png",
+                "mobile-app/wheels/djust.whl",
+            ],
+            gitignore=".venv-dev/\nscratch/\nmobile-app/wheels/\n",
+        )
+        out = tmp_path / "out.tar.gz"
+        _create_tarball(src, out)
+        with tarfile.open(out, "r:gz") as tar:
+            names = set(tar.getnames())
+
+        assert "app.py" in names
+        assert "pkg/mod.py" in names
+        assert ".venv-dev/lib/python3.12/site-packages/playwright/node" not in names
+        assert "scratch/shot.png" not in names
+        assert "mobile-app/wheels/djust.whl" not in names
+
+    def test_credentials_excluded_even_when_not_gitignored(self, tmp_path):
+        """SECURITY net: even in git mode, the EXCLUDE_* rules still drop a
+        ``.env`` variant / live SQLite DB / ``.pyc`` that the user forgot to
+        gitignore, so secrets never ship just because git would list them."""
+        import tarfile
+
+        from djust.deploy_cli import _create_tarball
+
+        src = self._git_repo(
+            tmp_path,
+            layout=["app.py", ".env.production", "db.sqlite3", "m.pyc"],
+            gitignore="",  # nothing ignored — rely entirely on the security net
+        )
+        out = tmp_path / "out.tar.gz"
+        _create_tarball(src, out)
+        with tarfile.open(out, "r:gz") as tar:
+            names = set(tar.getnames())
+
+        assert "app.py" in names
+        assert ".env.production" not in names
+        assert "db.sqlite3" not in names
+        assert "m.pyc" not in names
+
+    def test_non_git_source_uses_walker_fallback(self, tmp_path):
+        """A directory that is NOT a git repo keeps the os.walk behavior: a
+        stray ``.gitignore`` is inert (no git to interpret it), so a listed-but-
+        not-EXCLUDE_* path is still included. Guards against the git path
+        leaking into non-git deploys (`djust deploy-dir` on a plain folder)."""
+        import tarfile
+
+        from djust.deploy_cli import _create_tarball
+
+        src = tmp_path / "plain"
+        src.mkdir()
+        (src / ".gitignore").write_text("keepme/\n")
+        (src / "app.py").write_text("x")
+        (src / "keepme").mkdir()
+        (src / "keepme" / "data.txt").write_text("x")
+
+        out = tmp_path / "out.tar.gz"
+        _create_tarball(src, out)
+        with tarfile.open(out, "r:gz") as tar:
+            names = set(tar.getnames())
+
+        assert "app.py" in names
+        # No .git → .gitignore is not consulted → keepme/ is still shipped.
+        assert "keepme/data.txt" in names
+
+
+class TestTarballSizeWarning:
+    """`_tarball_size_warning` flags oversized tarballs before upload so a 413
+    becomes an actionable message instead of a raw nginx error page."""
+
+    def _tarball(self, tmp_path, files):
+        """Build a real .tar.gz from ``{relpath: byte_length}``."""
+        from djust.deploy_cli import _create_tarball
+
+        src = tmp_path / "src"
+        src.mkdir()
+        for rel, length in files.items():
+            target = src / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(b"x" * length)
+        out = tmp_path / "out.tar.gz"
+        _create_tarball(src, out)
+        return out
+
+    def test_no_warning_under_threshold(self, tmp_path):
+        from djust.deploy_cli import _tarball_size_warning
+
+        out = self._tarball(tmp_path, {"app.py": 100})
+        assert _tarball_size_warning(out, threshold=10_000_000) is None
+
+    def test_warning_lists_largest_members(self, tmp_path):
+        from djust.deploy_cli import _tarball_size_warning
+
+        out = self._tarball(
+            tmp_path,
+            {"small.py": 10, "big.bin": 4096, "mid.txt": 512},
+        )
+        msg = _tarball_size_warning(out, threshold=0)
+        assert msg is not None
+        # Mentions the size, the offending file, and a gitignore hint.
+        assert "big.bin" in msg
+        assert "MB" in msg
+        assert ".gitignore" in msg
+        # Largest member is listed before the smaller ones.
+        assert msg.index("big.bin") < msg.index("mid.txt")
+
+    def test_warning_uses_module_default_threshold(self, tmp_path):
+        """With no explicit threshold the module constant TARBALL_WARN_BYTES is
+        used; a tiny tarball is well under it and stays silent."""
+        from djust.deploy_cli import TARBALL_WARN_BYTES, _tarball_size_warning
+
+        assert TARBALL_WARN_BYTES >= 10 * 1024 * 1024
+        out = self._tarball(tmp_path, {"app.py": 100})
+        assert _tarball_size_warning(out) is None


### PR DESCRIPTION
## Problem

`djust deploy` (→ `deploy-dir` → `_create_tarball`) built a **152 MB** tarball for a real app and the server ingress rejected the upload with **413 Request Entity Too Large**. Root cause: `_create_tarball` walked the whole source tree minus a **hardcoded** `EXCLUDE_*` list, ignoring the user's `.gitignore`. Bloat with non-standard names slipped straight in:

- `.venv-dev/` — a second virtualenv (the matcher only knows `.venv`/`venv`), carrying Playwright's **115 MB** bundled `node` binary
- `scratch/` — screenshots, dylibs
- `mobile-app/wheels/` — locally-built android/ios wheels

All of these were **already gitignored**; the deploy just didn't consult it. `git archive HEAD` for the same project is 6.5 MB.

## Fix

1. **Respect `.gitignore`.** When the source is a git work tree, `_create_tarball` takes its file list from `git ls-files --cached --others --exclude-standard` (tracked ∪ untracked, minus ignored) — the user's `.gitignore` becomes the source of truth. Non-git directories fall back to the existing `os.walk` path, unchanged (the exclude predicate is now shared between both paths, so behavior is identical).
2. **Keep the security net.** `EXCLUDE_*` (`.env*`, `db.sqlite3*`, `.pyc`, …) is still applied to git-listed paths, so credentials / live DBs never ship even if the user forgot to ignore them (#1505 intent preserved).
3. **Warn before a wasted upload.** New `_tarball_size_warning` makes `deploy-dir` print a warning when the packed tarball exceeds ~50 MB, listing the largest included files so the user can gitignore build artifacts instead of hitting a raw 413.

## Verification

- 66/66 `test_deploy_cli.py` pass (6 new: gitignore-respect, credential security net, non-git fallback, size-warning both directions).
- Built the tarball against the real project tree: **152 MB → 4.4 MB**, with the Playwright binary / wheels / scratch gone and the largest member now a 0.37 MB doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)