### PR TITLE
docs(best-practices): add Deployment section (platform env contract + deploy doctor)

### DIFF
--- a/docs/BEST_PRACTICES_AI.md
+++ b/docs/BEST_PRACTICES_AI.md
@@ -987,6 +987,42 @@ class PropertyListView(LiveView):
 
 ---
 
+## 12. Deployment 🚀
+
+The `djust deploy` platform **injects config via environment variables** and serves from a **read-only rootfs**. Settings that hardcode platform-provided values, or that write to local files, deploy "successfully" then 500 at runtime.
+
+### Settings Pattern (CRITICAL for platform deploys)
+
+```python
+# ❌ WRONG — works in dev, breaks in prod
+SECRET_KEY = "django-insecure-dev-key"               # dev key on a public host (security risk)
+ALLOWED_HOSTS = ["localhost"]                          # → DisallowedHost (400) on the platform
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3",
+                         "NAME": BASE_DIR / "db.sqlite3"}}  # read-only rootfs → 500 on first write
+
+# ✅ CORRECT — read everything the platform injects from the env
+import os, dj_database_url
+SECRET_KEY = os.environ["SECRET_KEY"]
+ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "").split(",")
+DATABASES = {"default": dj_database_url.config(default=os.environ["DATABASE_URL"])}
+# (Individual os.environ["DB_NAME"], os.environ["DB_HOST"], … is equally fine.)
+```
+
+### Deploy Doctor
+
+`djust deploy` runs a static preflight over your settings *source text* (never imports it) and **warns** — without blocking — on: hardcoded `SECRET_KEY`, literal `ALLOWED_HOSTS`, a `DATABASES` block that reads no env config, or a sqlite engine. **Treat every doctor warning as deploy-blocking** — they predict runtime 500s.
+
+### Rollout Status
+
+`djust deploy` prints `Status: rolling out …` (not `active`) while a blue/green rollout still serves the OLD version, and only shows the URL once the new version is live. Wait for the URL before re-testing — "rolling out" means you'd be testing old code.
+
+**Deployment checklist:**
+- [ ] `SECRET_KEY`, `ALLOWED_HOSTS`, `DATABASES` all read from `os.environ` (no hardcoded values, no sqlite on the rootfs)
+- [ ] Zero `djust deploy` deploy-doctor warnings
+- [ ] Re-test only after `djust deploy` reports the live URL (not "rolling out")
+
+---
+
 ## Summary for AI Assistants
 
 **When writing djust code, always:**
@@ -1011,6 +1047,7 @@ class PropertyListView(LiveView):
 5. ❌ Missing default parameter values
 6. ❌ Skipping authorization checks
 7. ❌ Using `|safe` filter on user input (bypasses auto-escaping)
+8. ❌ Hardcoding `SECRET_KEY`/`ALLOWED_HOSTS`/`DATABASES` (or sqlite) for platform deploys instead of reading from `os.environ` — deploys "succeed" then 500 at runtime
 
 **Quick pattern matching:**
 - Search/filter → @debounce + private QuerySet + JIT

--- a/docs/guides/BEST_PRACTICES.md
+++ b/docs/guides/BEST_PRACTICES.md
@@ -19,6 +19,7 @@ A practical guide to building reactive LiveView applications with djust.
 - [Testing](#testing)
 - [Debugging](#debugging)
 - [Navigation](#navigation)
+- [Deployment](#deployment)
 - [Common Pitfalls](#common-pitfalls)
 
 ---
@@ -896,6 +897,51 @@ System check `djust.T010` detects `dj-click` used for navigation and suggests `d
 
 ---
 
+## Deployment
+
+When you deploy with `djust deploy` (to the djustlive platform), your app runs on a managed host that **injects configuration through environment variables** and serves the app from a **read-only root filesystem**. Settings that hardcode values the platform provides — or that write to local files — work in development but fail at runtime in production, often *after* a deploy that reports success.
+
+### Read platform config from the environment
+
+The platform injects `SECRET_KEY`, `ALLOWED_HOSTS`, and the database connection. Read them from the environment; never hardcode them:
+
+```python
+# ❌ Don't do this — works in dev, breaks in prod
+SECRET_KEY = "django-insecure-local-dev-key"        # a dev key served on a public host
+ALLOWED_HOSTS = ["localhost", "127.0.0.1"]           # → DisallowedHost (400) on the platform host
+DATABASES = {                                        # read-only rootfs → 500 on first write
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": BASE_DIR / "db.sqlite3"}
+}
+
+# ✅ Do this instead
+import os
+import dj_database_url
+
+SECRET_KEY = os.environ["SECRET_KEY"]
+ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "").split(",")
+DATABASES = {"default": dj_database_url.config(default=os.environ["DATABASE_URL"])}
+# (Assembling DATABASES from individual injected vars — os.environ["DB_NAME"],
+#  os.environ["DB_HOST"], … — is equally fine; the point is to read from the env.)
+```
+
+Why each matters on the platform:
+
+- **`SECRET_KEY`** — a hardcoded dev key on a public host is a security risk.
+- **`ALLOWED_HOSTS`** — if it doesn't include the platform host (read from the env), Django raises `DisallowedHost` (HTTP 400).
+- **`DATABASES`** — the app rootfs is read-only, so a sqlite `NAME` under the project directory 500s on the first write (`OperationalError: attempt to write a readonly database`). Use the injected `DATABASE_URL` / a managed Postgres.
+
+### `djust deploy` runs a preflight "deploy doctor"
+
+`djust deploy` statically inspects your resolved settings module and prints **warnings** (it does not block the deploy) when it finds any of the above — a hardcoded `SECRET_KEY`, an `ALLOWED_HOSTS` literal not read from the env, a `DATABASES` block that reads no configuration from the environment, or a sqlite engine. Treat those warnings as deploy-blocking yourself: an app that trips them typically 500s at runtime even though the deploy "succeeds". (The doctor reads the settings *source text* and never imports your settings, so it is safe to run against any project.)
+
+### "rolling out" vs "active"
+
+During a blue/green rollout the deployment can briefly report `active` while the **old** version is still serving the URL (the new root filesystem is still cutting over). `djust deploy` prints `Status: rolling out …` and keeps polling until the new version is actually serving, then shows the URL. Wait for that — re-testing the URL while it still says "rolling out" exercises the *old* code.
+
+See `DEPLOYMENT.md` for the full production checklist (ASGI setup, static files, `ALLOWED_HOSTS` / CSWSH hardening).
+
+---
+
 ## Common Pitfalls
 
 ### Service Instances in State
@@ -1296,3 +1342,6 @@ When building a djust LiveView:
 - [ ] Configure WebSocket routing in `asgi.py` with `ProtocolTypeRouter`
 - [ ] Use `djust.asgi.get_application()` for static file serving with ASGI servers
 - [ ] Run `python manage.py check --tag djust` to catch common issues
+- [ ] Read `SECRET_KEY`, `ALLOWED_HOSTS`, and `DATABASES` from the environment for platform deploys (never hardcode; no sqlite on the read-only rootfs)
+- [ ] Address every `djust deploy` "deploy doctor" warning before shipping — they predict runtime 500s on the platform
+- [ ] Wait for `djust deploy` to report the live URL (not "rolling out") before re-testing a deploy


### PR DESCRIPTION
## Summary

Per request, reviewed both best-practices guides and added a **Deployment** section capturing what this session's deploy-DX work (#1760 / #1761 / #1768) established — the platform env-injection contract that `djust deploy`'s new "deploy doctor" enforces.

Both guides previously had **no deployment guidance** (only ASGI/static-files pitfalls).

### `docs/guides/BEST_PRACTICES.md` (user guide)
- New `## Deployment` section + TOC entry + 3 checklist items.
- Covers: read `SECRET_KEY` / `ALLOWED_HOSTS` / `DATABASES` from `os.environ` (the platform injects them; no sqlite on the read-only rootfs), the non-blocking deploy-doctor preflight, and "rolling out" vs "active" during blue/green.

### `docs/BEST_PRACTICES_AI.md` (AI quick-reference)
- New `## 12. Deployment` section (✅/❌ settings pattern + deploy-doctor + rollout-status + a deployment checklist).
- Added the hardcoded-settings pitfall to the summary "Common pitfalls to avoid" list.

### Scope note
Only the user-facing deployment learning was added. The other findings from this session (the pyo3 0.29 FFI migration, the `test_tag_registry.py` global-registry isolation fix, the #1557 tenant analysis) are contributor/internal and live in their PRs/issues/CHANGELOG — they don't belong in a user-facing best-practices guide.

Docs-only; the doc-snippet pre-commit hook is scoped to README/QUICKSTART/`docs/website/guides/`, so these files aren't in its execution set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)