### PR TITLE
fix(websocket): arm recovery on the html_update (DJE-053) fallback path (#1785)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **WebSocket recovery no longer forces a full page reload on the `html_update` fallback (#1785).** When a LiveView event's VDOM diff returns no patches and the server sends a full-HTML `html_update` frame (the DJE-053 fallback), it now arms on-demand recovery — matching the patches path. Previously the `html_update` branch in `handle_event` skipped `_arm_recovery`, so a client that subsequently requested recovery (e.g. after a VDOM version mismatch on the full-HTML frame) received `Recovery HTML unavailable — the server may have restarted` and reloaded the whole page instead of morphing. Surfaced by a multi-replica djust.org `/insights/` page reloading on every time-range switch. Added a `WebsocketCommunicator` regression test (`TestWSRecoveryHtmlUpdate`-style, in `test_ws_recovery_html_update_1785.py`) plus a source pin.
+
 ## [1.0.4] - 2026-06-13
 
 ### Added

--- a/python/djust/tests/test_ws_recovery_html_update_1785.py
+++ b/python/djust/tests/test_ws_recovery_html_update_1785.py
@@ -1,0 +1,149 @@
+"""Regression tests for #1785 — the DJE-053 ``html_update`` fallback must arm recovery.
+
+Root cause (verified by local reproduction of the djust.org ``/insights/`` incident):
+when an event's VDOM diff returns ``patches=None``, ``handle_event`` sends a full
+``html_update`` frame but historically did NOT call ``self._arm_recovery(html, version)``
+— only the patches branch did. So when the client (which sees a version mismatch on the
+``html_update``) follows up with ``request_html``, the server's ``_recovery_html`` is
+``None`` and it replies with the non-recoverable error
+``"Recovery HTML unavailable — the server may have restarted"`` → the client does a full
+page reload.
+
+The fix arms recovery on the ``html_update`` branch too. These tests pin both the runtime
+behavior (a real ``WebsocketCommunicator`` round-trip) and the source.
+
+A view that sets ``self._force_full_html = True`` in its event handler deterministically
+forces the ``patches=None`` / ``html_update`` branch, so the test does not depend on
+losing the Rust ``last_vdom`` baseline.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from asgiref.sync import sync_to_async
+
+from djust import LiveView
+from djust.decorators import event_handler
+
+
+class _WSForceFullView(LiveView):
+    """Module-level view whose event forces the full-HTML (``html_update``) path."""
+
+    template = (
+        '<div dj-view="djust.tests.test_ws_recovery_html_update_1785._WSForceFullView" '
+        'dj-id="0">Count: {{ count }}</div>'
+    )
+
+    def mount(self, request, **kwargs):
+        self.count = 0
+
+    @event_handler()
+    def bump_full(self, **kwargs):
+        self.count += 1
+        # Force the DJE-053-class fallback: patches=None → html_update frame.
+        self._force_full_html = True
+
+
+async def _receive_until(communicator, wanted_type, *, tries=5, timeout=3):
+    """Drain frames until one whose ``type`` == ``wanted_type`` (or return last seen)."""
+    last = None
+    for _ in range(tries):
+        last = await communicator.receive_json_from(timeout=timeout)
+        if last.get("type") == wanted_type:
+            return last
+    return last
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_html_update_fallback_arms_recovery_so_request_html_succeeds():
+    """The load-bearing regression test.
+
+    Drive ``handle_event`` down the ``html_update`` (patches=None) path via a real
+    ``WebsocketCommunicator``, then send ``request_html`` and assert the server returns
+    an ``html_recovery`` frame — NOT the "Recovery HTML unavailable" error.
+
+    Gate-off: reverting the ``_arm_recovery`` call in the ``html_update`` branch makes
+    ``request_html`` return ``{"type":"error","error":"Recovery HTML unavailable ..."}``,
+    failing the final assertion. (Verified during the #1785 investigation.)
+    """
+    pytest.importorskip("channels")
+    from channels.testing import WebsocketCommunicator
+    from django.contrib.sessions.backends.db import SessionStore
+    from django.test import override_settings
+
+    from djust.websocket import LiveViewConsumer
+
+    with override_settings(LIVEVIEW_ALLOWED_MODULES=[__name__]):
+
+        def _create_session():
+            s = SessionStore()
+            s.create()
+            return s.session_key
+
+        session_key = await sync_to_async(_create_session)()
+
+        class _ScopeSession:
+            def __init__(self, key):
+                self.session_key = key
+
+        communicator = WebsocketCommunicator(LiveViewConsumer.as_asgi(), "/ws/")
+        communicator.scope["session"] = _ScopeSession(session_key)
+
+        connected, _ = await communicator.connect()
+        assert connected, "WebsocketCommunicator must connect"
+        await communicator.receive_json_from(timeout=2)  # drain connect frame
+
+        # Mount.
+        await communicator.send_json_to(
+            {
+                "type": "mount",
+                "view": f"{__name__}._WSForceFullView",
+                "url": "/force-full/",
+            }
+        )
+        mount_resp = await _receive_until(communicator, "mount")
+        assert mount_resp.get("type") == "mount", f"expected mount, got {mount_resp!r}"
+
+        # Event that forces the html_update (no-patches) fallback.
+        await communicator.send_json_to(
+            {"type": "event", "event": "bump_full", "params": {}, "ref": 1}
+        )
+        event_resp = await _receive_until(communicator, "html_update")
+        assert event_resp.get("type") == "html_update", (
+            f"event with _force_full_html must fall back to html_update; got {event_resp!r}"
+        )
+        assert not event_resp.get("patches"), "html_update fallback must carry no patches"
+
+        # Client behavior: a version mismatch on the html_update makes the client
+        # request recovery. Simulate it directly.
+        await communicator.send_json_to({"type": "request_html"})
+        recovery_resp = await _receive_until(communicator, "html_recovery")
+
+        assert recovery_resp.get("type") == "html_recovery", (
+            "After an html_update fallback, request_html must return an 'html_recovery' "
+            "frame — meaning the html_update branch armed recovery. Got: "
+            f"{recovery_resp!r}. Without _arm_recovery in the html_update branch this is "
+            "an error frame 'Recovery HTML unavailable' → forced page reload (#1785)."
+        )
+        assert recovery_resp.get("html"), "html_recovery frame must carry the recovery HTML"
+
+        await communicator.disconnect()
+
+
+def test_html_update_branch_arms_recovery_source():
+    """Belt-and-suspenders source pin: ``handle_event`` must arm recovery on BOTH the
+    patches branch and the ``html_update`` (patches=None) fallback branch.
+
+    If a future refactor drops the ``_arm_recovery`` call from the html_update branch,
+    this fails fast even if the integration test is skipped under some CI config.
+    """
+    import djust.websocket as ws_mod
+
+    source = inspect.getsource(ws_mod.LiveViewConsumer.handle_event)
+    assert source.count("self._arm_recovery(") >= 2, (
+        "handle_event must arm recovery in BOTH the patches branch and the html_update "
+        "fallback branch (#1785) — found fewer than 2 _arm_recovery calls."
+    )

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -3739,6 +3739,18 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         )
                     else:
                         # patches=None means VDOM diff failed or was skipped - send full HTML
+                        #
+                        # Arm on-demand recovery with the RAW rendered HTML *before*
+                        # the strip/extract below reassigns ``html`` — mirrors the
+                        # recovery-arming in the patches branch above. Without this,
+                        # a client that requests recovery after
+                        # a version mismatch on THIS html_update frame gets
+                        # "Recovery HTML unavailable" → forced full page reload (#1785).
+                        # ``_recovery_html`` expects the pre-strip HTML (it strips +
+                        # extracts on demand in ``handle_request_html``), matching the
+                        # value the patches branch passes.
+                        self._arm_recovery(html, version)
+
                         # Batch strip + extract into a single thread hop
                         # to avoid two separate sync_to_async crossings.
                         def _sync_strip_and_extract(raw_html):

--- a/tests/unit/test_arm_recovery_helper_1645.py
+++ b/tests/unit/test_arm_recovery_helper_1645.py
@@ -63,8 +63,9 @@ def test_arm_recovery_call_site_count_matches_known_send_paths():
     arm leaves the count unchanged, but is caught by
     ``test_render_send_paths_route_through_arm_recovery`` extended with its name.
 
-    Known sites (4): _run_async_work patches-branch + full-HTML-fallback,
-    handle_event, server_push.
+    Known sites (5): _run_async_work patches-branch + full-HTML-fallback,
+    handle_event patches-branch, handle_event full-HTML (html_update) fallback
+    (#1785), server_push.
     """
     import inspect
 
@@ -72,8 +73,8 @@ def test_arm_recovery_call_site_count_matches_known_send_paths():
 
     src = inspect.getsource(ws_mod)
     call_sites = src.count("self._arm_recovery(")
-    assert call_sites == 4, (
-        f"expected 4 self._arm_recovery() call sites (the known render-send "
+    assert call_sites == 5, (
+        f"expected 5 self._arm_recovery() call sites (the known render-send "
         f"paths), found {call_sites}. If you added a render-send path, arm the "
         f"recovery baseline there and update this count + the enumerated list "
         f"(#1655/#1645/#1639)."


### PR DESCRIPTION
## Summary

Fixes #1785. On the DJE-053 `html_update` fallback (an event's VDOM diff returns no patches → the server sends full HTML), `handle_event` did **not** arm on-demand recovery — only the patches branch did. So a client that subsequently requested recovery (e.g. after a VDOM version mismatch on the full-HTML frame) received `Recovery HTML unavailable — the server may have restarted` and **reloaded the whole page**.

## Root cause (verified by local reproduction — gate-off confirmed)

Reproduced frame-by-frame over a real `LiveViewConsumer` WebSocket:

1. mount → `version 1`
2. event → diff returns `patches=None` → server sends `html_update` (DJE-053)
3. client (`02-response-handler.js:58`) sees a version mismatch → sends `request_html`
4. `request_html` → `_recovery_html` is `None` → "Recovery HTML unavailable" → reload

`handle_event`'s `patches is None` branch (`python/djust/websocket.py:~3752`) sent the full HTML but skipped `_arm_recovery`. (`_run_async_work` already arms recovery on *its* full-HTML fallback — `handle_event` was the gap.)

## Fix

Arm recovery with the raw pre-strip HTML in the `html_update` branch, mirroring the patches branch. One call + comment.

## Tests

- **`test_ws_recovery_html_update_1785.py`** — a `WebsocketCommunicator` round-trip that forces the `html_update` fallback (`_force_full_html`) and asserts `request_html` now returns an `html_recovery` frame (client morphs) instead of the error (reload). **Gate-off self-test: fails without the fix.**
- Updated the `_arm_recovery` call-site count guard (#1645/#1125): 4 → 5 (the new legitimate site).

## Verification

`make test` green — Python + Rust + JS (1686).

## Notes

- Surfaced by djust.org `/insights/` reloading on every time-range switch (multi-replica, djust 1.0.4).
- Follow-up **#1788** (consumer-owned VDOM send-version) removes the residual recovery round-trip (the version desync); this PR stops the *reload*.
- Pre-existing serial-`pytest`-order test pollution (S005 + two `auto_navigate_meta` tests) is **not** introduced here — those pass in isolation and under parallel `make test`; will be filed as a separate test-isolation tech-debt issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
