### PR TITLE
fix(websocket): consumer-owned monotonic VDOM send-version (#1788)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Consumer-owned monotonic VDOM send-version (#1788).** The WebSocket
+  ``version`` stamped on every client-checked frame was the Rust view's
+  internal counter, which resets on a mid-session VDOM baseline loss (e.g. the
+  patch-compression ``_rust_view.reset()`` path). The resulting non-sequential
+  version failed the client's ``clientVdomVersion === data.version - 1`` check,
+  forcing an ``html_update`` → ``request_html`` recovery round-trip (a full page
+  reload before #1785). The consumer now owns a monotonic per-connection
+  counter (``_next_version()``) used as the single source of truth across every
+  client-checked send path (events, async work, mount, server_push, db_notify,
+  ticks, time-travel, hot-reload patches, and ``StreamingMixin.push_state``), so
+  a post-baseline-loss ``html_update`` stays in sequence and the client accepts
+  it directly with no recovery round-trip. Recovery (``html_recovery``) now
+  carries the consumer version of the frame it replaces. New regression tests in
+  ``python/djust/tests/test_ws_send_version_1788.py`` pin the monotonic sequence
+  across the baseline-loss boundary plus the send-path call-site coverage.
+
 ## [1.0.5] - 2026-06-15
 
 ### Added

--- a/python/djust/streaming.py
+++ b/python/djust/streaming.py
@@ -269,8 +269,14 @@ class StreamingMixin:
         from asgiref.sync import sync_to_async
         import json
 
-        # Re-render the full view
-        html, patches, version = await sync_to_async(self.render_with_diff)()
+        # Re-render the full view. The Rust ``version`` is DISCARDED for the
+        # wire — this path bypasses ``_send_update`` and sends frames directly,
+        # but it is a client-CHECKED send path (the client writes
+        # ``clientVdomVersion = data.version`` at 02-response-handler.js:77), so
+        # both frames MUST stamp the consumer-owned monotonic counter
+        # (#1788, HIDDEN #2). Stamping the Rust version here would desync the
+        # client against every other send path.
+        html, patches, _version = await sync_to_async(self.render_with_diff)()
 
         if patches is not None:
             patch_list = json.loads(patches) if patches else []
@@ -278,7 +284,7 @@ class StreamingMixin:
                 {
                     "type": "patch",
                     "patches": patch_list,
-                    "version": version,
+                    "version": self._ws_consumer._next_version(),
                 }
             )
         else:
@@ -288,7 +294,7 @@ class StreamingMixin:
                 {
                     "type": "html_update",
                     "html": html,
-                    "version": version,
+                    "version": self._ws_consumer._next_version(),
                 }
             )
         await self._ws_consumer._flush_push_events()

--- a/python/djust/tests/test_ws_send_version_1788.py
+++ b/python/djust/tests/test_ws_send_version_1788.py
@@ -1,0 +1,452 @@
+"""Regression tests for #1788 — consumer-owned monotonic VDOM wire version.
+
+Root cause (verified by local reproduction of djust.org ``/insights/`` ``set_period``):
+the wire ``version`` stamped on every client-checked frame was the Rust view's
+``self.version`` (``crates/djust_live/src/lib.rs``), which is coupled to the Rust-view
+object's *baseline lifetime*, not the connection. When the Rust view loses its
+``last_vdom`` baseline mid-session (e.g. the patch-compression path calls
+``_rust_view.reset()``, which sets ``version = 0`` and ``last_vdom = None``), the very
+next ``render_with_diff`` returns ``(html, patches=None, version=1)`` — a NON-sequential
+version that does NOT satisfy the client's
+``clientVdomVersion === data.version - 1`` check
+(``python/djust/static/djust/src/02-response-handler.js:58``). The client then treats the
+``html_update`` as a version mismatch and sends ``request_html`` (recovery round-trip;
+pre-#1785 it was a full page reload).
+
+The fix: the *consumer* owns a monotonic per-connection counter (``_last_sent_version``)
+and stamps every client-checked outbound frame via ``_next_version()``. The wire version
+is then decoupled from the Rust view's lifetime, so a baseline loss produces a correctly
+sequenced ``html_update`` (``v_n -> v_{n+1}``) the client accepts directly — no recovery.
+
+CRITICAL FIDELITY NOTE: ``_force_full_html = True`` does NOT lose the Rust baseline (it
+keeps ``last_vdom`` and the version increments sequentially), so it does NOT reproduce the
+drift and would give a FALSE PASS. The TRUE baseline-loss trigger is
+``view_instance._rust_view.reset()`` — that is what these tests use.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from asgiref.sync import sync_to_async
+
+from djust import LiveView
+from djust.decorators import event_handler
+
+
+class _WSVersionView(LiveView):
+    """Module-level view used to drive real ``WebsocketCommunicator`` round-trips.
+
+    ``bump`` produces a normal text diff (patches present). ``lose_baseline`` first
+    resets the Rust view (dropping ``last_vdom`` + setting Rust ``version=0``) and then
+    bumps state, so the subsequent ``render_with_diff`` returns ``patches=None`` with a
+    non-sequential Rust version — the exact #1788 drift trigger.
+    """
+
+    template = (
+        '<div dj-view="djust.tests.test_ws_send_version_1788._WSVersionView" '
+        'dj-id="0">Count: {{ count }}</div>'
+    )
+
+    def mount(self, request, **kwargs):
+        self.count = 0
+
+    @event_handler()
+    def bump(self, **kwargs):
+        self.count += 1
+
+    @event_handler()
+    def lose_baseline(self, **kwargs):
+        # TRUE baseline-loss trigger: reset the Rust view so its internal
+        # version counter resets to 0 and last_vdom is dropped. The next
+        # render_with_diff then returns patches=None with a non-sequential
+        # Rust version — reproducing the production drift.
+        if getattr(self, "_rust_view", None) is not None:
+            self._rust_view.reset()
+        self.count += 1
+
+
+# Module-mutable template content for the HVR view, so a hot-reload re-render
+# reliably produces a patch (the hotreload handler re-renders and diffs against
+# the previous VDOM; identical output yields a 'reload' frame, not a patch).
+_HVR_TEMPLATE_BODY = ["Count: {{ count }}"]
+
+
+class _WSHvrView(LiveView):
+    """View used to exercise the channel-layer ``hotreload`` handler (HIDDEN #1)."""
+
+    @property
+    def template(self):
+        body = _HVR_TEMPLATE_BODY[0]
+        return (
+            '<div dj-view="djust.tests.test_ws_send_version_1788._WSHvrView" '
+            f'dj-id="0">{body}</div>'
+        )
+
+    def get_template(self):
+        # The hotreload handler calls get_template() to fetch the new content.
+        return self.template
+
+    def mount(self, request, **kwargs):
+        self.count = 0
+
+    @event_handler()
+    def bump(self, **kwargs):
+        self.count += 1
+
+
+async def _receive_until(communicator, wanted_type, *, tries=6, timeout=3):
+    """Drain frames until one whose ``type`` == ``wanted_type`` (or return last seen)."""
+    last = None
+    for _ in range(tries):
+        last = await communicator.receive_json_from(timeout=timeout)
+        if last.get("type") == wanted_type:
+            return last
+    return last
+
+
+async def _connect_and_mount(view_suffix="_WSVersionView", url="/version/"):
+    """Lifted harness from test_ws_recovery_html_update_1785.py.
+
+    Returns (communicator, mount_frame).
+    """
+    pytest.importorskip("channels")
+    from channels.testing import WebsocketCommunicator
+    from django.contrib.sessions.backends.db import SessionStore
+
+    from djust.websocket import LiveViewConsumer
+
+    def _create_session():
+        s = SessionStore()
+        s.create()
+        return s.session_key
+
+    session_key = await sync_to_async(_create_session)()
+
+    class _ScopeSession:
+        def __init__(self, key):
+            self.session_key = key
+
+    communicator = WebsocketCommunicator(LiveViewConsumer.as_asgi(), "/ws/")
+    communicator.scope["session"] = _ScopeSession(session_key)
+
+    connected, _ = await communicator.connect()
+    assert connected, "WebsocketCommunicator must connect"
+    await communicator.receive_json_from(timeout=2)  # drain connect frame
+
+    await communicator.send_json_to(
+        {
+            "type": "mount",
+            "view": f"{__name__}.{view_suffix}",
+            "url": url,
+        }
+    )
+    mount_frame = await _receive_until(communicator, "mount")
+    assert mount_frame.get("type") == "mount", f"expected mount, got {mount_frame!r}"
+    return communicator, mount_frame
+
+
+def _frame_version(frame):
+    assert frame is not None
+    return frame.get("version")
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_baseline_loss_html_update_stays_monotonic_no_recovery():
+    """(a) Round-trip removal — the load-bearing #1788 test.
+
+    mount (v=m) -> normal bump (v=m+1) -> induce baseline loss -> next event emits an
+    ``html_update`` whose version is m+2 (consumer stayed monotonic across the baseline
+    loss) and satisfies the client's ``prev == emitted - 1`` check, so the client would
+    NOT send ``request_html``.
+
+    Gate-off check: if ``_send_update`` stamps the *Rust* version instead of the consumer
+    counter, the baseline-loss ``html_update`` carries Rust ``version=1`` (non-sequential)
+    and the ``prev == emitted - 1`` assertion fails — proving the test exercises the fix.
+    """
+    from django.test import override_settings
+
+    with override_settings(LIVEVIEW_ALLOWED_MODULES=[__name__]):
+        communicator, mount_frame = await _connect_and_mount()
+        m = _frame_version(mount_frame)
+        assert m == 1, f"happy-path mount baseline must be 1, got {m!r}"
+
+        # Normal diff event — should be a patch frame at m+1.
+        await communicator.send_json_to(
+            {"type": "event", "event": "bump", "params": {}, "ref": 1}
+        )
+        ev1 = await _receive_until(communicator, "patch")
+        assert ev1.get("type") == "patch", f"normal bump should patch, got {ev1!r}"
+        v1 = _frame_version(ev1)
+        assert v1 == m + 1, f"first event must be m+1 ({m + 1}), got {v1!r}"
+
+        # Baseline-loss event — forces patches=None -> html_update fallback.
+        await communicator.send_json_to(
+            {"type": "event", "event": "lose_baseline", "params": {}, "ref": 2}
+        )
+        ev2 = await _receive_until(communicator, "html_update")
+        assert ev2.get("type") == "html_update", (
+            f"baseline-loss event must fall back to html_update; got {ev2!r}"
+        )
+        assert not ev2.get("patches"), "html_update fallback must carry no patches"
+        v2 = _frame_version(ev2)
+
+        # Consumer stayed monotonic across the baseline-loss boundary.
+        assert v2 == m + 2, (
+            f"baseline-loss html_update must be m+2 ({m + 2}) — consumer-owned version "
+            f"must stay monotonic across the Rust baseline reset; got {v2!r}. "
+            "If this is 1, the wire version is still the Rust counter (#1788 not fixed)."
+        )
+        # Client check would PASS: prev (v1) == emitted (v2) - 1 → no request_html.
+        assert v1 == v2 - 1, (
+            f"client check clientVdomVersion === data.version - 1 must PASS across the "
+            f"baseline loss: prev={v1}, emitted={v2}. A failure here is the recovery storm."
+        )
+
+        await communicator.disconnect()
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_version_sequence_strictly_monotonic_across_baseline_boundary():
+    """(b) DRIFT GUARD (load-bearing).
+
+    mount -> normal event -> baseline-loss html_update -> NORMAL diff event. The full
+    version sequence must be strictly m, m+1, m+2, m+3 with no jump/reset at the
+    baseline-loss boundary. This catches the case where ONE send path stamps a different
+    counter than the others (the entire drift risk of #1788).
+    """
+    from django.test import override_settings
+
+    with override_settings(LIVEVIEW_ALLOWED_MODULES=[__name__]):
+        communicator, mount_frame = await _connect_and_mount()
+        m = _frame_version(mount_frame)
+
+        await communicator.send_json_to(
+            {"type": "event", "event": "bump", "params": {}, "ref": 1}
+        )
+        f1 = await _receive_until(communicator, "patch")
+
+        await communicator.send_json_to(
+            {"type": "event", "event": "lose_baseline", "params": {}, "ref": 2}
+        )
+        f2 = await _receive_until(communicator, "html_update")
+
+        # After a reset(), the next diff has a fresh baseline so this normal
+        # event produces patches again.
+        await communicator.send_json_to(
+            {"type": "event", "event": "bump", "params": {}, "ref": 3}
+        )
+        f3 = await _receive_until(communicator, "patch")
+
+        seq = [m, _frame_version(f1), _frame_version(f2), _frame_version(f3)]
+        assert seq == [m, m + 1, m + 2, m + 3], (
+            "wire version sequence must be strictly monotonic across the baseline-loss "
+            f"boundary (no jump/reset). Expected {[m, m + 1, m + 2, m + 3]}, got {seq}. "
+            "A discontinuity means a send path drifted off the consumer counter."
+        )
+
+        await communicator.disconnect()
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_hotreload_frame_advances_consumer_counter_then_event_passes():
+    """(c) HVR-then-event.
+
+    A hot-reload patch frame (``hotreload=True``) is exempt from the client *version
+    check* but it WRITES ``clientVdomVersion = data.version`` (02-response-handler.js:77),
+    so it MUST stamp the consumer counter. After an HVR frame, the next normal event's
+    version must still satisfy ``prev == emitted - 1`` — proving HIDDEN #1 (the hotreload
+    send path) is on the consumer counter.
+    """
+    from channels.layers import get_channel_layer
+    from django.test import override_settings
+
+    # Reset the mutable template body for a clean run.
+    _HVR_TEMPLATE_BODY[0] = "Count: {{ count }}"
+
+    with override_settings(LIVEVIEW_ALLOWED_MODULES=[__name__], DEBUG=True):
+        communicator, mount_frame = await _connect_and_mount(
+            view_suffix="_WSHvrView", url="/hvr/"
+        )
+        m = _frame_version(mount_frame)
+
+        # Normal event first to advance the counter to m+1.
+        await communicator.send_json_to(
+            {"type": "event", "event": "bump", "params": {}, "ref": 1}
+        )
+        ev1 = await _receive_until(communicator, "patch")
+        v1 = _frame_version(ev1)
+        assert v1 == m + 1
+
+        # Drive the REAL hotreload handler via the channel-layer group the
+        # consumer joins on connect ("djust_hotreload", websocket.py:1478).
+        # Change the template body so the re-render produces an actual patch
+        # (identical content yields a 'reload' frame, not a patch). The
+        # hotreload patch frame must stamp the consumer counter (HIDDEN #1) —
+        # it WRITES clientVdomVersion even though it's exempt from the check.
+        _HVR_TEMPLATE_BODY[0] = "Counter is now: {{ count }}"
+        channel_layer = get_channel_layer()
+        await channel_layer.group_send(
+            "djust_hotreload", {"type": "hotreload", "file": "x.html"}
+        )
+
+        hvr = await _receive_until(communicator, "patch")
+        assert hvr.get("type") == "patch" and hvr.get("hotreload") is True, (
+            f"channel-layer hotreload must emit a hotreload patch frame; got {hvr!r}"
+        )
+        vh = _frame_version(hvr)
+        assert vh == v1 + 1, (
+            f"hotreload patch must stamp the consumer counter (HIDDEN #1, #1788): "
+            f"expected {v1 + 1}, got {vh!r}. The hotreload send path WRITES "
+            "clientVdomVersion so it must use self._next_version()."
+        )
+
+        # Next normal event must chain off the consumer counter (proves the
+        # hotreload frame did NOT drift the wire version).
+        await communicator.send_json_to(
+            {"type": "event", "event": "bump", "params": {}, "ref": 2}
+        )
+        ev2 = await _receive_until(communicator, "patch")
+        v2 = _frame_version(ev2)
+        assert v2 == vh + 1, (
+            f"event after hotreload must chain off the consumer counter: "
+            f"prev={vh}, emitted={v2}. If the hotreload frame stamped a different "
+            "counter, this fails — the recovery storm HIDDEN #1 guards against."
+        )
+
+        await communicator.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Source-pin / call-site count tests (#1125 / #1448): pin that every
+# client-checked send path uses the consumer counter and pin the call-site
+# count so a future new send path that forgets the helper trips the test.
+# ---------------------------------------------------------------------------
+
+
+def test_next_version_helper_exists_and_consumer_init():
+    """The consumer must define ``_next_version`` and init ``_last_sent_version = 0``."""
+    import djust.websocket as ws_mod
+
+    assert hasattr(ws_mod.LiveViewConsumer, "_next_version"), (
+        "LiveViewConsumer must define _next_version() — the single source of truth "
+        "for the outbound VDOM wire version (#1788)."
+    )
+    init_src = inspect.getsource(ws_mod.LiveViewConsumer.__init__)
+    assert "_last_sent_version" in init_src, (
+        "LiveViewConsumer.__init__ must initialize self._last_sent_version (#1788)."
+    )
+
+
+def test_next_version_is_monotonic():
+    """``_next_version`` must return strictly increasing integers starting at 1."""
+    import djust.websocket as ws_mod
+
+    class _Probe(ws_mod.LiveViewConsumer):
+        def __init__(self):  # bypass Channels consumer __init__ machinery
+            self._last_sent_version = 0
+
+    p = _Probe()
+    seq = [p._next_version() for _ in range(5)]
+    assert seq == [1, 2, 3, 4, 5], f"_next_version must be monotonic from 1, got {seq}"
+
+
+def test_every_client_checked_send_path_uses_next_version():
+    """Source-pin: every ``_send_update(...)`` call that stamps a client-checked frame
+    must pass ``version=self._next_version()`` (NOT the Rust ``version``), and the two
+    HIDDEN participants (hotreload, streaming) must route through the consumer counter.
+
+    Pins the migrated call-site count so a future send path that forgets the helper
+    trips this test (#1125). OUT-OF-SCOPE paths are explicitly excluded: child_update /
+    sticky_update (per-child Map) and mount_batch per-target object are NOT counted.
+    """
+    import re
+
+    import djust.streaming as streaming_mod
+    import djust.websocket as ws_mod
+
+    ws_src = inspect.getsource(ws_mod)
+
+    # Count every INVOCATION of self._next_version() — both the inline kwarg
+    # form ``version=self._next_version()`` and the assignment form
+    # ``X = self._next_version()`` (used where _arm_recovery must capture the
+    # same version, or where a local Rust ``version`` is also needed for
+    # telemetry). Excludes the docstring reference inside _arm_recovery (which
+    # is prose, not a call: ``v = self._next_version()`` rendered in backticks).
+    inline = len(re.findall(r"version=self\._next_version\(\)", ws_src))
+    assign = len(re.findall(r"\b[a-z_]+ = self\._next_version\(\)", ws_src))
+    # The _arm_recovery docstring contains one prose ``v = self._next_version()``
+    # that matches the assignment regex; subtract it.
+    assign_doc_refs = ws_src.count("``v = self._next_version()``")
+    real_invocations = inline + assign - assign_doc_refs
+
+    # Pin: every client-checked send path routes through the helper.
+    # Sites (verified at implementation, see PR #1788):
+    #   INLINE (version=self._next_version()), 11:
+    #     _run_async_work error arms: 2
+    #     _dispatch_single_event: 2
+    #     actor event path: 1
+    #     handle_hot_reload (HIDDEN #1): 1
+    #     handle_time_travel_jump: 1
+    #     handle_time_travel_component_jump: 1
+    #     handle_forward_replay: 1
+    #     db_notify: 1
+    #     _run_tick: 1
+    #   ASSIGNMENT (X = self._next_version()), 6:
+    #     _run_async_work success arms: 2 (version, before _arm_recovery)
+    #     handle_mount: 1 (mount frame; covers actor mount)
+    #     handle_event patch + html fallback: 2 (wire_version, before _arm_recovery)
+    #     server_push: 1 (wire_version, before _arm_recovery)
+    # Total real invocations = 17.
+    EXPECTED_NEXT_VERSION_INVOCATIONS = 17
+    assert real_invocations == EXPECTED_NEXT_VERSION_INVOCATIONS, (
+        f"expected {EXPECTED_NEXT_VERSION_INVOCATIONS} self._next_version() invocations "
+        f"across client-checked send paths; found {real_invocations} "
+        f"(inline={inline}, assign={assign}, doc_refs={assign_doc_refs}). A new "
+        "client-checked send path must route through self._next_version() (#1788), or an "
+        "existing one drifted off it. Update this count ONLY if you intentionally "
+        "added/removed a client-checked send path."
+    )
+
+    # The mount frame must stamp the consumer counter (covers actor mount too).
+    mount_src = inspect.getsource(ws_mod.LiveViewConsumer.handle_mount)
+    assert "self._next_version()" in mount_src, (
+        "handle_mount must stamp the mount frame version via self._next_version() so the "
+        "client baseline = 1 and the actor mount path does not trust result['version']."
+    )
+
+    # handle_request_html must send the consumer-owned recovery version, NOT a fresh
+    # Rust version (the client sets clientVdomVersion = data.version directly on
+    # html_recovery — 03-websocket.js:727).
+    req_html_src = inspect.getsource(ws_mod.LiveViewConsumer.handle_request_html)
+    assert "_recovery_version" in req_html_src, (
+        "handle_request_html must send self._recovery_version (the consumer version of "
+        "the frame being replaced), not a fresh Rust version (#1788)."
+    )
+
+    # HIDDEN #2 — streaming push_state must route through the consumer counter.
+    stream_src = inspect.getsource(streaming_mod.StreamingMixin.push_state)
+    assert stream_src.count("self._ws_consumer._next_version()") >= 2, (
+        "StreamingMixin.push_state bypasses _send_update and sends patch + html_update "
+        "directly; both MUST stamp self._ws_consumer._next_version() (HIDDEN #2, #1788). "
+        f"Found {stream_src.count('self._ws_consumer._next_version()')} of 2."
+    )
+
+
+def test_arm_recovery_stores_consumer_version():
+    """``_arm_recovery`` must capture the consumer's last-sent version (``_last_sent_version``)
+    rather than rely on a passed Rust version — recovery sets
+    ``clientVdomVersion = data.version`` directly client-side, so the recovery version must
+    equal the consumer version of the frame it replaces (#1788).
+    """
+    import djust.websocket as ws_mod
+
+    arm_src = inspect.getsource(ws_mod.LiveViewConsumer._arm_recovery)
+    assert "_last_sent_version" in arm_src, (
+        "_arm_recovery must store self._recovery_version = self._last_sent_version so the "
+        "html_recovery frame carries the consumer version of the frame it replaces (#1788)."
+    )

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -401,6 +401,19 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
         # applied class swap and is echoed to the client for telemetry.
         self._hvr_version: int = 0
         self._hvr_last_reload_id: Optional[str] = None
+        # Consumer-owned monotonic VDOM wire version (#1788). This is the
+        # SINGLE SOURCE OF TRUTH for the ``version`` field on every
+        # client-checked outbound frame (patch / html_update / mount /
+        # html_recovery). It is decoupled from the Rust view's internal
+        # ``self.version`` (which resets to 0 on baseline loss — e.g. a
+        # patch-compression ``_rust_view.reset()``). Stamping the consumer
+        # counter keeps the wire sequence strictly monotonic per-CONNECTION,
+        # so a post-baseline-loss ``html_update`` still satisfies the client's
+        # ``clientVdomVersion === data.version - 1`` check
+        # (``static/djust/src/02-response-handler.js:58``) and the client
+        # accepts it directly without a ``request_html`` recovery round-trip.
+        # SEPARATE from ``_hvr_version`` above (telemetry for ``hvr-applied``).
+        self._last_sent_version: int = 0
         # Sticky LiveViews (Phase B): per-connection stash of preserved
         # sticky children staged in handle_live_redirect_mount BEFORE the
         # old view is torn down. Re-registered on the new parent after
@@ -955,7 +968,11 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 # _recovery_html leaves it None, the next request_html returns
                 # "Recovery HTML unavailable", and the client freezes at the
                 # transitional state even though the backend advanced (#1636).
-                self._arm_recovery(html, version)
+                # Stamp the consumer-owned wire version (#1788), discarding the
+                # Rust ``version`` for the wire. Order: _next_version() THEN
+                # _arm_recovery (so _recovery_version == this frame's version).
+                version = self._next_version()
+                self._arm_recovery(html)
                 await self._send_update(
                     patches=patch_list,
                     version=version,
@@ -973,8 +990,10 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                     )
                 )(html)
                 # The fallback sends the full render to the client, so the
-                # recovery baseline must track it too (#1636).
-                self._arm_recovery(html, version)
+                # recovery baseline must track it too (#1636). Consumer-owned
+                # wire version (#1788); order: _next_version() THEN _arm_recovery.
+                version = self._next_version()
+                self._arm_recovery(html)
                 await self._send_update(
                     html=html_content,
                     version=version,
@@ -1011,7 +1030,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         patch_list = fast_json_loads(patches) if patches else []
                         await self._send_update(
                             patches=patch_list,
-                            version=version,
+                            version=self._next_version(),  # consumer-owned (#1788)
                             event_name=event_name,
                             source="async",
                         )
@@ -1026,7 +1045,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         )(html)
                         await self._send_update(
                             html=html_content,
-                            version=version,
+                            version=self._next_version(),  # consumer-owned (#1788)
                             event_name=event_name,
                             source="async",
                         )
@@ -1036,7 +1055,26 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         "[djust] Error in handle_async_result for task '%s'", task_name
                     )
 
-    def _arm_recovery(self, html: str, version: int) -> None:
+    def _next_version(self) -> int:
+        """Single source of truth for the outbound VDOM wire version (#1788).
+
+        Monotonic per-CONNECTION; decoupled from the Rust view's ``self.version``
+        (which resets to 0 on baseline loss — e.g. a patch-compression
+        ``_rust_view.reset()``). Every client-checked frame stamps THIS so the
+        wire sequence stays strictly monotonic across a Rust baseline reset, and
+        a post-baseline-loss ``html_update`` still satisfies the client's
+        ``clientVdomVersion === data.version - 1`` check — no ``request_html``
+        recovery round-trip.
+
+        Uses ``getattr`` for the read so consumers built via a partial
+        constructor (test fakes that override ``__init__``, or any edge path
+        that bypasses the base ``__init__``) still get a valid monotonic
+        sequence starting at 1.
+        """
+        self._last_sent_version = getattr(self, "_last_sent_version", 0) + 1
+        return self._last_sent_version
+
+    def _arm_recovery(self, html: str) -> None:
         """Arm the on-demand VDOM recovery baseline.
 
         Single source of truth for the ``request_html`` recovery state
@@ -1047,9 +1085,18 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
         centralizing it here (#1645) makes a new send path inherit correct arming
         by calling one method. The one-time clear (``_recovery_html = None`` in
         ``handle_request_html``) is the only other writer.
+
+        The recovery version is the consumer's CURRENT ``_last_sent_version``
+        (#1788) — NOT a Rust version. Recovery (``html_recovery``) sets
+        ``clientVdomVersion = data.version`` directly on the client
+        (``static/djust/src/03-websocket.js:727``), so the recovery frame MUST
+        carry the consumer version of the frame it replaces. The canonical call
+        ordering at every arming site is therefore: allocate ``v`` from
+        ``_next_version()`` FIRST, THEN arm recovery (which captures
+        ``_last_sent_version == v``), THEN send the frame with ``version=v``.
         """
         self._recovery_html = html
-        self._recovery_version = version
+        self._recovery_version = getattr(self, "_last_sent_version", 0)
 
     async def _send_update(
         self,
@@ -1310,7 +1357,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
         if patch_list is not None:
             await self._send_update(
                 patches=patch_list,
-                version=version,
+                version=self._next_version(),  # consumer-owned (#1788)
                 event_name=event_name,
                 async_pending=has_async,
                 source="event",
@@ -1334,7 +1381,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 return
             await self._send_update(
                 html=html_content,
-                version=version,
+                version=self._next_version(),  # consumer-owned (#1788)
                 event_name=event_name,
                 async_pending=has_async,
                 source="event",
@@ -2351,6 +2398,14 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
 
         # Send success response (HTML only if generated)
         logger.info("Successfully mounted view: %s", view_path)
+        # Stamp the consumer-owned wire version (#1788) rather than the Rust
+        # ``version`` (or the actor ``result['version']``). On a fresh
+        # connection this is 1, so the client baseline = 1 and the first event
+        # (version 2) satisfies ``clientVdomVersion === data.version - 1``. The
+        # client sets ``clientVdomVersion = data.version`` directly on mount
+        # (``static/djust/src/03-websocket.js:382``), so the source MUST be the
+        # consumer counter to keep every subsequent frame in sequence.
+        version = self._next_version()
         response = {
             "type": "mount",
             "session_id": self.session_id,
@@ -2901,10 +2956,12 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 # Call actor event handler (will call Python handler internally)
                 result = await self.actor_handle.event(event_name, params)
 
-                # Send patches if available, otherwise full HTML
+                # Send patches if available, otherwise full HTML.
+                # Ignore the actor ``result['version']`` for the wire — the
+                # consumer owns the monotonic wire version (#1788). The actor's
+                # internal version still drives its diff-baselining server-side.
                 patches = result.get("patches")
                 html = result.get("html")
-                version = result.get("version", 0)
 
                 if patches:
                     # Parse patches JSON string to list
@@ -2921,7 +2978,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 await self._send_update(
                     patches=patches,
                     html=html,
-                    version=version,
+                    version=self._next_version(),  # consumer-owned (#1788)
                     cache_request_id=cache_request_id,
                     event_name=event_name,
                 )
@@ -3736,11 +3793,15 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         # Store rendered HTML for on-demand recovery.
                         # Client sends request_html when applyPatches() fails
                         # (e.g., {% if %} blocks shifting DOM structure).
-                        self._arm_recovery(html, version)
+                        # Consumer-owned wire version (#1788): allocate it, THEN
+                        # arm recovery (so _recovery_version == this frame's
+                        # version — recovery sets clientVdomVersion directly).
+                        wire_version = self._next_version()
+                        self._arm_recovery(html)
 
                         await self._send_update(
                             patches=patch_list,
-                            version=version,
+                            version=wire_version,
                             cache_request_id=cache_request_id,
                             reset_form=should_reset_form,
                             timing=timing,
@@ -3762,7 +3823,15 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         # ``_recovery_html`` expects the pre-strip HTML (it strips +
                         # extracts on demand in ``handle_request_html``), matching the
                         # value the patches branch passes.
-                        self._arm_recovery(html, version)
+                        # Consumer-owned wire version (#1788) — THIS is the
+                        # #1788 path: a baseline loss makes the Rust ``version``
+                        # non-sequential, but ``wire_version`` stays monotonic so
+                        # the client accepts the html_update without recovery.
+                        # Allocate it BEFORE _arm_recovery (so _recovery_version
+                        # == this frame's version). The Rust ``version`` is still
+                        # used below for the DJE-053 warning + telemetry reason.
+                        wire_version = self._next_version()
+                        self._arm_recovery(html)
 
                         # Batch strip + extract into a single thread hop
                         # to avoid two separate sync_to_async crossings.
@@ -3831,7 +3900,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
 
                         await self._send_update(
                             html=html_content,
-                            version=version,
+                            version=wire_version,  # consumer-owned (#1788)
                             cache_request_id=cache_request_id,
                             reset_form=should_reset_form,
                             event_name=event_name,
@@ -4319,10 +4388,17 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                     )
                     return
 
-                # Send the patches to the client
+                # Send the patches to the client.
+                # HIDDEN #1 (#1788): the hotreload patch frame is EXEMPT from the
+                # client version *check* (``!data.hotreload`` in
+                # ``02-response-handler.js:58``) but it still WRITES
+                # ``clientVdomVersion = data.version`` (line 77). So it MUST stamp
+                # the consumer counter — otherwise the NEXT normal event would be
+                # rejected against a stale client version. The separate
+                # ``_hvr_version`` (``hvr-applied`` telemetry frame) is untouched.
                 await self._send_update(
                     patches=patches,
-                    version=version,
+                    version=self._next_version(),  # consumer-owned (#1788, HIDDEN #1)
                     hotreload=True,
                     file_path=file_path,
                 )
@@ -4717,21 +4793,30 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             await self.send_error("View not mounted")
             return
 
+        # The html_recovery frame carries the CONSUMER version of the frame it
+        # replaces (#1788): the client sets ``clientVdomVersion = data.version``
+        # directly on html_recovery (``static/djust/src/03-websocket.js:727``),
+        # so it MUST equal ``_recovery_version`` (captured by _arm_recovery from
+        # _last_sent_version). The fresh re-render below produces a NEW Rust
+        # version which is DISCARDED for the wire — sending it would desync the
+        # client against the consumer counter.
         version = getattr(self, "_recovery_version", 0)
 
         if self._has_live_sticky_children():
             # Re-render the parent fresh so the recovery HTML reflects the live
             # sticky child's CURRENT state (#1813). Mirrors the sync/render
             # sequence used by the async-result path (sync state to Rust, then
-            # render_with_diff for the full raw HTML).
+            # render_with_diff for the full raw HTML). The fresh Rust version is
+            # DISCARDED (#1788) — only the HTML is taken; ``version`` stays the
+            # consumer-owned ``_recovery_version``.
             def _sync_and_render():
                 if hasattr(self.view_instance, "_sync_state_to_rust"):
                     self.view_instance._sync_state_to_rust()
-                fresh_html, _patches, fresh_version = self.view_instance.render_with_diff()
-                return fresh_html, fresh_version
+                fresh_html, _patches, _fresh_version = self.view_instance.render_with_diff()
+                return fresh_html
 
             try:
-                html, version = await sync_to_async(_sync_and_render)()
+                html = await sync_to_async(_sync_and_render)()
             except Exception:  # noqa: BLE001 — fall back to cached snapshot
                 logger.exception(
                     "[djust] request_html fresh re-render failed; falling back "
@@ -4937,7 +5022,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             await self._send_update(
                 patches=patch_list,
                 html=html,
-                version=version,
+                version=self._next_version(),  # consumer-owned (#1788)
                 event_name="__time_travel_jump__",
             )
         except Exception as exc:  # noqa: BLE001 — dev-only, log + report
@@ -5010,7 +5095,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             await self._send_update(
                 patches=patch_list,
                 html=html,
-                version=version,
+                version=self._next_version(),  # consumer-owned (#1788)
                 event_name="__time_travel_component_jump__",
             )
         except Exception as exc:  # noqa: BLE001 — dev-only, log + report
@@ -5102,7 +5187,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             await self._send_update(
                 patches=patch_list,
                 html=html,
-                version=version,
+                version=self._next_version(),  # consumer-owned (#1788)
                 event_name="__forward_replay__",
             )
         except Exception as exc:  # noqa: BLE001 — dev-only, log + report
@@ -5235,10 +5320,14 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                     # handle_event. Without this, request_html after a failed
                     # broadcast-triggered patch finds _recovery_html=None and
                     # forces a page reload. See #1202.
-                    self._arm_recovery(html, version)
+                    # Consumer-owned wire version (#1788); order: _next_version()
+                    # THEN _arm_recovery (so _recovery_version == this frame's
+                    # version).
+                    wire_version = self._next_version()
+                    self._arm_recovery(html)
                     await self._send_update(
                         patches=patches,
-                        version=version,
+                        version=wire_version,
                         broadcast=True,
                         source="broadcast",
                     )
@@ -5347,7 +5436,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         patches = fast_json_loads(patches)
                     await self._send_update(
                         patches=patches,
-                        version=version,
+                        version=self._next_version(),  # consumer-owned (#1788)
                         broadcast=True,
                         source="broadcast",
                     )
@@ -5440,7 +5529,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                                 patches = fast_json_loads(patches)
                             await self._send_update(
                                 patches=patches,
-                                version=version,
+                                version=self._next_version(),  # consumer-owned (#1788)
                                 event_name="tick",
                                 source="tick",
                             )

--- a/python/tests/test_hotreload.py
+++ b/python/tests/test_hotreload.py
@@ -163,7 +163,12 @@ class TestHotReloadMessage:
 
         assert call_args["type"] == "patch"
         assert call_args["patches"] == patches
-        assert call_args["version"] == 2
+        # #1788: the hotreload patch frame stamps the CONSUMER-owned wire version
+        # (1 — the first frame on this fresh consumer), NOT the Rust version (2).
+        # The hotreload path WRITES clientVdomVersion (02-response-handler.js:77)
+        # even though it's exempt from the version check, so it must use the
+        # consumer counter to keep subsequent events in sequence (HIDDEN #1).
+        assert call_args["version"] == 1
         assert call_args["hotreload"] is True
         assert call_args["file"] == "test.html"
 
@@ -436,7 +441,9 @@ class TestHotReloadIntegration:
 
         assert call_args["type"] == "patch"
         assert call_args["patches"] == patches
-        assert call_args["version"] == 3
+        # #1788: consumer-owned wire version (1 — first frame on this fresh
+        # consumer), decoupled from the Rust version (3). See HIDDEN #1.
+        assert call_args["version"] == 1
         assert call_args["hotreload"] is True
         assert call_args["file"] == "templates/index.html"
 

--- a/tests/unit/test_arm_recovery_helper_1645.py
+++ b/tests/unit/test_arm_recovery_helper_1645.py
@@ -19,7 +19,13 @@ from djust.websocket import LiveViewConsumer
 
 def test_arm_recovery_sets_both_fields():
     consumer = LiveViewConsumer()
-    consumer._arm_recovery("<div>x</div>", 7)
+    # #1788: _arm_recovery no longer takes a version arg — it captures the
+    # consumer's current _last_sent_version (the version of the frame being
+    # armed), so the html_recovery frame carries the consumer version of the
+    # frame it replaces (the client sets clientVdomVersion = data.version
+    # directly on html_recovery).
+    consumer._last_sent_version = 7
+    consumer._arm_recovery("<div>x</div>")
     assert consumer._recovery_html == "<div>x</div>"
     assert consumer._recovery_version == 7
 

--- a/tests/unit/test_async_recovery_html_1636.py
+++ b/tests/unit/test_async_recovery_html_1636.py
@@ -85,7 +85,11 @@ async def test_async_render_stores_recovery_html():
 
     consumer._send_update.assert_awaited_once()
     assert consumer._recovery_html == "<div>after-async</div>"
-    assert consumer._recovery_version == 42
+    # #1788: _recovery_version is now the CONSUMER-owned wire version
+    # (_last_sent_version after one _next_version() in this single async render),
+    # NOT the Rust version (42). Decoupling the wire version from the Rust
+    # baseline is the whole point of #1788.
+    assert consumer._recovery_version == 1
 
 
 @pytest.mark.asyncio
@@ -93,11 +97,14 @@ async def test_recovery_html_refreshed_across_multiple_async_renders():
     """Consecutive async renders must each refresh the recovery baseline so a
     stale earlier render is never served on a later recovery."""
     consumer = _make_consumer(None)
+    # #1788: use NON-sequential Rust versions (10, 20, 30) to prove the
+    # recovery version tracks the CONSUMER counter (1, 2, 3 across three
+    # renders), not the Rust version.
     consumer.view_instance.render_with_diff = MagicMock(
         side_effect=[
-            ("<div>first</div>", '[{"type":"SetText","v":1}]', 1),
-            ("<div>second</div>", '[{"type":"SetText","v":2}]', 2),
-            ("<div>third</div>", '[{"type":"SetText","v":3}]', 3),
+            ("<div>first</div>", '[{"type":"SetText","v":1}]', 10),
+            ("<div>second</div>", '[{"type":"SetText","v":2}]', 20),
+            ("<div>third</div>", '[{"type":"SetText","v":3}]', 30),
         ]
     )
 
@@ -105,6 +112,7 @@ async def test_recovery_html_refreshed_across_multiple_async_renders():
         await _run(consumer)
 
     assert consumer._recovery_html == "<div>third</div>"
+    # Consumer counter after 3 renders == 3 (decoupled from Rust version 30).
     assert consumer._recovery_version == 3
 
 
@@ -119,7 +127,8 @@ async def test_async_full_html_fallback_stores_recovery_html():
     consumer._send_update.assert_awaited_once()
     # The async else-branch sends full HTML; recovery baseline must match it.
     assert consumer._recovery_html == "<div>full-html-fallback</div>"
-    assert consumer._recovery_version == 7
+    # #1788: consumer-owned wire version (1 after one render), not Rust 7.
+    assert consumer._recovery_version == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_server_push.py
+++ b/tests/unit/test_server_push.py
@@ -197,18 +197,22 @@ class TestServerPushHandler:
         await consumer.server_push({"state": {"x": 1}, "handler": None, "payload": None})
 
         assert consumer._recovery_html == "<div>rendered-after-push</div>"
-        assert consumer._recovery_version == 42
+        # #1788: _recovery_version is the CONSUMER-owned wire version (1 after a
+        # single push), decoupled from the Rust version (42).
+        assert consumer._recovery_version == 1
 
     @pytest.mark.asyncio
     async def test_recovery_html_refreshed_across_multiple_pushes(self):
         """Consecutive pushes must each refresh _recovery_html so a stale
         render from an earlier broadcast isn't served on a later recovery."""
         consumer = self._make_consumer()
+        # #1788: NON-sequential Rust versions (10, 20, 30) prove the recovery
+        # version tracks the CONSUMER counter (1, 2, 3 across three pushes).
         consumer.view_instance.render_with_diff = MagicMock(
             side_effect=[
-                ("<div>first</div>", '[{"op":"replace","v":"first"}]', 1),
-                ("<div>second</div>", '[{"op":"replace","v":"second"}]', 2),
-                ("<div>third</div>", '[{"op":"replace","v":"third"}]', 3),
+                ("<div>first</div>", '[{"op":"replace","v":"first"}]', 10),
+                ("<div>second</div>", '[{"op":"replace","v":"second"}]', 20),
+                ("<div>third</div>", '[{"op":"replace","v":"third"}]', 30),
             ]
         )
 
@@ -216,6 +220,7 @@ class TestServerPushHandler:
             await consumer.server_push({"state": {"x": 1}, "handler": None, "payload": None})
 
         assert consumer._recovery_html == "<div>third</div>"
+        # Consumer counter after 3 pushes == 3 (decoupled from Rust version 30).
         assert consumer._recovery_version == 3
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #1788. The WebSocket wire `version` stamped on every client-checked frame was the Rust view's internal `self.version`, coupled to the Rust-view object's **baseline lifetime** rather than the connection. On a mid-session VDOM baseline loss (e.g. the patch-compression `_rust_view.reset()` path sets `version=0` + `last_vdom=None`), the next `render_with_diff` returns `(html, patches=None, version=1)` — a **non-sequential** version that fails the client's `clientVdomVersion === data.version - 1` check (`02-response-handler.js:58`), forcing an `html_update` → `request_html` recovery round-trip (a full page reload before #1785).

The **consumer** now owns a monotonic per-connection counter (`_last_sent_version`, exposed via `_next_version()`) — the single source of truth for the wire version on **every** client-checked send path. The wire sequence stays strictly monotonic across a Rust baseline reset, so a post-baseline-loss `html_update` satisfies the client check and is accepted directly with **no recovery round-trip**. Rust `lib.rs` is untouched (its counter still drives diff-baselining).

## Reproduce-first (verified)

`python/djust/tests/test_ws_send_version_1788.py` uses real `WebsocketCommunicator` round-trips. The drift is reproduced via the **true** trigger `view_instance._rust_view.reset()` — NOT `_force_full_html=True`, which keeps `last_vdom` and increments sequentially (it would false-pass). Before the fix the baseline-loss `html_update` carried Rust `version=1` while the client expected `version=3`; after the fix it carries the monotonic consumer version `3`.

**Gate-off (#1468):** reverting the handle_event html-fallback `_send_update` to stamp the Rust `version` makes the strict-sequence guard fail with `[1, 2, 1, 4]` (discontinuity at the baseline-loss boundary) — the recovery storm. Restored; all 7 new tests green.

## Migrated send paths (file:line at merge time)

All client-checked frames that write `clientVdomVersion@77`:

| Path | Site |
|---|---|
| `handle_event` patch + html fallback (**THE #1788 path**) | `websocket.py` ~3791 / ~3828 |
| `_run_async_work` success arms (×2) + error arms (×2) | ~974/995, ~1033/1048 |
| `_dispatch_single_event` (×2) | ~1355/1379 |
| actor event path (ignore `result['version']`) | ~2976 |
| mount frame (covers actor mount; client baseline = 1) | `handle_mount` ~2403 |
| `server_push` | ~5321 |
| `db_notify` | ~5434 |
| `_run_tick` | ~5527 |
| `time_travel_jump` / `_component_jump` / `forward_replay` | ~5020/5093/5185 |
| **HIDDEN #1** — HVR patch frame (`hotreload`) | `websocket.py` ~4396 |
| **HIDDEN #2** — `StreamingMixin.push_state` (bypasses `_send_update`) | `streaming.py` ~287/297 |

`_arm_recovery` now captures `_last_sent_version` (the consumer version of the frame it arms), so the `html_recovery` frame — which the client applies via `clientVdomVersion = data.version` directly (`03-websocket.js:727`) — carries the right version. `handle_request_html`'s sticky fresh-re-render **discards** the fresh Rust version. `_next_version()`/`_arm_recovery` read via `getattr` so partial-construct test fakes still get a valid sequence.

## Out of scope (confirmed untouched)

- `child_update`/`sticky_update` — per-child `clientVdomVersions` Map.
- `mount_batch` per-target `_clientVdomVersions` object. **CONFIRM-DON'T-FIX:** a mount_batch'd view's later events route through the main `handle_event`/`clientVdomVersion` seam, which the client lazily inits from the first event after a batch. This change keeps the batch mount versions monotonic per-connection but the client never feeds them into the main check, so the seam is **neither fixed nor worsened**.
- `noop`/`embedded_update` (no version field), SSE (separate transport), Rust `lib.rs`.

## No client change

The client only does relative `version - 1` checks and direct `clientVdomVersion = data.version` writes — no absolute-version expectations. This is a server-side source change that preserves the same relative sequence (mount=1, event=2, …).

## Tests

- New: `python/djust/tests/test_ws_send_version_1788.py` (7 tests).
- Updated `_recovery_version` assertions (now consumer-owned, decoupled from Rust version) in `test_arm_recovery_helper_1645`, `test_async_recovery_html_1636`, `test_server_push`; HVR version assertions in `test_hotreload`.
- Full local suite shows **zero net regressions** vs the `origin/main` baseline (the repo has a pre-existing local-runner collection artifact identical on both branches; CI is authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)