### PR TITLE
fix(docs): subclass LiveView in examples — auto-included mixins crash MRO

### DIFF
--- a/docs/ai/loading-states.md
+++ b/docs/ai/loading-states.md
@@ -31,10 +31,12 @@
 
 ```python
 from djust import LiveView
-from djust.mixins.async_work import AsyncWorkMixin
 from djust.decorators import event_handler
 
-class MyView(AsyncWorkMixin, LiveView):
+# AsyncWorkMixin is already included in LiveView — just subclass LiveView.
+# (Inheriting it explicitly, e.g. `class MyView(AsyncWorkMixin, LiveView)`, raises
+#  TypeError: Cannot create a consistent method resolution.)
+class MyView(LiveView):
     def mount(self, request, **kwargs):
         self.loading = False
         self.result = ""
@@ -81,7 +83,7 @@ def _do_work(self):
 ## Complete Example
 
 ```python
-class ReportView(AsyncWorkMixin, LiveView):
+class ReportView(LiveView):  # AsyncWorkMixin is built into LiveView
     template_name = "report.html"
 
     def mount(self, request, **kwargs):

--- a/docs/guides/navigation.md
+++ b/docs/guides/navigation.md
@@ -11,14 +11,18 @@ djust provides `live_patch()` and `live_redirect()` for managing URL state witho
 
 ## Quick Start
 
-### 1. Add NavigationMixin to your view
+### 1. Subclass LiveView (navigation is built in)
+
+`NavigationMixin` is already included in `LiveView`, so its navigation helpers are always
+available — just subclass `LiveView`. Do **not** also inherit `NavigationMixin`
+(`class ProductListView(NavigationMixin, LiveView)`): it is already in `LiveView`'s bases, so
+that raises `TypeError: Cannot create a consistent method resolution`.
 
 ```python
 from djust import LiveView
-from djust.mixins.navigation import NavigationMixin
 from djust.decorators import event_handler
 
-class ProductListView(NavigationMixin, LiveView):
+class ProductListView(LiveView):
     template_name = 'products/list.html'
 
     def mount(self, request, **kwargs):
@@ -149,7 +153,7 @@ Declarative `live_redirect`. On click, navigates to a different view over the We
 ### Filtering with URL Params
 
 ```python
-class SearchView(NavigationMixin, LiveView):
+class SearchView(LiveView):  # navigation is built in — no NavigationMixin needed
     template_name = 'search.html'
 
     def mount(self, request, **kwargs):
@@ -196,7 +200,7 @@ class SearchView(NavigationMixin, LiveView):
 ### Multi-Page App Navigation
 
 ```python
-class DashboardView(NavigationMixin, LiveView):
+class DashboardView(LiveView):  # navigation is built in — no NavigationMixin needed
     template_name = 'dashboard.html'
 
     def mount(self, request, **kwargs):

--- a/docs/guides/streaming.md
+++ b/docs/guides/streaming.md
@@ -13,14 +13,18 @@ djust's streaming system enables token-by-token updates for LLM chat responses, 
 
 ## Quick Start
 
-### 1. Add StreamingMixin to your view
+### 1. Subclass LiveView (streaming is built in)
+
+`StreamingMixin` is already included in `LiveView`, so the `stream_*` methods are always
+available — just subclass `LiveView`. Do **not** also inherit `StreamingMixin`
+(`class ChatView(StreamingMixin, LiveView)`): it is already in `LiveView`'s bases, so that
+raises `TypeError: Cannot create a consistent method resolution`.
 
 ```python
 from djust import LiveView
-from djust.streaming import StreamingMixin
 from djust.decorators import event_handler
 
-class ChatView(StreamingMixin, LiveView):
+class ChatView(LiveView):
     template_name = 'chat.html'
 
     async def mount(self, request, **kwargs):
@@ -200,7 +204,7 @@ document.querySelector('[dj-stream="output"]')
 ### LLM Chat with Error Handling
 
 ```python
-class AIChat(StreamingMixin, LiveView):
+class AIChat(LiveView):  # streaming is built in — no StreamingMixin needed
     template_name = 'ai_chat.html'
 
     async def mount(self, request, **kwargs):
@@ -250,7 +254,7 @@ class AIChat(StreamingMixin, LiveView):
 ### Live Log Viewer
 
 ```python
-class LogViewer(StreamingMixin, LiveView):
+class LogViewer(LiveView):  # streaming is built in — no StreamingMixin needed
     template_name = 'logs.html'
 
     async def mount(self, request, **kwargs):

--- a/docs/website/guides/loading-states.md
+++ b/docs/website/guides/loading-states.md
@@ -107,11 +107,13 @@ When an event handler does slow work (API calls, AI generation, file processing)
 
 ```python
 from djust import LiveView
-from djust.mixins.async_work import AsyncWorkMixin
 from djust.decorators import event_handler
 
 
-class ReportView(AsyncWorkMixin, LiveView):
+# AsyncWorkMixin is already included in LiveView — just subclass LiveView.
+# (Inheriting it explicitly, e.g. `class ReportView(AsyncWorkMixin, LiveView)`, raises
+#  TypeError: Cannot create a consistent method resolution.)
+class ReportView(LiveView):
     template_name = "report.html"
 
     def mount(self, request, **kwargs):
@@ -359,10 +361,10 @@ For simple text replacement on submit buttons, use `dj-disable-with` instead of 
 
 ### Progress with Streaming
 
-For operations where you want incremental progress (not just a spinner), combine `start_async()` with [StreamingMixin](streaming.md):
+For operations where you want incremental progress (not just a spinner), combine `start_async()` with the [streaming](streaming.md) helpers. Both `AsyncWorkMixin` and `StreamingMixin` are already built into `LiveView`, so just subclass `LiveView` — do not inherit them explicitly (it raises an MRO `TypeError`):
 
 ```python
-class ImportView(AsyncWorkMixin, StreamingMixin, LiveView):
+class ImportView(LiveView):  # AsyncWorkMixin + StreamingMixin are built in
     @event_handler()
     def start_import(self, **kwargs):
         self.importing = True

--- a/docs/website/guides/navigation.md
+++ b/docs/website/guides/navigation.md
@@ -20,14 +20,18 @@ djust provides `live_patch()` and `live_redirect()` for managing URL state witho
 
 ## Quick Start
 
-### 1. Add NavigationMixin to Your View
+### 1. Subclass LiveView (navigation is built in)
+
+`NavigationMixin` is already included in `LiveView`, so its navigation helpers are always
+available — just subclass `LiveView`. Do **not** also inherit `NavigationMixin`
+(`class ProductListView(NavigationMixin, LiveView)`): it is already in `LiveView`'s bases, so
+that raises `TypeError: Cannot create a consistent method resolution`.
 
 ```python
 from djust import LiveView
-from djust.mixins.navigation import NavigationMixin
 from djust.decorators import event_handler
 
-class ProductListView(NavigationMixin, LiveView):
+class ProductListView(LiveView):
     template_name = 'products/list.html'
 
     def mount(self, request, **kwargs):
@@ -215,7 +219,7 @@ contract. `dj-navigate` remains the explicit, always-on way to mark a single SPA
 ## Example: Search with URL State
 
 ```python
-class SearchView(NavigationMixin, LiveView):
+class SearchView(LiveView):  # navigation is built in — no NavigationMixin needed
     template_name = 'search.html'
 
     def mount(self, request, **kwargs):
@@ -343,7 +347,7 @@ def switch_view(self, view="", **kwargs):
 ```
 
 ```python
-class DashboardView(NavigationMixin, LiveView):
+class DashboardView(LiveView):  # navigation is built in — no NavigationMixin needed
     template_name = 'dashboard.html'
     VALID_TABS = {"overview", "settings", "logs"}
 

--- a/docs/website/guides/streaming.md
+++ b/docs/website/guides/streaming.md
@@ -22,14 +22,18 @@ djust's streaming system enables token-by-token updates for LLM chat responses, 
 
 ## Quick Start
 
-### 1. Add StreamingMixin to Your View
+### 1. Subclass LiveView (streaming is built in)
+
+`StreamingMixin` is already included in `LiveView`, so the `stream_*` methods are
+always available — just subclass `LiveView`. Do **not** also inherit `StreamingMixin`
+(e.g. `class ChatView(StreamingMixin, LiveView)`); because it is already in `LiveView`'s
+bases, that raises `TypeError: Cannot create a consistent method resolution`.
 
 ```python
 from djust import LiveView
-from djust.streaming import StreamingMixin
 from djust.decorators import event_handler
 
-class ChatView(StreamingMixin, LiveView):
+class ChatView(LiveView):
     template_name = 'chat.html'
 
     async def mount(self, request, **kwargs):
@@ -150,7 +154,7 @@ document.querySelector('[dj-stream="output"]')
 ## Full Example: LLM Chat with Error Handling
 
 ```python
-class AIChat(StreamingMixin, LiveView):
+class AIChat(LiveView):  # streaming is built in — no StreamingMixin needed
     template_name = 'ai_chat.html'
 
     async def mount(self, request, **kwargs):


### PR DESCRIPTION
## Problem

`LiveView` already includes a stack of mixins in its bases (`StreamingMixin`,
`StreamsMixin`, `NavigationMixin`, `AsyncWorkMixin`, `ModelBindingMixin`, … — the
full `LiveView.__mro__`). Several guide examples inherit one of these **before**
`LiveView`:

```python
class ChatView(StreamingMixin, LiveView):   # ❌
```

Because the mixin is already an ancestor of `LiveView`, Python can't linearize the
bases and raises at class-definition time:

```
TypeError: Cannot create a consistent method resolution order (MRO) for bases StreamingMixin, LiveView
```

A reader who copies the example gets a view that won't even import.
(`class X(LiveView, StreamingMixin)` — LiveView first — happens to work, but the
guides teach the crashing order.)

## Fix

Subclass `LiveView` only — the `stream_*` / navigation / async helpers are available
without re-inheriting — and drop the now-unnecessary mixin imports. Verified
empirically: every rewritten base list constructs without error; each original
raises the MRO `TypeError`.

## Sites (15 across 6 files)

- `docs/guides/streaming.md`, `docs/website/guides/streaming.md` — `StreamingMixin` (×5)
- `docs/guides/navigation.md`, `docs/website/guides/navigation.md` — `NavigationMixin` (×6)
- `docs/ai/loading-states.md`, `docs/website/guides/loading-states.md` — `AsyncWorkMixin` (×4, incl. one `AsyncWorkMixin, StreamingMixin, LiveView`)

> `docs/guides/BEST_PRACTICES.md:787` has the same issue but is omitted from this PR
> because that file currently has unrelated in-progress edits; the one-line fix will
> land alongside those.

The ADR examples that use `class X(LiveView, StreamingMixin)` (LiveView first) are
left as-is — that order is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
