### PR TITLE
feat(checks): S007 flags client_name|safe stored-XSS pattern (#1821)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **System check S007 — unsafe ``client_name|safe`` stored-XSS detection
+  (#1821).** A new template static-analysis check (severity WARNING) flags
+  ``{{ <expr>.client_name|safe }}`` patterns in template files. An upload
+  entry's ``client_name`` is the attacker-controlled original filename, stored
+  without sanitisation; auto-escaping is the only default protection, and
+  ``|safe`` bypasses it — turning a ``<script>``-bearing filename into a stored
+  XSS vector. The matcher is anchored on the ``{{ ... }}`` variable form (not a
+  bare substring), tolerates whitespace around the pipe, and word-boundary
+  guards reject ``notclient_name`` / ``client_name_foo``. Honours
+  ``DJUST_CONFIG['suppress_checks']`` (``S007`` or ``djust.S007``). New cases in
+  ``TestS007ClientNameSafeRegex`` and ``TestS007CheckIntegration`` in
+  ``python/tests/test_checks.py``.
+
 ### Fixed
 
 - **Consumer-owned monotonic VDOM send-version (#1788).** The WebSocket

--- a/docs/guides/error-codes.md
+++ b/docs/guides/error-codes.md
@@ -536,6 +536,42 @@ class PublicCounterView(LiveView):
 
 ---
 
+### S007: Unsafe rendering of a client-supplied filename
+
+**Severity**: Warning
+
+**What causes it**: A template renders an upload entry's `client_name` with the
+`|safe` filter, e.g. `{{ upload_entry.client_name|safe }}`. The `client_name` is
+the attacker-controlled original filename of an upload, stored without
+sanitisation; `|safe` disables Django's auto-escaping, so a filename containing
+`<script>...</script>` renders as live HTML — a **stored XSS** vector.
+
+**Fix**: Remove the `|safe` filter so auto-escaping (the safe default) applies:
+
+```html
+<!-- Unsafe: filename is attacker-controlled -->
+{{ upload_entry.client_name|safe }}
+
+<!-- Safe: auto-escaping neutralises HTML in the filename -->
+{{ upload_entry.client_name }}
+```
+
+If the value is genuinely pre-sanitised server-side, escape it explicitly with
+`django.utils.html.escape()` before rendering, or suppress the check:
+
+```python
+# settings.py — only if client_name is pre-sanitised
+DJUST_CONFIG = {"suppress_checks": ["S007"]}  # or "djust.S007"
+```
+
+**Detection**: matches `{{ <expr>.client_name|safe }}` (whitespace around `|`
+tolerated); word-boundary guards mean `notclient_name` and `client_name_foo` do
+not trigger it.
+
+**Related**: [#1821](https://github.com/djust-org/djust/issues/1821), S001 (`mark_safe()` with f-string)
+
+---
+
 ## Template Errors (T0xx)
 
 ### T001: Deprecated @event syntax

--- a/docs/system-checks.md
+++ b/docs/system-checks.md
@@ -32,6 +32,7 @@ Run checks with: `python manage.py check --deploy` or `python manage.py djust_ch
 | S003 | Security | Warning | Bare except: pass swallows all exceptions |
 | S004 | Security | Warning | DEBUG=True with non-localhost ALLOWED_HOSTS |
 | S005 | Security | Warning | LiveView exposes state without authentication |
+| S007 | Security | Warning | `client_name\|safe` renders an unsanitised upload filename (stored XSS) |
 | T001 | Templates | Warning | Deprecated @click/@input syntax |
 | T002 | Templates | Info | LiveView template missing dj-root |
 | T003 | Templates | Info | wrapper_template uses {% include %} instead of liveview_content |
@@ -299,6 +300,21 @@ Added in v1.0.0 (#1605). The older mechanism (`SILENCED_SYSTEM_CHECKS` / `DJUST_
 - **What it detects**: LiveView `mount()` does not check `request.user.is_authenticated`
 - **Suppression**: `SILENCED_SYSTEM_CHECKS = ["djust.S005"]`
 - **False positives**: Intentionally public views (anonymous landing pages, public dashboards)
+
+### S007 — `client_name|safe` renders an unsanitised upload filename
+- **Severity**: Warning
+- **Method**: Template scan (regex over template files)
+- **What it detects**: `{{ <expr>.client_name|safe }}` (whitespace around `|` is
+  tolerated). An upload entry's `client_name` is the attacker-controlled
+  original filename, stored without sanitisation. `|safe` disables Django's
+  auto-escaping, so a `<script>`-bearing filename renders as live HTML —
+  a stored-XSS vector.
+- **Fix**: Remove `|safe` (auto-escaping is the safe default), or sanitise the
+  value first with `django.utils.html.escape()`.
+- **Suppression**: `DJUST_CONFIG = {'suppress_checks': ['S007']}` (or
+  `'djust.S007'`) — only when the rendered value is pre-sanitised.
+- **False positives**: A `client_name` value that has already been sanitised
+  server-side before reaching the template.
 
 ---
 

--- a/python/djust/checks.py
+++ b/python/djust/checks.py
@@ -2672,6 +2672,22 @@ _DJ_ACTIVITY_NAME_RE = re.compile(
 _DJ_ROOT_RE = re.compile(r"dj-root")
 _INCLUDE_RE = re.compile(r"\{%\s*include\s+")
 _LIVEVIEW_CONTENT_RE = re.compile(r"\{\{\s*liveview_content\s*\|\s*safe\s*\}\}")
+# S007 (#1821) — `{{ <expr>.client_name|safe }}` stored-XSS scanner. Upload
+# entries (djust.uploads.UploadEntry, field defined at uploads/__init__.py:483)
+# store the client-supplied filename UNSANITISED — auto-escaping is the only
+# thing protecting templates that render `client_name`. Marking it `|safe`
+# bypasses that protection, so an attacker-controlled filename containing
+# `<script>...</script>` becomes a stored-XSS vector. We anchor on the
+# `{{ ... }}` variable form (NOT a bare `client_name|safe` substring) and
+# require `client_name` to be the rendered variable or its trailing attribute:
+#   - `[\w.]*\bclient_name` matches `entry.client_name`,
+#     `upload_entry.client_name`, `obj.uploads.0.client_name`, and bare
+#     `client_name`.
+#   - The `\b` word boundary rejects `notclient_name`; the trailing `\s*\|`
+#     rejects `client_name_foo` (a different attribute sharing the prefix).
+# Whitespace around `|` is tolerated (mirrors _LIVEVIEW_CONTENT_RE), so both
+# `client_name|safe` and `client_name | safe` are flagged.
+_CLIENT_NAME_SAFE_RE = re.compile(r"\{\{\s*[\w.]*\bclient_name\s*\|\s*safe\s*\}\}")
 # T004 (#1809) — `document.addEventListener('djust:...')`. The matcher captures
 # the event name (group 1) so the emission site can exempt the djust: events
 # that djust itself dispatches on `document` (see _DOC_DISPATCHED_DJUST_EVENTS).
@@ -3200,6 +3216,37 @@ def check_templates(app_configs, **kwargs):
                     line_number=lineno,
                 )
             )
+
+        # S007 (#1821) -- `{{ <expr>.client_name|safe }}` stored-XSS.
+        # An upload entry's `client_name` is the attacker-controlled original
+        # filename, stored without sanitisation; `|safe` disables Django's
+        # auto-escaping, so a `<script>`-bearing filename renders as live HTML.
+        # WARNING (not Error): a pre-sanitised value is a legitimate, if rare,
+        # use case. Honours DJUST_CONFIG['suppress_checks'] (mirrors T004/S004).
+        if not _is_check_suppressed("djust.S007"):
+            for match in _CLIENT_NAME_SAFE_RE.finditer(content):
+                lineno = content[: match.start()].count("\n") + 1
+                errors.append(
+                    DjustWarning(
+                        "%s:%d -- potentially unsafe rendering of client-supplied "
+                        "filename. `client_name` is user-controlled — using `|safe` "
+                        "bypasses XSS protection." % (relpath, lineno),
+                        hint=(
+                            "Use auto-escaping (remove `|safe`) or explicitly "
+                            "sanitize with django.utils.html.escape() first. "
+                            "Suppress with DJUST_CONFIG = {'suppress_checks': "
+                            "['S007']} if the value is pre-sanitised."
+                        ),
+                        id="djust.S007",
+                        fix_hint=(
+                            "Remove the `|safe` filter from `client_name` at "
+                            "line %d in `%s` (auto-escaping is the safe default)."
+                            % (lineno, relpath)
+                        ),
+                        file_path=filepath,
+                        line_number=lineno,
+                    )
+                )
 
         # T002 -- LiveView template missing dj-root (informational)
         # Since PR #297, dj-root is auto-inferred from dj-view on both

--- a/python/tests/test_checks.py
+++ b/python/tests/test_checks.py
@@ -4711,3 +4711,125 @@ class TestParsePsycopgVersion:
         from djust.checks import _parse_psycopg_version
 
         assert _parse_psycopg_version("not-a-version") == (0, 0)
+
+
+class TestS007ClientNameSafeRegex:
+    """S007 (#1821) -- regex unit tests for `client_name|safe` detection.
+
+    The matcher is anchored on the `{{ ... }}` variable form (NOT a bare
+    substring) and tolerates whitespace around `|` (mirrors _LIVEVIEW_CONTENT_RE).
+    """
+
+    def test_matches_upload_entry_dotted(self):
+        from djust.checks import _CLIENT_NAME_SAFE_RE
+
+        assert _CLIENT_NAME_SAFE_RE.search("{{ upload_entry.client_name|safe }}")
+
+    def test_matches_short_alias_dotted(self):
+        from djust.checks import _CLIENT_NAME_SAFE_RE
+
+        assert _CLIENT_NAME_SAFE_RE.search("{{ entry.client_name|safe }}")
+
+    def test_matches_whitespace_around_pipe(self):
+        from djust.checks import _CLIENT_NAME_SAFE_RE
+
+        assert _CLIENT_NAME_SAFE_RE.search("{{ entry.client_name | safe }}")
+
+    def test_matches_deeply_nested_path(self):
+        from djust.checks import _CLIENT_NAME_SAFE_RE
+
+        assert _CLIENT_NAME_SAFE_RE.search("{{ obj.uploads.0.client_name|safe }}")
+
+    def test_matches_bare_client_name(self):
+        from djust.checks import _CLIENT_NAME_SAFE_RE
+
+        assert _CLIENT_NAME_SAFE_RE.search("{{client_name|safe}}")
+
+    def test_no_match_without_safe(self):
+        from djust.checks import _CLIENT_NAME_SAFE_RE
+
+        assert not _CLIENT_NAME_SAFE_RE.search("{{ upload_entry.client_name }}")
+
+    def test_no_match_other_var(self):
+        from djust.checks import _CLIENT_NAME_SAFE_RE
+
+        assert not _CLIENT_NAME_SAFE_RE.search("{{ other_var|safe }}")
+
+    def test_no_match_word_boundary(self):
+        """`notclient_name` is a different variable -- must NOT match."""
+        from djust.checks import _CLIENT_NAME_SAFE_RE
+
+        assert not _CLIENT_NAME_SAFE_RE.search("{{ notclient_name|safe }}")
+
+    def test_no_match_trailing_attr(self):
+        """`client_name_foo` shares a prefix but is a different attribute."""
+        from djust.checks import _CLIENT_NAME_SAFE_RE
+
+        assert not _CLIENT_NAME_SAFE_RE.search("{{ entry.client_name_foo|safe }}")
+
+    def test_no_match_other_filter(self):
+        from djust.checks import _CLIENT_NAME_SAFE_RE
+
+        assert not _CLIENT_NAME_SAFE_RE.search("{{ entry.client_name|escape }}")
+
+
+class TestS007CheckIntegration:
+    """S007 (#1821) -- EMPIRICAL CANARY (#1459): construct the stored-XSS
+    template shape and assert the check FIRES; construct the safe shapes and
+    assert it does NOT fire. Plus suppression (#1468 gate-off: disabling the
+    S007 emission makes the positive tests fail)."""
+
+    def _scan(self, tmp_path, settings, body):
+        tpl_dir = tmp_path / "templates"
+        tpl_dir.mkdir(parents=True)
+        (tpl_dir / "uploads.html").write_text(body)
+        settings.TEMPLATES = [
+            {
+                "DIRS": [str(tpl_dir)],
+                "BACKEND": "django.template.backends.django.DjangoTemplateBackend",
+            }
+        ]
+        from djust.checks import check_templates
+
+        errors = check_templates(None)
+        return [e for e in errors if e.id == "djust.S007"]
+
+    def test_s007_fires_on_client_name_safe(self, tmp_path, settings):
+        """CANARY positive: `{{ upload_entry.client_name|safe }}` -> S007 fires."""
+        s007 = self._scan(tmp_path, settings, "<p>{{ upload_entry.client_name|safe }}</p>")
+        assert len(s007) == 1, "S007 should fire for client_name|safe: %r" % s007
+        assert "client_name" in s007[0].msg
+        assert "user-controlled" in s007[0].msg
+        assert s007[0].line_number == 1
+
+    def test_s007_silent_without_safe(self, tmp_path, settings):
+        """CANARY negative: no `|safe` -> auto-escaping protects -> no S007."""
+        s007 = self._scan(tmp_path, settings, "<p>{{ upload_entry.client_name }}</p>")
+        assert s007 == [], "S007 must NOT fire without |safe: %r" % s007
+
+    def test_s007_silent_for_other_var(self, tmp_path, settings):
+        """CANARY negative: a different var with |safe is not client_name."""
+        s007 = self._scan(tmp_path, settings, "<p>{{ other_var|safe }}</p>")
+        assert s007 == [], "S007 must NOT fire for a non-client_name var: %r" % s007
+
+    def test_s007_fires_whitespace_variant(self, tmp_path, settings):
+        """CANARY positive: `{{ entry.client_name | safe }}` (spaced pipe) fires."""
+        s007 = self._scan(tmp_path, settings, "<p>{{ entry.client_name | safe }}</p>")
+        assert len(s007) == 1, "S007 should fire for the spaced-pipe variant: %r" % s007
+
+    def test_s007_reports_correct_line(self, tmp_path, settings):
+        """Line number points at the offending {{ ... }} expression."""
+        body = "<div>\n  <span>ok</span>\n  {{ entry.client_name|safe }}\n</div>"
+        s007 = self._scan(tmp_path, settings, body)
+        assert len(s007) == 1
+        assert s007[0].line_number == 3
+
+    def test_s007_suppressed_short_id(self, tmp_path, settings):
+        settings.DJUST_CONFIG = {"suppress_checks": ["S007"]}
+        s007 = self._scan(tmp_path, settings, "<p>{{ upload_entry.client_name|safe }}</p>")
+        assert s007 == [], "S007 should be silenced by suppress_checks=['S007']: %r" % s007
+
+    def test_s007_suppressed_qualified_id(self, tmp_path, settings):
+        settings.DJUST_CONFIG = {"suppress_checks": ["djust.S007"]}
+        s007 = self._scan(tmp_path, settings, "<p>{{ upload_entry.client_name|safe }}</p>")
+        assert s007 == [], "S007 should be silenced by suppress_checks=['djust.S007']: %r" % s007


### PR DESCRIPTION
## Summary

Adds template static-analysis check **S007** (severity WARNING) that flags `{{ <expr>.client_name|safe }}` patterns in template files. Closes #1821.

An upload entry's `client_name` (`djust.uploads.UploadEntry`, field at `python/djust/uploads/__init__.py:483`) is the **attacker-controlled** original filename, stored without sanitisation. Auto-escaping is the only default protection; `|safe` bypasses it, turning a `<script>`-bearing filename into a **stored-XSS** vector.

## Implementation

- **Match pattern** (`_CLIENT_NAME_SAFE_RE` in `python/djust/checks.py`): `\{\{\s*[\w.]*\bclient_name\s*\|\s*safe\s*\}\}`
  - Anchored on the `{{ ... }}` variable form (not a bare substring), mirroring `_LIVEVIEW_CONTENT_RE`.
  - Tolerates whitespace around `|` (`client_name|safe` and `client_name | safe`).
  - Word boundary rejects `notclient_name`; trailing `\s*\|` rejects `client_name_foo`.
- **Emission site**: inside `check_templates` (the registered template-scan check), per-file loop, right after the T001 block. Honours `DJUST_CONFIG['suppress_checks']` via `_is_check_suppressed("djust.S007")` (accepts `S007` or `djust.S007`).
- `%s`-style message formatting throughout. Uses the issue's suggested message.

## Tests (`python/tests/test_checks.py`)

- **New cases in `TestS007ClientNameSafeRegex`** (10 regex unit cases): dotted/short/nested/bare positives; `without |safe`, other var, word-boundary, trailing-attr, wrong-filter negatives.
- **New cases in `TestS007CheckIntegration`** (7 cases): empirical-canary positives (`client_name|safe` fires; whitespace variant fires; line number), negatives (no `|safe`; other var), short + qualified-id suppression.

### Empirical canary (#1459) + gate-off (#1468)
- Positive: `{{ upload_entry.client_name|safe }}` → S007 fires (also verified end-to-end through `manage.py check` on a canary template).
- Negatives: no `|safe`, and `{{ other_var|safe }}` → silent.
- Suppression: `suppress_checks=['S007']` and `['djust.S007']` → silenced.
- **Gate-off**: disabling the emission (`if False and ...`) makes the 3 behaviour-meaningful positive integration tests fail — confirming non-tautological.

### Dogfood (#1060)
`manage.py check` against `examples/demo_project` reports **0 S007 findings** (68 total issues across all checks, none S007); the demo has no `client_name` in templates.

## Issue × file × test

| Issue | Files | Covering tests |
|-------|-------|----------------|
| #1821 | `python/djust/checks.py`, `docs/system-checks.md`, `docs/guides/error-codes.md`, `CHANGELOG.md` | `TestS007ClientNameSafeRegex` (10), `TestS007CheckIntegration` (7) in `python/tests/test_checks.py` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)