### PR TITLE
security(validation): audit + pin type-coercion edge cases (#1820)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Audited event-handler type-coercion edge cases — no bypass found, behavior pinned (#1820).** `validate_handler_params()` coerces event params by default (`coerce=True`) because Template `data-*` attributes always arrive as strings. The audit empirically exercised the malformed/adversarial inputs from the issue against the real coercion code and confirmed the paths are **safe by design** — no code change was required: **(int)** `page="999 OR 1=1"` and hex `id="0x41"` make `int()` raise, so the original string is kept and type validation rejects the event (`valid is False`, handler **not** invoked) — there is no silent truncation to `999`; **(bool)** the dangerous case — `active="true; DROP TABLE"` — coerces to `False` because bool coercion is an **allowlist** (`value.lower() in {"true","1","yes","on"}`), NOT `bool(non_empty_string)`, so the falsy-but-non-empty `"false"`/`"0"` are also `False` (no truthiness logic-bypass); **(float)** malformed strings are rejected, while `"1e309"`/`"inf"`/`"nan"` are accepted as the valid Python floats they are (intentional, documented contract — handlers doing bound checks or arithmetic on a coerced `float` must guard non-finite values themselves); **(List[T])** a malformed element abandons the whole coercion (no partial `[1,2]`) and the subscripted generic is skipped by the type validator, so the handler receives the unmodified original string. The strictest posture remains `@event_handler(coerce_types=False)`, which rejects any string for a typed param outright (so no separate `@strict_types` decorator was added). The audited contract is documented in `SECURITY_AUDIT.md` (Type Coercion Contract table) and pinned by `TestCoercionSecurityEdgeCases` (11 characterization cases) in `python/tests/test_validation.py`; non-tautology was verified (#1468) by mutating the coercion to the unsafe variants and confirming 5 of the new tests fail with the exact dangerous symptoms.
+
 ### Fixed
 
 - **Consumer-owned monotonic VDOM send-version (#1788).** The WebSocket

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -71,15 +71,15 @@ All handlers in `python/djust/websocket.py` process untrusted client data:
 - ✅ **Component lookup** (line 1088): Validates component exists before routing
 
 **Potential Issues**:
-- ⚠️ **Type coercion** (line 1017, 1108, 1149): `coerce=True` by default - could allow unexpected type conversions leading to logic bugs
-  - Example: Attacker sends `{"id": "999 OR 1=1"}` with coercion → might bypass validation if not careful
+- ✅ **Type coercion** (line 1017, 1108, 1149): `coerce=True` by default — AUDITED SAFE (#1820). Malformed strings (`"999 OR 1=1"`, hex `"0x41"`, `"3.14 OR 1=1"`) fail coercion (`int()`/`float()` raise), are kept as the original string, then rejected by type validation (`valid is False`) — the handler is NOT invoked. No silent truncation to `999`. See "Type Coercion Contract" below.
+  - Example: Attacker sends `{"id": "999 OR 1=1"}` with coercion → `int()` raises → event rejected, handler never runs.
 - ⚠️ **Positional args** (line 981): `params.pop("_args", [])` - arbitrary list merged into params - could override named params
 - ⚠️ **Embedded view routing** (line 989-1000): `view_id` lookup - what if view_id is a crafted string attempting injection?
-- 🔍 **Need to review**: `validate_handler_params()` implementation for edge cases
+- ✅ **Reviewed** (#1820): `validate_handler_params()` implementation edge cases — audited safe (see "Type Coercion Contract" below).
 
 **Test Coverage**:
 - ✅ `test_event_security.py` - Extensive event handler security tests
-- ❌ **Missing**: Type coercion edge case tests (e.g., SQL injection via coerced strings)
+- ✅ **Type coercion edge cases** (#1820): `TestCoercionSecurityEdgeCases` in `python/tests/test_validation.py` (incl. SQL-injection-style strings, hex, bool allowlist, float overflow, typed-list)
 - ❌ **Missing**: Positional args override tests
 
 ---
@@ -337,7 +337,7 @@ Later: `self.api_client.call()` → `AttributeError: 'str' object has no attribu
 
 ### High Priority
 
-5. ⚠️ **TODO**: Review `validate_handler_params()` type coercion edge cases
+5. ✅ **DONE** (#1820): Reviewed `validate_handler_params()` type coercion edge cases — see "Type Coercion Contract" below. Audited safe: malformed `int`/`float` inputs are rejected (not truncated); `bool` uses an allowlist (not `bool(non_empty_string)`); typed-list malformed elements are not partially coerced. Pinned by `TestCoercionSecurityEdgeCases` in `python/tests/test_validation.py`.
 6. ⚠️ **TODO**: Add runtime state serialization validation (`_is_serializable()`)
 7. ⚠️ **TODO**: Search codebase for `|safe` filter usage (potential XSS)
 8. ⚠️ **TODO**: Verify Rust template engine handles JavaScript context properly
@@ -369,7 +369,7 @@ Later: `self.api_client.call()` → `AttributeError: 'str' object has no attribu
 
 - ❌ **URL injection** tests
 - ❌ **File upload security** tests
-- ❌ **Type coercion edge cases**
+- ✅ **Type coercion edge cases** (#1820): `TestCoercionSecurityEdgeCases` in `python/tests/test_validation.py` (11 cases)
 - ❌ **Positional args override** tests
 - ❌ **Template XSS** tests (Rust side)
 
@@ -430,6 +430,33 @@ if not isinstance(user_id, int):  # ✅ Strict type check
     raise ValueError("ID must be integer")
 User.objects.filter(id=user_id)
 ```
+
+#### Type Coercion Contract (`validate_handler_params`, audited #1820)
+
+djust coerces event-handler params by default (`coerce=True`) because Template
+`data-*` attributes always arrive as strings. The coercion was audited (#1820)
+and is **safe by design** — it does NOT silently convert adversarial strings
+into valid-looking values. Empirically verified behavior per target type
+(`python/djust/validation.py:_coerce_single_value` →
+`validate_parameter_types`):
+
+| Target type | Coercion | Malformed input (e.g.) | Outcome |
+|---|---|---|---|
+| `int` | `int(value)` (base-10) | `"999 OR 1=1"`, `"0x41"` | `int()` raises → original string kept → type validation fails → **event rejected, handler NOT called** (no truncation to `999`) |
+| `float` | `float(value)` | `"3.14 OR 1=1"` | raises → **rejected** |
+| `float` | `float(value)` | `"1e309"`, `"inf"`, `"nan"` | valid Python floats → **accepted** (intentional). Handlers doing bound checks/arithmetic on a coerced `float` must guard non-finite values (`math.isfinite`) themselves |
+| `bool` | **ALLOWLIST**: `value.lower() in ("true","1","yes","on")` | `"true; DROP TABLE"`, `"false"`, `"0"` | → `False`. This is NOT `bool(non_empty_string)`, so non-allowlisted strings are falsy — **no truthiness logic-bypass** |
+| `Decimal` / `UUID` | `Decimal(value)` / `UUID(value)` | malformed | raises → original kept → rejected |
+| `List[T]` | element-wise coerce | `"1,2,OR 1=1"` | inner coercion raises → **whole** coercion abandoned, original string kept (no partial `[1,2]`). `List[T]` is a subscripted generic so `validate_parameter_types` skips it — the handler receives the unmodified original string; type your handler defensively |
+
+Rejected events are logged (`sanitize_for_log`) and the handler is never
+invoked. The strictest posture is `@event_handler(coerce_types=False)` (read by
+`get_handler_coerce_setting` in `python/djust/websocket_utils.py` and passed as
+`coerce=False`), under which ANY string for a typed param is rejected outright —
+this is the existing knob that fulfills the role of a "strict types" option, so
+no separate `@strict_types` decorator was added.
+
+Pinned by `TestCoercionSecurityEdgeCases` in `python/tests/test_validation.py`.
 
 ### Rule 4: Escape at Render Time, Not Storage
 

--- a/python/tests/test_validation.py
+++ b/python/tests/test_validation.py
@@ -1038,5 +1038,238 @@ class TestPositionalArgsMapping:
         assert result["coerced_params"]["confirm"] is True
 
 
+class TestCoercionSecurityEdgeCases:
+    """Security regression tests for type-coercion edge cases (issue #1820).
+
+    These PIN the audited-safe behavior of ``validate_handler_params`` against
+    malformed / adversarial inputs. The coercion contract is:
+
+      - ``str -> int``  : ``int()`` (base-10). Malformed strings RAISE in
+        ``int()``; coercion keeps the original string, type validation then
+        rejects the event (``valid is False``) — the handler is NOT invoked
+        (see ``websocket.py`` ~1275 / 2943 / 3080 / 3192). It does NOT
+        silently truncate ``"999 OR 1=1"`` to ``999``.
+      - ``str -> bool`` : ALLOWLIST — ``value.lower() in
+        ("true", "1", "yes", "on")``. This is NOT ``bool(non_empty_string)``,
+        so adversarial strings such as ``"true; DROP TABLE"`` and the
+        falsy-but-non-empty ``"false"`` / ``"0"`` coerce to ``False``. There
+        is no truthiness logic-bypass.
+      - ``str -> float``: ``float()``. Malformed strings are rejected (as for
+        ``int``). Note: ``"inf"`` / ``"-inf"`` / ``"nan"`` ARE accepted because
+        they are valid Python floats — this is an intentional, documented
+        contract (see ``test_coerce_float_special_values`` and
+        ``test_float_inf_nan_pass_as_valid_floats_known_contract`` below).
+
+    NOTE: these are CHARACTERIZATION tests — they pin the *current, audited*
+    behavior. No behavior change ships with #1820; the audit concluded the
+    coercion paths are already safe (malformed input is rejected, bool uses an
+    allowlist), so these tests are not "gate-off-able" against a code change.
+    They guard against future regressions that would weaken the contract.
+    """
+
+    # --- str -> int (issue #1820 case 1 + 4) -------------------------------
+
+    def test_sql_injection_string_to_int_is_rejected_not_truncated(self):
+        """``page="999 OR 1=1"`` (page: int) must be REJECTED, not truncated.
+
+        Confirms djust mirrors Python ``int()`` semantics: ``int("999 OR 1=1")``
+        raises ``ValueError``, so the event is rejected rather than silently
+        coerced to ``999`` (which would bypass an integer-comparison guard).
+        """
+
+        def handler(self, page: int = 0, **kwargs):
+            pass
+
+        result = validate_handler_params(handler, {"page": "999 OR 1=1"}, "paginate")
+        assert result["valid"] is False
+        # Original string preserved (NOT truncated to int 999).
+        assert result["coerced_params"]["page"] == "999 OR 1=1"
+        assert not isinstance(result["coerced_params"]["page"], int)
+        # Type error names the offending param.
+        assert any(e["param"] == "page" for e in result["type_errors"])
+
+    def test_hex_string_to_int_is_rejected(self):
+        """``id="0x41"`` / ``id="0x41414141"`` (id: int) must be REJECTED.
+
+        ``int()`` is base-10 only, so hex literals raise and are rejected
+        rather than coerced (Python's ``int("0x41")`` raises ValueError).
+        """
+
+        def handler(self, id: int = 0, **kwargs):
+            pass
+
+        for hexstr in ("0x41", "0x41414141"):
+            result = validate_handler_params(handler, {"id": hexstr}, "load")
+            assert result["valid"] is False, f"{hexstr!r} should be rejected"
+            assert result["coerced_params"]["id"] == hexstr  # not coerced
+
+    def test_well_formed_int_still_coerces(self):
+        """Guard the happy path: a legitimate numeric string still coerces."""
+
+        def handler(self, page: int = 0, **kwargs):
+            pass
+
+        result = validate_handler_params(handler, {"page": "42"}, "paginate")
+        assert result["valid"] is True
+        assert result["coerced_params"]["page"] == 42
+
+    # --- str -> bool (issue #1820 case 2 — the designated dangerous one) ---
+
+    def test_bool_coercion_uses_allowlist_not_truthiness(self):
+        """``active="true; DROP TABLE"`` (active: bool) must coerce to False.
+
+        The dangerous failure mode would be ``bool(non_empty_string)``, under
+        which ANY non-empty string (including ``"false"`` and ``"0"``) is
+        ``True`` — a real logic bypass. djust uses an ALLOWLIST instead, so an
+        adversarial non-allowlisted string is ``False``.
+        """
+
+        def handler(self, active: bool = False, **kwargs):
+            pass
+
+        result = validate_handler_params(
+            handler, {"active": "true; DROP TABLE"}, "toggle"
+        )
+        # bool coercion never raises -> always a valid bool -> valid is True.
+        assert result["valid"] is True
+        assert result["coerced_params"]["active"] is False
+
+    def test_bool_falsy_strings_are_false_not_true(self):
+        """The crux: ``"false"`` / ``"0"`` / ``"no"`` / ``"off"`` -> False.
+
+        If bool coercion were ``bool(non_empty_string)`` these would all be
+        ``True`` (a logic bypass). The allowlist makes them ``False``.
+        """
+
+        def handler(self, active: bool = False, **kwargs):
+            pass
+
+        for falsy in ("false", "False", "FALSE", "0", "no", "off", "anything", "2"):
+            result = validate_handler_params(handler, {"active": falsy}, "toggle")
+            assert result["valid"] is True
+            assert result["coerced_params"]["active"] is False, (
+                f"{falsy!r} must coerce to False (allowlist), not True"
+            )
+
+    def test_bool_truthy_allowlist_values_are_true(self):
+        """Only the documented allowlist values coerce to True."""
+
+        def handler(self, active: bool = False, **kwargs):
+            pass
+
+        for truthy in ("true", "True", "TRUE", "1", "yes", "YES", "on", "ON"):
+            result = validate_handler_params(handler, {"active": truthy}, "toggle")
+            assert result["valid"] is True
+            assert result["coerced_params"]["active"] is True, (
+                f"{truthy!r} must coerce to True"
+            )
+
+    # --- str -> float (issue #1820 case 3) ---------------------------------
+
+    def test_malformed_float_string_is_rejected(self):
+        """``amount="3.14 OR 1=1"`` (amount: float) must be REJECTED."""
+
+        def handler(self, amount: float = 0.0, **kwargs):
+            pass
+
+        result = validate_handler_params(handler, {"amount": "3.14 OR 1=1"}, "pay")
+        assert result["valid"] is False
+        assert result["coerced_params"]["amount"] == "3.14 OR 1=1"  # not coerced
+
+    def test_float_overflow_to_inf_known_contract(self):
+        """``amount="1e309"`` overflows to ``inf`` and is accepted.
+
+        CHARACTERIZATION: ``float("1e309")`` is ``inf``, a valid float, so it
+        passes type validation. This is an intentional contract — handlers
+        that perform bound checks or arithmetic on a coerced ``float`` should
+        guard against non-finite values themselves (``math.isfinite``).
+        """
+        import math
+
+        def handler(self, amount: float = 0.0, **kwargs):
+            pass
+
+        result = validate_handler_params(handler, {"amount": "1e309"}, "pay")
+        assert result["valid"] is True
+        assert math.isinf(result["coerced_params"]["amount"])
+
+    def test_float_inf_nan_pass_as_valid_floats_known_contract(self):
+        """``amount="inf"`` / ``"nan"`` (amount: float) are accepted.
+
+        CHARACTERIZATION of the documented contract (mirrors
+        ``test_coerce_float_special_values``): ``inf`` / ``-inf`` / ``nan`` are
+        valid Python floats and so pass validation. Documented here at the
+        handler-validation layer (not just the raw-coerce layer) so the
+        security implication — non-finite floats reach handlers and downstream
+        comparisons (``nan > x`` is always False) must be guarded by the
+        application — is pinned and discoverable.
+        """
+        import math
+
+        def handler(self, amount: float = 0.0, **kwargs):
+            pass
+
+        r_inf = validate_handler_params(handler, {"amount": "inf"}, "pay")
+        assert r_inf["valid"] is True
+        assert math.isinf(r_inf["coerced_params"]["amount"])
+
+        r_nan = validate_handler_params(handler, {"amount": "nan"}, "pay")
+        assert r_nan["valid"] is True
+        assert math.isnan(r_nan["coerced_params"]["amount"])
+
+    # --- list / typed-list adversarial inputs ------------------------------
+
+    def test_typed_list_with_malformed_element_is_not_partially_coerced(self):
+        """``ids="1,2,OR 1=1"`` (ids: List[int]): NO partial coercion.
+
+        EMPIRICALLY VERIFIED CONTRACT (issue #1820 audit): a malformed element
+        makes the *whole* typed-list coercion raise inside ``_coerce_value``
+        (``int("OR 1=1")`` -> ValueError), which ``coerce_parameter_types``
+        catches and recovers from by KEEPING THE ORIGINAL STRING. Crucially:
+
+          - The handler does NOT receive a partially-coerced ``[1, 2]`` (no
+            silent truncation of the malformed tail).
+          - The injected text never becomes a list element.
+
+        ``validate_parameter_types`` intentionally SKIPS subscripted generics
+        like ``List[int]`` (its guard is ``isinstance(expected_type, type)``),
+        so the raw string reaches the handler rather than being flagged as a
+        type error. A handler typed ``ids: List[int]`` must therefore treat its
+        input defensively — but the value it gets is the unmodified original
+        string, never adversarial list contents. This test pins that contract;
+        if a future change starts partially coercing, it fails.
+        """
+
+        def handler(self, ids: List[int] = None, **kwargs):
+            pass
+
+        result = validate_handler_params(handler, {"ids": "1,2,OR 1=1"}, "bulk")
+        coerced = result["coerced_params"]["ids"]
+        # Original string preserved verbatim — NOT a list, NOT partially coerced.
+        assert coerced == "1,2,OR 1=1"
+        assert not isinstance(coerced, list)
+        # Sanity: a well-formed typed list DOES coerce fully.
+        ok = validate_handler_params(handler, {"ids": "1,2,3"}, "bulk")
+        assert ok["coerced_params"]["ids"] == [1, 2, 3]
+
+    # --- coercion-disabled posture is at least as strict ------------------
+
+    def test_strict_posture_via_coerce_false_rejects_all_strings(self):
+        """``coerce=False`` is the strictest posture: every str fails int/bool.
+
+        This is the existing knob that approximates the issue's suggested
+        ``@strict_types`` for callers that want zero coercion — a string
+        ``"42"`` for an ``int`` param is rejected outright.
+        """
+
+        def handler(self, page: int = 0, active: bool = False, **kwargs):
+            pass
+
+        result = validate_handler_params(
+            handler, {"page": "42", "active": "true"}, "evt", coerce=False
+        )
+        assert result["valid"] is False
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #1820.

## Summary

Audited the type-coercion paths in `validate_handler_params()`
(`python/djust/validation.py`) against the malformed/adversarial inputs from
#1820, **empirically** (probe + reproducer tests against the real code, not
inspection). **Conclusion: the coercion is safe by design — no code change
required.** This PR is test-hardening + documentation only.

## Empirical raise-vs-coerce findings (per input type)

| Issue test case | Type | Actual behavior | Verdict |
|---|---|---|---|
| `page="999 OR 1=1"` | `int` | `int()` raises → original string kept → type validation fails → **event rejected, handler NOT called**. NOT truncated to `999`. | Safe |
| `id="0x41"` / `"0x41414141"` | `int` | `int()` is base-10 → raises → **rejected**. | Safe |
| `active="true; DROP TABLE"` | `bool` | **Allowlist** (`value.lower() in {"true","1","yes","on"}`) → `False`. NOT `bool(non_empty_string)`. `"false"`/`"0"` also → `False`. | Safe — **no bypass** |
| `amount="1e309"` / `"inf"` / `"nan"` | `float` | Valid Python floats → **accepted** (intentional, pre-existing documented contract). Malformed `"3.14 OR 1=1"` → rejected. | Documented contract |
| `ids="1,2,OR 1=1"` | `List[int]` | Malformed element abandons the whole coercion (no partial `[1,2]`); subscripted generic skipped by the type validator → handler gets the **unmodified original string**. | Safe |

**The designated dangerous case (bool) is safe**: djust uses an allowlist, not
`bool(non_empty_string)`, so there is no truthiness logic-bypass.

## Decision: test-hardening-only (no behavior change)

Per #1820's branch: *if already safe → add security regression tests that pin
the safe behavior, document the contract, optionally add `@strict_types` only
if low-risk + clearly valuable.* The coercion already rejects malformed input
and the strict posture already exists as `@event_handler(coerce_types=False)`,
so a separate `@strict_types` decorator would add public API surface for no new
capability — **not added**.

## Changes

- **`python/tests/test_validation.py`** — new `TestCoercionSecurityEdgeCases`
  (11 cases) pinning the audited contract (int/hex rejection, bool allowlist
  incl. falsy-string + truthy-string sets, float malformed-rejection + inf/nan
  characterization, typed-list no-partial-coercion, `coerce=False` strict
  posture).
- **`SECURITY_AUDIT.md`** — marks the high-priority TODO done, flips the
  coercion note ⚠️→✅, checks off the test-coverage gap, adds a "Type Coercion
  Contract" table.
- **`CHANGELOG.md`** — `### Security` entry under `[Unreleased]`.

## Non-tautology / gate-off (#1468)

No production change to gate off, so non-tautology was proven by **mutating the
coercion to the unsafe variants** (`bool(non_empty_string)`; regex int-
truncation) and confirming **5 of the new tests fail** with exactly the
dangerous symptoms #1820 describes (`"true; DROP TABLE"`/`"false"` → `True`;
`"999 OR 1=1"` → `999`; typed-list → `[1,2,0]`). Original code restored;
`test_validation.py`: 87 passed.

## Commit shape (#1173)

1. `security(validation):` — tests only (no CHANGELOG)
2. `docs(security):` — CHANGELOG `### Security` + `SECURITY_AUDIT.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)