### PR TITLE
fix(vdom): dj-if MoveSubtree fires on relative position, not absolute offset (#1826)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **dj-if ``MoveSubtree`` keyed on RELATIVE position, not absolute offset
+  (#1826).** A ``{% if %}``-wrapped element inside a ``{% for %}`` loop dropped
+  a table row per toggle (P0 regression in 1.0.6rc1). ``diff_html``'s
+  matched-boundary move-decision in ``crates/djust_vdom/src/diff.rs`` compared
+  ABSOLUTE child offsets (``old_off + ob.open`` vs ``new_off + nb.open``).
+  Filling an EARLIER empty dj-if body inserts nodes that shift the absolute
+  index of every LATER boundary even though those boundaries did NOT move
+  relative to their siblings — so the differ emitted spurious
+  ``MoveSubtree { id: "if-b-0" / "if-c-0" }`` ops the client could not pair
+  (``close marker not found``), ~15/22 patches failed, and an ``html_recovery``
+  morph dropped a row. The decision now keys on the boundary's position
+  RELATIVE to its non-boundary siblings (a new ``non_boundary_count_before``
+  helper over the existing ``excluded`` mask) plus its ordinal among same-level
+  boundaries; both are invariant to a sibling boundary's span-length change, so
+  only a GENUINE reposition (a real element inserted/removed before the
+  boundary, or a boundary reorder) emits a move. The move TARGET index is
+  unchanged. The ``#text``-flattening also seen in #1826 (Defect 1) is an
+  html5ever foster-parenting artifact of a bare ``<tbody>`` fragment (no
+  ``<table>`` ancestor); it does not reproduce in production and is scoped out
+  to follow-up #1827. Covered by the Rust reproducer
+  ``crates/djust_vdom/tests/test_dj_if_loop_spurious_move_1826.rs``
+  (loop-fill no-spurious-move + client-faithful round-trip + genuine-reposition
+  guard; gate-off verified per #1468) and 4 regression cases in
+  ``python/djust/tests/test_diff_html_if_marker_rows_1826.py``. The two #1666
+  guards and the proptest / torture dj-if round-trip nets stay green.
+
 ## [1.0.6rc1] - 2026-06-17
 
 ### Added

--- a/crates/djust_vdom/src/diff.rs
+++ b/crates/djust_vdom/src/diff.rs
@@ -106,6 +106,20 @@ fn find_top_level_boundaries(children: &[VNode]) -> (Vec<Boundary>, Vec<bool>) {
     (boundaries, excluded)
 }
 
+/// Count how many NON-boundary siblings precede the local index `open`.
+///
+/// `excluded` is the mask from [`find_top_level_boundaries`] (index `k` is
+/// `true` when it falls inside ANY boundary marker span). This collapses the
+/// boundary spans so that a boundary's "significant position" is measured
+/// against its real (non-marker) siblings ONLY — not the absolute child
+/// index, which shifts whenever an EARLIER boundary body fills/empties
+/// (#1826). Two renders that keep the same non-boundary neighborhood around a
+/// boundary yield the same count even if an earlier sibling boundary changed
+/// span length.
+fn non_boundary_count_before(excluded: &[bool], open: usize) -> usize {
+    (0..open).filter(|&k| !excluded[k]).count()
+}
+
 /// Serialize a boundary's full marker-pair span (open..=close, inclusive) to
 /// HTML for `InsertSubtree.html`.
 fn serialize_boundary_html(children: &[VNode], open: usize, close: usize) -> String {
@@ -297,21 +311,51 @@ fn diff_children(
             new_boundaries.iter().map(|b| (b.id.as_str(), b)).collect();
         let old_ids: AHashMap<&str, &Boundary> =
             old_boundaries.iter().map(|b| (b.id.as_str(), b)).collect();
+        // Ordinal of each NEW boundary among same-level boundaries (its index
+        // in `new_boundaries`). Paired with the non-boundary-sibling count to
+        // decide MoveSubtree by RELATIVE position (#1826).
+        let new_ordinals: AHashMap<&str, usize> = new_boundaries
+            .iter()
+            .enumerate()
+            .map(|(i, b)| (b.id.as_str(), i))
+            .collect();
 
-        for ob in &old_boundaries {
+        for (old_ordinal, ob) in old_boundaries.iter().enumerate() {
             if let Some(nb) = new_ids.get(ob.id.as_str()) {
-                // Matched in both. If the boundary's significant position
-                // shifted (siblings changed around it), emit MoveSubtree to
-                // relocate the id-less marker span — a plain MoveChild can't
-                // target the markers (#1666). Then recurse into the body.
-                let old_open_abs = old_off + ob.open;
-                let new_open_abs = new_off + nb.open;
-                if old_open_abs != new_open_abs {
+                // Matched in both. Emit MoveSubtree to relocate the id-less
+                // marker span ONLY when the boundary actually repositioned
+                // relative to its real (non-marker) siblings — a plain
+                // MoveChild can't target the markers (#1666). Then recurse
+                // into the body.
+                //
+                // #1826: the decision must NOT use the absolute child offset
+                // (`old_off + ob.open` vs `new_off + nb.open`). Filling an
+                // EARLIER empty dj-if body inserts nodes that shift the
+                // absolute index of every LATER boundary even though those
+                // boundaries did NOT move relative to their siblings — which
+                // emitted spurious MoveSubtree ops the client couldn't pair
+                // (`close marker not found`). Instead key on (count of
+                // non-boundary siblings before the boundary, ordinal among
+                // same-level boundaries): both are invariant to a sibling
+                // boundary's span-length change, so only a GENUINE reposition
+                // (a real element inserted/removed before the boundary, or a
+                // boundary reorder) flips the key and emits the move.
+                let old_key = (
+                    non_boundary_count_before(&old_excluded, ob.open),
+                    old_ordinal,
+                );
+                let new_key = (
+                    non_boundary_count_before(&new_excluded, nb.open),
+                    new_ordinals[ob.id.as_str()],
+                );
+                if old_key != new_key {
                     out.push(Patch::MoveSubtree {
                         id: ob.id.clone(),
                         path: ppath.to_vec(),
                         d: pid.map(|s| s.to_string()),
-                        index: new_open_abs,
+                        // The move TARGET stays the absolute new index — only
+                        // the move DECISION was wrong, not this value.
+                        index: new_off + nb.open,
                     });
                 }
                 // Matched in both -> recurse into the body slice.

--- a/crates/djust_vdom/tests/test_dj_if_loop_spurious_move_1826.rs
+++ b/crates/djust_vdom/tests/test_dj_if_loop_spurious_move_1826.rs
@@ -1,0 +1,220 @@
+//! Regression: a `{% if %}`-wrapped element inside a `{% for %}` loop must NOT
+//! emit spurious `MoveSubtree` ops against LATER dj-if boundaries when an
+//! EARLIER boundary body fills (#1826, P0 regression in 1.0.6rc1).
+//!
+//! Production shape (browser symptom): N "main" rows, each immediately
+//! followed by its own `<!--dj-if id="if-<n>-0"-->…<!--/dj-if-->` block whose
+//! body goes empty → non-empty when a flag toggles. On 1.0.6rc1 `diff_html`
+//! emitted `MoveSubtree { id: "if-b-0" }` / `{ id: "if-c-0" }` because the
+//! move-decision compared ABSOLUTE child offsets: filling `if-a-0`'s body
+//! inserts a node that shifts the absolute index of `if-b-0`/`if-c-0` even
+//! though they did NOT move relative to their siblings. The client can't pair
+//! those marker moves ("close marker not found"), ~15/22 patches fail, an
+//! `html_recovery` morph runs, and a row is visibly dropped per toggle.
+//!
+//! The fix (`crates/djust_vdom/src/diff.rs`, matched-boundary block) keys the
+//! move-decision on the boundary's position RELATIVE to its non-boundary
+//! siblings (+ its ordinal among same-level boundaries), so a sibling
+//! boundary's span-length change never triggers a move.
+//!
+//! Container note: the production DOM wraps these rows in `<table><tbody>`.
+//! Exercising Defect 2 here we use a NON-table container (`<div>`/`<span>`)
+//! so the html5ever foster-parenting that flattens a bare `<tbody>`'s `<tr>`
+//! to a `#text` node (Defect 1 in #1826 — an ENVIRONMENT artifact that does
+//! not reproduce with the real `<table>` ancestor) cannot confound the
+//! move-decision assertions. We hand-build the VNode trees directly (not via
+//! `diff_html`) so the boundaries carry stable inner `djust_id`s, mirroring a
+//! real keyed render. A separate Python test in
+//! `python/djust/tests/test_diff_html_if_marker_rows_1826.py` exercises the
+//! `diff_html` entry point and documents the table-fragment foster-parenting.
+
+mod common;
+
+use common::{
+    apply_all, assert_handles_resolve, count, dj_if_close, dj_if_open, elem, elem_with_text,
+    find_by_djust_id, IdGen,
+};
+use djust_vdom::diff::diff_nodes;
+use djust_vdom::{Patch, VNode};
+
+const ITEMS: [&str; 3] = ["a", "b", "c"];
+
+/// Build the `<div>` container for the loop. When `show` is false every
+/// boundary body is EMPTY; when true each body holds one `<span class="detail">`.
+///
+/// dj-ids are allocated from a single `IdGen` in render order so the OLD and
+/// NEW trees share ids for nodes present in both (the three `span.main` rows
+/// and — when shown — the detail spans only exist in NEW). This mirrors how
+/// `sync_ids` carries stable ids forward across a real re-render.
+fn build(show: bool) -> VNode {
+    let gen = IdGen::new();
+    let mut children: Vec<VNode> = Vec::new();
+    for n in ITEMS {
+        // The persistent "main" row (present in both renders).
+        children.push(elem_with_text("span", n, &gen).with_attr("class", "main"));
+        // Its own dj-if boundary.
+        children.push(dj_if_open(&format!("if-{}-0", n)));
+        if show {
+            children.push(
+                elem_with_text("span", &format!("detail {}", n), &gen).with_attr("class", "detail"),
+            );
+        }
+        children.push(dj_if_close());
+    }
+    elem("div", &gen).with_children(children)
+}
+
+#[test]
+fn djif_loop_fill_emits_no_spurious_move_for_later_boundaries() {
+    let old = build(false);
+    let new = build(true);
+
+    let patches = diff_nodes(&old, &new, &[]);
+
+    // (b) — LOAD-BEARING. Filling earlier boundary bodies must NOT emit a
+    // MoveSubtree for the later boundaries. This is the exact #1826 symptom
+    // (`if-b-0`, `if-c-0`). FAILS on 1.0.6rc1 (2 spurious moves).
+    let later_moves = count(
+        &patches,
+        |p| matches!(p, Patch::MoveSubtree { id, .. } if id == "if-b-0" || id == "if-c-0"),
+    );
+    assert_eq!(
+        later_moves, 0,
+        "spurious MoveSubtree for later dj-if boundaries (#1826); patches: {:#?}",
+        patches
+    );
+
+    // No boundary should move at all here — none repositioned relative to its
+    // siblings. (Pins the broader invariant, not just the two cited ids.)
+    let any_move = count(&patches, |p| matches!(p, Patch::MoveSubtree { .. }));
+    assert_eq!(
+        any_move, 0,
+        "no boundary repositioned relative to siblings, so no MoveSubtree expected; patches: {:#?}",
+        patches
+    );
+
+    // (a) — the in-body inserted detail node is the `<span>` ELEMENT, never a
+    // flattened `#text` node. (Defect-1 guard for the non-table container; the
+    // bare-`<tbody>` foster-parenting that produces `#text` is documented in
+    // the Python test as expected html5ever behavior.)
+    for p in &patches {
+        if let Patch::InsertChild { node, .. } = p {
+            assert_eq!(
+                node.tag, "span",
+                "inserted body node must be the <span> element, not a flattened #text; patch: {:#?}",
+                p
+            );
+        }
+    }
+    // Sanity: the fill actually produced the three detail inserts (the test
+    // would be vacuous otherwise — the boundary bodies must really have filled).
+    let span_inserts = count(
+        &patches,
+        |p| matches!(p, Patch::InsertChild { node, .. } if node.tag == "span"),
+    );
+    assert_eq!(
+        span_inserts, 3,
+        "expected three detail-span inserts (one per filled boundary); patches: {:#?}",
+        patches
+    );
+
+    // (c) — CLIENT-FAITHFUL. Apply the patch stream to a clone of OLD and
+    // assert it reproduces NEW structurally (all 3 rows + 3 details present),
+    // and that every targeting handle resolves in the client tracker.
+    assert_handles_resolve(&patches, &old, "1826");
+    let mut client = old.clone();
+    apply_all(&mut client, &patches, &new);
+    assert!(
+        structurally_equal(&client, &new),
+        "client tracker after apply_all must match NEW; got {} top-level children, want {}",
+        client.children.len(),
+        new.children.len()
+    );
+    // Both detail spans for b and c must be present after apply (the dropped-row
+    // symptom is exactly their absence).
+    for n in ITEMS {
+        let want = format!("detail {}", n);
+        assert!(
+            contains_text(&client, &want),
+            "row detail '{}' missing after apply_all — this is the dropped-row symptom",
+            want
+        );
+    }
+}
+
+#[test]
+fn djif_genuine_reposition_still_emits_move_subtree() {
+    // GUARD (do-not-over-correct): a REAL element inserted BEFORE a matched,
+    // empty boundary IS a genuine reposition (its non-boundary-sibling count
+    // goes 0 → 1) and MUST still emit MoveSubtree. Mirrors
+    // `test_diff_robustness_gaps::matched_djif_boundary_repositioned_via_move_subtree`.
+    let gen = IdGen::new();
+    let keep = elem_with_text("p", "keep", &gen);
+    let keep_id = keep.djust_id.clone().unwrap();
+
+    let old =
+        VNode::element("div").with_children(vec![dj_if_open("if-a"), dj_if_close(), keep.clone()]);
+    let new = VNode::element("div").with_children(vec![
+        elem_with_text("section", "new", &gen),
+        dj_if_open("if-a"),
+        dj_if_close(),
+        keep,
+    ]);
+
+    let patches = diff_nodes(&old, &new, &[]);
+
+    // The matched boundary is NOT torn down/re-inserted — it MOVES.
+    assert_eq!(
+        count(&patches, |p| matches!(
+            p,
+            Patch::RemoveSubtree { .. } | Patch::InsertSubtree { .. }
+        )),
+        0,
+        "matched boundary must move, not tear-down/re-insert; patches: {:#?}",
+        patches
+    );
+    assert_eq!(
+        count(&patches, |p| matches!(p, Patch::MoveSubtree { id, .. } if id == "if-a")),
+        1,
+        "genuine reposition (real element inserted before boundary) MUST emit MoveSubtree; patches: {:#?}",
+        patches
+    );
+    // The "keep" node still resolves (untouched).
+    assert!(find_by_djust_id(&new, &keep_id).is_some());
+}
+
+// ---- local structural helpers (id-agnostic; dj-id attrs differ by design) ----
+
+fn structurally_equal(a: &VNode, b: &VNode) -> bool {
+    if a.tag != b.tag || a.text != b.text {
+        return false;
+    }
+    let fa: Vec<(&str, &str)> = a
+        .attrs
+        .iter()
+        .filter(|(k, _)| k.as_str() != "dj-id")
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    let fb: Vec<(&str, &str)> = b
+        .attrs
+        .iter()
+        .filter(|(k, _)| k.as_str() != "dj-id")
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    // Attribute order is insertion order; both built the same way.
+    if fa != fb || a.children.len() != b.children.len() {
+        return false;
+    }
+    a.children
+        .iter()
+        .zip(&b.children)
+        .all(|(x, y)| structurally_equal(x, y))
+}
+
+/// True if `text` appears as a `#text` node anywhere in the tree.
+fn contains_text(node: &VNode, text: &str) -> bool {
+    if node.text.as_deref() == Some(text) {
+        return true;
+    }
+    node.children.iter().any(|c| contains_text(c, text))
+}

--- a/python/djust/tests/test_diff_html_if_marker_rows_1826.py
+++ b/python/djust/tests/test_diff_html_if_marker_rows_1826.py
@@ -1,0 +1,122 @@
+"""Regression for #1826 (P0, 1.0.6rc1): a ``{% if %}``-wrapped element inside a
+``{% for %}`` loop must not emit spurious ``MoveSubtree`` ops against LATER
+dj-if boundaries when an EARLIER boundary body fills.
+
+Exercises the ``diff_html`` entry point directly (the same surface the browser
+symptom flowed through). The matched-boundary move-decision in
+``crates/djust_vdom/src/diff.rs`` used to compare ABSOLUTE child offsets, so
+filling ``if-a-0``'s empty body shifted the absolute index of ``if-b-0`` /
+``if-c-0`` and emitted ``MoveSubtree`` ops the client could not pair
+(``close marker not found``) → ~15/22 patches failed → ``html_recovery`` morph
+dropped a row per toggle. The fix keys the decision on the boundary's position
+RELATIVE to its non-boundary siblings (+ its ordinal among same-level
+boundaries).
+
+Defect-1 note (documented, NOT fixed here, follow-up #1827): with a BARE
+``<tbody>`` fragment (no ``<table>`` ancestor) html5ever foster-parents the
+``<tr>`` out and ``diff_html`` flattens the inserted body node to a ``#text``
+node. This is an ENVIRONMENT artifact — the real production DOM has the
+``<table>`` ancestor, where the ``<tr>`` is preserved. The ``<div>``/``<span>``
+shape below exercises Defect 2 cleanly (no foster-parenting); the two table
+cases pin that the flattening is purely the bare-fragment context.
+"""
+
+import json
+
+import djust._rust as rust
+
+ITEMS = ("a", "b", "c")
+
+
+def _div_dom(show):
+    """Non-table container: ``<div>`` of ``<span class=main>`` rows, each
+    followed by its own dj-if boundary whose body is empty (``show=False``)
+    or holds a ``<span class=detail>`` (``show=True``)."""
+    out = ["<div>"]
+    for n in ITEMS:
+        out.append(f'<span class="main">{n}</span>')
+        inner = f'<span class="detail">detail {n}</span>' if show else ""
+        out.append(f'<!--dj-if id="if-{n}-0"-->{inner}<!--/dj-if-->')
+    out.append("</div>")
+    return "".join(out)
+
+
+def _table_dom(show, wrap_table):
+    """Table rows. ``wrap_table=False`` is the bare ``<tbody>`` fragment that
+    triggers html5ever foster-parenting; ``True`` wraps in ``<table>`` (the
+    real production shape)."""
+    out = ["<table><tbody>" if wrap_table else "<tbody>"]
+    for n in ITEMS:
+        out.append(f'<tr class="main"><td>{n}</td></tr>')
+        inner = f'<tr class="detail"><td>detail {n}</td></tr>' if show else ""
+        out.append(f'<!--dj-if id="if-{n}-0"-->{inner}<!--/dj-if-->')
+    out.append("</tbody>")
+    if wrap_table:
+        out.append("</table>")
+    return "".join(out)
+
+
+def test_div_loop_fill_emits_no_spurious_move_subtree():
+    """LOAD-BEARING #1826 assertion: filling earlier dj-if bodies must not
+    move later boundaries, and the inserted body node is the real element."""
+    patches = json.loads(diff := rust.diff_html(_div_dom(False), _div_dom(True)))
+    moves = [p for p in patches if p["type"] == "MoveSubtree"]
+    assert not moves, f"spurious MoveSubtree for later dj-if boundaries (#1826): {[m.get('id') for m in moves]}\n{diff}"
+
+    inserts = [p for p in patches if p["type"] == "InsertChild"]
+    # Three boundary bodies filled -> three element inserts, none flattened.
+    assert len(inserts) == 3, f"expected 3 detail inserts, got {len(inserts)}: {diff}"
+    flattened = [p for p in inserts if (p.get("node") or {}).get("tag") == "#text"]
+    assert not flattened, f"non-table container must insert the <span> element, not #text: {flattened}"
+    assert all((p.get("node") or {}).get("tag") == "span" for p in inserts), diff
+
+
+def test_div_loop_round_trip_keeps_all_rows():
+    """Toggling show=False -> True then True -> False must be symmetric: the
+    forward fill inserts exactly the bodies the reverse empty removes, with no
+    marker moves in either direction (the dropped-row symptom is a marker move
+    the client can't pair)."""
+    fwd = json.loads(rust.diff_html(_div_dom(False), _div_dom(True)))
+    rev = json.loads(rust.diff_html(_div_dom(True), _div_dom(False)))
+    assert not [p for p in fwd if p["type"] == "MoveSubtree"], fwd
+    assert not [p for p in rev if p["type"] == "MoveSubtree"], rev
+    # Forward fills 3 bodies; reverse empties them (RemoveSubtree per boundary
+    # is the empty-body path; either way, no marker MOVE).
+    assert len([p for p in fwd if p["type"] == "InsertChild"]) == 3, fwd
+
+
+def test_table_wrapped_preserves_tr_and_no_move():
+    """Production shape (``<table><tbody>``): no spurious MoveSubtree, and the
+    inserted body node is the real ``<tr>`` element (no foster-parenting)."""
+    patches = json.loads(rust.diff_html(_table_dom(False, True), _table_dom(True, True)))
+    assert not [p for p in patches if p["type"] == "MoveSubtree"], patches
+    inserts = [p for p in patches if p["type"] == "InsertChild"]
+    assert inserts, patches
+    assert all((p.get("node") or {}).get("tag") == "tr" for p in inserts), (
+        "with the <table> ancestor the inserted body node is the <tr> element",
+        patches,
+    )
+
+
+def test_bare_tbody_text_flatten_is_environment_artifact():
+    """DOCUMENTS Defect 1: a BARE ``<tbody>`` fragment (no ``<table>``) makes
+    html5ever foster-parent the ``<tr>`` out, so ``diff_html`` flattens the
+    inserted body node to a ``#text`` node. This is expected html5ever
+    behavior for an out-of-context table fragment — it does NOT reproduce in
+    production (real DOM has the ``<table>`` ancestor; see the table-wrapped
+    test above). Tracked as follow-up #1827 for optional ``diff_html``
+    table-fragment context-sensitivity. The #1826 P0 fix (no spurious
+    MoveSubtree) holds regardless of the container.
+    """
+    patches = json.loads(rust.diff_html(_table_dom(False, False), _table_dom(True, False)))
+    # The P0 fix holds even in the bare-fragment case.
+    assert not [p for p in patches if p["type"] == "MoveSubtree"], patches
+    inserts = [p for p in patches if p["type"] == "InsertChild"]
+    flattened = [p for p in inserts if (p.get("node") or {}).get("tag") == "#text"]
+    # Pin the CURRENT (environment-artifact) behavior so a future
+    # context-sensitivity fix updates this test deliberately.
+    assert flattened, (
+        "bare <tbody> fragment is expected to foster-parent <tr> to #text "
+        "(html5ever); if this changed, the table-fragment context fix landed",
+        patches,
+    )


### PR DESCRIPTION
Fixes #1826 (P0 VDOM dj-if `MoveSubtree` regression, 1.0.6rc1). Filed follow-up #1827 (Defect 1, out of scope here).

## Root cause (Defect 2 — the P0)

`diff_html`'s matched-boundary move-decision in `crates/djust_vdom/src/diff.rs` compared **absolute** child offsets:

```rust
let old_open_abs = old_off + ob.open;
let new_open_abs = new_off + nb.open;
if old_open_abs != new_open_abs { /* MoveSubtree */ }
```

A `{% if %}` wrapping a `<tr>` inside a `{% for %}` loop renders N rows, each followed by its own `<!--dj-if id="if-<n>-0"-->…<!--/dj-if-->` boundary. When an **earlier** empty boundary body fills (`show` toggles false→true), the inserted node shifts the **absolute** index of every **later** boundary even though those boundaries did **not** move relative to their siblings. The differ emitted spurious `MoveSubtree { id: "if-b-0" }` / `{ id: "if-c-0" }` ops the client cannot pair (`close marker not found`) → ~15/22 patches fail → `html_recovery` morph drops a row per toggle.

Reproduced bit-exactly against the 1.0.6rc1 build (the issue's reproducer): `MoveSubtree ids == ['if-b-0', 'if-c-0']`. The spurious move fires in **every** container (div/span/table), confirming it is independent of the table-fragment artifact.

## Fix

Key the move-decision on the boundary's position **relative** to its non-boundary siblings, plus its ordinal among same-level boundaries:

- New private helper `non_boundary_count_before(excluded, open)` over the existing `excluded` mask (collapses boundary spans so an earlier boundary's span-length change is invisible).
- `old_key = (non_boundary_count_before(&old_excluded, ob.open), old_ordinal)`; `new_key = (non_boundary_count_before(&new_excluded, nb.open), new_ordinals[id])`. Emit `MoveSubtree` iff `old_key != new_key`.
- Move **target** index unchanged (`new_off + nb.open`) — only the *decision* was wrong.

A **genuine** reposition (a real element inserted before the boundary, `nb_before` 0→1) still flips the key and emits the move.

## Defect 1 (#text flattening) — scoped out (#1079)

The `#text`-flattened insert is an html5ever foster-parenting artifact of a **bare** `<tbody>` fragment (no `<table>` ancestor). Verified: `<table><tbody>…` preserves the `<tr>` (0 flattened); div/span yields `<span>`. Does not reproduce in production (real DOM has the `<table>`). Tracked in follow-up **#1827** (`diff_html` could route table fragments through the existing `parse_html_fragment(html, "table")`, parser.rs:278). Not fixed here.

## Tests

| File | What it pins |
|------|--------------|
| `crates/djust_vdom/tests/test_dj_if_loop_spurious_move_1826.rs` | Loop-fill: **no** `MoveSubtree` for later boundaries (load-bearing, fails on rc1); element-not-`#text` insert; client-faithful `apply_all` round-trip keeping all rows; `assert_handles_resolve`. Plus a genuine-reposition guard. |
| `python/djust/tests/test_diff_html_if_marker_rows_1826.py` | `diff_html`-level div/span (no move, no `#text`) + table-wrapped (`<tr>` preserved) + bare-`<tbody>` documents Defect 1 as environment artifact. 4 cases. |

**Gate-off (#1468):** reverting the move-decision to the absolute-offset form makes the load-bearing assertion fail with `left: 2  right: 0` (the 2 spurious moves); the genuine-reposition guard still passes under both — proving the assertion is non-tautological. Restored; both pass.

## Verification

- `cargo test -p djust_vdom` — all binaries green (the two #1666 guards `matched_djif_boundary_repositioned_via_move_subtree` / `matched_djif_boundary_no_move_when_position_unchanged`, the `proptest_random_toggles_handles_always_resolve` net, and the `torture_*dj_if*` / `torture_*round_trip*` nets all pass).
- Scoped `pytest` over VDOM/diff/render Python tests: 223 passed, 1 skipped (free-threaded-only).
- `cargo fmt --check` + `cargo clippy -p djust_vdom --tests` clean.

CI is authoritative for the full suite (pushed `--no-verify` from a git worktree per #1796).

🤖 Generated with [Claude Code](https://claude.com/claude-code)