### PR TITLE
chore(checks): declare __all__ in checks/utils.py — clears CodeQL py/unused-global-variable (#2415/#2416/#2417)

### DIFF
--- a/python/djust/checks/utils.py
+++ b/python/djust/checks/utils.py
@@ -14,6 +14,36 @@ import djust.checks as _root
 
 logger = logging.getLogger(__name__)
 
+# Shared surface this module provides to the sibling check submodules
+# (configuration, components, templates, …). Declared explicitly because
+# some of these — notably the ``_LIVE_RENDER_*`` regexes — are consumed only
+# by sibling modules (templates.py + components.py) and never read within
+# utils.py itself, so they read as module-unused to static analysis even
+# though they are live shared constants. Listing them here documents the
+# contract and marks them as exported.
+__all__ = [
+    # result classes
+    "DjustError",
+    "DjustWarning",
+    "DjustInfo",
+    # discovery / parsing helpers
+    "_is_check_suppressed",
+    "_get_project_app_dirs",
+    "_get_template_dirs",
+    "_iter_python_files",
+    "_iter_template_files",
+    "_iter_js_files",
+    "_parse_python_file",
+    "_has_noqa",
+    "_walk_subclasses",
+    "_strip_verbatim_blocks",
+    # shared scanner regexes
+    "_LIVE_RENDER_TAG_RE",
+    "_LIVE_RENDER_STICKY_TRUTHY_RE",
+    "_LIVE_RENDER_STICKY_FALSY_RE",
+    "_VERBATIM_BLOCK_RE",
+]
+
 
 class _DjustCheckMixin:
     """Mixin that adds fix_hint, file_path, and line_number to check results."""


### PR DESCRIPTION
Clears three CodeQL `py/unused-global-variable` alerts (#2415 / #2416 / #2417) on `python/djust/checks/utils.py`.

## Cause

The #1822 `checks.py` → `checks/` split routed the A075 sticky+lazy scanner regexes into `checks/utils.py` as shared constants:

- `_LIVE_RENDER_TAG_RE` (L222)
- `_LIVE_RENDER_STICKY_TRUTHY_RE` (L230)
- `_LIVE_RENDER_STICKY_FALSY_RE` (L236)

They are **read by sibling submodules** — `templates.py` (lines 451/455/458) and `components.py` (lines 632/637/638) — but never within `utils.py` itself, so the query flags them as module-unused. They are **not dead code**; moving them into a submodule would duplicate the regex across two consumers (anti-#1646), so `utils.py` is the correct single home.

## Fix

Declare `__all__` in `utils.py` listing its shared surface. `py/unused-global-variable` excludes names in `__all__`, and `__all__` documents the contract the sibling submodules import.

## Verification

- Pure declaration — no behavior change.
- The three regexes resolve unchanged from `djust.checks.utils`, the `djust.checks` package root, and `from djust.checks.utils import *`.
- All `__all__` names exist; full checks suite green (443 passed).
- The CodeQL "Analyze Python" job on this PR re-evaluates the alerts (utils.py is not path-ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)