### PR TITLE
fix(websocket): arm recovery on all render-send paths so _recovery_version stays current (#1817)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **WebSocket: recovery version no longer goes stale across non-arming
+  render-send paths (#1817).** After #1816 (#1788) every client-checked
+  outbound frame stamps the consumer-owned `_last_sent_version`, and
+  `_arm_recovery` captures `_recovery_version = _last_sent_version` at arm time;
+  `handle_request_html` sends the `html_recovery` frame stamped with that
+  `_recovery_version`. But several render-send paths advanced the wire version
+  WITHOUT arming recovery — the async-result error arms, the deferred-activity
+  render, the hotreload frame, the time-travel jumps (`handle_time_travel_jump`
+  / `handle_time_travel_component_jump` / `handle_forward_replay`), and the
+  tick / `db_notify` broadcasts. After such a frame the client's applied version
+  was ahead of `_recovery_version`, so a later `request_html` returned an
+  `html_recovery` stamped with the stale `_recovery_version` — the client reset
+  `clientVdomVersion` backwards and the next successful diff's `data.version - 1`
+  no longer matched, forcing an extra recovery round-trip (severity low,
+  post-#1785: an extra round-trip, not data loss). Structural cure (#1646
+  parallel-path discipline): one helper, `_next_version_armed(html)`, advances
+  the wire version AND arms recovery in a single step, and every render-send
+  path is routed through it; non-render baselines (mount) stay on bare
+  `_next_version()`. The actor event path is left on bare `_next_version()`
+  pending follow-up (its `result['html']` is not the pre-strip render the
+  recovery path expects). New end-to-end regression test
+  `test_time_travel_jump_recovery_version_is_current` (a real
+  `WebsocketCommunicator` round-trip) plus helper-level unit tests in
+  `python/djust/tests/test_recovery_version_staleness_1817.py`; the
+  `_next_version_armed` render-send call-site count is pinned by
+  `test_every_client_checked_send_path_uses_next_version` in
+  `python/djust/tests/test_ws_send_version_1788.py`, and the consolidated single
+  `_arm_recovery` call site is pinned by
+  `test_arm_recovery_call_site_count_matches_known_send_paths` in
+  `tests/unit/test_arm_recovery_helper_1645.py`.
+
 ## [1.0.6] - 2026-06-18
 
 Stable release consolidating 1.0.6rc1–rc3. Headline: two P0 VDOM data-loss

--- a/python/djust/tests/test_recovery_version_staleness_1817.py
+++ b/python/djust/tests/test_recovery_version_staleness_1817.py
@@ -1,0 +1,274 @@
+"""Regression tests for #1817 — ``_recovery_version`` staleness across render-send paths.
+
+Root cause
+----------
+After #1816 (#1788) every client-checked outbound WS frame stamps the
+consumer-owned ``_last_sent_version`` via ``_next_version()``
+(``websocket.py``). ``_arm_recovery(html)`` captures
+``_recovery_version = _last_sent_version`` at arm time, and
+``handle_request_html`` sends an ``html_recovery`` frame stamped with that
+``_recovery_version``. The client sets ``clientVdomVersion = data.version``
+directly on ``html_recovery`` (``static/djust/src/03-websocket.js:727``).
+
+The bug: several RENDER-SEND paths (the async-result error arms, the
+deferred-activity render, the hotreload frame, the time-travel jumps, and the
+tick / db_notify broadcasts) advanced ``_next_version()`` WITHOUT arming
+recovery. So after such a frame the client's applied version was AHEAD of
+``_recovery_version``. A later ``request_html`` then returned an
+``html_recovery`` stamped with the STALE ``_recovery_version`` → the client
+reset ``clientVdomVersion`` backwards → the next successful diff's
+``data.version - 1`` no longer matched → an extra recovery round-trip.
+
+The fix: route every render-send path through the shared
+``_next_version_armed(html)`` helper, which advances the wire version AND arms
+recovery in one step, so ``_recovery_version == _last_sent_version`` after each
+applied frame. Recovery then always resets the client to the version it is
+actually on.
+
+Fidelity
+--------
+``test_time_travel_jump_recovery_version_is_current`` drives the REAL
+``LiveViewConsumer`` through a real ``WebsocketCommunicator`` end-to-end:
+mount → arming event → time-travel jump (a render-send drift path) →
+``request_html``, and asserts the ``html_recovery`` frame carries the version
+the client is CURRENTLY on (post-jump), not the stale pre-jump version. The
+GATE-OFF evidence (reverting the arm on the jump path) is recorded in the PR.
+"""
+
+from __future__ import annotations
+
+import pytest
+from asgiref.sync import sync_to_async
+
+from djust import LiveView
+from djust.decorators import event_handler
+
+
+class _TTRecoveryView(LiveView):
+    """Time-travel-enabled view used to drive the jump render-send drift path.
+
+    ``time_travel_enabled = True`` makes each ``@event_handler`` dispatch record
+    a ``state_before`` / ``state_after`` snapshot, so a ``time_travel_jump`` to
+    a past snapshot can restore ``count`` and re-render. The re-render is a
+    render-send (the client applies it as new display state + writes
+    ``clientVdomVersion``), so it MUST arm recovery (#1817).
+    """
+
+    time_travel_enabled = True
+
+    template = (
+        '<div dj-view="djust.tests.test_recovery_version_staleness_1817._TTRecoveryView" '
+        'dj-id="0">Count: {{ count }}</div>'
+    )
+
+    def mount(self, request, **kwargs):
+        self.count = 0
+
+    @event_handler()
+    def bump(self, **kwargs):
+        self.count += 1
+
+
+async def _receive_until(communicator, wanted_type, *, tries=8, timeout=3):
+    """Drain frames until one whose ``type`` == ``wanted_type`` (or return last seen)."""
+    last = None
+    for _ in range(tries):
+        last = await communicator.receive_json_from(timeout=timeout)
+        if last.get("type") == wanted_type:
+            return last
+    return last
+
+
+async def _connect_and_mount(view_suffix, url):
+    """WS harness lifted from test_ws_send_version_1788.py. Returns (communicator, mount)."""
+    pytest.importorskip("channels")
+    from channels.testing import WebsocketCommunicator
+    from django.contrib.sessions.backends.db import SessionStore
+
+    from djust.websocket import LiveViewConsumer
+
+    def _create_session():
+        s = SessionStore()
+        s.create()
+        return s.session_key
+
+    session_key = await sync_to_async(_create_session)()
+
+    class _ScopeSession:
+        def __init__(self, key):
+            self.session_key = key
+
+    communicator = WebsocketCommunicator(LiveViewConsumer.as_asgi(), "/ws/")
+    communicator.scope["session"] = _ScopeSession(session_key)
+
+    connected, _ = await communicator.connect()
+    assert connected, "WebsocketCommunicator must connect"
+    await communicator.receive_json_from(timeout=2)  # drain connect frame
+
+    await communicator.send_json_to(
+        {"type": "mount", "view": f"{__name__}.{view_suffix}", "url": url}
+    )
+    mount_frame = await _receive_until(communicator, "mount")
+    assert mount_frame.get("type") == "mount", f"expected mount, got {mount_frame!r}"
+    return communicator, mount_frame
+
+
+def _frame_version(frame):
+    assert frame is not None
+    return frame.get("version")
+
+
+# ---------------------------------------------------------------------------
+# (1) End-to-end real-WebsocketCommunicator reproduction (load-bearing, #1210).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_time_travel_jump_recovery_version_is_current():
+    """mount → bump → time_travel_jump → request_html.
+
+    The ``time_travel_jump`` is a render-send DRIFT path: it advances the wire
+    version and the client applies it (clientVdomVersion = jump version). BEFORE
+    #1817 the jump did NOT arm recovery, so a subsequent ``request_html``
+    returned an ``html_recovery`` stamped with the STALE pre-jump version. AFTER
+    the fix the ``html_recovery`` version equals the post-jump version the
+    client is currently on.
+
+    Gate-off check: revert the arm on the jump path (use bare ``_next_version()``
+    in ``handle_time_travel_jump``) and the final assertion fails with the stale
+    pre-jump version — proving this test exercises the fix.
+    """
+    from django.test import override_settings
+
+    # DEBUG=True is required for time-travel handlers (dev-only feature).
+    with override_settings(LIVEVIEW_ALLOWED_MODULES=[__name__], DEBUG=True):
+        communicator, mount_frame = await _connect_and_mount(
+            view_suffix="_TTRecoveryView", url="/tt/"
+        )
+        v_mount = _frame_version(mount_frame)
+        assert v_mount == 1, f"fresh mount baseline must be 1, got {v_mount!r}"
+
+        # (2) Arming event: a normal diff. Records time-travel snapshot[0]
+        # (state_before={count:0}, state_after={count:1}) AND arms recovery at
+        # this version (the canonical handle_event armed path).
+        await communicator.send_json_to({"type": "event", "event": "bump", "params": {}, "ref": 1})
+        ev1 = await _receive_until(communicator, "patch")
+        assert ev1.get("type") == "patch", f"bump should patch, got {ev1!r}"
+        v_arm = _frame_version(ev1)
+        assert v_arm == v_mount + 1, f"arming event must be {v_mount + 1}, got {v_arm!r}"
+
+        # (3) DRIFT path: jump back to snapshot[0]'s state_before (count → 0).
+        # This re-renders (count 1 → 0 produces a patch) and advances the wire
+        # version; the client applies it (clientVdomVersion = jump version).
+        await communicator.send_json_to({"type": "time_travel_jump", "index": 0, "which": "before"})
+        # The jump emits a patch/html_update render frame first, then a
+        # time_travel_state frame. Capture the render frame's version.
+        jump_render = None
+        for _ in range(8):
+            frame = await communicator.receive_json_from(timeout=3)
+            if frame.get("type") in ("patch", "html_update"):
+                jump_render = frame
+                break
+            if frame.get("type") == "error":
+                pytest.fail(f"time_travel_jump errored: {frame!r}")
+        assert jump_render is not None, "time_travel_jump must emit a render frame"
+        v_jump = _frame_version(jump_render)
+        assert v_jump == v_arm + 1, (
+            f"jump render must advance the wire version to {v_arm + 1} "
+            f"(client now at this version); got {v_jump!r}"
+        )
+
+        # (4) request_html → html_recovery. Its version MUST be the post-jump
+        # version the client is currently on (v_jump), NOT the stale pre-jump
+        # arming version (v_arm). BEFORE #1817 this was v_arm.
+        await communicator.send_json_to({"type": "request_html"})
+        recovery = await _receive_until(communicator, "html_recovery")
+        assert recovery.get("type") == "html_recovery", (
+            f"request_html must return html_recovery; got {recovery!r}"
+        )
+        v_recovery = _frame_version(recovery)
+        assert v_recovery == v_jump, (
+            f"html_recovery version must equal the client's CURRENT version "
+            f"after the time-travel jump ({v_jump}); got {v_recovery!r}. A stale "
+            f"value (the pre-jump arming version {v_arm}) is the #1817 drift: the "
+            "client would reset backwards and the next diff would mismatch, "
+            "forcing an extra recovery round-trip. The jump render-send path must "
+            "arm recovery via self._next_version_armed(html)."
+        )
+
+        await communicator.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# (2) Direct unit tests on the helper + per-path arm invariant.
+# ---------------------------------------------------------------------------
+
+
+class _ArmProbe:
+    """Minimal probe exercising the consumer's version/recovery helpers directly.
+
+    Bypasses Channels consumer machinery; only the version + recovery state
+    are needed to assert the ``_next_version_armed`` contract.
+    """
+
+    def __init__(self):
+        from djust.websocket import LiveViewConsumer
+
+        self._last_sent_version = 0
+        self._recovery_html = None
+        self._recovery_version = 0
+        # Bind the real implementations so the probe exercises production code.
+        self._next_version = LiveViewConsumer._next_version.__get__(self)
+        self._arm_recovery = LiveViewConsumer._arm_recovery.__get__(self)
+        self._next_version_armed = LiveViewConsumer._next_version_armed.__get__(self)
+
+
+def test_next_version_armed_advances_and_arms_together():
+    """``_next_version_armed`` must advance the wire version AND set
+    ``_recovery_version == _last_sent_version`` AND store the passed html — in one
+    call, so the two can never drift apart (#1817)."""
+    p = _ArmProbe()
+
+    v1 = p._next_version_armed("<html>v1</html>")
+    assert v1 == 1, f"first armed version must be 1, got {v1!r}"
+    assert p._last_sent_version == 1
+    assert p._recovery_version == 1, (
+        "armed call must leave _recovery_version == _last_sent_version (#1817)"
+    )
+    assert p._recovery_html == "<html>v1</html>", "armed call must store the passed html"
+
+    v2 = p._next_version_armed("<html>v2</html>")
+    assert v2 == 2
+    assert p._recovery_version == 2, "_recovery_version must track each armed frame"
+    assert p._recovery_html == "<html>v2</html>"
+
+
+def test_bare_next_version_does_not_arm_then_armed_resyncs():
+    """A bare ``_next_version()`` (a non-render baseline / unarmed path) leaves
+    ``_recovery_version`` BEHIND; a following ``_next_version_armed`` resyncs it.
+
+    This is the #1817 drift-and-recovery shape in miniature: bare advance creates
+    the staleness, the armed helper closes it.
+    """
+    p = _ArmProbe()
+
+    # Arm once at v1.
+    p._next_version_armed("<html>v1</html>")
+    assert p._recovery_version == 1
+
+    # A bare advance (the pre-#1817 drift) leaves _recovery_version stale.
+    bare = p._next_version()
+    assert bare == 2
+    assert p._last_sent_version == 2
+    assert p._recovery_version == 1, (
+        "bare _next_version() must NOT arm — this is exactly the staleness that "
+        "made html_recovery stamp an old version (#1817)"
+    )
+
+    # The armed helper resyncs the recovery baseline to the current version.
+    armed = p._next_version_armed("<html>v3</html>")
+    assert armed == 3
+    assert p._recovery_version == 3, (
+        "_next_version_armed must bring _recovery_version current with _last_sent_version (#1817)"
+    )

--- a/python/djust/tests/test_ws_recovery_html_update_1785.py
+++ b/python/djust/tests/test_ws_recovery_html_update_1785.py
@@ -137,13 +137,20 @@ def test_html_update_branch_arms_recovery_source():
     """Belt-and-suspenders source pin: ``handle_event`` must arm recovery on BOTH the
     patches branch and the ``html_update`` (patches=None) fallback branch.
 
-    If a future refactor drops the ``_arm_recovery`` call from the html_update branch,
-    this fails fast even if the integration test is skipped under some CI config.
+    If a future refactor drops the recovery arming from the html_update branch, this
+    fails fast even if the integration test is skipped under some CI config.
+
+    #1817: both branches now arm via the shared ``_next_version_armed(html)`` helper
+    (which advances the wire version AND arms recovery in one step) rather than a bare
+    ``_arm_recovery(html)`` line. Count either form so the pin survives the refactor
+    while still enforcing that BOTH branches arm.
     """
     import djust.websocket as ws_mod
 
     source = inspect.getsource(ws_mod.LiveViewConsumer.handle_event)
-    assert source.count("self._arm_recovery(") >= 2, (
+    arms = source.count("self._arm_recovery(") + source.count("self._next_version_armed(")
+    assert arms >= 2, (
         "handle_event must arm recovery in BOTH the patches branch and the html_update "
-        "fallback branch (#1785) — found fewer than 2 _arm_recovery calls."
+        "fallback branch (#1785) — via self._next_version_armed(html) (#1817) or a bare "
+        f"self._arm_recovery(html). Found {arms} arming calls (need >= 2)."
     )

--- a/python/djust/tests/test_ws_send_version_1788.py
+++ b/python/djust/tests/test_ws_send_version_1788.py
@@ -174,9 +174,7 @@ async def test_baseline_loss_html_update_stays_monotonic_no_recovery():
         assert m == 1, f"happy-path mount baseline must be 1, got {m!r}"
 
         # Normal diff event — should be a patch frame at m+1.
-        await communicator.send_json_to(
-            {"type": "event", "event": "bump", "params": {}, "ref": 1}
-        )
+        await communicator.send_json_to({"type": "event", "event": "bump", "params": {}, "ref": 1})
         ev1 = await _receive_until(communicator, "patch")
         assert ev1.get("type") == "patch", f"normal bump should patch, got {ev1!r}"
         v1 = _frame_version(ev1)
@@ -224,9 +222,7 @@ async def test_version_sequence_strictly_monotonic_across_baseline_boundary():
         communicator, mount_frame = await _connect_and_mount()
         m = _frame_version(mount_frame)
 
-        await communicator.send_json_to(
-            {"type": "event", "event": "bump", "params": {}, "ref": 1}
-        )
+        await communicator.send_json_to({"type": "event", "event": "bump", "params": {}, "ref": 1})
         f1 = await _receive_until(communicator, "patch")
 
         await communicator.send_json_to(
@@ -236,9 +232,7 @@ async def test_version_sequence_strictly_monotonic_across_baseline_boundary():
 
         # After a reset(), the next diff has a fresh baseline so this normal
         # event produces patches again.
-        await communicator.send_json_to(
-            {"type": "event", "event": "bump", "params": {}, "ref": 3}
-        )
+        await communicator.send_json_to({"type": "event", "event": "bump", "params": {}, "ref": 3})
         f3 = await _receive_until(communicator, "patch")
 
         seq = [m, _frame_version(f1), _frame_version(f2), _frame_version(f3)]
@@ -269,15 +263,11 @@ async def test_hotreload_frame_advances_consumer_counter_then_event_passes():
     _HVR_TEMPLATE_BODY[0] = "Count: {{ count }}"
 
     with override_settings(LIVEVIEW_ALLOWED_MODULES=[__name__], DEBUG=True):
-        communicator, mount_frame = await _connect_and_mount(
-            view_suffix="_WSHvrView", url="/hvr/"
-        )
+        communicator, mount_frame = await _connect_and_mount(view_suffix="_WSHvrView", url="/hvr/")
         m = _frame_version(mount_frame)
 
         # Normal event first to advance the counter to m+1.
-        await communicator.send_json_to(
-            {"type": "event", "event": "bump", "params": {}, "ref": 1}
-        )
+        await communicator.send_json_to({"type": "event", "event": "bump", "params": {}, "ref": 1})
         ev1 = await _receive_until(communicator, "patch")
         v1 = _frame_version(ev1)
         assert v1 == m + 1
@@ -290,9 +280,7 @@ async def test_hotreload_frame_advances_consumer_counter_then_event_passes():
         # it WRITES clientVdomVersion even though it's exempt from the check.
         _HVR_TEMPLATE_BODY[0] = "Counter is now: {{ count }}"
         channel_layer = get_channel_layer()
-        await channel_layer.group_send(
-            "djust_hotreload", {"type": "hotreload", "file": "x.html"}
-        )
+        await channel_layer.group_send("djust_hotreload", {"type": "hotreload", "file": "x.html"})
 
         hvr = await _receive_until(communicator, "patch")
         assert hvr.get("type") == "patch" and hvr.get("hotreload") is True, (
@@ -307,9 +295,7 @@ async def test_hotreload_frame_advances_consumer_counter_then_event_passes():
 
         # Next normal event must chain off the consumer counter (proves the
         # hotreload frame did NOT drift the wire version).
-        await communicator.send_json_to(
-            {"type": "event", "event": "bump", "params": {}, "ref": 2}
-        )
+        await communicator.send_json_to({"type": "event", "event": "bump", "params": {}, "ref": 2})
         ev2 = await _receive_until(communicator, "patch")
         v2 = _frame_version(ev2)
         assert v2 == vh + 1, (
@@ -357,12 +343,21 @@ def test_next_version_is_monotonic():
 
 def test_every_client_checked_send_path_uses_next_version():
     """Source-pin: every ``_send_update(...)`` call that stamps a client-checked frame
-    must pass ``version=self._next_version()`` (NOT the Rust ``version``), and the two
-    HIDDEN participants (hotreload, streaming) must route through the consumer counter.
+    must route through the consumer counter — RENDER-SEND paths via
+    ``self._next_version_armed(html)`` (#1817) and the NON-render baseline paths via
+    bare ``self._next_version()`` — and the two HIDDEN participants (hotreload via the
+    armed helper, streaming) must route through the consumer counter.
 
     Pins the migrated call-site count so a future send path that forgets the helper
-    trips this test (#1125). OUT-OF-SCOPE paths are explicitly excluded: child_update /
-    sticky_update (per-child Map) and mount_batch per-target object are NOT counted.
+    trips this test (#1125 / #1448). OUT-OF-SCOPE paths are explicitly excluded:
+    child_update / sticky_update (per-child Map) and mount_batch per-target object are
+    NOT counted.
+
+    #1817: the bare ``_next_version()`` is reserved for NON-render frames (the mount
+    baseline) plus the one path deliberately left unarmed pending follow-up (the actor
+    event path — its ``result['html']`` shape is not the pre-strip render the recovery
+    path expects). The shared helper ``_next_version_armed(html)`` (which internally
+    calls ``_next_version()`` once) is the canonical primitive for render-send paths.
     """
     import re
 
@@ -371,45 +366,72 @@ def test_every_client_checked_send_path_uses_next_version():
 
     ws_src = inspect.getsource(ws_mod)
 
-    # Count every INVOCATION of self._next_version() — both the inline kwarg
-    # form ``version=self._next_version()`` and the assignment form
-    # ``X = self._next_version()`` (used where _arm_recovery must capture the
-    # same version, or where a local Rust ``version`` is also needed for
-    # telemetry). Excludes the docstring reference inside _arm_recovery (which
-    # is prose, not a call: ``v = self._next_version()`` rendered in backticks).
-    inline = len(re.findall(r"version=self\._next_version\(\)", ws_src))
-    assign = len(re.findall(r"\b[a-z_]+ = self\._next_version\(\)", ws_src))
-    # The _arm_recovery docstring contains one prose ``v = self._next_version()``
-    # that matches the assignment regex; subtract it.
-    assign_doc_refs = ws_src.count("``v = self._next_version()``")
-    real_invocations = inline + assign - assign_doc_refs
+    # --- RENDER-SEND paths: must route through _next_version_armed(html) (#1817) ---
+    # Both the inline kwarg form ``version=self._next_version_armed(html)`` and the
+    # assignment form ``X = self._next_version_armed(html)`` (where a local is reused
+    # below — e.g. wire_version for telemetry / a separate strip/extract).
+    armed_inline = len(re.findall(r"version=self\._next_version_armed\(", ws_src))
+    armed_assign = len(re.findall(r"\b[a-z_]+ = self\._next_version_armed\(", ws_src))
+    armed_invocations = armed_inline + armed_assign
 
-    # Pin: every client-checked send path routes through the helper.
-    # Sites (verified at implementation, see PR #1788):
-    #   INLINE (version=self._next_version()), 11:
-    #     _run_async_work error arms: 2
-    #     _dispatch_single_event: 2
-    #     actor event path: 1
+    # Render-send sites routed through the armed helper (verified at #1817):
+    #   INLINE (version=self._next_version_armed(html)), 10:
+    #     _run_async_work error arms: 2 (patch + html fallback)
+    #     deferred-activity render: 2 (patch + html fallback)
     #     handle_hot_reload (HIDDEN #1): 1
     #     handle_time_travel_jump: 1
     #     handle_time_travel_component_jump: 1
     #     handle_forward_replay: 1
     #     db_notify: 1
     #     _run_tick: 1
-    #   ASSIGNMENT (X = self._next_version()), 6:
-    #     _run_async_work success arms: 2 (version, before _arm_recovery)
-    #     handle_mount: 1 (mount frame; covers actor mount)
-    #     handle_event patch + html fallback: 2 (wire_version, before _arm_recovery)
-    #     server_push: 1 (wire_version, before _arm_recovery)
-    # Total real invocations = 17.
-    EXPECTED_NEXT_VERSION_INVOCATIONS = 17
-    assert real_invocations == EXPECTED_NEXT_VERSION_INVOCATIONS, (
-        f"expected {EXPECTED_NEXT_VERSION_INVOCATIONS} self._next_version() invocations "
-        f"across client-checked send paths; found {real_invocations} "
-        f"(inline={inline}, assign={assign}, doc_refs={assign_doc_refs}). A new "
-        "client-checked send path must route through self._next_version() (#1788), or an "
-        "existing one drifted off it. Update this count ONLY if you intentionally "
-        "added/removed a client-checked send path."
+    #   ASSIGNMENT (X = self._next_version_armed(html)), 5:
+    #     _run_async_work success arms: 2
+    #     handle_event patch + html fallback: 2 (wire_version)
+    #     server_push: 1 (wire_version)
+    # Total armed invocations = 15.
+    EXPECTED_ARMED_INVOCATIONS = 15
+    assert armed_invocations == EXPECTED_ARMED_INVOCATIONS, (
+        f"expected {EXPECTED_ARMED_INVOCATIONS} self._next_version_armed() invocations "
+        f"across RENDER-SEND paths; found {armed_invocations} "
+        f"(inline={armed_inline}, assign={armed_assign}). Every render-send path must "
+        "arm recovery via self._next_version_armed(html) so _recovery_version stays "
+        "current (#1817). Update this count ONLY if you intentionally added/removed a "
+        "render-send path."
+    )
+
+    # --- NON-render / pending paths: bare self._next_version() ---
+    # The bare form is now reserved for: the helper body's single delegated call, the
+    # mount baseline (non-render), and the actor event path (left unarmed, #1817
+    # follow-up). Count send-site bare invocations EXCLUDING the helper-internal one.
+    bare_inline = len(re.findall(r"version=self\._next_version\(\)", ws_src))
+    bare_assign = len(re.findall(r"\b[a-z_]+ = self\._next_version\(\)(?!_armed)", ws_src))
+    # The helper body contains one ``version = self._next_version()`` delegation;
+    # exclude it so this counts only true send-site baseline allocations.
+    helper_src = inspect.getsource(ws_mod.LiveViewConsumer._next_version_armed)
+    helper_internal = len(re.findall(r"\b[a-z_]+ = self\._next_version\(\)", helper_src))
+    bare_send_sites = bare_inline + bare_assign - helper_internal
+
+    # Bare send-site invocations (verified at #1817):
+    #   INLINE: 1 — actor event path (left unarmed pending follow-up).
+    #   ASSIGNMENT: 1 — handle_mount baseline (non-render; covers actor mount).
+    EXPECTED_BARE_SEND_SITES = 2
+    assert bare_send_sites == EXPECTED_BARE_SEND_SITES, (
+        f"expected {EXPECTED_BARE_SEND_SITES} bare self._next_version() send-site "
+        f"invocations (mount baseline + actor event path); found {bare_send_sites} "
+        f"(inline={bare_inline}, assign={bare_assign}, helper_internal={helper_internal}). "
+        "A render-send path on the BARE helper is the #1817 drift — route it through "
+        "self._next_version_armed(html). Update this count ONLY if you intentionally "
+        "added/removed a non-render baseline path."
+    )
+
+    # The armed helper must exist and delegate to _next_version + _arm_recovery (#1817).
+    assert hasattr(ws_mod.LiveViewConsumer, "_next_version_armed"), (
+        "LiveViewConsumer must define _next_version_armed(html) — the canonical "
+        "render-send primitive that advances the wire version AND arms recovery (#1817)."
+    )
+    assert "self._next_version()" in helper_src and "self._arm_recovery(" in helper_src, (
+        "_next_version_armed must delegate to _next_version() AND _arm_recovery(html) "
+        "so the version allocation and recovery baseline can never drift (#1817)."
     )
 
     # The mount frame must stamp the consumer counter (covers actor mount too).

--- a/python/djust/websocket.py
+++ b/python/djust/websocket.py
@@ -1038,10 +1038,9 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 # "Recovery HTML unavailable", and the client freezes at the
                 # transitional state even though the backend advanced (#1636).
                 # Stamp the consumer-owned wire version (#1788), discarding the
-                # Rust ``version`` for the wire. Order: _next_version() THEN
-                # _arm_recovery (so _recovery_version == this frame's version).
-                version = self._next_version()
-                self._arm_recovery(html)
+                # Rust ``version`` for the wire, AND arm recovery in one step so
+                # _recovery_version == this frame's version (#1817).
+                version = self._next_version_armed(html)
                 await self._send_update(
                     patches=patch_list,
                     version=version,
@@ -1060,9 +1059,8 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 )(html)
                 # The fallback sends the full render to the client, so the
                 # recovery baseline must track it too (#1636). Consumer-owned
-                # wire version (#1788); order: _next_version() THEN _arm_recovery.
-                version = self._next_version()
-                self._arm_recovery(html)
+                # wire version + recovery arm in one step (#1788, #1817).
+                version = self._next_version_armed(html)
                 await self._send_update(
                     html=html_content,
                     version=version,
@@ -1097,9 +1095,12 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
 
                     if patches is not None:
                         patch_list = fast_json_loads(patches) if patches else []
+                        # Render-send: arm recovery so _recovery_version tracks
+                        # this error re-render's version (#1817). ``html`` is the
+                        # pre-strip render from render_with_diff() above.
                         await self._send_update(
                             patches=patch_list,
-                            version=self._next_version(),  # consumer-owned (#1788)
+                            version=self._next_version_armed(html),
                             event_name=event_name,
                             source="async",
                         )
@@ -1114,7 +1115,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         )(html)
                         await self._send_update(
                             html=html_content,
-                            version=self._next_version(),  # consumer-owned (#1788)
+                            version=self._next_version_armed(html),
                             event_name=event_name,
                             source="async",
                         )
@@ -1166,6 +1167,47 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
         """
         self._recovery_html = html
         self._recovery_version = getattr(self, "_last_sent_version", 0)
+
+    def _next_version_armed(self, html: str) -> int:
+        """Advance the wire version AND refresh the recovery baseline in one step.
+
+        This is the canonical primitive for every RENDER-SEND path — any frame
+        that ships a freshly-rendered patch/HTML the client applies as new
+        display state (and that WRITES ``clientVdomVersion = data.version``,
+        ``static/djust/src/02-response-handler.js:77``). It folds the
+        ``_next_version()`` allocation and the ``_arm_recovery(html)`` capture
+        into a single call so the two can never drift apart.
+
+        Why this exists (#1817): before #1816 (#1788) several render-send paths —
+        the async-result error arms, the deferred-activity render, the hotreload
+        frame, the time-travel jumps, and the tick / db_notify broadcasts —
+        advanced ``_next_version()`` WITHOUT arming recovery. After such a frame
+        the client's applied version was ahead of ``_recovery_version``, so a
+        later ``request_html`` returned an ``html_recovery`` stamped with the
+        STALE ``_recovery_version`` (``handle_request_html`` uses
+        ``self._recovery_version`` for the wire). The client then reset
+        ``clientVdomVersion`` backwards (``03-websocket.js:727``) and the NEXT
+        successful diff's ``data.version - 1`` no longer matched — forcing an
+        extra recovery round-trip. Routing every render-send path through this
+        helper keeps ``_recovery_version == _last_sent_version`` after each
+        applied frame, so recovery always resets the client to the version it is
+        actually on (#1646 parallel-path discipline: one helper, not N hand-copied
+        two-line pairs).
+
+        ``html`` MUST be the full PRE-STRIP HTML returned by
+        ``render_with_diff()`` (before ``_strip_comments_and_whitespace`` /
+        ``_extract_liveview_content``) — ``handle_request_html`` strips and
+        extracts the cached ``_recovery_html`` on demand, so arming with the
+        already-stripped/extracted content would double-process it.
+
+        NON-render frames (the mount baseline, ``navigate`` / ``reload`` /
+        error-only frames with no new render HTML) must stay on the bare
+        ``_next_version()`` — they advance the wire sequence but have no
+        client-applied display HTML to recover to.
+        """
+        version = self._next_version()
+        self._arm_recovery(html)
+        return version
 
     async def _send_update(
         self,
@@ -1424,9 +1466,11 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
 
         has_async = getattr(self.view_instance, "_async_pending", None) is not None
         if patch_list is not None:
+            # Render-send: arm recovery so _recovery_version tracks this deferred
+            # render's version (#1817). ``html`` is the pre-strip render.
             await self._send_update(
                 patches=patch_list,
-                version=self._next_version(),  # consumer-owned (#1788)
+                version=self._next_version_armed(html),
                 event_name=event_name,
                 async_pending=has_async,
                 source="event",
@@ -1437,6 +1481,10 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             # VDOM diff returned no patches — send full HTML like the
             # main path does. Mirrors the fallback branch so clients
             # behave identically for deferred vs live events.
+            # Capture the PRE-STRIP html for recovery arming BEFORE the
+            # strip/extract reassigns ``html`` (#1817 — _arm_recovery expects
+            # the unstripped render, which handle_request_html strips on demand).
+            recovery_html = html
             try:
 
                 def _sync_strip_and_extract(raw_html):
@@ -1450,7 +1498,7 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 return
             await self._send_update(
                 html=html_content,
-                version=self._next_version(),  # consumer-owned (#1788)
+                version=self._next_version_armed(recovery_html),
                 event_name=event_name,
                 async_pending=has_async,
                 source="event",
@@ -3864,11 +3912,10 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         # Store rendered HTML for on-demand recovery.
                         # Client sends request_html when applyPatches() fails
                         # (e.g., {% if %} blocks shifting DOM structure).
-                        # Consumer-owned wire version (#1788): allocate it, THEN
-                        # arm recovery (so _recovery_version == this frame's
-                        # version — recovery sets clientVdomVersion directly).
-                        wire_version = self._next_version()
-                        self._arm_recovery(html)
+                        # Consumer-owned wire version + recovery arm in one step
+                        # (#1788, #1817): _recovery_version == this frame's version
+                        # (recovery sets clientVdomVersion directly).
+                        wire_version = self._next_version_armed(html)
 
                         await self._send_update(
                             patches=patch_list,
@@ -3898,11 +3945,13 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         # #1788 path: a baseline loss makes the Rust ``version``
                         # non-sequential, but ``wire_version`` stays monotonic so
                         # the client accepts the html_update without recovery.
-                        # Allocate it BEFORE _arm_recovery (so _recovery_version
-                        # == this frame's version). The Rust ``version`` is still
-                        # used below for the DJE-053 warning + telemetry reason.
-                        wire_version = self._next_version()
-                        self._arm_recovery(html)
+                        # Allocate the wire version AND arm recovery in one step
+                        # (#1788, #1817) so _recovery_version == this frame's
+                        # version, arming with the RAW pre-strip ``html`` before
+                        # the strip/extract below reassigns it. The Rust
+                        # ``version`` is still used below for the DJE-053 warning
+                        # + telemetry reason.
+                        wire_version = self._next_version_armed(html)
 
                         # Batch strip + extract into a single thread hop
                         # to avoid two separate sync_to_async crossings.
@@ -4467,9 +4516,15 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 # the consumer counter — otherwise the NEXT normal event would be
                 # rejected against a stale client version. The separate
                 # ``_hvr_version`` (``hvr-applied`` telemetry frame) is untouched.
+                # Render-send: the hotreload frame is exempt from the client
+                # version CHECK but it still WRITES clientVdomVersion (#1788,
+                # HIDDEN #1), so it advances the client past _recovery_version.
+                # Arm recovery so a later request_html serves the post-HVR HTML,
+                # not a stale pre-HVR baseline (#1817). ``html`` is the pre-strip
+                # render from render_with_diff() above.
                 await self._send_update(
                     patches=patches,
-                    version=self._next_version(),  # consumer-owned (#1788, HIDDEN #1)
+                    version=self._next_version_armed(html),
                     hotreload=True,
                     file_path=file_path,
                 )
@@ -5096,7 +5151,9 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             await self._send_update(
                 patches=patch_list,
                 html=html,
-                version=self._next_version(),  # consumer-owned (#1788)
+                # Render-send: arm recovery so _recovery_version tracks this
+                # jump's version (#1817). ``html`` is the pre-strip render.
+                version=self._next_version_armed(html),
                 event_name="__time_travel_jump__",
             )
         except Exception as exc:  # noqa: BLE001 — dev-only, log + report
@@ -5169,7 +5226,9 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             await self._send_update(
                 patches=patch_list,
                 html=html,
-                version=self._next_version(),  # consumer-owned (#1788)
+                # Render-send: arm recovery so _recovery_version tracks this
+                # component-jump's version (#1817). ``html`` is the pre-strip render.
+                version=self._next_version_armed(html),
                 event_name="__time_travel_component_jump__",
             )
         except Exception as exc:  # noqa: BLE001 — dev-only, log + report
@@ -5261,7 +5320,9 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
             await self._send_update(
                 patches=patch_list,
                 html=html,
-                version=self._next_version(),  # consumer-owned (#1788)
+                # Render-send: arm recovery so _recovery_version tracks this
+                # forward-replay's version (#1817). ``html`` is the pre-strip render.
+                version=self._next_version_armed(html),
                 event_name="__forward_replay__",
             )
         except Exception as exc:  # noqa: BLE001 — dev-only, log + report
@@ -5394,11 +5455,9 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                     # handle_event. Without this, request_html after a failed
                     # broadcast-triggered patch finds _recovery_html=None and
                     # forces a page reload. See #1202.
-                    # Consumer-owned wire version (#1788); order: _next_version()
-                    # THEN _arm_recovery (so _recovery_version == this frame's
-                    # version).
-                    wire_version = self._next_version()
-                    self._arm_recovery(html)
+                    # Consumer-owned wire version + recovery arm in one step
+                    # (#1788, #1817): _recovery_version == this frame's version.
+                    wire_version = self._next_version_armed(html)
                     await self._send_update(
                         patches=patches,
                         version=wire_version,
@@ -5508,9 +5567,12 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                 if patches is not None:
                     if isinstance(patches, str):
                         patches = fast_json_loads(patches)
+                    # Render-send: arm recovery so _recovery_version tracks this
+                    # db_notify broadcast's version (#1817), mirroring server_push.
+                    # ``html`` is the pre-strip render from render_with_diff() above.
                     await self._send_update(
                         patches=patches,
-                        version=self._next_version(),  # consumer-owned (#1788)
+                        version=self._next_version_armed(html),
                         broadcast=True,
                         source="broadcast",
                     )
@@ -5601,9 +5663,12 @@ class LiveViewConsumer(AsyncWebsocketConsumer):
                         if patches is not None:
                             if isinstance(patches, str):
                                 patches = fast_json_loads(patches)
+                            # Render-send: arm recovery so _recovery_version
+                            # tracks this tick's version (#1817). ``html`` is the
+                            # pre-strip render from render_with_diff() above.
                             await self._send_update(
                                 patches=patches,
-                                version=self._next_version(),  # consumer-owned (#1788)
+                                version=self._next_version_armed(html),
                                 event_name="tick",
                                 source="tick",
                             )

--- a/tests/unit/test_arm_recovery_helper_1645.py
+++ b/tests/unit/test_arm_recovery_helper_1645.py
@@ -6,6 +6,12 @@ assignment at every send path (handle_event, server_push, _run_async_work). That
 is exactly the drift that caused #1639 — the async path was added without the
 arming. This pins the consolidation: the assignment lives in one helper, and
 every render-send path routes through it.
+
+#1817 extends the consolidation: render-send paths now allocate the wire version
+AND arm recovery in a SINGLE step via ``_next_version_armed(html)`` (which calls
+``_arm_recovery`` internally), so the version allocation and recovery baseline
+can never drift apart either. ``_arm_recovery`` therefore now has exactly one
+direct call site — the ``_next_version_armed`` helper body.
 """
 
 from __future__ import annotations
@@ -46,32 +52,41 @@ def test_arm_recovery_is_the_only_arming_mechanism():
 
 
 def test_render_send_paths_route_through_arm_recovery():
-    """Each render-send path must call _arm_recovery rather than hand-assign."""
+    """Each render-send path must arm the recovery baseline (#1645).
+
+    #1817: render-send paths now arm via the shared ``_next_version_armed(html)``
+    helper (which advances the wire version AND calls ``_arm_recovery`` in one
+    step) rather than a hand-copied ``_next_version()`` + ``_arm_recovery(html)``
+    pair. Accept either form so the pin survives the #1817 consolidation while
+    still enforcing that each path arms and never hand-assigns ``_recovery_html``.
+    """
     for name in ("handle_event", "server_push", "_run_async_work"):
         method_src = inspect.getsource(getattr(LiveViewConsumer, name))
-        assert "_arm_recovery(" in method_src, (
-            f"{name} must arm the recovery baseline via self._arm_recovery(...) "
-            f"so it can't drift from the other send paths (#1645)."
+        arms = "_arm_recovery(" in method_src or "_next_version_armed(" in method_src
+        assert arms, (
+            f"{name} must arm the recovery baseline via self._next_version_armed(html) "
+            f"(#1817) or self._arm_recovery(...) so it can't drift from the other send "
+            f"paths (#1645)."
         )
         # And must NOT hand-assign _recovery_html directly anymore.
         assert "_recovery_html =" not in method_src, (
             f"{name} still hand-assigns _recovery_html; route it through "
-            f"_arm_recovery instead (#1645)."
+            f"_arm_recovery / _next_version_armed instead (#1645)."
         )
 
 
 def test_arm_recovery_call_site_count_matches_known_send_paths():
     """Count-based guard (#1655, Action #1125): pin the number of
-    ``self._arm_recovery(...)`` call sites so a NEW render-send path can't be
-    added without consciously arming the recovery baseline (the #1639 shape:
-    a send path that renders+sends but forgets to arm). A new path that arms
-    bumps this count (update the list + N below); a new path that FORGETS to
-    arm leaves the count unchanged, but is caught by
-    ``test_render_send_paths_route_through_arm_recovery`` extended with its name.
+    ``self._arm_recovery(...)`` call sites so the single-source-of-truth helper
+    invariant can't silently regress.
 
-    Known sites (5): _run_async_work patches-branch + full-HTML-fallback,
-    handle_event patches-branch, handle_event full-HTML (html_update) fallback
-    (#1785), server_push.
+    #1817 consolidation: after #1817 every render-send path arms via the shared
+    ``_next_version_armed(html)`` helper, which is the ONLY place that calls
+    ``_arm_recovery(html)`` directly. So the direct ``self._arm_recovery(`` count
+    collapses to exactly 1 (the helper body). The render-send call-site count is
+    now pinned by ``_next_version_armed`` invocations in
+    ``test_ws_send_version_1788.test_every_client_checked_send_path_uses_next_version``
+    — a NEW render-send path that forgets to arm trips THAT count test.
     """
     import inspect
 
@@ -79,9 +94,18 @@ def test_arm_recovery_call_site_count_matches_known_send_paths():
 
     src = inspect.getsource(ws_mod)
     call_sites = src.count("self._arm_recovery(")
-    assert call_sites == 5, (
-        f"expected 5 self._arm_recovery() call sites (the known render-send "
-        f"paths), found {call_sites}. If you added a render-send path, arm the "
-        f"recovery baseline there and update this count + the enumerated list "
-        f"(#1655/#1645/#1639)."
+    assert call_sites == 1, (
+        f"expected exactly 1 self._arm_recovery() call site — the _next_version_armed "
+        f"helper body, the single source of truth for recovery arming after the #1817 "
+        f"consolidation; found {call_sites}. A direct _arm_recovery() call outside the "
+        f"helper means a path bypassed _next_version_armed (re-route it), and the "
+        f"render-send call-site count is pinned by the _next_version_armed count test "
+        f"in test_ws_send_version_1788 (#1655/#1645/#1639/#1817)."
+    )
+
+    # The single direct call site lives in the _next_version_armed helper.
+    helper_src = inspect.getsource(ws_mod.LiveViewConsumer._next_version_armed)
+    assert helper_src.count("self._arm_recovery(") == 1, (
+        "the single _arm_recovery() call site must be inside _next_version_armed "
+        "(the consolidated render-send arming helper, #1817)."
     )


### PR DESCRIPTION
## Summary

Closes #1817 (P2 tech-debt, severity LOW, pre-existing — surfaced in PR #1816/#1788 code review).

After #1816 (#1788) every client-checked outbound WS frame stamps the consumer-owned `_last_sent_version` via `_next_version()` (`python/djust/websocket.py`). `_arm_recovery(html)` captures `_recovery_version = _last_sent_version` at arm time, and `handle_request_html` sends an `html_recovery` frame stamped with that `_recovery_version`. The client sets `clientVdomVersion = data.version` directly on `html_recovery` (`static/djust/src/03-websocket.js:727`) — and on EVERY versioned frame (`02-response-handler.js:77`).

## Root cause

Several **render-send** paths advanced `_next_version()` WITHOUT arming recovery. After such a frame the client's applied version was AHEAD of `_recovery_version`. A later `request_html` then returned an `html_recovery` stamped with the STALE `_recovery_version` → the client reset `clientVdomVersion` backwards → the next successful diff's `data.version - 1` no longer matched → an extra recovery round-trip (mismatch → request_html → html_recovery → morph). Not data loss post-#1785, but a real extra round-trip.

## The fix — one helper (#1646 parallel-path discipline)

```python
def _next_version_armed(self, html: str) -> int:
    """Advance the wire version AND refresh the recovery baseline in one step."""
    version = self._next_version()
    self._arm_recovery(html)
    return version
```

Every **render-send** path is routed through `_next_version_armed(html)`. **Non-render** baselines stay on bare `_next_version()`.

### Sites migrated (render-send → `_next_version_armed`, 15 invocations across 13 logical sends)

| Path | file:line | Status before |
|---|---|---|
| `_run_async_work` success — patches | `websocket.py:1043` | armed (folded into helper) |
| `_run_async_work` success — html fallback | `websocket.py:1063` | armed (folded) |
| `_run_async_work` **error** — patches | `websocket.py:1103` | **UNARMED → fixed** |
| `_run_async_work` **error** — html fallback | `websocket.py:1118` | **UNARMED → fixed** |
| Deferred-activity render — patches | `websocket.py:1473` | **UNARMED → fixed** |
| Deferred-activity render — html fallback | `websocket.py:1501` | **UNARMED → fixed** (arms with pre-strip `recovery_html` captured before strip/extract) |
| `handle_event` — patches | `websocket.py:3918` | armed (folded) |
| `handle_event` — html_update fallback | `websocket.py:3954` | armed (folded) |
| `handle_hot_reload` (HIDDEN #1) | `websocket.py:4527` | **UNARMED → fixed** |
| `handle_time_travel_jump` | `websocket.py:5156` | **UNARMED → fixed** |
| `handle_time_travel_component_jump` | `websocket.py:5231` | **UNARMED → fixed** |
| `handle_forward_replay` | `websocket.py:5325` | **UNARMED → fixed** |
| `server_push` (broadcast) | `websocket.py:5460` | armed (folded) |
| `db_notify` (broadcast) | `websocket.py:5575` | **UNARMED → fixed** |
| `_run_tick` | `websocket.py:5671` | **UNARMED → fixed** |

All 5 issue-cited sites + the async-error path are fixed.

### Left on bare `_next_version()` (deliberate)

- **`handle_mount` baseline** (`websocket.py:2527`) — non-render: establishes the client baseline; no prior render HTML to recover to. Correct to leave bare.
- **Actor event path** (`websocket.py:3100`) — **left unarmed pending follow-up.** This is the `use_actors=True` (opt-in/experimental) variant of `handle_event`. Its `result['html']` comes from the Rust actor and its shape (pre-strip full render vs already-extracted content) is not guaranteed to be the pre-strip HTML the recovery path (`handle_request_html` strips+extracts on demand) expects. Arming it with possibly-extracted content would be worse than the LOW-severity drift. The non-actor sync path arms; the actor path can be armed once its html shape is verified. Recommend a follow-up issue.
- `_next_version()` inside `_next_version_armed` itself (`websocket.py:1208`) — the single delegated allocation.

## Reproduce-first (#1210) + gate-off (#1468)

New `python/djust/tests/test_recovery_version_staleness_1817.py`:

- **`test_time_travel_jump_recovery_version_is_current`** — a real `WebsocketCommunicator` against `LiveViewConsumer.as_asgi()`: mount (v1) → `bump` arming event (v2, arms recovery) → `time_travel_jump` drift render (v3, client now at v3) → `request_html` → asserts `html_recovery.version == 3` (the client's current version), not the stale v2.
- Two helper-level unit tests pinning the `_next_version_armed` contract (advances + arms together; bare advance leaves recovery stale, armed resyncs).

**Reproduce-before / gate-off evidence** — reverting the arm on the jump path (`version=self._next_version()` in `handle_time_travel_jump`) makes the end-to-end test FAIL with the exact stale-version symptom:

```
AssertionError: html_recovery version must equal the client's CURRENT version
after the time-travel jump (3); got 2. A stale value (the pre-jump arming
version 2) is the #1817 drift...
assert 2 == 3
```

Restoring `_next_version_armed(html)` → passes.

## Source-pin tests updated for the consolidation

- `test_ws_send_version_1788.py::test_every_client_checked_send_path_uses_next_version` — now pins 15 `_next_version_armed` render-send invocations + 2 bare send-site invocations (mount baseline + actor path).
- `test_ws_recovery_html_update_1785.py::test_html_update_branch_arms_recovery_source` — accepts arming via `_next_version_armed`.
- `tests/unit/test_arm_recovery_helper_1645.py::test_arm_recovery_call_site_count_matches_known_send_paths` — `_arm_recovery` now has exactly 1 direct call site (the helper body); the render-send count moved to the `_next_version_armed` pin.

## Verification

- `python/djust/tests/test_recovery_version_staleness_1817.py` — 3 passed.
- Regression sweep (`-k "websocket or recovery or send_version or request_html or async_work or time_travel or arm_recovery"`) — 198 passed; adjacent-path sweep (mount_batch/streaming/hotreload/tick/db_notify/deferred) — 296 passed.
- Pre-push full suite — pytest Passed; all hooks green. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)