### PR TITLE
test(js): make dj-transition active/end-on-next-frame test deterministic (#1830)

### DIFF
--- a/tests/js/dj_transition.test.js
+++ b/tests/js/dj_transition.test.js
@@ -13,7 +13,7 @@ import fs from 'fs';
 
 const clientCode = fs.readFileSync('./python/djust/static/djust/client.js', 'utf-8');
 
-function createDom(bodyHtml = '') {
+function createDom(bodyHtml = '', opts = {}) {
     const dom = new JSDOM(
         `<!DOCTYPE html><html><head></head><body>
             <div dj-view="test.V" dj-root>${bodyHtml}</div>
@@ -27,6 +27,27 @@ function createDom(bodyHtml = '') {
     }
     dom.window.WebSocket = MockWebSocket;
     dom.window.DJUST_USE_WEBSOCKET = false;
+    if (opts.controlledRaf) {
+        // Replace jsdom's timer-backed requestAnimationFrame with a queue we
+        // drive explicitly via `dom.flushFrame()`. dj-transition captures
+        // `globalThis.requestAnimationFrame` at _runTransition time, so a frame
+        // never fires on a real timer — phase transitions advance only when the
+        // test drives them, making the active/end-on-next-frame ordering
+        // deterministic instead of racing the 16 ms rAF fallback (#1830, #1795
+        // family: assert an ordering invariant, never real-frame timing).
+        const rafCbs = [];
+        dom.window.requestAnimationFrame = function (cb) {
+            rafCbs.push(cb);
+            return rafCbs.length;
+        };
+        dom.flushFrame = function () {
+            // Drain the callbacks queued so far (snapshot first so a callback
+            // that schedules another frame doesn't run in the same flush).
+            const due = rafCbs.splice(0);
+            due.forEach((cb) => cb(0));
+            return due.length;
+        };
+    }
     dom.window.eval(clientCode);
     dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
     return dom;
@@ -103,19 +124,26 @@ describe('dj-transition', () => {
         expect(dom.window.djust.djTransition._parseSpec('a, b, c')).toBeNull();
     });
 
-    it('applies start class synchronously, active/end on next frame', async () => {
-        dom = createDom('<div id="t" dj-transition="start-cls active-cls end-cls"></div>');
+    it('applies start class synchronously, active/end on next frame', () => {
+        // Controlled rAF: the phase-2/3 frame fires only when we drive it, so
+        // the ordering (start now, active/end next frame) is deterministic and
+        // never races the 16 ms rAF fallback under load (#1830). Fully
+        // synchronous — no awaits, no timers.
+        dom = createDom('<div id="t" dj-transition="start-cls active-cls end-cls"></div>', {
+            controlledRaf: true,
+        });
         const el = dom.window.document.getElementById('t');
-        // The module runs on DOMContentLoaded — phase-1 is applied
-        // SYNCHRONOUSLY at module eval time. Assert BEFORE the 16 ms
-        // rAF fallback fires (which would kick us into phase 2/3) —
-        // flush the microtask queue only.
-        await new Promise((r) => setTimeout(r, 0));
-        expect(el.classList.contains('start-cls')).toBe(true);
 
-        // After the next "frame" (fallback setTimeout 16 ms), phase-2
-        // and phase-3 land and phase-1 is removed.
-        await nextFrame(dom);
+        // Phase 1 is applied SYNCHRONOUSLY by the DOMContentLoaded init sweep
+        // (_installDjTransitionObserver → querySelectorAll → _runTransition →
+        // classList.add(start)). The phase-2/3 transition is queued on our
+        // controllable rAF and has NOT run yet — the ordering invariant.
+        expect(el.classList.contains('start-cls')).toBe(true);
+        expect(el.classList.contains('active-cls')).toBe(false);
+        expect(el.classList.contains('end-cls')).toBe(false);
+
+        // Drive exactly one frame: phase-2 + phase-3 land, phase-1 is removed.
+        expect(dom.flushFrame()).toBeGreaterThan(0); // a frame was actually queued
         expect(el.classList.contains('start-cls')).toBe(false);
         expect(el.classList.contains('active-cls')).toBe(true);
         expect(el.classList.contains('end-cls')).toBe(true);


### PR DESCRIPTION
Closes #1830.

## The flake
`tests/js/dj_transition.test.js > applies start class synchronously, active/end on next frame` intermittently failed under the full parallel `make test` JS run (`AssertionError: expected false to be true`) while passing 3/3 in isolation. It relied on a `setTimeout(0)` microtask flush winning a race against dj-transition's 16 ms rAF fallback — under load the real rAF fired first, advancing past phase 1 before the `start-cls` assertion. Same outlier-sensitivity class as #1795 (never assert on real-frame timing) and the rc1 perf-benchmark mean→median fix.

## Fix
Add an opt-in `controlledRaf` mode to the test's `createDom` that replaces jsdom's timer-backed `requestAnimationFrame` with a queue driven explicitly via `dom.flushFrame()`. dj-transition captures `globalThis.requestAnimationFrame` at `_runTransition` time, so with the stub a frame fires only when the test drives it.

The rewritten test is **fully synchronous** and asserts the **ordering invariant**:
- phase 1 (`start-cls`) is applied synchronously by the DOMContentLoaded init sweep (`querySelectorAll('[dj-transition]').forEach(_runTransition)`);
- `active-cls`/`end-cls` are NOT present until exactly one driven frame;
- after `flushFrame()`, phase-2/3 land and `start-cls` is removed.

No timer can race it. Other tests keep the real-timer rAF + `waitForClass`/`nextFrame` helpers — the new mode is opt-in, so their behavior is unchanged.

## Non-tautological (gate-off, #1468)
Neutering the `flushFrame()` drive makes the post-frame assertions fail (`expected true to be false` — `start-cls` persists), proving the driven frame is what advances the transition.

## Verified
Rewritten test passes 3/3; full `dj_transition.test.js` 11/11; pre-push full suite + all hooks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)