### PR TITLE
feat(checks): T017 — flag dj-view/dj-root on a table-section element (#1837)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **System check T017 — warn on ``dj-view`` / ``dj-root`` on a table-section
+  element (#1837).** A new template static-analysis check (severity WARNING)
+  flags a ``dj-view`` or ``dj-root`` attribute placed on an HTML table-section
+  element (``<tbody>``, ``<thead>``, ``<tfoot>``, ``<tr>``, ``<td>``, ``<th>``,
+  ``<caption>``, ``<col>``, ``<colgroup>``). Such a view renders to *silent
+  garbage*: html5ever foster-parents the table elements out of the tree at
+  render time, so ``<tbody dj-view="…">{% for %}<tr>…{% endfor %}</tbody>``
+  renders as ``<html><head></head><body>text</body></html>`` (all rows
+  dropped) with NO error. The matcher is same-tag-scoped (a ``<div dj-view>``
+  wrapping a ``<table><tbody>`` does NOT false-match — the attribute must be on
+  the table-section opening tag itself), word-boundaries the tag name so
+  ``<trx`` / ``<tablefoo`` don't match, and tolerates attribute order /
+  whitespace / case. The fix hint points the developer to a wrapping element
+  (the ``<table>`` or a surrounding ``<div>``). Honors
+  ``DJUST_CONFIG['suppress_checks']`` for both the short (``T017``) and
+  fully-qualified (``djust.T017``) id forms. Covered by ``TestT017TableSectionRegex``
+  and ``TestT017CheckIntegration`` in
+  ``python/tests/test_checks_t017_table_section_1837.py`` (regex word-boundary /
+  attribute-order cases, fires/no-false-positive empirical canary per #1459, and
+  suppression).
+
 ### Fixed
 
 - **WebSocket: recovery version no longer goes stale across non-arming

--- a/docs/system-checks.md
+++ b/docs/system-checks.md
@@ -44,6 +44,7 @@ Run checks with: `python manage.py check --deploy` or `python manage.py djust_ch
 | T013 | Templates | Warning | dj-view with empty or dynamic value |
 | T014 | Templates | Warning | Deprecated data-dj-id attribute |
 | T015 | Templates | Warning | Legacy data-djust-root / data-djust-view root attributes |
+| T017 | Templates | Warning | dj-view / dj-root on a table-section element (foster-parented to silent garbage) |
 | Q001 | Quality | Info | print() statement found |
 | Q002 | Quality | Warning | f-string in logger call |
 | Q003 | Quality | Info | console.log without djustDebug guard |
@@ -411,6 +412,30 @@ Added in v1.0.0 (#1605). The older mechanism (`SILENCED_SYSTEM_CHECKS` / `DJUST_
   are never flagged.
 - **Scope**: Static check only — djust 1.0's runtime does not accept the
   legacy attributes; the template must be migrated to the `dj-` spelling.
+
+### T017 — dj-view / dj-root on a table-section element
+- **Severity**: Warning
+- **Method**: Regex (template scan)
+- **What it detects**: A `dj-view` or `dj-root` attribute placed on an HTML
+  table-section element (`<tbody>`, `<thead>`, `<tfoot>`, `<tr>`, `<td>`,
+  `<th>`, `<caption>`, `<col>`, `<colgroup>`). Such a view renders to **silent
+  garbage**: html5ever foster-parents the table elements out of the tree at
+  render time, so `<tbody dj-view="…">{% for %}<tr>…{% endfor %}</tbody>`
+  renders as `<html><head></head><body>text</body></html>` (all rows dropped)
+  with **no error** (#1837).
+- **Fix**: Put `dj-view` / `dj-root` on a wrapping element (the `<table>` or a
+  surrounding `<div>`); a table-section element is foster-parented at render
+  time and cannot be a standalone parse root.
+- **Suppression**: Fix the templates; or
+  `DJUST_CONFIG = {"suppress_checks": ["T017"]}`
+- **False positives**: None expected; the match is scoped to the same tag
+  (`[^>]*?` stops at the table-section tag's own `>`), so a `<div dj-view>`
+  wrapping a `<table><tbody>` is never flagged, and a word-boundary on the tag
+  name rejects `<trx` / `<tablefoo`. `<table dj-view>` (the recommended wrap
+  target) is intentionally not flagged.
+- **Scope**: Static check only — it does not change html5ever's HTML5-spec
+  foster-parenting; it warns at startup so the silent failure is caught before
+  a request hits.
 
 ---
 

--- a/python/djust/checks/templates.py
+++ b/python/djust/checks/templates.py
@@ -133,6 +133,34 @@ _LIVE_RENDER_LAZY_TRUTHY_RE = re.compile(
 )
 _LIVE_RENDER_LAZY_FALSY_RE = re.compile(r"""\blazy\s*=\s*(?:False|"\s*"|'\s*'|0)\b""")
 
+# T017 (#1837) — `dj-view` / `dj-root` placed on an HTML table-section element.
+# Such a view renders to SILENT GARBAGE: html5ever foster-parents the table
+# elements out of the tree at render time, so
+# `<tbody dj-view="…">{% for %}<tr>…{% endfor %}</tbody>` renders as
+# `<html><head></head><body>text</body></html>` (all rows dropped) with NO
+# error. The fix is to put the root attribute on a wrapping element (the
+# `<table>` or a surrounding `<div>`).
+#
+# Detection: match an OPENING table-section tag that carries `dj-view=` or
+# `dj-root=` ON THE SAME TAG. The `[^>]*` attribute span stops at the tag's
+# own `>` (opening tags can't contain a literal `>` in attributes), so the
+# attribute must be on the table-section tag itself — `<div dj-view><table>
+# <tbody>…` does NOT match because the `dj-view` is on the `<div>`, not on
+# any table-section opening tag. The `\b` word-boundary after the tag name
+# rejects `<tablefoo` / `<trx`. Attribute order/whitespace is tolerated:
+# both `<tbody dj-view=…>` and `<tbody class="x" dj-root>` match.
+#
+# `col` / `colgroup` are matched too — they're self-closing-ish but the same
+# `<col …>` opening-tag shape applies. We list the alternatives longest-first
+# (`colgroup` before `col`, `tfoot`/`thead` before `td`/`th`/`tr`) so the
+# alternation prefers the longer name; the trailing `(?![\w-])` boundary
+# makes ordering immaterial but the explicit order keeps the intent clear.
+_DJ_TABLE_SECTION_ROOT_RE = re.compile(
+    r"<(tbody|thead|tfoot|colgroup|caption|col|tr|td|th)(?![\w-])"
+    r"[^>]*?\b(dj-view|dj-root)\b",
+    re.IGNORECASE,
+)
+
 
 @register("djust")
 def check_templates(app_configs, **kwargs):
@@ -356,6 +384,9 @@ def check_templates(app_configs, **kwargs):
 
         # T015 -- legacy data-djust-root / data-djust-view root attributes
         _check_legacy_root_attrs(content, relpath, filepath, errors)
+
+        # T017 -- dj-view / dj-root on a table-section element (#1837)
+        _check_table_section_root(content, relpath, filepath, errors)
 
         # A070 / A071 -- {% dj_activity %} name validation (v0.7.0).
         # A070 (Warning): tag with no name arg — renders a no-op wrapper
@@ -739,6 +770,61 @@ def _check_legacy_root_attrs(content, relpath, filepath, errors):
                 fix_hint=(
                     "Replace '%s' with '%s' at line %d in `%s`."
                     % (old_attr, new_attr, lineno, relpath)
+                ),
+                file_path=filepath,
+                line_number=lineno,
+            )
+        )
+
+
+def _check_table_section_root(content, relpath, filepath, errors):
+    """T017 (#1837): Detect dj-view / dj-root on an HTML table-section element.
+
+    A LiveView whose root element is a table-section element (``<tbody>``,
+    ``<thead>``, ``<tfoot>``, ``<tr>``, ``<td>``, ``<th>``, ``<caption>``,
+    ``<col>``, ``<colgroup>``) renders to *silently broken* output:
+    html5ever foster-parents the table elements out of the tree at render
+    time. Empirically, a ``<tbody dj-view="...">{% for %}<tr>...{% endfor %}
+    </tbody>`` template renders as ``<html><head></head><body>text</body>
+    </html>`` -- all the ``<tr>`` / ``<td>`` structure is dropped, leaving
+    only text, with NO error (#1837).
+
+    The match is scoped to the SAME tag: ``[^>]*?`` stops at the
+    table-section tag's own ``>``, so ``<div dj-view><table><tbody>...`` (the
+    root attribute on a wrapping element) never false-matches. The
+    word-boundary on the tag name rejects ``<tablefoo`` / ``<trx``.
+
+    SCOPE: this is a static system check only. It does not change the
+    renderer's foster-parenting behavior (that is html5ever's HTML5-spec
+    parsing); it warns the developer at startup so the silent failure is
+    caught before a request hits.
+    """
+    if _is_check_suppressed("djust.T017"):
+        return
+    for match in _DJ_TABLE_SECTION_ROOT_RE.finditer(content):
+        lineno = content[: match.start()].count("\n") + 1
+        tag_name = match.group(1).lower()
+        attr = match.group(2).lower()
+        errors.append(
+            DjustWarning(
+                "%s:%d -- '%s' is on a <%s> table-section element, which is "
+                "foster-parented out of the tree at render time (the rendered "
+                "output silently drops the table rows, with no error)."
+                % (relpath, lineno, attr, tag_name),
+                hint=(
+                    "A table-section element (<tbody>, <thead>, <tfoot>, <tr>, "
+                    "<td>, <th>, <caption>, <col>, <colgroup>) cannot be a "
+                    "standalone parse root -- html5ever foster-parents it. Put "
+                    "%s on a wrapping element (the <table> or a surrounding "
+                    "<div>) instead. Suppress this check with "
+                    "DJUST_CONFIG = {'suppress_checks': ['T017']}." % attr
+                ),
+                id="djust.T017",
+                fix_hint=(
+                    "Put `dj-view`/`dj-root` on a wrapping element (the "
+                    "`<table>` or a surrounding `<div>`); a table-section "
+                    "element is foster-parented at render time and cannot be "
+                    "a parse root. (line %d in `%s`)" % (lineno, relpath)
                 ),
                 file_path=filepath,
                 line_number=lineno,

--- a/python/tests/test_checks_t017_table_section_1837.py
+++ b/python/tests/test_checks_t017_table_section_1837.py
@@ -1,0 +1,151 @@
+"""Tests for djust system check T017 (#1837).
+
+T017 (WARNING) flags ``dj-view`` / ``dj-root`` placed on an HTML
+table-section element (``<tbody>``, ``<thead>``, ``<tfoot>``, ``<tr>``,
+``<td>``, ``<th>``, ``<caption>``, ``<col>``, ``<colgroup>``). Such a view
+renders to silent garbage: html5ever foster-parents the table elements out of
+the tree at render time, so ``<tbody dj-view="...">{% for %}<tr>...{% endfor %}
+</tbody>`` renders as ``<html><head></head><body>text</body></html>`` (all rows
+dropped) with NO error.
+
+Empirical canary (#1459): the "fires" cases assert the check actually catches
+the bug class it claims to catch; the "does NOT fire" case pins the
+no-false-positive contract; the suppression cases pin the opt-out.
+"""
+
+from django.test import override_settings
+
+from djust.checks import _DJ_TABLE_SECTION_ROOT_RE
+
+
+class TestT017TableSectionRegex:
+    """Regex unit cases (mirrors the TestS007ClientNameSafeRegex style)."""
+
+    def test_matches_tbody_dj_view(self):
+        assert _DJ_TABLE_SECTION_ROOT_RE.search('<tbody dj-view="x.V">') is not None
+
+    def test_matches_tr_dj_root(self):
+        assert _DJ_TABLE_SECTION_ROOT_RE.search("<tr dj-root>") is not None
+
+    def test_matches_all_table_section_tags(self):
+        for tag in (
+            "tbody",
+            "thead",
+            "tfoot",
+            "tr",
+            "td",
+            "th",
+            "caption",
+            "col",
+            "colgroup",
+        ):
+            html = '<%s dj-view="x.V">' % tag
+            assert _DJ_TABLE_SECTION_ROOT_RE.search(html) is not None, tag
+
+    def test_tolerates_attribute_order(self):
+        """dj-root after other attributes still matches."""
+        assert (
+            _DJ_TABLE_SECTION_ROOT_RE.search('<thead class="h" id="x" dj-root="x.V">') is not None
+        )
+
+    def test_tolerates_extra_whitespace(self):
+        assert _DJ_TABLE_SECTION_ROOT_RE.search('<tbody    dj-view="x.V"  >') is not None
+
+    def test_case_insensitive(self):
+        assert _DJ_TABLE_SECTION_ROOT_RE.search('<TBODY DJ-VIEW="x.V">') is not None
+
+    def test_word_boundary_rejects_trx(self):
+        """`<trx` must NOT match `tr` (word-boundary on tag name)."""
+        assert _DJ_TABLE_SECTION_ROOT_RE.search('<trx dj-view="x.V">') is None
+
+    def test_word_boundary_rejects_tablefoo(self):
+        assert _DJ_TABLE_SECTION_ROOT_RE.search("<tablefoo dj-view>") is None
+
+    def test_table_itself_not_flagged(self):
+        """`<table dj-view>` is the recommended wrap target — never flagged."""
+        assert _DJ_TABLE_SECTION_ROOT_RE.search('<table dj-view="x.V">') is None
+
+    def test_div_wrapping_table_not_flagged(self):
+        """`dj-view` on a <div> wrapping a <table><tbody> must NOT match —
+        the attribute is on the wrapper, not on any table-section tag."""
+        html = (
+            '<div dj-view="x.V"><table><tbody>'
+            "{% for r in rows %}<tr><td>{{ r }}</td></tr>{% endfor %}"
+            "</tbody></table></div>"
+        )
+        assert _DJ_TABLE_SECTION_ROOT_RE.search(html) is None
+
+    def test_plain_table_section_without_attr_not_flagged(self):
+        assert _DJ_TABLE_SECTION_ROOT_RE.search('<tbody class="x">') is None
+
+
+def _scan(tmp_path, settings, body, fname="t.html"):
+    """Drive the real ``check_templates`` against a temp template dir."""
+    tpl_dir = tmp_path / "templates"
+    tpl_dir.mkdir()
+    (tpl_dir / fname).write_text(body)
+    settings.TEMPLATES = [
+        {
+            "DIRS": [str(tpl_dir)],
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "APP_DIRS": False,
+        }
+    ]
+    from djust.checks import check_templates
+
+    errors = check_templates(None)
+    return [e for e in errors if e.id == "djust.T017"]
+
+
+class TestT017CheckIntegration:
+    """Integration tests for T017 via the actual check function (#1837)."""
+
+    def test_fires_on_tbody_dj_view(self, tmp_path, settings):
+        """T017 fires for a <tbody dj-view="..."> root template."""
+        t017 = _scan(
+            tmp_path,
+            settings,
+            '<tbody dj-view="x.V">{% for r in rows %}<tr><td>{{ r }}</td></tr>{% endfor %}</tbody>',
+        )
+        assert len(t017) == 1
+        assert "table-section" in t017[0].msg
+        assert "tbody" in t017[0].msg
+        assert "wrapping element" in t017[0].hint
+
+    def test_fires_on_tr_dj_root(self, tmp_path, settings):
+        """T017 fires for a <tr dj-root> root template (second variant)."""
+        t017 = _scan(tmp_path, settings, "<tr dj-root><td>cell</td></tr>")
+        assert len(t017) == 1
+        assert "tr" in t017[0].msg
+
+    def test_does_not_fire_on_div_wrapping_table(self, tmp_path, settings):
+        """No false positive: dj-view on a <div> wrapping a <table><tbody>."""
+        t017 = _scan(
+            tmp_path,
+            settings,
+            '<div dj-view="x.V"><table><tbody>'
+            "{% for r in rows %}<tr><td>{{ r }}</td></tr>{% endfor %}"
+            "</tbody></table></div>",
+        )
+        assert t017 == []
+
+    def test_does_not_fire_on_table_dj_view(self, tmp_path, settings):
+        """No false positive: dj-view directly on the <table> element."""
+        t017 = _scan(
+            tmp_path,
+            settings,
+            '<table dj-view="x.V"><tbody><tr><td>x</td></tr></tbody></table>',
+        )
+        assert t017 == []
+
+    @override_settings(DJUST_CONFIG={"suppress_checks": ["T017"]})
+    def test_suppressed_short_id(self, tmp_path, settings):
+        """T017 is suppressible via the short id form."""
+        t017 = _scan(tmp_path, settings, '<tbody dj-view="x.V"><tr><td>x</td></tr></tbody>')
+        assert t017 == []
+
+    @override_settings(DJUST_CONFIG={"suppress_checks": ["djust.T017"]})
+    def test_suppressed_qualified_id(self, tmp_path, settings):
+        """T017 is suppressible via the fully-qualified id form."""
+        t017 = _scan(tmp_path, settings, '<tbody dj-view="x.V"><tr><td>x</td></tr></tbody>')
+        assert t017 == []


### PR DESCRIPTION
Closes #1837.

## Problem (empirical render-garbage evidence)

A LiveView whose root element is a table-section element renders to **silently broken** output — html5ever foster-parents the table elements out of the tree at render time, with **no error**. Reproduced directly:

```python
class V(LiveView):
    template='<tbody dj-view="x.V" dj-id="0">{% for r in rows %}<tr><td>{{ r }}</td></tr>{% endfor %}</tbody>'
    def mount(self,request,**k): self.rows=["a"]
    def get_context_data(self,**k): return {"rows": self.rows}
v=V(); v.mount(Req()); html,_,_=v.render_with_diff()
```

renders as:

```
<html dj-id="0"><head dj-id="1"></head><body dj-id="2">a</body></html>
```

The entire `<tr><td>a</td></tr>` structure is dropped, leaving only the text `a`.

## The check

- **ID**: `djust.T017` — **Severity**: WARNING — `python/djust/checks/templates.py`
- **Detection**: regex `_DJ_TABLE_SECTION_ROOT_RE` matching an opening table-section tag (`<tbody>`, `<thead>`, `<tfoot>`, `<tr>`, `<td>`, `<th>`, `<caption>`, `<col>`, `<colgroup>`) carrying `dj-view=` / `dj-root=` **on the same tag**. The `[^>]*?` attribute span stops at the tag's own `>`, so the attribute must be on the table-section tag itself; `\b`/`(?![\w-])` word-boundaries the tag name. Case-insensitive; tolerates attribute order/whitespace.
- **fix_hint**: "Put `dj-view`/`dj-root` on a wrapping element (the `<table>` or a surrounding `<div>`); a table-section element is foster-parented at render time and cannot be a parse root."
- Honors `_is_check_suppressed("djust.T017")` (both `T017` and `djust.T017` forms).

## Empirical canary (#1459)

`python/tests/test_checks_t017_table_section_1837.py` (`TestT017TableSectionRegex`, `TestT017CheckIntegration`):

- **Fires**: `<tbody dj-view="x.V">…` → 1× `djust.T017`; `<tr dj-root>…` → 1× `djust.T017`.
- **Does NOT fire** (no false positive): `<div dj-view="x.V"><table><tbody>{% for %}<tr>…</table></div>` → 0; `<table dj-view="x.V">…` → 0.
- **Suppression**: `T017` and `djust.T017` in `DJUST_CONFIG['suppress_checks']` → 0.
- **Regex unit cases**: word-boundary rejects `<trx` / `<tablefoo`; tolerates attribute order/whitespace/case; `<table dj-view>` (the wrap target) not flagged.

17 tests, all green.

## Gate-off (#1468)

With the T017 emission early-returned (`if True: return`), the fires tests fail (non-tautological):

```
test_fires_on_tbody_dj_view: assert len(t017) == 1
E   assert 0 == 1  +  where 0 = len([])
test_fires_on_tr_dj_root: assert 0 == 1
```

Restored after verification.

## Dogfood (#1060)

`cd examples/demo_project && manage.py check | grep T017` → no match (T017 does not fire spuriously); `manage.py check` exits 0 (121 issues, 0 silenced — unchanged).

## Tests

- `pytest -k "T017 or table_section or check_templates"` → 18 passed.
- `pytest -k "check"` (full checks suite) → 460 passed, 0 failed (no T-series regression).
- Pre-push full suite + ruff passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
