### PR TITLE
fix(checks): V004 no longer false-fires on framework-invoked lifecycle hooks (#1684)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`V004` no longer false-fires on framework-invoked lifecycle hooks (#1684).** The `V004` system check ("public method looks like an event handler but is missing `@event_handler`") flagged user overrides of hooks the framework calls *directly* (`self.X()` / `getattr` / `hasattr`) rather than through the user-event router — these must NOT carry `@event_handler`, but their names match the event-handler-like regex and were absent from the `V004` lifecycle-skip set in `checks/components.py`. Canonical symptom: `handle_presence_leave` (bit `djust-org/djust-start#5`). Added the 8 framework-invoked hooks (`handle_presence_join`/`handle_presence_leave`/`handle_cursor_move`/`handle_tick`/`handle_async_result`/`handle_component_event`/`handle_info`/`on_wizard_complete`) to the skip set. The fix originally landed on the `1.1` branch (#1685) against the pre-`#1822`-split `checks.py`; it was never ported to `main`'s split `checks/` (so the false-positive was live through 1.0.8) — this lands it on `main`. New regression `TestV004LifecycleMethods::test_v004_ignores_framework_invoked_hooks_1684` (gate-off verified, #1468).
+
 ## [1.0.8] - 2026-06-23
 
 ### Security

--- a/python/djust/checks/components.py
+++ b/python/djust/checks/components.py
@@ -284,6 +284,20 @@ def check_liveviews(app_configs, **kwargs):
                 "handle_disconnect",
                 "handle_connect",
                 "handle_event",
+                # Framework-invoked lifecycle hooks (#1684). The framework calls
+                # these directly (self.X() / getattr / hasattr), NOT via the
+                # user-event router, so they must NOT carry @event_handler — but
+                # their names match the event-handler-like regex. Fix originally
+                # landed on the 1.1 branch (#1685) against the pre-split checks.py;
+                # ported here so main's split checks/ carries it too.
+                "handle_presence_join",  # presence.py track_presence()
+                "handle_presence_leave",  # presence.py untrack_presence()
+                "handle_cursor_move",  # websocket.py cursor_move (LiveCursorMixin)
+                "handle_tick",  # websocket.py tick loop (LiveView)
+                "handle_async_result",  # websocket.py/sse.py background-work completion
+                "handle_component_event",  # mixins/components.py child-component callback
+                "handle_info",  # websocket.py channel-layer/info (NotificationMixin)
+                "on_wizard_complete",  # wizard.py submit_wizard() (WizardMixin)
             ):
                 continue
             if is_event_handler(method):

--- a/python/tests/test_checks.py
+++ b/python/tests/test_checks.py
@@ -3906,6 +3906,28 @@ class TestV004LifecycleMethods:
         """handle_event() is a lifecycle method — V004 must not fire."""
         self._make_view_with_method("handle_event")
 
+    def test_v004_ignores_framework_invoked_hooks_1684(self):
+        """Framework-invoked lifecycle hooks (#1684) must not trip V004.
+
+        These are called by the framework directly (presence/cursor/tick/
+        background-work/component/info/wizard paths), not the user-event router,
+        so they must NOT carry @event_handler — but their names match the
+        event-handler-like regex. Fix landed on 1.1 via #1685; ported to main's
+        split checks/components.py. Regression for the canonical symptom
+        (handle_presence_leave, which bit djust-org/djust-start#5).
+        """
+        for method_name in (
+            "handle_presence_join",
+            "handle_presence_leave",
+            "handle_cursor_move",
+            "handle_tick",
+            "handle_async_result",
+            "handle_component_event",
+            "handle_info",
+            "on_wizard_complete",
+        ):
+            self._make_view_with_method(method_name)
+
 
 # ---------------------------------------------------------------------------
 # T013 — allow {{ ... }} Django template variable in dj-view (issue #395)


### PR DESCRIPTION
`V004` ("public method looks like an event handler but is missing `@event_handler`") false-fires on user overrides of hooks the framework calls **directly** (`self.X()` / `getattr` / `hasattr`), not via the user-event router. Those must NOT carry `@event_handler`, but their names match the event-handler-like regex and were absent from the `V004` lifecycle-skip set in `checks/components.py`. Canonical symptom: `handle_presence_leave` (bit `djust-org/djust-start#5`).

## Why this is on main
The fix originally landed on the **`1.1` branch** (#1685) against the *pre-#1822-split* `checks.py`. main split `checks.py` into `checks/*.py` and the fix was **never ported** — so the false-positive has been live on main, **including in 1.0.8**. This lands it on main; it also unblocks a clean `main`→`1.1` merge (the `checks.py` modify/delete conflict then resolves to "accept main's delete").

## Fix
Added the 8 framework-invoked hooks to the `V004` skip set: `handle_presence_join`, `handle_presence_leave`, `handle_cursor_move`, `handle_tick`, `handle_async_result`, `handle_component_event`, `handle_info`, `on_wizard_complete`.

## Verification
New `TestV004LifecycleMethods::test_v004_ignores_framework_invoked_hooks_1684` (loops all 8). **Gate-off verified (#1468)**: reverting the skip-list additions turns it red. 8 V004 tests pass.

Closes #1684.

🤖 Generated with [Claude Code](https://claude.com/claude-code)