### PR TITLE
fix(types): disable import-untyped globally — mypy clean in a full dev env (ADR-023 follow-up)

### DIFF
--- a/docs/adr/023-incremental-type-enforcement.md
+++ b/docs/adr/023-incremental-type-enforcement.md
@@ -1,8 +1,8 @@
 # ADR-023: Incremental Type Enforcement — mypy Gate + Strict Islands
 
-**Status**: Accepted — foundation shipped 2026-06-24 (this PR); the strict-island ratchet is ongoing.
+**Status**: Accepted — foundation shipped 2026-06-24; the strict-island ratchet is **COMPLETE as of 2026-06-25** (M1 → M4g, PRs #1936–#1959). Every shipped non-test module in `python/djust/` is now strict-mypy-enforced — **546 module entries / 822 source files, zero lenient exceptions** (the final holdout, `components/rust_handlers`, flipped clean in M4g/#1959). The gate is environment-independent (PR #1960 disabled `import-untyped` globally so a full dev env matches CI).
 
-**Shipped in**: v1.1 (foundation — the enforced gate + the initial strict-island set + the `_rust.pyi` boundary). The per-module ratchet continues post-1.0 across the v1.1 code-quality arc.
+**Shipped in**: v1.1 (foundation — the enforced gate + the initial strict-island set + the `_rust.pyi` boundary) → the full ratchet (M2 public-API, M3 dispatch core, M4 the long tail, M4g the Rust-FFI boundary) completed across the v1.1 code-quality arc.
 
 **Relates to**: [ADR-022](022-v1.1-code-quality-single-path-convergence.md) (v1.1 code-quality headline). Type enforcement is a code-quality groundwork item under that arc — it makes a whole class of contract drift mechanically detectable, the same discipline ADR-022's anti-drift parity nets apply to transport paths.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,12 @@ target-version = "py310"
 # --------------------------------------------------------------------------- #
 python_version = "3.10"
 warn_unused_configs = true
+# `import-untyped` is raised in the IMPORTING (strict-island) module for a 3rd-party
+# lib that is INSTALLED but ships no stubs (yaml/requests in a full dev env). It is a
+# different code than the `import-not-found` that `ignore_missing_imports` covers, and
+# it is reported against the importer (not the lib), so a per-module override on the
+# lib cannot reach it. Disable globally so `mypy python/djust` is clean in every env.
+disable_error_code = ["import-untyped"]
 
 # Kill third-party + Django + PyYAML "missing library stubs" noise (and any
 # stale _rust import noise). The `_rust.pyi` stub still types the PyO3 surface


### PR DESCRIPTION
Post-ratchet fix. `mypy python/djust` was green in CI (minimal env: requests/yaml absent → import-not-found, suppressed by ignore_missing_imports) but RED in a full dev env (requests/yaml installed without stubs → import-untyped, reported against the importing strict-island modules permissions/deploy_cli/mcp.server). import-untyped is a different code than ignore_missing_imports covers + is scoped to the importer, so the ["yaml","requests"] override can't reach it. Fix: disable_error_code=["import-untyped"] in the global [tool.mypy]. mypy now Success (822 files) in a full local dev env. No code change; makes the ADR-023 gate environment-independent (clean local mypy + pre-commit for contributors with requests/yaml installed).