### PR TITLE
chore: track 1.1.0 on main (version bump + correct #1970 ROADMAP bucket)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "1.0.8"
+version = "1.1.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "1.0.8"
+version = "1.1.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "1.0.8"
+version = "1.1.0"
 dependencies = [
  "bincode",
  "criterion",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "1.0.8"
+version = "1.1.0"
 dependencies = [
  "ahash",
  "chrono",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "1.0.8"
+version = "1.1.0"
 dependencies = [
  "ahash",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.0.8"
+version = "1.1.0"
 edition = "2021"
 authors = ["djust contributors"]
 license = "MIT"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3714,10 +3714,12 @@ the old placement still serves during blue/green). `djust deploy` should print
 
 ---
 
-### Milestone: v1.0.8-3 — parse-phase loop render cache (the #1967 follow-up lever) (drain bucket → ships in 1.0.8)
+### Milestone: v1.1.0-1 — parse-phase loop render cache (the #1967 follow-up lever) (drain bucket → ships in 1.1.0)
 
 *Goal:* Drain the one tractable open issue left after the #1967/#1969 render-cache
-arc — #1970, the **parse-phase** half of the same optimization. The render cache
+arc — #1970, the **parse-phase** half of the same optimization. (Originally
+mislabeled "v1.0.8-3 / ships in 1.0.8"; 1.0.8 shipped 2026-06-23 and main now
+tracks 1.1 — this work lands in 1.1.0 via `[Unreleased]`.) The render cache
 (#1969) is Amdahl-bounded because html5ever parse + VDOM build are ~60% of
 `render_with_diff`; #1970 caches the parsed VNode subtree per item so an unchanged
 item skips BOTH render AND parse. Builds directly on
@@ -3736,7 +3738,7 @@ security surface — replay XSS / Redis auth / PII scrub).
 
 | Priority | Issue | Summary | Target |
 |---|---|---|---|
-| **P2** | cache PARSED VNode subtrees for unchanged loop items (#1970) | Extend the #1969 per-item render cache to also cache the parsed VNode subtree (skip html5ever re-parse on reorder of unchanged items); same flag + gates; re-assign dj-ids per current position to keep the keyed diff correct. | v1.0.8 |
+| **P2** | ~~cache PARSED VNode subtrees for unchanged loop items (#1970)~~ ✅ PR #1973 | Extend the #1969 per-item render cache to also cache the parsed VNode subtree (skip html5ever re-parse on reorder of unchanged items); same flag + gates; re-assign dj-ids per current position to keep the keyed diff correct. | v1.1.0 |
 
 **#1970 — parse-phase loop render cache** — #1969 added a flag-gated per-item RENDER
 cache (~1.6–1.7× render-phase on a reorder), but the render phase is only ~40% of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "djust"
-version = "1.0.8"
+version = "1.1.0"
 description = "Phoenix LiveView-style reactive components for Django with Rust-powered performance. Real-time UI updates over WebSocket, no JavaScript build step required."
 authors = [{name = "djust contributors"}]
 readme = "README.md"

--- a/python/djust/__init__.py
+++ b/python/djust/__init__.py
@@ -75,7 +75,7 @@ except ImportError:
     # Rust components not yet built - this is optional
     rust_components = None  # noqa: F841 — accessed as djust.rust_components by user code
 
-__version__ = "1.0.8"
+__version__ = "1.1.0"
 
 
 def enable_hot_reload():

--- a/python/djust/components/__init__.py
+++ b/python/djust/components/__init__.py
@@ -33,7 +33,7 @@ descriptors, mixins, rust handlers, gallery).
     python manage.py component_gallery
 """
 
-__version__ = "1.0.8"
+__version__ = "1.1.0"
 
 # ---------------------------------------------------------------------------
 # Core component classes (original djust.components)

--- a/uv.lock
+++ b/uv.lock
@@ -585,7 +585,7 @@ wheels = [
 
 [[package]]
 name = "djust"
-version = "1.0.8"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "channels", extra = ["daphne"] },


### PR DESCRIPTION
## Why

`main` was still at version `1.0.8` even though 1.0.8 shipped (2026-06-23, tag `v1.0.8`) and 1.1.0 is the active release (`v1.1.0rc1/rc2/rc3` cut on the `1.1` branch). That lag caused the #1970 drain to mislabel its ROADMAP milestone as "v1.0.8-3 / ships in 1.0.8". Per the maintainer: **start tracking 1.1 on main now; 1.0 is maintenance-only (bug/security fixes).**

## What

- **Version bump 1.0.8 → 1.1.0** via `make version VERSION=1.1.0` — `pyproject.toml`, `Cargo.toml`, `python/djust/__init__.py`, `python/djust/components/__init__.py`, `uv.lock`, `Cargo.lock` (all verified consistent via `make version-check`).
- **ROADMAP correction**: drain milestone `v1.0.8-3` → `v1.1.0-1` (ships in 1.1.0); `#1970` marked ✅ PR #1973; Target column → `v1.1.0`.

## Notes

- The #1967/#1969/#1970 perf work is under `## [Unreleased]` and reaches 1.1.0 via the established `chore(1.1): resync main into the v1.1 release branch` (done separately).
- `[Unreleased]` stays `[Unreleased]` (Keep-a-Changelog) — the version file is the signal that main now develops toward 1.1.0.
- Chose plain `1.1.0` (matching the project's `1.1.0rcN` style, no dev marker). Say the word if you want `1.1.0.dev0` or a different convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4VsbRKefaPjn6Rxs9ig1A