### PR TITLE
docs(roadmap): correct the #1970 bucket label (v1.0.8-3 → v1.1.0-1)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3714,7 +3714,9 @@ the old placement still serves during blue/green). `djust deploy` should print
 
 ---
 
-### Milestone: v1.0.8-3 — parse-phase loop render cache (the #1967 follow-up lever) (drain bucket → ships in 1.0.8)
+### Milestone: v1.1.0-1 — parse-phase loop render cache (the #1967 follow-up lever) (drain bucket → ships in 1.1.0)
+
+> NOTE: originally mislabeled `v1.0.8-3`/`ships in 1.0.8`; 1.0.8 was already shipped/frozen, so this is a v1.1.0 bucket (the work develops on the v1.1 line).
 
 *Goal:* Drain the one tractable open issue left after the #1967/#1969 render-cache
 arc — #1970, the **parse-phase** half of the same optimization. The render cache
@@ -3736,7 +3738,7 @@ security surface — replay XSS / Redis auth / PII scrub).
 
 | Priority | Issue | Summary | Target |
 |---|---|---|---|
-| **P2** | cache PARSED VNode subtrees for unchanged loop items (#1970) | Extend the #1969 per-item render cache to also cache the parsed VNode subtree (skip html5ever re-parse on reorder of unchanged items); same flag + gates; re-assign dj-ids per current position to keep the keyed diff correct. | v1.0.8 |
+| **P2** | cache PARSED VNode subtrees for unchanged loop items (#1970) | Extend the #1969 per-item render cache to also cache the parsed VNode subtree (skip html5ever re-parse on reorder of unchanged items); same flag + gates; re-assign dj-ids per current position to keep the keyed diff correct. | v1.1.0 |
 
 **#1970 — parse-phase loop render cache** — #1969 added a flag-gated per-item RENDER
 cache (~1.6–1.7× render-phase on a reorder), but the render phase is only ~40% of


### PR DESCRIPTION
1.0.8 was already shipped/frozen; the parse-phase loop-render-cache work (#1970) develops on the v1.1 line, so its ROADMAP bucket is v1.1.0-1 (ships in 1.1.0), not v1.0.8-3. Heading + prose + Priority-Matrix Target column corrected; added a one-line historical note. Docs-only.