### PR TITLE
test(vdom): make client-faithful harness dj-id resolution case-sensitive (#1977 follow-up)

### DIFF
--- a/tests/js/_significant_tree.js
+++ b/tests/js/_significant_tree.js
@@ -35,6 +35,8 @@ export function createHarnessDom(initialHtml) {
         window.CSS.escape = (s) => String(s).replace(/([^\w-])/g, '\\$1');
     }
 
+    installCaseSensitiveDjIdResolution(window);
+
     const logs = [];
     window.console = {
         log: (...args) => logs.push(['log', args.join(' ')]),
@@ -46,6 +48,62 @@ export function createHarnessDom(initialHtml) {
 
     window.eval(clientCode);
     return { dom, window, logs };
+}
+
+/**
+ * Make `[dj-id="…"]` selector resolution CASE-SENSITIVE in the jsdom window, so
+ * the harness matches real-browser semantics (#1977 follow-up).
+ *
+ * djust dj-ids are base62 (`0-9a-zA-Z`) from a monotonic counter, so any render
+ * past ~38 nodes emits sibling ids that differ only by case (`c` vs `C`). The
+ * client resolves structural ops with `node.querySelector(':scope >
+ * [dj-id="C"]')` (12-vdom-patch.js). Real browsers match custom-attribute VALUES
+ * case-sensitively (`dj-id` is not in the HTML spec's ASCII-case-insensitive
+ * attribute set), so `[dj-id="C"]` never matches `dj-id="c"`. jsdom's selector
+ * engine (nwsapi) matches them case-INSENSITIVELY, so without this shim the
+ * harness resolves the wrong sibling for any fixture that crosses ~38 nodes
+ * where a structural op targets a case-colliding sibling — silently
+ * false-positing AND (worse) masking real VDOM regressions.
+ *
+ * The shim wraps `querySelector` on Element/Document/DocumentFragment and only
+ * INTERVENES when nwsapi returns a dj-id that case-folds to the requested value
+ * but isn't an exact match — then it re-resolves case-sensitively among the
+ * native (case-insensitive) candidate set. Every other selector, and every
+ * exact match, delegates to native untouched (so escaped/special-char selectors
+ * are unaffected). The client only ever uses single `[dj-id="X"]` tokens via
+ * `querySelector`, so this is the complete surface.
+ */
+function installCaseSensitiveDjIdResolution(window) {
+    const DJID = /\[dj-id="([^"]*)"\]/;
+    const protos = [
+        window.Element && window.Element.prototype,
+        window.Document && window.Document.prototype,
+        window.DocumentFragment && window.DocumentFragment.prototype,
+    ].filter(Boolean);
+
+    for (const proto of protos) {
+        const nativeQS = proto.querySelector;
+        const nativeQSA = proto.querySelectorAll;
+        proto.querySelector = function (selector) {
+            const result = nativeQS.call(this, selector);
+            const m = typeof selector === 'string' && selector.match(DJID);
+            if (!result || !m) return result;
+            const want = m[1];
+            const got = result.getAttribute('dj-id');
+            if (got === want) return result; // exact match — nothing to correct
+            // Only correct nwsapi's case-insensitivity: same value up to case,
+            // but not an exact match. Re-resolve case-sensitively among the
+            // native candidate set (a superset of the exact-case matches).
+            if (got != null && got.toLowerCase() === want.toLowerCase()) {
+                const all = nativeQSA.call(this, selector);
+                for (let i = 0; i < all.length; i++) {
+                    if (all[i].getAttribute('dj-id') === want) return all[i];
+                }
+                return null; // no exact-case sibling — the id is genuinely absent
+            }
+            return result; // difference is not a case issue — leave native as-is
+        };
+    }
 }
 
 /**

--- a/tests/js/harness_djid_case_sensitivity.test.js
+++ b/tests/js/harness_djid_case_sensitivity.test.js
@@ -24,6 +24,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import fs from 'fs';
 import { createHarnessDom } from './_significant_tree.js';
 
 const CASE_COLLIDING_HTML =
@@ -65,5 +66,37 @@ describe('harness dj-id resolution is case-sensitive (real-browser fidelity)', (
         expect(remaining, 'only the lower (dj-id="c") row must remain').toEqual([
             { id: 'c', text: 'lower' },
         ]);
+    });
+
+    it('client resolves dj-id VALUE selectors only via single-token querySelector (shim surface invariant)', () => {
+        // The shim patches `querySelector` and extracts the FIRST `[dj-id="…"]`
+        // token, matching the client's actual usage. If the client ever resolves
+        // a dj-id VALUE via `querySelectorAll`/`closest`/`matches`, or via a
+        // multi-token descendant selector, the shim would silently revert to
+        // jsdom's case-insensitive matching with NO failure signal (the concern
+        // raised in PR #1978 review). Pin the surface so such a change fails
+        // loudly HERE, prompting the shim to be extended.
+        const srcDir = './python/djust/static/djust/src';
+        const offenders = [];
+        for (const file of fs.readdirSync(srcDir)) {
+            if (!file.endsWith('.js')) continue;
+            const src = fs.readFileSync(`${srcDir}/${file}`, 'utf-8');
+            src.split('\n').forEach((line, i) => {
+                // dj-id VALUE selector reached through a non-querySelector API...
+                if (/\.(querySelectorAll|closest|matches)\([^)]*dj-id="/.test(line)) {
+                    offenders.push(`${file}:${i + 1} ${line.trim()}`);
+                }
+                // ...or two dj-id tokens in one selector (only the first is
+                // case-corrected by the shim's regex).
+                if (/querySelector\([^)]*dj-id="[^)]*dj-id="/.test(line)) {
+                    offenders.push(`${file}:${i + 1} (multi-token) ${line.trim()}`);
+                }
+            });
+        }
+        expect(
+            offenders,
+            'dj-id VALUE selectors must be single-token querySelector-only; ' +
+                'extend installCaseSensitiveDjIdResolution if this changes'
+        ).toEqual([]);
     });
 });

--- a/tests/js/harness_djid_case_sensitivity.test.js
+++ b/tests/js/harness_djid_case_sensitivity.test.js
@@ -1,0 +1,69 @@
+/**
+ * Harness fidelity: dj-id resolution must be CASE-SENSITIVE (#1977 follow-up).
+ *
+ * djust dj-ids are base62 (`0-9a-zA-Z`) drawn from a monotonic counter, so any
+ * render past ~38 nodes emits sibling ids that differ only by case (e.g. `c`
+ * and `C`). The client resolves structural ops by
+ * `node.querySelector(':scope > [dj-id="C"]')` (12-vdom-patch.js: RemoveChild /
+ * InsertChild ref / MoveChild, and getNodeByPath Strategy-1).
+ *
+ * Real browsers match custom-attribute VALUES case-sensitively (per the HTML
+ * spec's attribute-selector rules — `dj-id` is not in the ASCII-case-insensitive
+ * attribute set), so `[dj-id="C"]` never matches `dj-id="c"` in Chrome/Firefox.
+ * jsdom's selector engine (nwsapi) matches them case-INSENSITIVELY, so the
+ * client-faithful VDOM harness (`vdom_client_faithful_diff.test.js`) silently
+ * resolves the WRONG sibling for any fixture that crosses ~38 nodes where a
+ * structural op targets a case-colliding sibling — a `RemoveChild{child_d:"C"}`
+ * deletes the `c` node instead, which can both false-positive and (worse) MASK a
+ * real VDOM regression.
+ *
+ * `createHarnessDom` therefore installs a case-sensitive `[dj-id="…"]` resolution
+ * shim so the harness environment matches real-browser semantics. These tests
+ * pin that: without the shim BOTH assertions below fail (jsdom returns the `c`
+ * node for `[dj-id="C"]`).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHarnessDom } from './_significant_tree.js';
+
+const CASE_COLLIDING_HTML =
+    '<div id="root">' +
+    '<table><tbody dj-id="0">' +
+    '<tr dj-id="c"><td>lower</td></tr>' +
+    '<tr dj-id="C"><td>upper</td></tr>' +
+    '</tbody></table>' +
+    '</div>';
+
+describe('harness dj-id resolution is case-sensitive (real-browser fidelity)', () => {
+    it('querySelector([dj-id="C"]) resolves the C node, not the case-colliding c node', () => {
+        const { window } = createHarnessDom(CASE_COLLIDING_HTML);
+        const tbody = window.document.querySelector('[dj-id="0"]');
+
+        expect(
+            tbody.querySelector(':scope > [dj-id="C"]')?.textContent,
+            'upper-case dj-id="C" must resolve the upper row'
+        ).toBe('upper');
+        expect(
+            tbody.querySelector(':scope > [dj-id="c"]')?.textContent,
+            'lower-case dj-id="c" must resolve the lower row'
+        ).toBe('lower');
+    });
+
+    it('RemoveChild{child_d:"C"} via the real client removes the C row, leaving c', async () => {
+        const { window } = createHarnessDom(CASE_COLLIDING_HTML);
+        const root = window.document.querySelector('#root');
+
+        await window.djust.applyPatches(
+            [{ type: 'RemoveChild', path: [0, 0], d: '0', index: 1, child_d: 'C' }],
+            root
+        );
+
+        const remaining = Array.from(root.querySelectorAll('tr')).map((tr) => ({
+            id: tr.getAttribute('dj-id'),
+            text: tr.textContent,
+        }));
+        expect(remaining, 'only the lower (dj-id="c") row must remain').toEqual([
+            { id: 'c', text: 'lower' },
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary

Surfaced during the #1977 investigation (whose `diff_html` list-shrink misroute claim the maintainer **retracted** — the differ is correct across ~18 faithful-pipeline shapes). The one verified, in-repo defect that came out of it: **the client-faithful VDOM harness is not faithful for larger fixtures.**

`tests/js/vdom_client_faithful_diff.test.js` (via `createHarnessDom`) runs the **real** `client.js` against a jsdom DOM. jsdom's selector engine (nwsapi) matches custom-attribute **values** case-**insensitively**, so `node.querySelector(':scope > [dj-id="C"]')` also matches `dj-id="c"`. djust dj-ids are base62 (`0-9a-zA-Z`) from a monotonic counter, so any render past ~38 nodes emits sibling ids that differ only by case (`c`/`C`). Without a fix the harness silently resolves the **wrong** sibling for such fixtures — a `RemoveChild{child_d:"C"}` deletes the `c` node — which can both false-positive and (worse) **mask a real VDOM regression**.

Real browsers match custom-attribute values case-sensitively (`dj-id` is not in the HTML spec's ASCII-case-insensitive attribute set), so **production is unaffected** — this is purely test-harness fidelity.

## Change

- `tests/js/_significant_tree.js` — `createHarnessDom` installs a case-sensitive `[dj-id="…"]` resolution shim. It **only** corrects nwsapi's case-collision (re-resolves among the native candidate set when nwsapi returns a case-folded-but-not-exact match) and delegates every other selector untouched, so escaped/special-char selectors and exact matches are unaffected. The client only ever uses single `[dj-id="X"]` tokens via `querySelector`, so this is the complete surface.
- `tests/js/harness_djid_case_sensitivity.test.js` — new regression test asserting both the raw `querySelector` resolution and the real-client `applyPatches`/`RemoveChild` path pick the correct case-sibling. **RED** before the shim (nwsapi returns the `c` node for `[dj-id="C"]`), **GREEN** after.

## Verification

- New test: RED before shim → GREEN after (non-tautological; gate-off proven).
- Full JS suite: **1748 tests pass, no regressions** (the shim is scoped to `createHarnessDom`'s own jsdom window).
- No production code touched; no CHANGELOG entry (test-infra only).

## Scope

Fixes exactly the harness-fidelity defect. #1977 stays **open** pending the reporter's bit-exact browser `diff_html(old,new)` capture (the real, un-reproduced-in-harness browser symptom). Two adjacent findings noted for follow-up, deliberately **not** fixed here: the `#1678` differential fixture is stale on main (a fresh regen drops its `MoveSubtree` patches), and `scripts/gen_vdom_diff_fixtures.py`'s docstring claims a pre-commit regen hook that doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)