### PR TITLE
test(vdom): refresh stale #1678 diff fixture + add a CI freshness gate (#1979)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,6 +141,19 @@ jobs:
       - name: Install test tools
         run: uv pip install pytest-xdist mypy
 
+      # Freshness gate for the client-faithful VDOM diff fixtures (#1979): the
+      # committed JSON must equal a fresh regen, or the harness pins stale patch
+      # output (as it did before #1979). Deterministic generator + this job
+      # already uses demo_project.settings, so a diff here is a genuine
+      # stale-fixture signal, not env drift.
+      - name: VDOM diff fixtures are fresh (#1979)
+        run: |
+          PYTHONPATH=. .venv/bin/python scripts/gen_vdom_diff_fixtures.py
+          if ! git diff --exit-code -- tests/js/fixtures/; then
+            echo "::error::VDOM diff fixtures are stale — run 'make gen-vdom-fixtures' and commit tests/js/fixtures/."
+            exit 1
+          fi
+
       - name: Run Python tests (parallel with pytest-xdist)
         run: |
           PYTHONPATH=. .venv/bin/python -m pytest tests/ python/tests/ -v -n auto

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,8 +149,14 @@ jobs:
       - name: VDOM diff fixtures are fresh (#1979)
         run: |
           PYTHONPATH=. .venv/bin/python scripts/gen_vdom_diff_fixtures.py
-          if ! git diff --exit-code -- tests/js/fixtures/; then
-            echo "::error::VDOM diff fixtures are stale — run 'make gen-vdom-fixtures' and commit tests/js/fixtures/."
+          # --porcelain (not `git diff --exit-code`) so a NEW scenario's
+          # never-`git add`ed output file is caught too, not only modified
+          # tracked fixtures (#1980 review).
+          DIRTY=$(git status --porcelain -- tests/js/fixtures/)
+          if [ -n "$DIRTY" ]; then
+            echo "::error::VDOM diff fixtures are stale or uncommitted — run 'make gen-vdom-fixtures' and commit tests/js/fixtures/."
+            echo "$DIRTY"
+            git diff -- tests/js/fixtures/
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,10 @@ check-lockfile-versions: ## Verify Cargo.lock/uv.lock self-entries match manifes
 check-bundle-init-order: ## Static check: declared-late/used-early let/const across bundle concat (closes #1372)
 	@node scripts/check-bundle-init-order.mjs
 
+.PHONY: gen-vdom-fixtures
+gen-vdom-fixtures: ## Regenerate client-faithful VDOM diff fixtures (CI gates freshness — closes #1979)
+	@$(PYTHON) scripts/gen_vdom_diff_fixtures.py
+
 .PHONY: test
 test: ## Run all tests (Python + JavaScript + Rust) in parallel
 	@echo "$(GREEN)Running all tests in parallel...$(NC)"

--- a/scripts/gen_vdom_diff_fixtures.py
+++ b/scripts/gen_vdom_diff_fixtures.py
@@ -26,9 +26,11 @@ pre-commit hook kept it fresh and none existed).
 Run:  make gen-vdom-fixtures      # or: .venv/bin/python scripts/gen_vdom_diff_fixtures.py
 """
 
+import atexit
 import json
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -39,6 +41,23 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "demo_project.settings")
 import django  # noqa: E402
 
 django.setup()
+
+# The LiveViewTestClient mount/event path persists to the session
+# (`django_session`), so the generator needs a migrated schema. Point the
+# default DB at an isolated throwaway file and migrate it HERE, so the generator
+# is self-contained: it works on a fresh CI runner (which has no migrated
+# db.sqlite3 — the #1980 CI failure) AND on a fresh dev checkout, WITHOUT
+# touching the developer's real demo db.sqlite3. `run_syncdb` is fine for this
+# test-only tool (not a deploy path, so the #1637 caveat doesn't apply).
+from django.conf import settings  # noqa: E402
+from django.core.management import call_command  # noqa: E402
+from django.db import connections  # noqa: E402
+
+_TMP_DB = tempfile.mktemp(prefix="djust_vdom_fixtures_", suffix=".sqlite3")
+settings.DATABASES["default"]["NAME"] = _TMP_DB
+connections.close_all()  # drop any connection bound to the previous NAME
+atexit.register(lambda: os.path.exists(_TMP_DB) and os.remove(_TMP_DB))
+call_command("migrate", run_syncdb=True, verbosity=0, interactive=False)
 
 # Register djust component tag handlers ({% kanban_board %}, {% empty_state %})
 # with the Rust engine — the #1678 fixture's active tab body is a nested

--- a/scripts/gen_vdom_diff_fixtures.py
+++ b/scripts/gen_vdom_diff_fixtures.py
@@ -29,6 +29,7 @@ Run:  make gen-vdom-fixtures      # or: .venv/bin/python scripts/gen_vdom_diff_f
 import atexit
 import json
 import os
+import shutil
 import sys
 import tempfile
 from pathlib import Path
@@ -53,10 +54,11 @@ from django.conf import settings  # noqa: E402
 from django.core.management import call_command  # noqa: E402
 from django.db import connections  # noqa: E402
 
-_TMP_DB = tempfile.mktemp(prefix="djust_vdom_fixtures_", suffix=".sqlite3")
-settings.DATABASES["default"]["NAME"] = _TMP_DB
+# mkdtemp gives a secure 0700 dir we own (no filename-generation race), removed on exit.
+_TMP_DB_DIR = tempfile.mkdtemp(prefix="djust_vdom_fixtures_")
+settings.DATABASES["default"]["NAME"] = os.path.join(_TMP_DB_DIR, "fixtures.sqlite3")
 connections.close_all()  # drop any connection bound to the previous NAME
-atexit.register(lambda: os.path.exists(_TMP_DB) and os.remove(_TMP_DB))
+atexit.register(lambda: shutil.rmtree(_TMP_DB_DIR, ignore_errors=True))
 call_command("migrate", run_syncdb=True, verbosity=0, interactive=False)
 
 # Register djust component tag handlers ({% kanban_board %}, {% empty_state %})

--- a/scripts/gen_vdom_diff_fixtures.py
+++ b/scripts/gen_vdom_diff_fixtures.py
@@ -75,8 +75,8 @@ def gen_kanban_tabs_1678():
     correctly gone (regenerated for freshness in #1979).
 
     NOTE: step 2 (card move) currently captures 0 patches — an in-place mutation
-    of `columns` isn't reflected in the render; tracked separately (see #1979
-    follow-up). Kept so the freshness gate pins that state until it's fixed."""
+    of `columns` isn't reflected in the render; tracked separately at #1981.
+    Kept so the freshness gate pins that state until it's fixed."""
     c = LiveViewTestClient(KanbanTabsView)
     c.mount(active_tab=0)
     egress = c.view_instance._strip_comments_and_whitespace

--- a/scripts/gen_vdom_diff_fixtures.py
+++ b/scripts/gen_vdom_diff_fixtures.py
@@ -14,10 +14,16 @@ capturing — exactly as production would send to the client:
                          equal after applying the patches.
 
 Output is committed JSON so the JS test has no Python/Rust dependency at run
-time. Regeneration is idempotent (deterministic dj-ids); a pre-commit hook
-re-runs this and ``git add``s the result so fixtures can't go stale.
+time. Regeneration is idempotent (deterministic dj-ids), so the committed
+fixtures must match a fresh regen exactly. Freshness is enforced by CI: the
+``python-tests`` job in ``.github/workflows/test.yml`` re-runs this generator
+and fails on any diff under ``tests/js/fixtures/`` (#1979). When a differ /
+template / component / fixture-view change alters the captured patch stream,
+regenerate and commit the result — otherwise the guard would keep pinning stale
+patch output (as happened before #1979, when this docstring wrongly claimed a
+pre-commit hook kept it fresh and none existed).
 
-Run:  .venv/bin/python scripts/gen_vdom_diff_fixtures.py
+Run:  make gen-vdom-fixtures      # or: .venv/bin/python scripts/gen_vdom_diff_fixtures.py
 """
 
 import json
@@ -57,8 +63,20 @@ def _patch_type_counts(patches):
 
 def gen_kanban_tabs_1678():
     """#1678: 8 sibling {% if active_tab==N %} blocks; mount tab0, switch to the
-    kanban tab (tab 3) — which emits MoveSubtree for the shifted later blocks —
-    then move a card across columns (the positional count-badge SetText)."""
+    kanban tab (tab 3), then move a card across columns.
+
+    The guarded core is the tab switch: it tears down tab0's body and inserts
+    tab3's NESTED-conditional kanban body (`RemoveChild` + `InsertSubtree`), the
+    marker-preservation + nested-InsertSubtree path that was the actual #1678
+    kanban `html_recovery` bug. It no longer emits `MoveSubtree` — since #1826
+    (`bd1c1f53`) the move decision keys on RELATIVE (non-boundary-sibling)
+    position, and the adjacent tab blocks keep their relative order across a
+    switch, so the earlier absolute-offset MoveSubtrees were spurious and are
+    correctly gone (regenerated for freshness in #1979).
+
+    NOTE: step 2 (card move) currently captures 0 patches — an in-place mutation
+    of `columns` isn't reflected in the render; tracked separately (see #1979
+    follow-up). Kept so the freshness gate pins that state until it's fixed."""
     c = LiveViewTestClient(KanbanTabsView)
     c.mount(active_tab=0)
     egress = c.view_instance._strip_comments_and_whitespace
@@ -88,7 +106,8 @@ def gen_kanban_tabs_1678():
         "scenario": "kanban_tabs_1678",
         "description": (
             "8-tab dashboard, tab 3 keyed kanban. Mount tab0 -> switch to tab3 "
-            "(MoveSubtree for shifted blocks) -> cross-column card move."
+            "(RemoveChild tab0 body + InsertSubtree tab3's nested-conditional "
+            "kanban body; no MoveSubtree since #1826) -> cross-column card move."
         ),
         "root_selector": ".tabs-content",
         "initial_html": initial_html,

--- a/tests/js/fixtures/vdom_diff_kanban_tabs_1678.json
+++ b/tests/js/fixtures/vdom_diff_kanban_tabs_1678.json
@@ -1,6 +1,6 @@
 {
   "scenario": "kanban_tabs_1678",
-  "description": "8-tab dashboard, tab 3 keyed kanban. Mount tab0 -> switch to tab3 (MoveSubtree for shifted blocks) -> cross-column card move.",
+  "description": "8-tab dashboard, tab 3 keyed kanban. Mount tab0 -> switch to tab3 (RemoveChild tab0 body + InsertSubtree tab3's nested-conditional kanban body; no MoveSubtree since #1826) -> cross-column card move.",
   "root_selector": ".tabs-content",
   "initial_html": "<div class=\"tabs-content\" dj-id=\"0\"><!--dj-if id=\"if-4017a4e7-0\"--><div class=\"tab tab0\" dj-id=\"1\"><p dj-id=\"2\">Tab 0 intro</p><!--dj-if id=\"if-4017a4e7-1\"--><div class=\"detail\" dj-id=\"3\">Detail for 0</div><!--/dj-if--><!--dj-if id=\"if-4017a4e7-2\"--><div class=\"extra\" dj-id=\"4\"><span dj-id=\"5\">x</span><!--dj-if id=\"if-4017a4e7-3\"--><b dj-id=\"6\">deep</b><!--/dj-if--></div><!--/dj-if--><p dj-id=\"7\">Tab 0 outro</p></div><!--/dj-if--><!--dj-if id=\"if-4017a4e7-4\"--><!--/dj-if--><!--dj-if id=\"if-4017a4e7-8\"--><!--/dj-if--><!--dj-if id=\"if-4017a4e7-12\"--><!--/dj-if--><!--dj-if id=\"if-4017a4e7-14\"--><!--/dj-if--><!--dj-if id=\"if-4017a4e7-15\"--><!--/dj-if--><!--dj-if id=\"if-4017a4e7-16\"--><!--/dj-if--><!--dj-if id=\"if-4017a4e7-17\"--><!--/dj-if--></div>",
   "steps": [
@@ -15,61 +15,12 @@
           "child_d": "1"
         },
         {
-          "type": "MoveSubtree",
-          "id": "if-4017a4e7-4",
-          "path": [],
-          "d": "0",
-          "index": 2
-        },
-        {
-          "type": "MoveSubtree",
-          "id": "if-4017a4e7-8",
-          "path": [],
-          "d": "0",
-          "index": 4
-        },
-        {
-          "type": "MoveSubtree",
-          "id": "if-4017a4e7-12",
-          "path": [],
-          "d": "0",
-          "index": 6
-        },
-        {
           "type": "InsertSubtree",
           "id": "if-4017a4e7-13",
           "path": [],
           "d": "0",
           "index": 7,
           "html": "<!--dj-if id=\"if-4017a4e7-13\"--><div class=\"kanban\" dj-id=\"9\"><div class=\"kanban-col\" data-col-id=\"todo\" dj-id=\"a\" dj-key=\"todo\" ondragleave=\"this.classList.remove('kanban-col-over')\" ondragover=\"event.preventDefault();this.classList.add('kanban-col-over')\" ondrop=\"(function(e,el){e.preventDefault();el.classList.remove('kanban-col-over');var cid=e.dataTransfer.getData('card');var from=e.dataTransfer.getData('from');var to=el.dataset.colId;if(from!==to){window.djust&amp;&amp;window.djust.handleEvent('move_card',{card_id:cid,from_col:from,to_col:to});}})( event,this)\"><div class=\"kanban-col-header\" dj-id=\"b\" style=\"border-top-color:#6366F1\"><span class=\"kanban-col-title\" dj-id=\"c\">To Do</span><span class=\"kanban-col-count\" dj-id=\"d\">2</span></div><div class=\"kanban-cards\" dj-id=\"e\"><div class=\"kanban-card\" data-card-id=\"c1\" data-col-id=\"todo\" dj-id=\"f\" dj-key=\"c1\" draggable=\"true\" ondragend=\"this.classList.remove('dragging')\" ondragstart=\"(function(e,el){e.dataTransfer.setData('card',el.dataset.cardId);e.dataTransfer.setData('from',el.dataset.colId);el.classList.add('dragging');})( event,this)\"><div class=\"kanban-card-title\" dj-id=\"g\">Alpha</div></div><div class=\"kanban-card\" data-card-id=\"c2\" data-col-id=\"todo\" dj-id=\"h\" dj-key=\"c2\" draggable=\"true\" ondragend=\"this.classList.remove('dragging')\" ondragstart=\"(function(e,el){e.dataTransfer.setData('card',el.dataset.cardId);e.dataTransfer.setData('from',el.dataset.colId);el.classList.add('dragging');})( event,this)\"><div class=\"kanban-card-title\" dj-id=\"i\">Bravo</div></div></div><button class=\"kanban-add-card\" data-value=\"todo\" dj-click=\"kanban_add_card\" dj-id=\"j\">+ Add card</button></div><div class=\"kanban-col\" data-col-id=\"doing\" dj-id=\"k\" dj-key=\"doing\" ondragleave=\"this.classList.remove('kanban-col-over')\" ondragover=\"event.preventDefault();this.classList.add('kanban-col-over')\" ondrop=\"(function(e,el){e.preventDefault();el.classList.remove('kanban-col-over');var cid=e.dataTransfer.getData('card');var from=e.dataTransfer.getData('from');var to=el.dataset.colId;if(from!==to){window.djust&amp;&amp;window.djust.handleEvent('move_card',{card_id:cid,from_col:from,to_col:to});}})( event,this)\"><div class=\"kanban-col-header\" dj-id=\"l\" style=\"border-top-color:#6366F1\"><span class=\"kanban-col-title\" dj-id=\"m\">Doing</span><span class=\"kanban-col-count\" dj-id=\"n\">1</span></div><div class=\"kanban-cards\" dj-id=\"o\"><div class=\"kanban-card\" data-card-id=\"c3\" data-col-id=\"doing\" dj-id=\"p\" dj-key=\"c3\" draggable=\"true\" ondragend=\"this.classList.remove('dragging')\" ondragstart=\"(function(e,el){e.dataTransfer.setData('card',el.dataset.cardId);e.dataTransfer.setData('from',el.dataset.colId);el.classList.add('dragging');})( event,this)\"><div class=\"kanban-card-title\" dj-id=\"q\">Charlie</div></div></div><button class=\"kanban-add-card\" data-value=\"doing\" dj-click=\"kanban_add_card\" dj-id=\"r\">+ Add card</button></div><div class=\"kanban-col\" data-col-id=\"done\" dj-id=\"s\" dj-key=\"done\" ondragleave=\"this.classList.remove('kanban-col-over')\" ondragover=\"event.preventDefault();this.classList.add('kanban-col-over')\" ondrop=\"(function(e,el){e.preventDefault();el.classList.remove('kanban-col-over');var cid=e.dataTransfer.getData('card');var from=e.dataTransfer.getData('from');var to=el.dataset.colId;if(from!==to){window.djust&amp;&amp;window.djust.handleEvent('move_card',{card_id:cid,from_col:from,to_col:to});}})( event,this)\"><div class=\"kanban-col-header\" dj-id=\"t\" style=\"border-top-color:#6366F1\"><span class=\"kanban-col-title\" dj-id=\"u\">Done</span><span class=\"kanban-col-count\" dj-id=\"v\">0</span></div><div class=\"kanban-cards\" dj-id=\"w\"></div><button class=\"kanban-add-card\" data-value=\"done\" dj-click=\"kanban_add_card\" dj-id=\"x\">+ Add card</button></div></div><!--/dj-if-->"
-        },
-        {
-          "type": "MoveSubtree",
-          "id": "if-4017a4e7-14",
-          "path": [],
-          "d": "0",
-          "index": 11
-        },
-        {
-          "type": "MoveSubtree",
-          "id": "if-4017a4e7-15",
-          "path": [],
-          "d": "0",
-          "index": 13
-        },
-        {
-          "type": "MoveSubtree",
-          "id": "if-4017a4e7-16",
-          "path": [],
-          "d": "0",
-          "index": 15
-        },
-        {
-          "type": "MoveSubtree",
-          "id": "if-4017a4e7-17",
-          "path": [],
-          "d": "0",
-          "index": 17
         }
       ],
       "expected_html": "<div class=\"tabs-content\" dj-id=\"0\"><!--dj-if id=\"if-4017a4e7-0\"--><!--/dj-if--><!--dj-if id=\"if-4017a4e7-4\"--><!--/dj-if--><!--dj-if id=\"if-4017a4e7-8\"--><!--/dj-if--><!--dj-if id=\"if-4017a4e7-12\"--><!--dj-if id=\"if-4017a4e7-13\"--><div class=\"kanban\" dj-id=\"9\"><div class=\"kanban-col\" data-col-id=\"todo\" dj-id=\"a\" dj-key=\"todo\" ondragleave=\"this.classList.remove('kanban-col-over')\" ondragover=\"event.preventDefault();this.classList.add('kanban-col-over')\" ondrop=\"(function(e,el){e.preventDefault();el.classList.remove('kanban-col-over');var cid=e.dataTransfer.getData('card');var from=e.dataTransfer.getData('from');var to=el.dataset.colId;if(from!==to){window.djust&amp;&amp;window.djust.handleEvent('move_card',{card_id:cid,from_col:from,to_col:to});}})( event,this)\"><div class=\"kanban-col-header\" dj-id=\"b\" style=\"border-top-color:#6366F1\"><span class=\"kanban-col-title\" dj-id=\"c\">To Do</span><span class=\"kanban-col-count\" dj-id=\"d\">2</span></div><div class=\"kanban-cards\" dj-id=\"e\"><div class=\"kanban-card\" data-card-id=\"c1\" data-col-id=\"todo\" dj-id=\"f\" dj-key=\"c1\" draggable=\"true\" ondragend=\"this.classList.remove('dragging')\" ondragstart=\"(function(e,el){e.dataTransfer.setData('card',el.dataset.cardId);e.dataTransfer.setData('from',el.dataset.colId);el.classList.add('dragging');})( event,this)\"><div class=\"kanban-card-title\" dj-id=\"g\">Alpha</div></div><div class=\"kanban-card\" data-card-id=\"c2\" data-col-id=\"todo\" dj-id=\"h\" dj-key=\"c2\" draggable=\"true\" ondragend=\"this.classList.remove('dragging')\" ondragstart=\"(function(e,el){e.dataTransfer.setData('card',el.dataset.cardId);e.dataTransfer.setData('from',el.dataset.colId);el.classList.add('dragging');})( event,this)\"><div class=\"kanban-card-title\" dj-id=\"i\">Bravo</div></div></div><button class=\"kanban-add-card\" data-value=\"todo\" dj-click=\"kanban_add_card\" dj-id=\"j\">+ Add card</button></div><div class=\"kanban-col\" data-col-id=\"doing\" dj-id=\"k\" dj-key=\"doing\" ondragleave=\"this.classList.remove('kanban-col-over')\" ondragover=\"event.preventDefault();this.classList.add('kanban-col-over')\" ondrop=\"(function(e,el){e.preventDefault();el.classList.remove('kanban-col-over');var cid=e.dataTransfer.getData('card');var from=e.dataTransfer.getData('from');var to=el.dataset.colId;if(from!==to){window.djust&amp;&amp;window.djust.handleEvent('move_card',{card_id:cid,from_col:from,to_col:to});}})( event,this)\"><div class=\"kanban-col-header\" dj-id=\"l\" style=\"border-top-color:#6366F1\"><span class=\"kanban-col-title\" dj-id=\"m\">Doing</span><span class=\"kanban-col-count\" dj-id=\"n\">1</span></div><div class=\"kanban-cards\" dj-id=\"o\"><div class=\"kanban-card\" data-card-id=\"c3\" data-col-id=\"doing\" dj-id=\"p\" dj-key=\"c3\" draggable=\"true\" ondragend=\"this.classList.remove('dragging')\" ondragstart=\"(function(e,el){e.dataTransfer.setData('card',el.dataset.cardId);e.dataTransfer.setData('from',el.dataset.colId);el.classList.add('dragging');})( event,this)\"><div class=\"kanban-card-title\" dj-id=\"q\">Charlie</div></div></div><button class=\"kanban-add-card\" data-value=\"doing\" dj-click=\"kanban_add_card\" dj-id=\"r\">+ Add card</button></div><div class=\"kanban-col\" data-col-id=\"done\" dj-id=\"s\" dj-key=\"done\" ondragleave=\"this.classList.remove('kanban-col-over')\" ondragover=\"event.preventDefault();this.classList.add('kanban-col-over')\" ondrop=\"(function(e,el){e.preventDefault();el.classList.remove('kanban-col-over');var cid=e.dataTransfer.getData('card');var from=e.dataTransfer.getData('from');var to=el.dataset.colId;if(from!==to){window.djust&amp;&amp;window.djust.handleEvent('move_card',{card_id:cid,from_col:from,to_col:to});}})( event,this)\"><div class=\"kanban-col-header\" dj-id=\"t\" style=\"border-top-color:#6366F1\"><span class=\"kanban-col-title\" dj-id=\"u\">Done</span><span class=\"kanban-col-count\" dj-id=\"v\">0</span></div><div class=\"kanban-cards\" dj-id=\"w\"></div><button class=\"kanban-add-card\" data-value=\"done\" dj-click=\"kanban_add_card\" dj-id=\"x\">+ Add card</button></div></div><!--/dj-if--><!--/dj-if--><!--dj-if id=\"if-4017a4e7-14\"--><!--/dj-if--><!--dj-if id=\"if-4017a4e7-15\"--><!--/dj-if--><!--dj-if id=\"if-4017a4e7-16\"--><!--/dj-if--><!--dj-if id=\"if-4017a4e7-17\"--><!--/dj-if--></div>"


### PR DESCRIPTION
Fixes #1979.

Two test-infra findings from the #1977/#1978 investigation.

## 1. The #1678 differential fixture was stale on `main`

A fresh regen of `tests/js/fixtures/vdom_diff_kanban_tabs_1678.json` **drops 7 `MoveSubtree` patches** from step 1 (leaving `RemoveChild` + `InsertSubtree`).

**Triage — this is a *correct* consequence of #1826, not a regression.** #1826 (`bd1c1f53`, "MoveSubtree fires on relative position, not absolute offset") landed *after* the fixture's last commit (PR #1682, 2026-06-01). The 8 tab-block dj-if boundaries are adjacent and keep their relative order across a tab switch → no genuine reposition → the old absolute-offset MoveSubtrees were spurious and #1826 correctly eliminated them. Verified:
- The (now #1978-hardened, case-sensitive) client-faithful harness **passes** with the fresh patches — the client reaches a fresh server render.
- The fixture still exercises the nested-conditional `InsertSubtree` + 9 dj-if markers that were the actual #1678 kanban `html_recovery` bug, so the guard stays meaningful.

## 2. The generator claimed a pre-commit regen hook that didn't exist

`scripts/gen_vdom_diff_fixtures.py`'s docstring said "a pre-commit hook re-runs this ... so fixtures can't go stale" — there was no such hook (which is why #1 went unnoticed). Replaced the claim with the actual mechanism + real enforcement:

- Corrected the docstring; fixed stale `MoveSubtree`-referencing text in `gen_kanban_tabs_1678` and the scenario `description`.
- `make gen-vdom-fixtures` convenience target.
- **CI freshness gate** in the `python-tests` job (`.github/workflows/test.yml`): re-runs the deterministic generator and fails on any diff under `tests/js/fixtures/`. That job already uses `demo_project.settings`, so a diff is a genuine stale-fixture signal, not env drift.

## Verification

- Generator is **deterministic** (two regens byte-identical) → the gate can't flake.
- **Empirical canary** (per the tooling-PR rule): hand-dirtied a fixture → gate fails; fresh → gate passes (exit 0).
- Harness green with the refreshed fixture; `check-yaml` validated the workflow.
- Test-infra only — no production code, no CHANGELOG.

## Out of scope (follow-up)

Step 2 (card move) captures **0 patches** — the card moves in state (`todo:[c1,c2]→[c2]`, `done:[]→[c1]`) but the render is identical. **Pre-existing** (the committed fixture had step 2 = `{}` too), likely in-place-`columns`-mutation change-detection. Not fixed here; a follow-up issue tracks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
