### PR TITLE
docs: replace nonexistent djust_tags/djust_scripts with live_tags + djust_client_config

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -99,8 +99,8 @@ class CounterView(LiveView):
 <html>
 <head>
     <title>Counter</title>
-    {% load djust_tags %}
-    {% djust_scripts %}
+    {% load live_tags %}
+    {% djust_client_config %}
 </head>
 <body dj-view="{{ dj_view_id }}">
     <div dj-root>

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ everything click.
 ### Template Anatomy
 
 ```html
-{% load djust_tags %}
+{% load live_tags %}
 <!DOCTYPE html>
 <html>
 <head>
-    {% djust_scripts %}              {# Loads the client runtime #}
+    {% djust_client_config %}        {# Emits client config meta tags; djust auto-injects the client runtime #}
 </head>
 <body dj-view="{{ dj_view_id }}">   {# Identifies the WebSocket session #}
     <div dj-root>                    {# Reactive boundary — only this is diffed #}
@@ -88,7 +88,7 @@ everything click.
 
 | Attribute | Where | Purpose |
 |---|---|---|
-| `{% djust_scripts %}` | `<head>` | Injects client JavaScript |
+| `{% djust_client_config %}` | `<head>` | Emits client config meta tags; djust auto-injects the ~5KB client runtime into every LiveView response — no manual `<script>` tag needed |
 | `dj-view="{{ dj_view_id }}"` | `<body>` | Connects page to WebSocket session |
 | `dj-root` | Inner `<div>` | Marks the reactive region; only HTML inside is diffed and patched |
 
@@ -232,12 +232,12 @@ class CounterView(LiveView):
 `myapp/templates/counter.html`:
 
 ```html
-{% load djust_tags %}
+{% load live_tags %}
 <!DOCTYPE html>
 <html>
 <head>
     <title>Counter</title>
-    {% djust_scripts %}
+    {% djust_client_config %}
 </head>
 <body dj-view="{{ dj_view_id }}">
     <div dj-root>

--- a/docs/website/core-concepts/templates.md
+++ b/docs/website/core-concepts/templates.md
@@ -10,8 +10,8 @@ Every LiveView template needs two things:
 <!DOCTYPE html>
 <html>
 <head>
-    {% load djust_tags %}
-    {% djust_scripts %}   {# Loads the ~5KB client JS #}
+    {% load live_tags %}
+    {% djust_client_config %}   {# Emits client config meta tags; djust auto-injects the ~5KB client JS #}
 </head>
 <body dj-view="{{ dj_view_id }}">   {# Connects page to WebSocket session #}
     <div dj-root>                    {# Reactive region — only this is patched #}
@@ -22,7 +22,7 @@ Every LiveView template needs two things:
 </html>
 ```
 
-- `{% djust_scripts %}` — injects the client JavaScript
+- `{% djust_client_config %}` — emits client config meta tags; djust auto-injects the client JavaScript into every LiveView response (no manual `<script>` tag needed)
 - `dj-view="{{ dj_view_id }}"` — on `<body>`, binds the page to the session (use the context variable `dj_view_id`)
 - `dj-root` — marks the reactive subtree; only HTML inside this element is diffed and patched
 

--- a/docs/website/getting-started/core-concepts.md
+++ b/docs/website/getting-started/core-concepts.md
@@ -123,7 +123,7 @@ This means complex re-renders that change one row in a 1000-row table only trans
 djust enforces strict security by default:
 
 - **Whitelisted handlers only** — only methods decorated with `@event_handler()` can be called by clients. Calling any other method name over WebSocket returns an error.
-- **CSRF protection** — WebSocket connections require a valid CSRF token (included automatically by `{% djust_scripts %}`)
+- **CSRF protection** — WebSocket connections require a valid CSRF token; the client reads it automatically from the `csrftoken` cookie (or a `{% csrf_token %}` hidden input if one is present in the page) — no djust template tag is needed to provide it
 - **Auth integration** — use `LoginRequiredMixin` or `@permission_required` exactly as in standard Django views
 
 ## Next Steps

--- a/docs/website/getting-started/first-liveview.md
+++ b/docs/website/getting-started/first-liveview.md
@@ -51,8 +51,8 @@ Create `myapp/templates/myapp/counter.html`:
 <html>
 <head>
     <title>Counter</title>
-    {% load djust_tags %}
-    {% djust_scripts %}
+    {% load live_tags %}
+    {% djust_client_config %}
 </head>
 <body dj-view="{{ dj_view_id }}">
     <div dj-root>
@@ -67,7 +67,7 @@ Create `myapp/templates/myapp/counter.html`:
 
 **Template requirements:**
 
-- `{% load djust_tags %}` and `{% djust_scripts %}` load the client JS (~5KB)
+- `{% load live_tags %}` and `{% djust_client_config %}` emit client config meta tags; djust auto-injects the client JS (~5KB) into every LiveView response
 - `dj-view="{{ dj_view_id }}"` on `<body>` connects the page to the WebSocket session
 - `dj-root` marks the reactive region — only this subtree is patched on updates
 - `dj-click="increment"` binds a click event to the `increment` handler

--- a/docs/website/guides/document-metadata.md
+++ b/docs/website/guides/document-metadata.md
@@ -67,7 +67,7 @@ def get_context_data(self, **kwargs):
 ```html
 <head>
     <title>{{ page_title }}</title>
-    {% djust_scripts %}
+    {% djust_client_config %}
 </head>
 ```
 
@@ -106,7 +106,7 @@ For the initial page load, include standard `<meta>` tags in your template as us
     <title>{{ page_title }}</title>
     <meta name="description" content="{{ page_description }}">
     <meta property="og:title" content="{{ page_title }}">
-    {% djust_scripts %}
+    {% djust_client_config %}
 </head>
 ```
 

--- a/docs/website/guides/reconnection.md
+++ b/docs/website/guides/reconnection.md
@@ -161,9 +161,9 @@ Form recovery and backoff with jitter work identically over the SSE (Server-Sent
 ## Example: Full Reconnection-Resilient Form
 
 ```html
-{% load djust_tags %}
+{% load live_tags %}
 <html>
-<head>{% djust_scripts %}</head>
+<head>{% djust_client_config %}</head>
 <body dj-view="{{ dj_view_id }}">
   <div dj-root>
     <form dj-submit="save_form">

--- a/docs/website/guides/template-cheatsheet.md
+++ b/docs/website/guides/template-cheatsheet.md
@@ -16,11 +16,11 @@ Quick reference for every directive, attribute, and Django tag used in djust tem
 Every LiveView template needs these two things:
 
 ```html
-{% load djust_tags %}
+{% load live_tags %}
 <!DOCTYPE html>
 <html>
 <head>
-    {% djust_scripts %}   {# Loads ~5KB client JavaScript #}
+    {% djust_client_config %}   {# Emits client config meta tags; auto-injects ~5KB client JavaScript #}
 </head>
 <body dj-view="{{ dj_view_id }}">   {# Binds page to WebSocket session #}
     <div dj-root>                    {# Reactive region — only this is diffed/patched #}
@@ -33,8 +33,8 @@ Every LiveView template needs these two things:
 
 | Attribute / Tag | Required | Description |
 |---|---|---|
-| `{% load djust_tags %}` | Yes | Load djust template tag library |
-| `{% djust_scripts %}` | Yes | Injects client JavaScript (~5KB) |
+| `{% load live_tags %}` | Yes | Load djust template tag library |
+| `{% djust_client_config %}` | Yes | Emits client config meta tags; djust auto-injects the client JavaScript (~5KB) into every LiveView response |
 | `dj-view="{{ dj_view_id }}"` | Yes | On `<body>` — identifies the WebSocket session |
 | `dj-root` | Yes | Marks the reactive subtree — only HTML inside is diffed |
 

--- a/examples/demo_project/demo_app/templates/forms/status_change_djust.html
+++ b/examples/demo_project/demo_app/templates/forms/status_change_djust.html
@@ -1,5 +1,3 @@
-{% load djust_tags %}
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -333,7 +331,6 @@
         </form>
     </div>
 
-    <!-- Djust LiveView Client (~5KB) -->
-    <script src="{% static 'djust/client.js' %}"></script>
+    <!-- djust auto-injects the LiveView client (~5KB) into this response; no manual <script> tag needed -->
 </body>
 </html>

--- a/examples/demo_project/djust_forms/templates/forms/status_change_djust.html
+++ b/examples/demo_project/djust_forms/templates/forms/status_change_djust.html
@@ -1,5 +1,3 @@
-{% load djust_tags %}
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -333,7 +331,6 @@
         </form>
     </div>
 
-    <!-- Djust LiveView Client (~5KB) -->
-    <script src="{% static 'djust/client.js' %}"></script>
+    <!-- djust auto-injects the LiveView client (~5KB) into this response; no manual <script> tag needed -->
 </body>
 </html>


### PR DESCRIPTION
## What

README, QUICKSTART, and several docs/website pages instruct users to use template tags that do not exist anywhere in the codebase:

- `{% load djust_tags %}` — there is no `djust_tags.py` module; the actual templatetag module is `live_tags`
- `{% djust_scripts %}` — this tag is not defined anywhere; the actual pattern is `{% djust_client_config %}` (emits client config meta tags), with `client.js` **auto-injected** by `_inject_client_script` (post_processing.py) — a manual `<script>` tag is even flagged by the project's own C012 check

Anyone following the quickstart verbatim gets `TemplateSyntaxError: 'djust_tags' is not a registered tag library` on their first page load.

## Changes

- Replace `{% load djust_tags %}` → `{% load live_tags %}` and `{% djust_scripts %}` → `{% djust_client_config %}` (+ "client runtime is auto-injected" note) across README.md, QUICKSTART.md, and docs/website (first-liveview, core-concepts, document-metadata, reconnection, templates, template-cheatsheet)
- Reword the CSRF claim in core-concepts.md to match reality: the client reads the `csrftoken` cookie / `csrf_token` hidden input (`djust_client_config` does not emit CSRF)
- Fix two demo templates (`examples/demo_project/**/status_change_djust.html`) that actually raised `TemplateSyntaxError` from `{% load djust_tags %}`, and remove their duplicate manual `client.js` script tag (double-load)

## Verification

`grep -rn "djust_scripts\|load djust_tags"` over `*.md/*.html/*.py` → 0 matches after this change. Canonical pattern cross-checked against `examples/demo_project/templates/base.html` and `_inject_client_script`.
