### PR TITLE
fix(ci): pin already-shipped CHANGELOG sections against the newest release tag (#2028)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -152,6 +152,18 @@ repos:
         files: ^CHANGELOG\.md$
         pass_filenames: false
 
+      # Pin already-shipped CHANGELOG sections against the newest release tag —
+      # a stray branch merge must never silently rewrite shipped history (the
+      # v1.1.0rc5 consolidation incident). See
+      # scripts/check-changelog-tagged-sections.py and
+      # tests/test_changelog_tagged_sections.py. Closes #2028.
+      - id: check-changelog-tagged-sections
+        name: check CHANGELOG shipped-section pins (#2028)
+        entry: python scripts/check-changelog-tagged-sections.py
+        language: python
+        files: ^CHANGELOG\.md$
+        pass_filenames: false
+
   # ADR status/version-line consistency — catches the drift class #1492
   # reconciled by hand (Accepted ADR still has a `Target version:` line).
   # See scripts/check-adr-status.py and tests/test_check_adr_status.py.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CI: `check-changelog-tagged-sections` pins already-shipped CHANGELOG sections against the newest release tag (#2028).** A 3-way merge of `CHANGELOG.md` across branches that diverged around a release cut can silently rewrite an already-shipped `## [X.Y.Z]` section with ZERO conflicts — git's diff3 has no notion that a version heading is immutable. The v1.1.0rc5 consolidation incident moved ~150 lines of unreleased content into the already-tagged `[1.1.0rc4]` body, falsely claiming unshipped work had gone out; neither `check-changelog-test-counts` nor `check-adr-status` catches it (both check the diff's own claims, not whether a shipped section changed at all). New pre-commit hook `scripts/check-changelog-tagged-sections.py` finds the newest release (top-most `## [X.Y.Z]` section whose `vX.Y.Z` tag exists) and asserts every section below it is byte-identical to that tag's frozen snapshot. Pinning against the *newest* tag (not each section's own tag) is required because this repo's rolling-rc sections keep accumulating entries after their own rc tag — a section is frozen once *superseded*, not at its own tag. Dogfooded clean against 119 shipped sections; empirical canary (#1459) confirms it catches a spurious injection into `[1.1.0rc4]`. 3 new cases in `tests/test_changelog_tagged_sections.py` (gate-off sentinel + non-tautology guard).
+
 ## [1.1.0rc5] - 2026-07-03
 
 ### Security

--- a/scripts/check-changelog-tagged-sections.py
+++ b/scripts/check-changelog-tagged-sections.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Pin already-shipped ``CHANGELOG.md`` sections against the newest release tag.
+
+Once a version's section is superseded by a newer release, it is *frozen* —
+a later branch merge must never rewrite it. But a 3-way merge of ``CHANGELOG.md``
+across branches that diverged around a release cut can do exactly that with ZERO
+conflicts (git's diff3 has no notion that a version heading is immutable),
+silently moving genuinely-unreleased content into an already-shipped section —
+see the v1.1.0rc5 consolidation incident (CLAUDE.md "Process canonicalizations
+from the v1.1.0rc5 retro").
+
+Neither ``check-changelog-test-counts.py`` nor ``make check-adr-status`` catches
+this class — both validate the diff's own numeric/version-line claims, not
+whether an already-shipped section changed at all.
+
+**Why not pin each section against its OWN tag?** This repo uses rolling-rc
+sections: a ``## [X.Y.ZrcN]`` heading keeps accumulating entries *after*
+``vX.Y.ZrcN`` is tagged, until the next rc/release renames ``[Unreleased]``. So
+a section is NOT frozen at its own tag — it's frozen once a *newer* release
+supersedes it. The authoritative frozen record of every superseded section is
+therefore the **newest release tag's** ``CHANGELOG.md``.
+
+The check: find the newest release (the top-most ``## [X.Y.Z]`` section in the
+working tree whose tag ``vX.Y.Z`` exists — the CHANGELOG is maintained
+newest-first). For every section BELOW it that also appears in that tag's
+``CHANGELOG.md``, assert the working-tree body is byte-identical to the tag's.
+The newest tagged section itself (may still be accumulating) and any newer,
+not-yet-tagged sections above it are skipped.
+
+Exits 0 on match or when there's nothing to check (no tagged section, or git
+unavailable). Exits 1 with a per-section diff on any mismatch.
+
+Usage::
+
+    python scripts/check-changelog-tagged-sections.py [path/to/CHANGELOG.md]
+
+Closes #2028.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+# A section heading: "## [X.Y.Z]" or "## [X.Y.Z] - 2026-06-30" etc. Captures the
+# version token inside the brackets. "[Unreleased]" is intentionally mutable.
+_HEADING_RE = re.compile(r"^## \[(?P<version>[^\]]+)\]")
+
+
+def _split_sections(text: str) -> "list[tuple[str, str]]":
+    """Return ``[(version, section_text), ...]`` in file order (newest first),
+    where section_text runs from the heading line through the line before the
+    next ``## [`` heading. ``[Unreleased]`` is skipped.
+    """
+    sections: list[tuple[str, str]] = []
+    current: str | None = None
+    buf: list[str] = []
+
+    def _flush() -> None:
+        if current is not None and current.lower() != "unreleased":
+            sections.append((current, "".join(buf)))
+
+    for line in text.splitlines(keepends=True):
+        m = _HEADING_RE.match(line)
+        if m:
+            _flush()
+            current = m.group("version").strip()
+            buf = [line]
+        elif current is not None:
+            buf.append(line)
+    _flush()
+    return sections
+
+
+def _git(*args: str) -> tuple[int, str]:
+    try:
+        proc = subprocess.run(
+            ["git", *args], cwd=str(REPO_ROOT), capture_output=True, text=True
+        )
+        return proc.returncode, proc.stdout
+    except (OSError, subprocess.SubprocessError):
+        return 1, ""
+
+
+def _tag_exists(tag: str) -> bool:
+    code, _ = _git("rev-parse", "--verify", "--quiet", f"refs/tags/{tag}")
+    return code == 0
+
+
+def check_changelog(changelog_path: Path) -> int:
+    if not changelog_path.exists():
+        print(f"CHANGELOG not found: {changelog_path}", file=sys.stderr)
+        return 0  # nothing to check — don't block
+
+    if _git("rev-parse", "--is-inside-work-tree")[0] != 0:
+        return 0  # not a git work tree — skip silently
+
+    working = _split_sections(changelog_path.read_text(encoding="utf-8"))
+
+    # Anchor = the newest release: the first (top-most) section whose tag exists.
+    anchor_ver: str | None = None
+    anchor_index = -1
+    for i, (ver, _) in enumerate(working):
+        if _tag_exists(f"v{ver}"):
+            anchor_ver = ver
+            anchor_index = i
+            break
+    if anchor_ver is None:
+        return 0  # no shipped section yet — nothing frozen to pin
+
+    code, snapshot_text = _git("show", f"v{anchor_ver}:CHANGELOG.md")
+    if code != 0:
+        return 0  # anchor tag had no CHANGELOG.md — can't pin
+    snapshot = dict(_split_sections(snapshot_text))
+
+    mismatches: list[str] = []
+    checked = 0
+    # Everything BELOW the anchor (older, superseded) is frozen in the anchor's
+    # snapshot. The anchor itself + anything above it (newer/untagged/Unreleased)
+    # is skipped.
+    for ver, body in working[anchor_index + 1 :]:
+        if ver not in snapshot:
+            continue  # not present in the anchor snapshot — can't pin
+        checked += 1
+        if body != snapshot[ver]:
+            diff = "".join(
+                difflib.unified_diff(
+                    snapshot[ver].splitlines(keepends=True),
+                    body.splitlines(keepends=True),
+                    fromfile=f"v{anchor_ver}:CHANGELOG.md  [## [{ver}] as shipped]",
+                    tofile=f"working CHANGELOG.md  [## [{ver}] now]",
+                )
+            )
+            mismatches.append(
+                f"\n✗ Section '## [{ver}]' was rewritten after it shipped "
+                f"(differs from the frozen copy in v{anchor_ver}).\n"
+                f"  An already-shipped CHANGELOG section is immutable — this is "
+                f"almost certainly a stray branch\n"
+                f"  merge rewriting shipped history (see #2028). Restore '[{ver}]' "
+                f"to match v{anchor_ver}.\n{diff}"
+            )
+
+    if mismatches:
+        print("CHANGELOG shipped-section pin FAILED:", file=sys.stderr)
+        for m in mismatches:
+            print(m, file=sys.stderr)
+        return 1
+
+    if checked:
+        print(
+            f"OK: {checked} shipped CHANGELOG section(s) match the newest "
+            f"release tag v{anchor_ver}."
+        )
+    return 0
+
+
+def main() -> int:
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_CHANGELOG
+    return check_changelog(path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_changelog_tagged_sections.py
+++ b/tests/test_changelog_tagged_sections.py
@@ -1,0 +1,111 @@
+"""#2028 — pin already-shipped CHANGELOG sections against the newest release tag.
+
+A stray branch merge can silently rewrite an already-shipped ``## [X.Y.Z]``
+section (the v1.1.0rc5 consolidation incident). ``check-changelog-tagged-sections.py``
+catches it by comparing every superseded section against the newest release
+tag's frozen ``CHANGELOG.md`` snapshot.
+
+These tests run against the REAL repo + tags (the check reads git tags from the
+repo root), so the empirical canary (#1459) is a permanent regression: injecting
+spurious content into a shipped section MUST make the check fail, and the
+untouched tree MUST pass.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check-changelog-tagged-sections.py"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+
+def _load_check():
+    spec = importlib.util.spec_from_file_location("check_changelog_tagged_sections", SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+check = _load_check()
+
+
+def _in_git_repo_with_a_shipped_section() -> bool:
+    """The check is a no-op outside a git work tree or before the first release
+    tag exists — skip those environments rather than assert on a no-op."""
+    if (
+        subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+        ).returncode
+        != 0
+    ):
+        return False
+    working = check._split_sections(CHANGELOG.read_text(encoding="utf-8"))
+    return any(check._tag_exists(f"v{ver}") for ver, _ in working)
+
+
+requires_shipped = pytest.mark.skipif(
+    not _in_git_repo_with_a_shipped_section(),
+    reason="no git work tree / no shipped CHANGELOG section tagged yet",
+)
+
+
+def _first_superseded_section() -> str:
+    """The version of the first section BELOW the anchor that the anchor's
+    snapshot contains — a genuinely-frozen section to mutate for the canary."""
+    working = check._split_sections(CHANGELOG.read_text(encoding="utf-8"))
+    anchor_i = next(i for i, (ver, _) in enumerate(working) if check._tag_exists(f"v{ver}"))
+    anchor_ver = working[anchor_i][0]
+    snap = dict(
+        check._split_sections(
+            subprocess.run(
+                ["git", "show", f"v{anchor_ver}:CHANGELOG.md"],
+                cwd=str(REPO_ROOT),
+                capture_output=True,
+                text=True,
+            ).stdout
+        )
+    )
+    for ver, _ in working[anchor_i + 1 :]:
+        if ver in snap:
+            return ver
+    raise AssertionError("no superseded section found to exercise the canary")
+
+
+@requires_shipped
+class TestChangelogTaggedSectionPin:
+    def test_current_tree_passes(self):
+        # The untouched working CHANGELOG must pin clean.
+        assert check.check_changelog(CHANGELOG) == 0
+
+    def test_rewriting_a_shipped_section_is_caught(self, tmp_path):
+        # Empirical canary (#1459): inject a spurious bullet into a frozen
+        # section in a COPY (real tags still back the comparison) → must fail.
+        ver = _first_superseded_section()
+        text = CHANGELOG.read_text(encoding="utf-8")
+        heading = f"## [{ver}]"
+        i = text.index(heading)
+        nl = text.index("\n", i) + 1
+        tampered = (
+            text[:nl]
+            + "\n- **SPURIOUS: unreleased content merged into a shipped section.**\n"
+            + text[nl:]
+        )
+        tampered_path = tmp_path / "CHANGELOG.md"
+        tampered_path.write_text(tampered, encoding="utf-8")
+
+        assert check.check_changelog(tampered_path) == 1
+
+    def test_gate_off_untampered_copy_passes(self, tmp_path):
+        # Non-tautology guard: the SAME copy without the injection passes, so it
+        # is the injection — not the copy path — that trips the check.
+        copy = tmp_path / "CHANGELOG.md"
+        copy.write_text(CHANGELOG.read_text(encoding="utf-8"), encoding="utf-8")
+        assert check.check_changelog(copy) == 0


### PR DESCRIPTION
## Summary

Closes #2028 (v1.1.0-6 drain). A 3-way merge of `CHANGELOG.md` across branches that diverged around a release cut can silently rewrite an already-shipped `## [X.Y.Z]` section with **zero conflicts** — git's diff3 has no notion that a version heading is immutable. The v1.1.0rc5 consolidation incident moved ~150 lines of unreleased content into the already-tagged `[1.1.0rc4]` body, falsely claiming unshipped work had gone out. Neither `check-changelog-test-counts` nor `check-adr-status` catches this class (both validate the diff's own numeric/version-line claims, not whether a shipped section changed at all).

## The check

`scripts/check-changelog-tagged-sections.py` finds the newest release (the top-most `## [X.Y.Z]` section whose `vX.Y.Z` tag exists — the CHANGELOG is newest-first) and asserts every section **below** it is byte-identical to that tag's frozen `CHANGELOG.md` snapshot.

**Why pin against the newest tag, not each section's own tag?** This repo uses rolling-rc sections: a `## [X.Y.ZrcN]` heading keeps accumulating entries *after* `vX.Y.ZrcN` is tagged, until the next rc renames `[Unreleased]`. So a section is **not** frozen at its own tag — it's frozen once a newer release supersedes it. The authoritative frozen record is the newest release tag's CHANGELOG. (A naive own-tag pin flooded false positives on 119 sections; the newest-tag pin is 0-mismatch.)

Wired as a pre-commit hook on `CHANGELOG.md`.

## Verification

- **Dogfood (#1060):** current tree pins clean — `OK: 119 shipped CHANGELOG section(s) match the newest release tag v1.1.0rc5.`
- **Empirical canary (#1459):** injecting a spurious bullet into shipped `[1.1.0rc4]` is caught with a clear diff; restoring passes. Locked in as a permanent test.
- **Tests:** 3 cases in `tests/test_changelog_tagged_sections.py` (current-tree-passes, rewrite-is-caught gate-off sentinel, untampered-copy non-tautology guard) — all green.

Two-commit shape: `2d26054f` (code+tests, no CHANGELOG) + `aa65a68b` (CHANGELOG docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)