### PR TITLE
fix(ci): cover python/djust/tests + fix stale setattr-chokepoint whitelist (#2032)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,6 +164,21 @@ jobs:
         run: |
           PYTHONPATH=. .venv/bin/python -m pytest tests/ python/tests/ -v -n auto
 
+      # #2032 — python/djust/tests/ was historically absent from the gating
+      # Python step: the explicit `tests/ python/tests/` paths override
+      # pyproject's `testpaths` (which DOES list python/djust/tests), so a large
+      # suite (V008 checks, mount-chokepoint structural pins, restore tests) ran
+      # in NEITHER CI nor the pre-push hook — and a RED TestSetattrChokepoint
+      # CWE-915 guard sat undetected on main. This runs it as a SOAK step
+      # (continue-on-error) per the #1534 rule: a CI surface the dev machine
+      # can't fully mirror (-n auto xdist over ~4000 newly-covered tests) ships
+      # non-gating until proven green on the runner. Promotion to a blocking
+      # gate + pre-push coverage is tracked in #2034.
+      - name: Run djust-package tests (python/djust/tests, soak — #2032)
+        continue-on-error: true
+        run: |
+          PYTHONPATH=. .venv/bin/python -m pytest python/djust/tests/ -v -n auto
+
       - name: Run Python linter
         run: uv run ruff check python/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI now covers `python/djust/tests/`, and the stale setattr-chokepoint security guard is green again (#2032).** The gating Python job ran `pytest tests/ python/tests/` — explicit paths that override pyproject's `testpaths` — so a large suite (V008 checks, mount-chokepoint structural pins, restore tests) ran in neither CI nor the pre-push hook. As a result the `TestSetattrChokepoint` CWE-915 mass-assignment guard had been RED on `main` undetected (a sanctioned `DynamicLiveView` function-view-decorator `setattr` site drifted off the whitelist's pinned line numbers). The whitelist is re-verified and corrected, and `python/djust/tests/` is added to CI as a non-gating soak step (`continue-on-error`, per the #1534 green-on-runner-first rule); promotion to a blocking gate + pre-push coverage is tracked in #2034. No runtime/behavior change.
+
 ## [1.1.0rc6] - 2026-07-03
 
 ### Fixed

--- a/python/djust/tests/test_mount_chokepoint_structural.py
+++ b/python/djust/tests/test_mount_chokepoint_structural.py
@@ -198,16 +198,21 @@ _VIEW_TARGET_NAMES = {"view", "view_instance", "component"}
 _SETATTR_WHITELIST = {
     # live_view.py function-view decorator: applies the DEVELOPER's own returned
     # state dict onto a locally-constructed DynamicLiveView. The keys come from the
-    # app author's function return value, not from a client frame — so they don't
-    # need safe_setattr's client-key guard. Two adjacent lines (callable vs not).
+    # app author's function return value (``result = func(request, ...)`` →
+    # ``for key, value in result.items(): setattr(view, key, value)``), NOT from a
+    # client frame — so they don't need safe_setattr's client-key guard. Two
+    # adjacent lines (callable vs not).
     # Line numbers shifted +11 in ADR-022 Iter 3 Phase 3.1 (#1913) when
     # ``_mounted_from_restore`` was added before the ``_framework_attrs`` snapshot
     # in ``LiveView.__init__``; shifted +8 again in ADR-023 M2 when type
     # annotations were added to live_view.py (optional-import block grew);
     # shifted +10 in #1981 (PR #1982) when ``_changed_keys``/``_force_full_html``
-    # were added to ``_FRAMEWORK_INTERNAL_ATTRS`` (comment block grew).
-    ("live_view.py", 1213),
-    ("live_view.py", 1215),
+    # were added to ``_FRAMEWORK_INTERNAL_ATTRS`` (comment block grew);
+    # shifted +12 (1213/1215 → 1225/1227) by later live_view.py growth, re-verified
+    # sanctioned in #2032 (v1.1.0-7): the sites are still the DynamicLiveView
+    # developer-dict application, not a new client-controlled setattr.
+    ("live_view.py", 1225),
+    ("live_view.py", 1227),
 }
 
 


### PR DESCRIPTION
## Summary

Closes #2032 (v1.1.0-7 drain). CI's Python job ran `pytest tests/ python/tests/` — explicit paths that **override** pyproject's `testpaths` (which lists `python/djust/tests`). So a large suite (V008 checks, mount-chokepoint structural pins, restore tests) ran in **neither CI nor the pre-push hook**, and the `TestSetattrChokepoint` **CWE-915 mass-assignment guard was RED on `main` undetected**.

## Security review (deliberate, not a mechanical bump)

The guard whitelists two sanctioned bare-`setattr` sites (the `DynamicLiveView` function-view decorator applying the developer's own returned dict). They drifted from the pinned `live_view.py:1213/1215` to `1225/1227`. I verified the moved sites are the **same** sanctioned application:

```python
result = func(request, *args, **kwargs)          # developer's function return
if isinstance(result, dict):
    for key, value in result.items():
        if not callable(value):
            setattr(view, key, value)             # 1225
        else:
            setattr(view, key, value)             # 1227
```

Keys come from the app author's function return value, **not a client frame** — so they legitimately bypass `safe_setattr`'s client-key guard. Not a new client-controlled write. Whitelist corrected `1213/1215 → 1225/1227` with the re-verification recorded in the comment.

## CI coverage (#1534-compliant soak)

Added `python/djust/tests/` to the `python-tests` job as a **`continue-on-error` soak step** — a CI surface the dev machine can't fully mirror (`-n auto` xdist over ~4000 newly-covered tests) ships non-gating until proven green on the runner. Promotion to a blocking gate + pre-push coverage is tracked in **#2034** (deliberate second step, per #1534).

## Verification

- `TestSetattrChokepoint` now green (14/14 in the file); the whole `python/djust/tests/` sweep was 8803 passed / 2 failed before, the 2 being exactly these.
- **Gate-off (#1468):** reverting the whitelist to `1213/1215` reds both chokepoint tests; restoring makes them pass.
- `test.yml` validated as well-formed YAML; soak step present in `python-tests`.

Two-commit shape: `80282fee` (whitelist + CI, no CHANGELOG) + the CHANGELOG docs commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)