### PR TITLE
fix(test): convert dj_transition 're-runs the sequence' to controllable-rAF stub (#2081)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`tests/js/dj_transition.test.js` "re-runs the sequence when the attribute value changes" — flaky under parallel CI load (#2081, #1830 flake class).** The case polled a wall-clock deadline (`waitForClass`, `setTimeout(tick, 5)`) racing jsdom's real ~16ms `requestAnimationFrame`, intermittently failing with `Error: class "s2" never applied within 300ms`. Converted to the controllable-rAF stub already established by the sibling case above it ("applies start class synchronously, active/end on next frame", #1839): the `controlledRaf` option in `createDom` queues `requestAnimationFrame` callbacks and drives them explicitly via `dom.flushFrame()`, so the test now asserts the ordering invariant (phase-1 class lands synchronously from the `MutationObserver` attribute-change callback; phase-2/3 classes are absent until the frame is driven) instead of racing a wall-clock timer — fully synchronous once the frame is driven, no timeout. The attribute re-trigger still goes through a real `MutationObserver` microtask (jsdom has no controllable stub for it), so the test awaits a single `Promise.resolve()` tick — FIFO-ordered after the observer's already-queued microtask, not a wall-clock wait. Gate-off verified (#1468): commenting out the second `dom.flushFrame()` call makes the post-frame assertions fail (`s2`/`a2`/`e2` stay in their pre-frame state). Ran the case 10x consecutively with zero flakes.
+
 - **Send-after-close RuntimeError noise: "Exception in ASGI application" on
   every reload-mid-mount under uvicorn (#2084).** A client that sends `mount`
   and immediately disconnects (page reload, quick navigation away) leaves the

--- a/tests/js/dj_transition.test.js
+++ b/tests/js/dj_transition.test.js
@@ -203,10 +203,28 @@ describe('dj-transition', () => {
     });
 
     it('re-runs the sequence when the attribute value changes', async () => {
-        dom = createDom('<div id="t" dj-transition="s a e"></div>');
+        // Controlled rAF: drive frame advancement explicitly instead of
+        // racing jsdom's real ~16ms requestAnimationFrame (#1830 flake
+        // class; mirrors the #1839 pattern used by the sibling case
+        // above — "applies start class synchronously, active/end on
+        // next frame"). MutationObserver attribute-change callbacks are
+        // still real microtasks (jsdom doesn't offer a controllable
+        // stub for them), so we await a single microtask tick after
+        // mutating the attribute — that's enough because the observer's
+        // "notify mutation observers" microtask is queued synchronously
+        // inside `setAttribute`, strictly before our `await
+        // Promise.resolve()` continuation is queued, so FIFO microtask
+        // ordering guarantees it runs first. Nothing here races a
+        // wall-clock timer.
+        dom = createDom('<div id="t" dj-transition="s a e"></div>', {
+            controlledRaf: true,
+        });
         const el = dom.window.document.getElementById('t');
-        // Wait for the listener registration to complete (rAF fired).
-        await waitForClass(el, 'a');
+
+        // Drive the initial mount's phase-2/3 frame (queued by the
+        // DOMContentLoaded init sweep).
+        expect(dom.flushFrame()).toBeGreaterThan(0); // a frame was actually queued
+        expect(el.classList.contains('a')).toBe(true);
 
         // Synchronous dispatch — handler runs inline, classList updates
         // are observable immediately.
@@ -215,9 +233,21 @@ describe('dj-transition', () => {
 
         // Re-trigger by swapping the spec.
         el.setAttribute('dj-transition', 's2 a2 e2');
-        await waitForClass(el, 's2');
+        await Promise.resolve(); // let the MutationObserver callback run
+
+        // Ordering invariant: phase 1 (start) is applied SYNCHRONOUSLY
+        // by the MutationObserver's attribute-change callback
+        // (_installDjTransitionFor → _runTransition → classList.add).
+        // The phase-2/3 transition is queued on our controllable rAF
+        // and has NOT run yet.
         expect(el.classList.contains('s2')).toBe(true);
-        await waitForClass(el, 'a2');
+        expect(el.classList.contains('a2')).toBe(false);
+        expect(el.classList.contains('e2')).toBe(false);
+
+        // Drive exactly one frame: phase-2 + phase-3 land, phase-1 is removed.
+        expect(dom.flushFrame()).toBeGreaterThan(0); // a frame was actually queued
+        expect(el.classList.contains('s2')).toBe(false);
+        expect(el.classList.contains('a2')).toBe(true);
         expect(el.classList.contains('e2')).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary

`tests/js/dj_transition.test.js`'s "re-runs the sequence when the attribute value changes" case still used a polling `waitForClass` helper (`Date.now() > deadline`, `setTimeout(tick, 5)`) racing jsdom's real ~16ms `requestAnimationFrame`. Under parallel CI load it intermittently failed with `Error: class "s2" never applied within 300ms` — the #1830 flake class.

This mirrors PR #1839's fix to the *sibling* case in the same file ("applies start class synchronously, active/end on next frame"): opt into the `controlledRaf` option already present in `createDom`, drive frame advancement explicitly via `dom.flushFrame()`, and assert an **ordering invariant** instead of racing a wall-clock timer.

## The assertion I changed to

Before driving the frame:
```js
expect(el.classList.contains('s2')).toBe(true);
expect(el.classList.contains('a2')).toBe(false);
expect(el.classList.contains('e2')).toBe(false);
```
After `dom.flushFrame()`:
```js
expect(el.classList.contains('s2')).toBe(false);
expect(el.classList.contains('a2')).toBe(true);
expect(el.classList.contains('e2')).toBe(true);
```

The attribute re-trigger (`el.setAttribute('dj-transition', 's2 a2 e2')`) still goes through a real `MutationObserver` — jsdom has no controllable stub for that primitive — so the test awaits a single `Promise.resolve()` tick (FIFO-ordered after the observer's already-queued microtask per the JS microtask-queue spec) rather than polling. Everything downstream of that tick (the phase-1/phase-2/3 ordering) is fully synchronous and driven explicitly.

## Gate-off evidence (#1468)

Temporarily commented out the second `dom.flushFrame()` call (the one that drives phase-2/3 for `s2`/`a2`/`e2`) and re-ran the test:

```
AssertionError: expected true to be false // Object.is equality
 ❯ tests/js/dj_transition.test.js:249:45
    249|         expect(el.classList.contains('s2')).toBe(false);
```

Confirms the post-frame assertions are non-tautological — they only pass because the frame was actually driven. Reverted the neutering before committing.

## 10x flake check

```
for i in $(seq 10); do npx vitest run tests/js/dj_transition.test.js -t "re-runs the sequence" || echo FAIL $i; done
```
10/10 clean — zero flakes. Full file (`npx vitest run tests/js/dj_transition.test.js`) also passed 10/10 (11/11 tests each run).

## Test plan
- [x] `npx vitest run tests/js/dj_transition.test.js` — 11/11 green
- [x] Target case run 10x consecutively — zero flakes
- [x] Gate-off: neutering the frame-drive makes the new assertion fail; restored and re-verified green

🤖 Generated with [Claude Code](https://claude.com/claude-code)