### PR TITLE
security(deps): bump postcss 8.5.16 → 8.5.20 (GHSA-r28c-9q8g-f849, #137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Verified locally: the `mcp` and WebSocket/`daphne` test suites pass under the new versions (the 1.27→1.28.1 `mcp` minor bump is the largest and carries no API break in the `djust.mcp` server tests). No API or behavioral change to djust.
 
+### Security
+
+- **postcss 8.5.16 → 8.5.20 — path traversal in source-map auto-loading (GHSA-r28c-9q8g-f849, Dependabot #137, high).** `postcss` ≤ 8.5.17 auto-loads a previous source map from a `sourceMappingURL` annotation without constraining the resolved path, so a crafted CSS input can make it read an arbitrary `.map` file off disk and surface its contents. **Not a runtime exposure for djust applications**: `postcss` is a dev-only transitive dependency (via `vite`), never packaged in the wheel and never served to a browser — the surface is a contributor or CI machine processing untrusted CSS. Lockfile-only change; `vite`'s existing `^8.5.16` range already admits the fix, so no `vite` bump and no `package.json` change were needed (`npm update postcss`, not `npm install`, which would have added postcss as a spurious direct *runtime* dependency). `nanoid` 3.3.15 → 3.3.16 rides along as postcss's own bumped requirement. The npm 10.9.2 in this environment strips `libc` metadata it does not emit from 10 rollup/lightningcss platform entries; those entries were restored verbatim from HEAD so the diff is exactly the security bump (7 lines) and `npm ci`'s musl-vs-glibc optional-dependency selection is unaffected. Verified with `npm ci` (lockfile internally consistent, postcss 8.5.20 installed), the full JS suite (1847 passing), and a `scripts/build-client.sh` run that reproduced the committed bundles byte-identically.
+
 ## [1.1.0rc8] - 2026-07-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -2321,9 +2321,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2484,9 +2484,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "dev": true,
       "funding": [
         {
@@ -2504,7 +2504,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Resolves Dependabot alert [#137](https://github.com/djust-org/djust/security/dependabot/137) (high).

**Advisory**: [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) — `postcss` ≤ 8.5.17 auto-loads a previous source map from a `sourceMappingURL` annotation without constraining the resolved path, so crafted CSS can make it read an arbitrary `.map` file off disk and surface its contents.

## Exposure

**Not a runtime exposure for djust applications.** `postcss` is a **dev-only transitive** dependency (via `vite`) — never packaged in the wheel, never served to a browser. The surface is a contributor or CI machine processing untrusted CSS.

## The diff is 7 lines

| | |
|---|---|
| `postcss` | 8.5.16 → 8.5.20 (patch floor is 8.5.18) |
| `nanoid` | 3.3.15 → 3.3.16 — postcss's own bumped requirement |

Lockfile-only. `vite`'s existing `^8.5.16` range already admits the fix, so **no `vite` bump and no `package.json` change**.

## Two things worth flagging for the reviewer

1. **`npm update postcss`, deliberately not `npm install postcss@…`.** The latter adds `postcss` to `package.json` as a direct **runtime** dependency — wrong twice over, since it is dev-only *and* purely transitive. Verified and discarded.
2. **npm 10.9.2 silently degrades the lockfile.** It strips `libc` metadata it does not itself emit from 10 `@rolldown/*` / `lightningcss-*` platform entries — fields a newer npm wrote, and which `npm ci` uses to select musl-vs-glibc binaries on Linux CI. That would have been ~37 lines of unrelated, potentially CI-affecting churn inside a security PR. Those entries are restored **verbatim from HEAD**, so this diff is exactly the security bump.

Related: this environment's npm points at a local proxy registry (`127.0.0.1:8418/npm/`) that lags public npm — it offers up to 8.5.20 while public is at 8.5.23. 8.5.20 clears the 8.5.18 patch floor, so the advisory is resolved, but the proxy will cap future bumps too.

## Verification

- `npm ci` — lockfile internally consistent, postcss 8.5.20 installed.
- Full JS suite: **1847 passing**.
- `scripts/build-client.sh` reproduces the committed bundles **byte-identically** (no artifact churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
