### PR TITLE
security(deps): crossbeam-epoch 0.9.18 → 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`crossbeam-epoch` 0.9.18 → 0.9.20 — invalid pointer dereference (RUSTSEC-2026-0204).** The `fmt::Pointer` impl for `Atomic`/`Shared` dereferences an invalid underlying pointer. Advisory dated 2026-07-06, fixed in 0.9.20. Transitive (`crossbeam-epoch` ← `crossbeam-deque` ← `rayon-core` ← … ← `djust_components`), and the existing caret range already admitted the fix, so this is a **lockfile-only** bump with no manifest change. Surfaced because the pre-push `cargo audit` hook blocks *every* push until clean, so it was blocking unrelated work; fixed on its own branch rather than folded into the feature PR that hit it. Verified `cargo audit` exits 0 and the workspace still tests green across 41 binaries.
+
+### Security
+
 - **Dependency security bumps — resolved 3 open Dependabot alerts (#134, #135, #136).** Bumped two `uv.lock` dependencies to their patched versions and raised their `[tool.uv]` `constraint-dependencies` security floors to match (so a future re-resolve can never fall back to a vulnerable version):
   - `pyasn1` 0.6.3 → 0.6.4 — two High advisories: GHSA-8ppf-4f7h-5ppj (#135, quadratic complexity in OBJECT IDENTIFIER and RELATIVE-OID processing allows denial of service) and GHSA-hm4w-wwcw-mr6r (#136, uncontrolled resource consumption when converting decoded REAL values). Pulled in transitively via the TLS/cert-parsing stack (`service-identity` → `pyopenssl`); floor bumped `>=0.6.3` → `>=0.6.4`.
   - `setuptools` 82.0.1 → 83.0.0 — GHSA-h35f-9h28-mq5c (#134, Moderate: `MANIFEST.in` exclusion bypass in sdist via Unicode normalization collision (NFC/NFD) on macOS APFS/HFS+). Build-time dependency only — not on any djust runtime path; floor bumped `>=78.1.1` → `>=83.0.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`crossbeam-epoch` 0.9.18 → 0.9.20 — invalid pointer dereference (RUSTSEC-2026-0204).** The `fmt::Pointer` impl for `Atomic`/`Shared` dereferences an invalid underlying pointer. Advisory dated 2026-07-06, fixed in 0.9.20. Transitive (`crossbeam-epoch` ← `crossbeam-deque` ← `rayon-core` ← … ← `djust_components`), and the existing caret range already admitted the fix, so this is a **lockfile-only** bump with no manifest change. Surfaced because the pre-push `cargo audit` hook blocks *every* push until clean, so it was blocking unrelated work; fixed on its own branch rather than folded into the feature PR that hit it. Verified `cargo audit` exits 0 and the workspace still tests green across 41 binaries.
 
-### Security
 
 - **Dependency security bumps — resolved 3 open Dependabot alerts (#134, #135, #136).** Bumped two `uv.lock` dependencies to their patched versions and raised their `[tool.uv]` `constraint-dependencies` security floors to match (so a future re-resolve can never fall back to a vulnerable version):
   - `pyasn1` 0.6.3 → 0.6.4 — two High advisories: GHSA-8ppf-4f7h-5ppj (#135, quadratic complexity in OBJECT IDENTIFIER and RELATIVE-OID processing allows denial of service) and GHSA-hm4w-wwcw-mr6r (#136, uncontrolled resource consumption when converting decoded REAL values). Pulled in transitively via the TLS/cert-parsing stack (`service-identity` → `pyopenssl`); floor bumped `>=0.6.3` → `>=0.6.4`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## The advisory

**RUSTSEC-2026-0204** — `crossbeam-epoch` 0.9.18: invalid pointer dereference in
the `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is
invalid. Dated 2026-07-06, fixed in 0.9.20.

Transitive: `crossbeam-epoch` ← `crossbeam-deque` ← `rayon-core` ← … ←
`djust_components`. The existing caret range already admitted the fix, so this
is a **lockfile-only** bump — no manifest change.

## Why it's on its own branch

The pre-push `cargo audit` hook blocks **every** push until it is clean, so this
was blocking unrelated work (an ADR-026 feature branch). Fixed separately per
the repo's `security(deps):` convention rather than folded into the feature PR
that happened to trip it.

## Verification

- `cargo audit` exits **0** (was: `error: 1 vulnerability found!`)
- `cargo test --workspace --exclude djust_live` — **41 test binaries green**

The two remaining `cargo audit` warnings (`bincode` unmaintained, `anyhow`
unsound) are pre-existing and allow-listed; this PR does not change them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
