### PR TITLE
docs: reconcile the three client-size figures, which had drifted apart (#2133)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ djust/
 │   ├── templatetags/       # Django template tags
 │   ├── tenants/            # Multi-tenant support
 │   ├── backends/           # Presence backends (memory, redis)
-│   └── static/djust/       # Client JS (~87 KB gzipped, 388 KB raw, 35 source modules)
+│   └── static/djust/       # Client JS (~58 KB gz minified; 184 KB gz / 727 KB raw unminified, 55 modules)
 ├── crates/
 │   ├── djust/              # PyO3 bindings (entry point for Python)
 │   ├── djust_core/         # Core types, serialization, context
@@ -89,7 +89,7 @@ djust/
 - **Error handling**: Use `Result` types; no `unwrap()` in library code
 
 ### JavaScript
-- Client JS size budget: current ~87 KB gzipped (388 KB raw across 35 source modules in `static/djust/src/`); pre-minified distribution target for v0.6.0 is ~37 KB gzipped / ~30 KB brotli. When adding a feature, measure its gzipped delta — aim under 2 KB gzipped per new module. Top 3 modules (`12-vdom-patch.js`, `09-event-binding.js`, `03-websocket.js`) are 42% of the budget; reducing them requires structural care. No new dependencies without discussion.
+- Client JS size budget: the SHIPPED artifact is `client.min.js.gz` at **~58 KB** — that is the number `scripts/check-doc-snippets.py` enforces against README (±3 KB band) and the only one a user downloads. Unminified `client.js` is ~184 KB gz / 727 KB raw across 55 modules in `static/djust/src/`; it is a build input, not a deliverable. (These read ~87 KB / 388 KB / 35 modules until #2133 — three stale numbers that had drifted apart because only the README one was checked.) When adding a feature, measure its gzipped delta — aim under 2 KB gzipped per new module. Top 3 modules (`12-vdom-patch.js`, `09-event-binding.js`, `03-websocket.js`) are 42% of the budget; reducing them requires structural care. No new dependencies without discussion.
 - **No `console.log`** without `if (globalThis.djustDebug)` guard — unguarded logging is auto-rejected
 - New JS feature files in `static/djust/src/` must have corresponding test files in `tests/js/`
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ no JavaScript to write, no bundler, and no build step in your project.
 - **Fast** — Rust-powered template engine and virtual DOM diffing (10–100x faster than plain Django rendering; see [Performance](#performance))
 - **Reactive components** — Phoenix LiveView-style server-side reactivity
 - **Django compatible** — works with existing Django templates and components
-- **No build step** — ~55 KB gzipped client JavaScript, no bundling required
+- **No build step** — ~58 KB gzipped client JavaScript, no bundling required
 - **WebSocket updates** — real-time DOM patches over WebSocket, with HTTP fallback
 - **Minimal payloads** — diffing sends only what changed
 - **Rust core** — performance-critical paths (templates, VDOM, parsing) are written in Rust
@@ -930,7 +930,7 @@ def search(self, query: str = "", **kwargs):
 ```
 ┌─────────────────────────────────────────────┐
 │  Browser                                    │
-│  ├── client.js (~55 KB gz) — events & DOM  │
+│  ├── client.js (~58 KB gz) — events & DOM  │
 │  └── WebSocket connection                   │
 └─────────────────────────────────────────────┘
            ↕ WebSocket (Binary/JSON)


### PR DESCRIPTION
`main` is **red**: three tests in `tests/test_check_doc_snippets.py` fail on a clean checkout, so every branch inherits failures it did not cause and **every push is blocked by the pre-push hook**. That is the state that trains people to read a red suite as noise — the same argument as #2124.

```
README.md:25  — client-size claim `~55 KB` outside the band [55.4, 61.4] KB (measured 58.4)
README.md:933 — same
```

The check is doing its job; the number drifted. `client.min.js.gz` grew across #2114, #2115 and #2120 — the `dj-virtual` client work — none of which crossed the band alone, and cumulatively they did.

## Reconciling all three figures, not just the checked one

| where | said | actual | describes |
|---|---|---|---|
| README ×2 | ~55 KB | **~58 KB** | `client.min.js.gz` — the shipped artifact |
| CLAUDE.md | ~87 KB gz, 388 KB raw, 35 modules | **~184 KB gz, 727 KB raw, 55 modules** | `client.js` — a build input |

Only the README one was checked, which is exactly how three numbers for "the client size" drifted apart. The CLAUDE.md pair had drifted much further, and it describes a *different artifact* — so the wording now says which number is which and which one is enforced.

Also dropped CLAUDE.md's "pre-minified distribution target for v0.6.0 is ~37 KB gzipped": minification shipped long ago, so that is neither a target nor accurate.

**Verified: 34/34 in `tests/test_check_doc_snippets.py`, from 31/34.**

Docs-only; no code paths touched.

Closes #2133