### PR TITLE
ci: report test-summary on docs-only PRs so it can be a required check (#2163)

### DIFF
--- a/.github/workflows/test-summary-docs-shim.yml
+++ b/.github/workflows/test-summary-docs-shim.yml
@@ -1,0 +1,107 @@
+name: Tests (docs-only shim)
+
+# Makes `test-summary` reportable on a docs-only PR so it can safely be a
+# REQUIRED status check (#2163).
+#
+# The problem this exists for: `test.yml` filters with `paths-ignore` for
+# `**.md`, `docs/**` and `CHANGELOG.md`. When every changed file matches that
+# list the whole workflow is skipped, and a skipped WORKFLOW never creates its
+# check runs at all — unlike a skipped JOB, which does report and which branch
+# protection treats as satisfied. A required `test-summary` would therefore sit
+# at "Expected — Waiting for status to be reported" forever on a docs-only PR.
+#
+# Measured on this repo, not assumed: PR #2182 (ROADMAP.md only) produced
+# exactly ONE check and no `test-summary`; PR #2183 (ROADMAP.md + a .py file)
+# produced 14 including `test-summary`. This repo's two-commit convention
+# (impl+tests / docs+CHANGELOG) makes docs-only PRs a routine shape.
+#
+# Why the two-job shape rather than a bare "always succeed" job: `paths` here
+# and `paths-ignore` in test.yml are NOT mutually exclusive. A PR touching both
+# a .md and a .py triggers BOTH workflows, and a shim that unconditionally
+# reported success would put a second, always-green `test-summary` alongside
+# the real one — masking a genuine failure, which is precisely the class of bug
+# #2163 is about. So the reporting job is gated on a real docs-only computation:
+#
+#   docs-only PR  -> test.yml skipped;  shim reports test-summary = success
+#   mixed PR      -> test.yml reports;  shim job SKIPPED (never green-washes)
+#   code-only PR  -> test.yml reports;  shim not triggered at all
+#
+# The `detect` job's own check run is incidental and must NOT be made required.
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'CHANGELOG.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect:
+    name: Detect docs-only change
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.check.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify the changed files
+        id: check
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Use the merge-base so the comparison matches what the PR actually
+          # changes, not everything main gained since the branch point.
+          MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+          FILES=$(git diff --name-only "$MERGE_BASE" "$HEAD_SHA")
+
+          echo "Changed files:"
+          echo "$FILES" | sed 's/^/  /'
+
+          # Mirrors test.yml's paths-ignore EXACTLY. If that list changes and
+          # this one does not, the guard test in
+          # python/djust/tests/test_ci_docs_shim_2163.py fails.
+          DOCS_ONLY=true
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md|docs/*|CHANGELOG.md) ;;
+              *) DOCS_ONLY=false; echo "  -> non-docs file: $f" ;;
+            esac
+          done <<< "$FILES"
+
+          # An empty diff must NOT be classified as docs-only: there is nothing
+          # to vouch for, and test.yml may still have run.
+          if [ -z "$(echo "$FILES" | tr -d '[:space:]')" ]; then
+            DOCS_ONLY=false
+            echo "  -> empty diff, refusing to vouch"
+          fi
+
+          echo "docs_only=$DOCS_ONLY" >> "$GITHUB_OUTPUT"
+          echo "docs_only=$DOCS_ONLY"
+
+  # MUST be named `test-summary` — it stands in for test.yml's job of the same
+  # name, which is the required status check.
+  test-summary:
+    name: test-summary
+    needs: detect
+    if: needs.detect.outputs.docs_only == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docs-only change — full suite not applicable
+        run: |
+          echo "Every changed file matches test.yml's paths-ignore"
+          echo "(**.md, docs/**, CHANGELOG.md), so the full suite did not run."
+          echo "Reporting test-summary so a required check is not left pending (#2163)."

--- a/python/djust/tests/test_ci_docs_shim_2163.py
+++ b/python/djust/tests/test_ci_docs_shim_2163.py
@@ -1,0 +1,145 @@
+"""The docs-only shim must stay aligned with test.yml's paths-ignore (#2163).
+
+`test.yml` skips the whole workflow when every changed file matches its
+``paths-ignore``. A skipped WORKFLOW never creates its check runs at all
+(unlike a skipped JOB, which reports and satisfies branch protection), so a
+required ``test-summary`` would hang at "Expected — Waiting for status to be
+reported" on a docs-only PR. ``test-summary-docs-shim.yml`` reports the
+context in exactly that case.
+
+The two path lists are therefore one contract split across two files — the
+#1646 drift shape. If someone adds ``*.rst`` to test.yml's ``paths-ignore``
+and not to the shim, an ``.rst``-only PR skips test.yml, the shim classifies
+it as non-docs, its ``test-summary`` job is skipped, and the PR is
+unmergeable with no visible cause. These tests make that drift fail loudly
+here instead.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+WORKFLOWS = pathlib.Path(__file__).resolve().parents[3] / ".github" / "workflows"
+TEST_YML = WORKFLOWS / "test.yml"
+SHIM_YML = WORKFLOWS / "test-summary-docs-shim.yml"
+
+
+def _load(path: pathlib.Path) -> dict:
+    assert path.is_file(), f"missing workflow: {path}"
+    # `on:` is the YAML 1.1 boolean True, so it round-trips as the key True.
+    return yaml.safe_load(path.read_text())
+
+
+def _trigger(doc: dict, event: str) -> dict:
+    on = doc.get("on", doc.get(True))
+    assert on is not None, "workflow has no trigger block"
+    return on[event]
+
+
+def test_shim_workflow_exists() -> None:
+    assert SHIM_YML.is_file(), (
+        "the docs-only shim is what lets test-summary be a REQUIRED check; "
+        "deleting it silently re-opens #2163"
+    )
+
+
+def test_shim_paths_match_test_yml_paths_ignore() -> None:
+    """The one contract this file exists to pin."""
+    ignored = _trigger(_load(TEST_YML), "pull_request")["paths-ignore"]
+    shim_paths = _trigger(_load(SHIM_YML), "pull_request")["paths"]
+
+    assert sorted(shim_paths) == sorted(ignored), (
+        "test-summary-docs-shim.yml's `paths` must mirror test.yml's "
+        f"`paths-ignore` exactly.\n  test.yml paths-ignore: {sorted(ignored)}\n"
+        f"  shim paths           : {sorted(shim_paths)}\n"
+        "Drift means some file type skips test.yml without the shim "
+        "vouching for it, and a required test-summary hangs forever."
+    )
+
+
+def test_shim_case_arms_match_the_same_list() -> None:
+    """The bash classifier must cover the same globs as the trigger.
+
+    The trigger decides whether the shim RUNS; the `case` arms decide whether
+    it VOUCHES. Both have to agree, or the shim runs and then declines.
+    """
+    ignored = _trigger(_load(TEST_YML), "pull_request")["paths-ignore"]
+    body = SHIM_YML.read_text()
+
+    m = re.search(r"^\s*case \"\$f\" in\n\s*([^\n]+)\)", body, re.M)
+    assert m, 'could not locate the `case "$f" in` arm in the shim'
+    arms = {a.strip() for a in m.group(1).split("|")}
+
+    # GitHub-glob -> shell-`case`-glob. The distinction that matters: GitHub
+    # needs `**` to cross a `/`, while shell `case` matches against the whole
+    # string with `*` already spanning `/`. So `**.md` is `*.md` here and
+    # `docs/**` is `docs/*` — collapsing `**` to `*` is the whole rule.
+    expected = {p.replace("**", "*") for p in ignored}
+    assert arms == expected, (
+        f"shim `case` arms {sorted(arms)} do not cover test.yml's paths-ignore {sorted(expected)}"
+    )
+
+
+def test_shim_reporting_job_is_named_test_summary() -> None:
+    """The job name IS the required-check contract; renaming it breaks the gate."""
+    jobs = _load(SHIM_YML)["jobs"]
+    assert "test-summary" in jobs, (
+        f"shim must define a job literally named `test-summary` "
+        f"(found: {sorted(jobs)}) — the name is what branch protection matches"
+    )
+
+
+def test_shim_reporting_job_is_gated_not_unconditional() -> None:
+    """The shim must never green-wash a mixed PR.
+
+    `paths` here and `paths-ignore` in test.yml are not mutually exclusive: a
+    PR touching a .md AND a .py triggers both workflows. If the shim reported
+    success unconditionally it would sit a second, always-green `test-summary`
+    next to the real one and mask a genuine failure.
+    """
+    job = _load(SHIM_YML)["jobs"]["test-summary"]
+    cond = job.get("if", "")
+    assert "docs_only" in cond and "true" in cond, (
+        f"the test-summary job must be gated on the detect job's docs_only output, got if: {cond!r}"
+    )
+    assert job.get("needs") == "detect" or "detect" in (job.get("needs") or []), (
+        "the test-summary job must depend on `detect` for its gating input"
+    )
+
+
+def test_test_yml_push_and_pull_request_filters_agree() -> None:
+    """test.yml carries the SAME paths-ignore list twice — pin them together.
+
+    `push:` and `pull_request:` each declare their own `paths-ignore`. The shim
+    mirrors the pull_request one, so if the two triggers drift the shim can be
+    correct for PRs while `main`'s push runs disagree about what a docs-only
+    change is. Found while gate-off-testing this file: a mutation aimed at the
+    first block silently landed on `push` and changed nothing the other tests
+    could see.
+    """
+    pr = _trigger(_load(TEST_YML), "pull_request")["paths-ignore"]
+    push = _trigger(_load(TEST_YML), "push")["paths-ignore"]
+    assert sorted(pr) == sorted(push), (
+        "test.yml's push and pull_request paths-ignore lists have drifted:\n"
+        f"  push        : {sorted(push)}\n  pull_request: {sorted(pr)}\n"
+        "The shim mirrors pull_request; divergence means push runs classify "
+        "docs-only differently."
+    )
+
+
+def test_test_yml_still_filters_by_path() -> None:
+    """If test.yml ever drops paths-ignore, the shim becomes dead weight.
+
+    Not a failure — but it should be deleted rather than left to double-report,
+    so this asserts the premise the shim is built on still holds.
+    """
+    assert "paths-ignore" in _trigger(_load(TEST_YML), "pull_request"), (
+        "test.yml no longer filters pull_request by path — the docs-only shim "
+        "is now redundant and should be REMOVED along with these tests, since "
+        "two workflows reporting `test-summary` is worse than one"
+    )


### PR DESCRIPTION
Refs #2163. **Prerequisite only** — branch protection is deliberately not changed here.

## The gap

```
$ gh api repos/djust-org/djust/branches/main/protection -q .required_status_checks
null
$ gh api repos/djust-org/djust/rules/branches/main -q length
0
```

The entire `test-summary` aggregate — rust, python, javascript, browser-smoke, nav-hooks-guard, security-tests, demo-checks, benchmarks — can be red and the merge button stays live. #1713 one level up.

## Why the obvious fix breaks the repo

Turning the requirement on today makes docs-only PRs unmergeable. `test.yml` filters with `paths-ignore`, and **a skipped WORKFLOW never creates its check runs at all** — unlike a skipped JOB, which reports and which branch protection treats as satisfied. A required `test-summary` would hang at *"Expected — Waiting for status to be reported"*.

Measured on this repo, not assumed — using the two PRs from this very drain:

| PR | Files | Checks | `test-summary`? |
|---|---|---|---|
| #2182 | `ROADMAP.md` | **1** | **absent** |
| #2183 | `ROADMAP.md` + `.py` | 14 | present |

The two-commit convention (impl+tests / docs+CHANGELOG) makes docs-only PRs routine.

## Why the shim is not a bare "always succeed" job

`paths` here and `paths-ignore` in `test.yml` are **not mutually exclusive** — a PR touching a `.md` *and* a `.py` triggers both workflows. An unconditional shim would put a second, always-green `test-summary` beside the real one and **mask a genuine failure** — the exact bug class #2163 is about.

So a `detect` job classifies the diff and the reporting job is gated on it:

| PR shape | `test.yml` | shim |
|---|---|---|
| docs-only | skipped | reports `test-summary` = success |
| mixed | reports (gates) | job **SKIPPED** — cannot green-wash |
| code-only | reports (gates) | not triggered |

An empty diff is explicitly *not* docs-only — there is nothing to vouch for.

## Anti-drift

The shim's path list and `test.yml`'s `paths-ignore` are one contract in two files (#1646). Seven guards in `test_ci_docs_shim_2163.py` pin it — including the bash `case` arms, which decide whether the shim *vouches*, separately from the trigger that decides whether it *runs*.

**Gate-off — all five drift mutations go red.** The harness asserts the mutation applied and reports `INVALID` on a collection error rather than a count (#2135):

```
BASELINE                             -> 0 failed, 7 passed
test.yml adds *.rst (both blocks)    -> 2 failed
test.yml push/PR drift (PR only)     -> 1 failed
shim reporting job ungated           -> 1 failed
shim job renamed                     -> 2 failed
case arm drops *.md                  -> 1 failed
```

### Two things writing those guards turned up

1. Shell `case` matches `/` with a plain `*`, so `**.md` translates to `*.md`. My first parity test asserted the wrong mapping and failed — correctly.
2. **`test.yml` declares `paths-ignore` twice** (`push` at `:6`, `pull_request` at `:12`). A gate-off mutation with `count=1` silently landed on `push`, which no guard read — an invalid measurement that looked like a passing test. That is its own #1646 drift, now pinned by `test_test_yml_push_and_pull_request_filters_agree`.

## Not done here

Branch protection stays untouched until this shim has reported green on a real runner (#1534). Order: land this → confirm the context name on a green run → then add `test-summary` to required checks.

Full suite: **10238 passed, 218 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)