### PR TITLE
fix(scripts): close two leaked file handles (CodeQL #2594, #2595)

### DIFF
--- a/scripts/strike-shipped-roadmap-rows.py
+++ b/scripts/strike-shipped-roadmap-rows.py
@@ -22,13 +22,14 @@ ROADMAP = pathlib.Path("ROADMAP.md")
 DRY = "--apply" not in sys.argv
 
 state, closer = {}, {}
-for line in open("/tmp/closers.tsv"):
-    if line.startswith("#"):
-        continue
-    num, st, pr = (line.rstrip("\n").split("\t") + ["", ""])[:3]
-    state[num] = st
-    if pr.strip():
-        closer[num] = pr.strip()
+with open("/tmp/closers.tsv") as fh:
+    for line in fh:
+        if line.startswith("#"):
+            continue
+        num, st, pr = (line.rstrip("\n").split("\t") + ["", ""])[:3]
+        state[num] = st
+        if pr.strip():
+            closer[num] = pr.strip()
 
 ROW = re.compile(r"^\|\s*\*\*P\d\*\*")
 # Split on unescaped pipes only. A naive split('|') treats the `\|` inside a
@@ -38,7 +39,7 @@ ROW = re.compile(r"^\|\s*\*\*P\d\*\*")
 CELL = re.compile(r"(?<!\\)\|")
 out, struck, skipped_open, skipped_unknown = [], [], [], []
 
-for lineno, line in enumerate(open(ROADMAP), 1):
+for lineno, line in enumerate(ROADMAP.read_text().splitlines(keepends=True), 1):
     if not ROW.match(line) or "~~" in line:
         out.append(line)
         continue


### PR DESCRIPTION
Closes CodeQL **#2594** and **#2595** (`py/file-not-closed`, warning) — the only two open code-scanning alerts.

Both are in `scripts/strike-shipped-roadmap-rows.py`, which I added in the #2181 ROADMAP sweep. Two bare `open()` calls used as iterators, relying on refcount collection rather than closing.

| Line | Was | Now |
|---|---|---|
| `:25` | `for line in open("/tmp/closers.tsv"):` | `with open(...) as fh:` / `for line in fh:` |
| `:41` | `for lineno, line in enumerate(open(ROADMAP), 1):` | `ROADMAP.read_text().splitlines(keepends=True)` |

`ROADMAP` is already a `pathlib.Path`, and the whole file is buffered into `out` regardless — so `read_text()` is both closed-by-construction and closer to what the code actually does than streaming a handle it never releases.

## Why bother on a throwaway script

Low stakes in isolation. But this script **rewrites `ROADMAP.md`**, and a write-capable tool holding handles it never closes is the wrong default to keep in `scripts/` — particularly this one, whose first version silently destroyed prose via the escaped-pipe bug.

## Verification

Behaviour unchanged, measured rather than assumed:

- dry run leaves `ROADMAP.md` **byte-identical** (`md5 f8d01c19…` before and after)
- same skip classes reported
- `#2017` and `#1561` still correctly left un-struck as the only open issues
- `ast.parse` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)