### PR TITLE
fix(templates): match Django unordered list indentation

### DIFF
--- a/crates/djust_templates/src/filters.rs
+++ b/crates/djust_templates/src/filters.rs
@@ -3981,9 +3981,8 @@ fn unordered_list(items: &[Value], depth: usize, items_are_safe: bool) -> String
         match sublist {
             Some(sub) if !sub.is_empty() => {
                 let sub_content = unordered_list(sub, depth + 1, items_are_safe);
-                let sub_indent = "\t".repeat(depth + 1);
                 result.push(format!(
-                    "{indent}<li>{escaped_item}\n{sub_indent}<ul>\n{sub_content}\n{sub_indent}</ul>\n{indent}</li>"
+                    "{indent}<li>{escaped_item}\n{indent}<ul>\n{sub_content}\n{indent}</ul>\n{indent}</li>"
                 ));
             }
             _ => {

--- a/python/tests/test_context_item_safety_2287.py
+++ b/python/tests/test_context_item_safety_2287.py
@@ -439,8 +439,8 @@ class TestTheGrantIsRefusedForShapesItCannotDescribe:
         markup for the sublist, so neither may djust's.
 
         Byte equality is deliberately NOT asserted for the ``unordered_list``
-        half: nested sublists carry a separate, pre-existing indentation
-        divergence (#2301) that reproduces with nothing marked safe at all.
+        half: nested safe-item propagation is a separate concern from the
+        indentation parity covered by ``test_nested_unmarked_list_matches_django``.
         """
         value = [mark_safe("<b>a</b>"), [mark_safe("<i>b</i>")]]
         expected = django_render('{{ p|join:", " }}', value)
@@ -450,6 +450,10 @@ class TestTheGrantIsRefusedForShapesItCannotDescribe:
         )
         assert_no_more_permissive_than_django('{{ p|join:", " }}', value)
         assert_no_more_permissive_than_django("{{ p|unordered_list }}", value)
+
+    def test_nested_unmarked_list_matches_django(self) -> None:
+        """The nested list wrapper stays at the parent indent (#2301)."""
+        assert_agrees("{{ p|unordered_list }}", ["a", ["b"]])
 
     @pytest.mark.parametrize("name", sorted(PER_ELEMENT))
     def test_a_stale_grant_cannot_reach_a_non_string_item(self, name: str) -> None:


### PR DESCRIPTION
## Summary

- Keep nested `<ul>` and `</ul>` at the parent list item indentation, matching Django.
- Add byte-equality coverage for an unmarked nested list.

Fixes #2301

## Validation

- `pytest -q python/tests/test_context_item_safety_2287.py -k nested_unmarked_list_matches_django` — passed (1 passed).
- `cargo test -p djust_templates unordered_list -- --nocapture` — unavailable locally: installed Cargo does not understand `Cargo.lock` version 4.