### PR TITLE
chore(ci): gate external PRs on a maintainer approval, and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,33 @@
+# Code owners for djust.
+#
+# GitHub requests a review from the owner of every path a PR touches. Paired
+# with "Require review from Code Owners" in branch protection, this makes the
+# reviewer explicit in the PR UI rather than something a contributor has to
+# guess at.
+#
+# Note on scope: this names the reviewer, it does not enforce that an external
+# contributor waits for one — branch protection cannot condition on who
+# authored a PR. That is what `.github/workflows/external-pr-gate.yml` does.
+
+# Everything, by default.
+*                                   @johnrtipton
+
+# Security-boundary code. Called out separately not because the owner differs
+# but because the diff deserves a slower read: four live XSSes were fixed in
+# these paths in a single drain (2026-08-28), every one of them a filter or a
+# grant that escaped nothing itself and leaned on the render-time auto-escape
+# that something downstream then removed.
+/crates/djust_templates/src/renderer.rs    @johnrtipton
+/crates/djust_templates/src/filters.rs     @johnrtipton
+/crates/djust_live/src/lib.rs              @johnrtipton
+/python/djust/auth/                        @johnrtipton
+/python/djust/security.py                  @johnrtipton
+/python/djust/serialization.py             @johnrtipton
+/python/djust/websocket.py                 @johnrtipton
+
+# Anything that changes how the project is built, released, or gated.
+/.github/                                  @johnrtipton
+/scripts/                                  @johnrtipton
+/Makefile                                  @johnrtipton
+/pyproject.toml                            @johnrtipton
+/Cargo.toml                                @johnrtipton

--- a/.github/workflows/external-pr-gate.yml
+++ b/.github/workflows/external-pr-gate.yml
@@ -1,0 +1,124 @@
+name: external-pr-gate
+
+# Blocks a PR from outside the org until a maintainer with write access has
+# approved it.
+#
+# WHY THIS EXISTS
+# ---------------
+# Branch protection cannot condition on WHO authored a PR — "require review" is
+# all-or-nothing, and turning it on for everyone would block the automated
+# internal pipeline. This job is the author-conditional half: it is a no-op for
+# a PR from someone with write access, and RED for an external PR until a
+# maintainer approves.
+#
+# It was added after an external contributor's PR (#2306) was merged with
+# `gh pr merge --admin`, which bypassed the review requirement. The fix is not
+# only this check — an admin can still force past a red check — but a red
+# required check makes the state visible rather than silent, which is what the
+# failure mode actually was.
+#
+# SECURITY NOTE
+# -------------
+# This uses `pull_request_target`, which runs with repository context and a
+# writable token even for fork PRs. It therefore MUST NOT check out or execute
+# any code from the PR. It reads API metadata only. Do not add
+# `actions/checkout` here without a `ref` pinned to the base branch, and do not
+# run any build, install, or test step in this workflow.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: external-pr-gate-${{ github.event.pull_request.number || github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  maintainer-approval:
+    name: external PRs require a maintainer approval
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check author permission, then require an approval if external
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const author = pr.user.login;
+
+            // Bots that open PRs against this repo as part of normal operation.
+            const AUTOMATION = new Set(['dependabot[bot]', 'github-actions[bot]']);
+            if (AUTOMATION.has(author)) {
+              core.info(`${author} is repository automation — gate does not apply.`);
+              return;
+            }
+
+            // Decide "internal" from the collaborator permission API rather than
+            // from author_association alone: association is a per-PR snapshot and
+            // reports CONTRIBUTOR for an org member who simply is not a direct
+            // collaborator on this repo.
+            let permission = 'none';
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner, repo, username: author,
+              });
+              permission = data.permission;  // admin | maintain | write | triage | read | none
+            } catch (e) {
+              // 404 means "not a collaborator", which is a valid answer, not a failure.
+              if (e.status !== 404) throw e;
+            }
+
+            const TRUSTED = new Set(['admin', 'maintain', 'write']);
+            if (TRUSTED.has(permission)) {
+              core.info(`${author} has '${permission}' access — internal PR, gate does not apply.`);
+              return;
+            }
+
+            core.info(`${author} has '${permission}' access — EXTERNAL PR, a maintainer approval is required.`);
+
+            // An approval only counts if the reviewer themselves has write access.
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+
+            // Latest state per reviewer wins: an APPROVED that was later dismissed
+            // or changed to REQUEST_CHANGES must not keep the gate green.
+            const latest = new Map();
+            for (const r of reviews) {
+              if (r.state === 'COMMENTED') continue;  // does not change approval state
+              latest.set(r.user.login, r.state);
+            }
+
+            const approvers = [];
+            for (const [login, state] of latest) {
+              if (state !== 'APPROVED') continue;
+              if (login === author) continue;  // cannot approve your own PR
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner, repo, username: login,
+                });
+                if (TRUSTED.has(data.permission)) approvers.push(`${login} (${data.permission})`);
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+            }
+
+            if (approvers.length > 0) {
+              core.info(`Approved by: ${approvers.join(', ')}`);
+              return;
+            }
+
+            core.setFailed(
+              `This PR is from an external contributor (${author}) and has no approving ` +
+              `review from a maintainer with write access.\n\n` +
+              `This is not a problem with the contribution — it is the review gate doing ` +
+              `its job. A maintainer should review the diff and submit an approving review; ` +
+              `this check re-runs on review submission and will turn green.\n\n` +
+              `Do NOT merge past this with admin privileges.`
+            );


### PR DESCRIPTION
Follows from #2306 being merged with `gh pr merge --admin`, which bypassed the review requirement on an external contributor's PR. **The contribution was good and stays merged** — the process was wrong, and this closes it.

## Why branch protection alone cannot do this

`main` already requires 1 approval. Two things defeated it:

- `enforce_admins: false`, so `--admin` walked past it.
- Branch protection has **no condition on who authored a PR**. "Require review" is all-or-nothing, so turning it on for everyone would also block the automated internal pipeline — 18 PRs merged that way in the drain this was found in.

So the enforcement has to be split: a check that knows the difference between an internal and an external author.

## What this adds

**`.github/workflows/external-pr-gate.yml`** — no-op for a PR from anyone with write access; **RED** for an external PR until a maintainer with write access approves. Re-runs on review submission, so approving turns it green without a push.

Three details that matter:

| | |
|---|---|
| Uses the **collaborator permission API**, not `author_association` | association is a per-PR snapshot and reports `CONTRIBUTOR` for an org member who is not a direct collaborator |
| Only the **latest review state per reviewer** counts | a dismissed or superseded approval must not keep the gate green |
| Self-approval excluded, `dependabot[bot]` / `github-actions[bot]` exempt | otherwise the gate is either trivially satisfiable or blocks routine automation |

**`.github/CODEOWNERS`** — names the reviewer in the PR UI. It does not enforce the wait; the workflow does. Security-boundary paths are listed separately, because four live XSSes were fixed in them in a single drain.

## Honest limitation

**An admin can still force past a red required check.** This does not make it impossible — it makes it *visible*. The actual failure mode was silence: nothing indicated the PR was external, and nothing went red. A red check that has to be deliberately overridden is a different act from a merge that looks routine.

If you want it genuinely unbypassable, that is `enforce_admins: true`, and the cost is that the internal pipeline stops at "PR open, awaiting review" on every PR. That trade-off was considered and deliberately not taken here.

## Security note on `pull_request_target`

The workflow uses `pull_request_target`, which runs with repository context and a writable token **even for fork PRs**. It reads API metadata only:

- no `actions/checkout`
- no build, install, or test step
- `permissions:` narrowed to `contents: read`, `pull-requests: read`

A comment in the file states this, because adding a checkout here later would be a privilege-escalation footgun rather than an obvious mistake.

## Changed outside this diff

Repository fork-PR approval policy, via the API: `first_time_contributors` → **`all_external_contributors`**. An outside PR can no longer execute workflow code against the runners before a maintainer has looked at it. Separate concern from merging — that one is about untrusted CI execution.

## To finish the setup

This check needs to be added to the branch ruleset's **required status checks** to block rather than merely report. I have not done that, since it changes merge behaviour repo-wide.

## Not self-merging this

Leaving it for your review — merging the external-PR gate by admin bypass would be a poor way to introduce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
