### PR TITLE
docs: replace the unsupported performance claims with measured figures

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ no JavaScript to write, no bundler, and no build step in your project.
 
 ## Features
 
-- **Fast** — Rust-powered template engine and virtual DOM diffing (10–100x faster than plain Django rendering; see [Performance](#performance))
+- **Fast** — Rust-powered template engine and virtual DOM diffing (roughly 7–11x faster than Django on variable- and filter-heavy templates, and no faster on static markup; see [Performance](#performance))
 - **Reactive components** — Phoenix LiveView-style server-side reactivity
 - **Django compatible** — works with existing Django templates and components
 - **No build step** — ~58 KB gzipped client JavaScript, no bundling required
@@ -263,21 +263,42 @@ written, no build step.
 
 ## Performance
 
-Benchmarked on an M1 MacBook Pro (2021):
+Full render throughput, same template on both engines, parsed once on each
+side. Measured with `benchmarks/benchmark.py` on an Apple silicon laptop,
+Django 5.2.16 / Python 3.12, `DEBUG=False`, release build:
 
-| Operation | Django | djust | Speedup |
-|-----------|---------|-------|---------|
-| Template rendering (100 items) | 2.5 ms | 0.15 ms | **16.7x** |
-| Large list (10k items) | 450 ms | 12 ms | **37.5x** |
-| Virtual DOM diff | N/A | 0.08 ms | **sub-ms** |
-| Round-trip update | 50 ms | 5 ms | **10x** |
+| Template shape | Rows | Django | djust | Speedup |
+|---|---|---|---|---|
+| Static markup (no variables) | 100 | 0.03 ms | 0.03 ms | **1.0x** |
+| Static markup (no variables) | 10,000 | 2.85 ms | 2.81 ms | **1.0x** |
+| Simple list (2 vars/row) | 100 | 0.62 ms | 0.09 ms | **6.8x** |
+| Simple list (2 vars/row) | 10,000 | 63.7 ms | 8.96 ms | **7.1x** |
+| Filtered list (typical page) | 100 | 2.32 ms | 0.21 ms | **10.8x** |
+| Filtered list (typical page) | 10,000 | 241 ms | 21.5 ms | **11.2x** |
 
-Run the benchmarks yourself:
+**The speedup depends entirely on what the template does.** Static markup is
+string concatenation and there is nothing to accelerate — djust is not faster,
+and says so. The advantage grows with variable and filter density, which is the
+direction real pages go.
+
+Two things this table does *not* measure, both of which matter:
+
+- **The VDOM patch.** On an update djust re-renders and sends a diff, where
+  Django can only re-render and ship the whole page. The wire-size difference is
+  not in these numbers at all.
+- **The round trip.** WebSocket transport, diffing and client apply are excluded.
+
+Run it yourself:
 
 ```bash
-cd benchmarks
-python benchmark.py
+make build          # release build — a debug build reverses the result
+python benchmarks/benchmark.py
 ```
+
+The script refuses to run against a debug extension. `make dev-build` produces
+an unoptimized one that is roughly 7.6x slower and measures Django as the
+faster engine; since that is what most test workflows build, it is an easy and
+badly misleading mistake to make.
 
 ## Installation
 

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Reproduce the README's performance table.
+
+    python benchmarks/benchmark.py
+
+The README used to cite this script and it did not exist, so its figures could
+not be checked by anyone — including us. They were also wrong: measured against
+this harness, the published 16.7x and 37.5x are 1.0x-11.3x depending entirely on
+what the template does.
+
+WHAT THIS MEASURES
+------------------
+Full render throughput of the same template on both engines, template parsed
+once on each side. That is the fair comparison and it is narrow on purpose:
+
+  * It is NOT djust's whole value proposition. djust re-renders and then sends a
+    VDOM patch, where Django can only re-render and ship the whole page. The
+    wire-size difference is not captured here at all.
+  * It says nothing about the WebSocket round trip, diffing, or client apply.
+
+Numbers are per render, median of 7 timed batches. Speedup is Django/djust, so
+higher is better for djust and 1.0x means "no difference".
+
+TWO WAYS TO GET A WRONG ANSWER, BOTH GUARDED BELOW
+--------------------------------------------------
+1. Benchmarking a DEBUG build. `make dev-build` produces an unoptimized
+   extension; `make build` produces the release one. The difference is ~7.6x and
+   it INVERTS the result -- a debug build measures Django as ~2x faster than
+   djust. Since `make dev-build` is what most test and mutation workflows run,
+   a debug .so is usually what is installed. This script refuses to run on one.
+2. Leaving `DEBUG=True` in Django settings, which inflates BOTH engines and
+   flatters neither consistently. Forced off below.
+"""
+
+from __future__ import annotations
+
+import os
+import statistics
+import sys
+import time
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "demo_project.settings")
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for path in (REPO_ROOT, os.path.join(REPO_ROOT, "examples", "demo_project")):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+import django  # noqa: E402
+
+django.setup()
+
+from django.conf import settings  # noqa: E402
+
+settings.DEBUG = False  # see the module docstring
+
+from django.template import Context  # noqa: E402
+from django.template import Template as DjangoTemplate  # noqa: E402
+
+from djust import _rust  # noqa: E402
+
+
+def _refuse_a_debug_build() -> str:
+    """A debug extension inverts the result. Refuse rather than mislead."""
+    so = _rust.__file__
+    size = os.path.getsize(so)
+    # Release is ~6 MB; a debug build carries symbols and runs ~30 MB+.
+    if size > 20_000_000:
+        sys.exit(
+            f"REFUSING TO RUN: {os.path.basename(so)} is {size / 1e6:.0f} MB, "
+            f"which is a DEBUG build.\n"
+            f"A debug build is unoptimized and reverses this comparison "
+            f"(it measures Django as faster).\n"
+            f"Run `make build` first, then re-run this script."
+        )
+    return f"{size / 1e6:.1f} MB (release)"
+
+
+class Row:
+    """A plain object, because attribute access is what real templates walk."""
+
+    __slots__ = ("name", "value")
+
+    def __init__(self, name: str, value: int) -> None:
+        self.name = name
+        self.value = value
+
+
+SHAPES: dict[str, str] = {
+    # The honest floor: nothing to accelerate, so nothing is accelerated.
+    "Static markup (no variables)": "<ul>{% for r in rows %}<li>item</li>{% endfor %}</ul>",
+    "Simple list (2 vars/row)": (
+        "<ul>{% for r in rows %}<li>{{ r.name }}: {{ r.value }}</li>{% endfor %}</ul>"
+    ),
+    # Closest to a real page: filters, a tag, and a conditional per row.
+    "Filtered list (typical page)": (
+        "<ul>{% for r in rows %}<li class='{% cycle 'a' 'b' %}'>"
+        "{{ r.name|upper|truncatechars:12 }}: {{ r.value|floatformat:2 }}"
+        "{% if r.value %} <em>{{ r.value|add:1 }}</em>{% endif %}</li>{% endfor %}</ul>"
+    ),
+}
+
+SIZES: tuple[tuple[int, int], ...] = ((100, 300), (10_000, 10))
+
+
+def bench(fn, repetitions: int) -> float:
+    """Milliseconds per call, median of 7 batches."""
+    fn()  # warm
+    batches = []
+    for _ in range(7):
+        start = time.perf_counter()
+        for _ in range(repetitions):
+            fn()
+        batches.append((time.perf_counter() - start) / repetitions)
+    return statistics.median(batches) * 1e3
+
+
+def main() -> None:
+    build = _refuse_a_debug_build()
+    print(f"djust extension : {build}")
+    print(f"Django          : {django.get_version()}")
+    print(f"Python          : {sys.version.split()[0]}")
+    print(f"settings.DEBUG  : {settings.DEBUG}")
+    print()
+    print(f"{'Template shape':32} {'Rows':>6} {'Django':>10} {'djust':>10} {'Speedup':>9}")
+    print("-" * 72)
+
+    for label, source in SHAPES.items():
+        for rows_n, repetitions in SIZES:
+            rows = [Row(f"name{i}", i) for i in range(rows_n)]
+            context = {"rows": rows}
+
+            # Both engines parse once, then render repeatedly.
+            django_template = DjangoTemplate(source)
+            django_context = Context(context)
+            django_ms = bench(lambda: django_template.render(django_context), repetitions)
+
+            view = _rust.RustLiveView(source)
+            view.update_state(context)
+            view.render()  # establish the baseline render
+            djust_ms = bench(view.render, repetitions)
+
+            print(
+                f"{label:32} {rows_n:6} {django_ms:9.2f}m {djust_ms:9.2f}m "
+                f"{django_ms / djust_ms:8.1f}x"
+            )
+
+    print()
+    print("Speedup is Django/djust. 1.0x means no difference — expected for")
+    print("static markup, where there is nothing to accelerate. The advantage")
+    print("grows with variable and filter density, which is what real pages do.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/BEST_PRACTICES_AI.md
+++ b/docs/BEST_PRACTICES_AI.md
@@ -172,7 +172,7 @@ class ProductListView(LiveView):
 
 ## 2. JIT Serialization Pattern (CRITICAL) ⚡
 
-### The Pattern (10-100x Performance Boost)
+### The Pattern (Rust-backed serialization)
 
 ```python
 # ✅ CORRECT: Private → Public in get_context_data

--- a/docs/JIT_SERIALIZATION_PATTERN.md
+++ b/docs/JIT_SERIALIZATION_PATTERN.md
@@ -65,7 +65,8 @@ class MyListView(BaseViewWithNavbar):
         # JIT will automatically:
         # - Extract ALL field paths used in template
         # - Apply optimal select_related/prefetch_related
-        # - Serialize using fast Rust code (10-100x faster than Python)
+        # - Serialize using fast Rust code (faster than the Python path; this
+        #   subsystem has no published measurement — see #TBD)
         # - Auto-generate count variables (e.g., items_count)
         self.items = self._items
 
@@ -239,7 +240,7 @@ When you assign a QuerySet to a public instance variable and call `super().get_c
    - You don't need to manually optimize (though you can for complex cases)
    - `_djust_annotations` on the model class are applied automatically
 
-3. **Rust Serialization with Python Fallback**: QuerySet serialized using Rust (10-100x faster than Python)
+3. **Rust Serialization with Python Fallback**: QuerySet serialized using Rust (faster than the Python path; unmeasured — see #TBD)
    - Sub-millisecond serialization for hundreds of objects
    - Automatic type conversion and JSON formatting
    - Falls back to Python codegen for `@property` attributes that Rust can't access
@@ -339,7 +340,8 @@ def get_context_data(self, **kwargs):
 
 Using the JIT pattern provides:
 
-- **10-100x faster serialization** - Rust vs Python
+- **Faster serialization** - Rust vs Python (unmeasured; the published
+  figure was carried over from template-rendering claims and did not apply)
 - **Sub-millisecond VDOM diffing** - Fast template rendering
 - **Automatic query optimization** - No N+1 queries
 - **Smaller payloads** - Efficient serialization format

--- a/docs/RUST_TEMPLATE_API.md
+++ b/docs/RUST_TEMPLATE_API.md
@@ -5,7 +5,9 @@
 The djust Rust template engine (`djust_templates` crate) provides a high-performance Django-compatible template processor written in Rust. This engine delivers sub-millisecond rendering and is fully compatible with Django template syntax.
 
 **Performance Benefits:**
-- **10-100x faster** template rendering vs Django
+- **Roughly 7-11x faster** template rendering vs Django on variable- and
+  filter-heavy templates, and no faster on static markup — see the README's
+  Performance section for the measured table and `benchmarks/benchmark.py`
 - **Sub-millisecond** parsing and rendering for typical templates
 - **Zero Python overhead** for template processing
 - **Compiled AST** for efficient re-rendering

--- a/docs/TEMPLATE_BACKEND.md
+++ b/docs/TEMPLATE_BACKEND.md
@@ -7,7 +7,7 @@
 `DjustTemplateBackend` is a Django template backend that enables **any Django view** to use djust's high-performance Rust template rendering engine, **without requiring LiveView**.
 
 This provides the best of both worlds:
-- ✅ **10-100x faster rendering** (Rust vs Python)
+- ✅ **Faster rendering** (Rust vs Python) — measured at roughly 7-11x on variable- and filter-heavy templates, and no faster on static markup; see the README's Performance section
 - ✅ **Standard Django views** (`TemplateView`, `render()`, etc.)
 - ✅ **No client.js injection** (smaller page sizes, better caching)
 - ✅ **Drop-in replacement** for Django's default backend
@@ -21,7 +21,7 @@ Add `DjustTemplateBackend` to your `TEMPLATES` setting:
 ```python
 # settings.py
 TEMPLATES = [
-    # Djust backend (Rust rendering, 10-100x faster)
+    # Djust backend (Rust rendering; ~7-11x faster on filter-heavy templates)
     {
         'BACKEND': 'djust.template_backend.DjustTemplateBackend',
         'DIRS': [BASE_DIR / 'templates'],
@@ -98,7 +98,7 @@ def my_view(request):
 ┌─────────────────────────────────────┐
 │  Rust Template Engine               │
 │  render_template(template, context) │
-│  - 10-100x faster than Django       │
+│  - ~7-11x faster (filter-heavy)     │
 │  - Automatic template caching       │
 │  - Sub-millisecond compilation      │
 └─────────────────────────────────────┘
@@ -114,7 +114,7 @@ def my_view(request):
 
 | Feature | DjustTemplateBackend | LiveView |
 |---------|---------------------|----------|
-| **Rendering** | Rust (10-100x faster) | Rust (10-100x faster) |
+| **Rendering** | Rust (~7-11x faster) | Rust (~7-11x faster) |
 | **Client.js** | ❌ No (smaller pages) | ✅ Yes (~58 KB gz) |
 | **WebSocket** | ❌ No | ✅ Yes |
 | **Interactivity** | ❌ Static only | ✅ Real-time updates |

--- a/docs/ai/jit.md
+++ b/docs/ai/jit.md
@@ -1,6 +1,6 @@
 # JIT Serialization
 
-Rust-powered serialization (10-100x faster than Python). Requires the private/public variable pattern.
+Rust-powered serialization (unmeasured; the previously quoted multiple was carried over from template-rendering claims). Requires the private/public variable pattern.
 
 ```python
 # CORRECT: private -> public in get_context_data()

--- a/docs/components/RUST_COMPONENTS.md
+++ b/docs/components/RUST_COMPONENTS.md
@@ -5,7 +5,9 @@ High-performance UI components backed by Rust with a Pythonic API, similar to Ju
 ## Overview
 
 Rust components provide:
-- **10-100x faster rendering** through Rust implementation
+- **Faster rendering** through Rust implementation — the template engine
+  measures roughly 7-11x on variable- and filter-heavy templates (see the
+  README's Performance section); component rendering specifically is unmeasured
 - **Type-safe HTML generation** with auto-escaping
 - **Framework-agnostic** - renders to Bootstrap5, Tailwind, or Plain HTML
 - **Pythonic API** with both kwargs and builder pattern

--- a/docs/components/TOOLTIP_COMPONENT_REPORT.md
+++ b/docs/components/TOOLTIP_COMPONENT_REPORT.md
@@ -166,7 +166,7 @@ icon_tip = Tooltip(
 ```python
 from djust._rust import RustTooltip
 
-# ~0.4μs per render (10-100x faster than Python)
+# ~0.4μs per render (the cross-engine multiple here is unmeasured)
 tooltip = RustTooltip("Hover me", "Tooltip text", "top", "hover", True)
 html = tooltip.render()
 ```

--- a/docs/guides/BEST_PRACTICES.md
+++ b/docs/guides/BEST_PRACTICES.md
@@ -68,7 +68,7 @@ These types are safe to store in state:
 |------|----------|-------|
 | Primitives | `str`, `int`, `float`, `bool`, `None` | ✓ Always safe |
 | Collections | `list`, `dict`, `tuple`, `set` | ✓ Safe if contents are serializable |
-| Django models | `User`, `Product`, etc. | ✓ Serialized via JIT (10-100x faster) |
+| Django models | `User`, `Product`, etc. | ✓ Serialized via JIT (Rust-backed) |
 | Django QuerySets | `Product.objects.filter(...)` | ✓ Use private → public pattern |
 | Date/time | `datetime`, `date`, `time` | ✓ Auto-converted to ISO strings |
 | UUID | `uuid.UUID` | ✓ Auto-converted to string |
@@ -199,7 +199,7 @@ class ProductListView(LiveView):
 
 ### Why the private → public pattern?
 
-Assigning a QuerySet to a public variable inside `get_context_data()` lets djust's Rust JIT serializer handle the conversion — 10-100x faster than Python serialization. This is the single biggest performance optimization in djust.
+Assigning a QuerySet to a public variable inside `get_context_data()` lets djust's Rust JIT serializer handle the conversion. The serialization path is unmeasured — the figure previously quoted here was carried over from template-rendering claims, which measure roughly 7-11x on filter-heavy templates (README Performance).
 
 ```python
 # GOOD: Let Rust JIT serialize

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -148,7 +148,7 @@ def on_scroll(self, position: int = 0, **kwargs):
 
 ## JIT Serialization (Critical Pattern)
 
-QuerySets MUST be stored in private variables (`self._items`) and assigned to public variables (`self.items`) only inside `get_context_data()`. This enables Rust-based serialization (10-100x faster than Python).
+QuerySets MUST be stored in private variables (`self._items`) and assigned to public variables (`self.items`) only inside `get_context_data()`. This enables Rust-based serialization (faster than the Python path; unmeasured).
 
 ```python
 # CORRECT

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # djust
 
-> djust is a Python/Rust framework that brings Phoenix LiveView-style reactive server-side rendering to Django. Real-time UI updates over WebSockets with ~58 KB gzipped client JS, zero build step, and Rust-powered VDOM diffing + template rendering for 10-100x performance.
+> djust is a Python/Rust framework that brings Phoenix LiveView-style reactive server-side rendering to Django. Real-time UI updates over WebSockets with ~58 KB gzipped client JS, zero build step, and Rust-powered VDOM diffing + template rendering (roughly 7-11x faster than Django on variable- and filter-heavy templates; see the README's Performance section for the measured table and the benchmark script).
 
 ## Docs
 


### PR DESCRIPTION
The README's Performance table did not reproduce, and the script it told readers to run did not exist — so nobody could check the figures, including us.

## What was claimed vs what measures

| | claimed | measured |
|---|---|---|
| 100 items | Django 2.5 ms / djust 0.15 ms → **16.7x** | Django 2.32 ms / djust 0.21 ms → **10.8x** |
| 10k items | Django 450 ms / djust 12 ms → **37.5x** | Django 241 ms / djust 21.5 ms → **11.2x** |
| headline | "10–100x faster than plain Django" | **1.0x – 11.2x**, entirely template-dependent |

**The two halves of each published row appear to come from different templates.** The Django column matches a *filter-heavy* template; the djust column matches a *simple* one. That inflates the ratio by roughly the gap shown.

**"10–100x" had support at neither end.** I could not reach 16.7x on any shape, let alone 100x. And the low end is not 10x — it is **1.0x**, because static markup is string concatenation and there is nothing to accelerate.

## What is true, and it is a better claim

| Template shape | Rows | Django | djust | Speedup |
|---|---|---|---|---|
| Static markup (no variables) | 100 | 0.03 ms | 0.03 ms | **1.0x** |
| Static markup (no variables) | 10,000 | 2.85 ms | 2.81 ms | **1.0x** |
| Simple list (2 vars/row) | 100 | 0.62 ms | 0.09 ms | **6.8x** |
| Simple list (2 vars/row) | 10,000 | 63.7 ms | 8.96 ms | **7.1x** |
| Filtered list (typical page) | 100 | 2.32 ms | 0.21 ms | **10.8x** |
| Filtered list (typical page) | 10,000 | 241 ms | 21.5 ms | **11.2x** |

The advantage **grows with variable and filter density**, which is the direction real pages go. A flat, honest 7–11x on realistic templates is a stronger claim than an unreproducible 16.7x, because a reader can run it.

## `benchmarks/benchmark.py` now exists

It produces exactly the table above, and carries two guards — because **both** of these mistakes were made while producing these numbers:

1. **It refuses to run against a debug extension.** `make dev-build` produces an unoptimized build that is ~7.6x slower and **measures Django as the faster engine**. Since `dev-build` is what most test and mutation workflows run, a debug `.so` is usually what is installed. I benchmarked one and concluded djust was slower than Django before catching it. **Verified empirically**: the script exits on the 34 MB debug `.so` and runs on the 6.5 MB release one.
2. **It forces `settings.DEBUG = False`**, which otherwise inflates both engines.

## The table now says what it does *not* measure

Render throughput is not djust's whole value proposition, and letting one number stand in for it is how the original claims drifted. Explicitly excluded: the **VDOM patch** (djust sends a diff where Django ships the whole page — the wire-size difference is not in these numbers at all) and the **round trip**.

## 12 further sites corrected

The same "10–100x" appeared across `docs/`. Left alone, they would contradict the README. Corrected by category rather than uniformly:

- **Template rendering** (`RUST_TEMPLATE_API.md`, `TEMPLATE_BACKEND.md`, `llms.txt`) → carries the measured range.
- **Serialization** (`JIT_SERIALIZATION_PATTERN.md`, `BEST_PRACTICES*.md`, `ai/jit.md`, `llms-full.txt`) → **figure removed, not replaced.** That is a different subsystem with no measurement behind it; substituting the template number would repeat the original error one subsystem over.
- **Component rendering** (`RUST_COMPONENTS.md`, `TOOLTIP_COMPONENT_REPORT.md`) → figure removed, noted as unmeasured.

## Caveats

Measured on Apple silicon, Django 5.2.16 / Python 3.12, not the M1 MacBook Pro (2021) the old table cited. Different hardware moves absolute times but should not move a 3–4x ratio gap. Anyone can now re-run it.

Two follow-ups worth having, not done here: the **serialization** and **VDOM diff** subsystems have no measurements at all, and now visibly say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
