### PR TITLE
test(templates): sweep every filter for the saturating-width abort, not just the three (#2328)

### DIFF
--- a/python/tests/test_filter_argument_contract_2328.py
+++ b/python/tests/test_filter_argument_contract_2328.py
@@ -466,6 +466,33 @@ class TestErrorsSurfaceUsefully:
         out = _rust.render_template('{{ p|ljust:"1000000" }}', {"p": "ab"})
         assert len(out) == 1_000_000
 
+    def test_no_other_filter_allocates_from_a_saturating_width(self) -> None:
+        """`center`/`ljust`/`rjust` are capped — but are they the whole set?
+
+        `python_int` saturates past `isize`, so a 21-digit argument becomes
+        `isize::MAX` for EVERY numeric filter, not only the three that were
+        capped. Any other filter that turned that into an allocation would abort
+        the same way, and the argument-axis differential's corpus has no
+        huge-width case at all, so it never exercised this. Enumerating the
+        surface rather than trusting the three (v1.0.0rc4 finding #1).
+
+        Caveat worth stating: an allocator abort kills the interpreter, so a
+        regression here takes pytest down with it rather than failing a case.
+        That is a loud failure, just an ugly one — and far better than the
+        silence of not checking. The subprocess-per-filter version that proved
+        this the first time is too slow for the suite.
+        """
+        values: dict[str, Any] = dict(VALUES)
+        values.setdefault("urlizetrunc", "see http://example.com/aaaa now")
+        for name in django_argument_filters():
+            value = values.get(name, TEXT)
+            for width in ("9" * 21, "18446744073709551615", "999999999"):
+                source = '{{ p|%s:"%s" }}' % (name, width)
+                try:
+                    _rust.render_template(source, {"p": value})
+                except RuntimeError:
+                    pass  # A raise is fine; an abort is what this rules out.
+
     def test_urlizetrunc_is_not_capped(self) -> None:
         """Its limit is a comparison bound, never an allocation, so the pad cap
         would be a divergence for nothing. A huge limit means "do not


### PR DESCRIPTION
Test-only follow-up to #2348, which merged while this was being written. One
27-line test, no source change.

## What it closes

#2348 capped the pad width because `python_int` **saturates** past `isize`
rather than failing, so a 21-digit argument became `isize::MAX` and
`" ".repeat()` aborted the process. The cap answered *"these three filters
abort on a saturating width."*

It did not answer *"are these three the whole set."* Saturation happens in the
shared chokepoint, so a 21-digit argument becomes `isize::MAX` for **every**
numeric filter — any other one that turned that into an allocation would abort
identically. The argument-axis differential built for #2328 has no huge-width
case at all, so nothing had exercised it.

## Measured before pinning

All 24 argument-taking filters × 3 saturating widths (`"9"*21`, `usize::MAX`,
`999999999`), each in **its own subprocess** — an allocator abort kills the
interpreter, so a single in-process loop would stop at the first offender and
report nothing about the filters after it:

```
center / ljust / rjust   RuntimeError: ... asks for a width of ... past djust's cap
every other filter       OK
```

`center`/`ljust`/`rjust` really are the complete allocating set, and all three
are capped on `main` already. So this PR adds no fix — it pins the enumeration
so a future filter that starts allocating from its width is caught.

## The caveat, stated in the docstring

The in-suite version runs in-process, because subprocess-per-filter is too slow
for the suite. If a future filter regresses, this takes pytest down rather than
failing a case — a loud failure rather than an ugly one, and far better than the
silence of not checking. The subprocess harness that proved it is in the PR
discussion above rather than the repo.

Enumerate-every-variant (v1.0.0rc4 finding #1) applied to the axis #2328
created rather than the one it was handed.

## Verification

- `pytest tests/ python/tests/ python/djust/tests/ -n auto` → **14021 passed**,
  220 skipped, 0 failed
- branched from `ec986062` (the #2348 squash-merge), 0 commits behind `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
