### PR TITLE
test: name and remove the stray warning that made the LiveViewForm deprecation test flaky

### DIFF
--- a/python/djust/tests/test_async_integration.py
+++ b/python/djust/tests/test_async_integration.py
@@ -16,6 +16,37 @@ from djust.live_view import LiveView
 from djust.decorators import event_handler, background
 
 
+def _close_swallowed_coroutines(mock_ensure_future):
+    """Close the coroutines a mocked ``asyncio.ensure_future`` swallowed.
+
+    ``patch.object(asyncio, "ensure_future")`` records the coroutine and never
+    schedules it, so it is never awaited. CPython emits
+    ``RuntimeWarning: coroutine 'LiveViewConsumer._run_async_work' was never
+    awaited`` when the collector eventually reclaims it — at an arbitrary
+    allocation point, attributed to whatever frame happens to be running then
+    (observed in the wild at ``_pytest/config/compat.py`` and
+    ``django/utils/translation/trans_real.py``, neither of which has anything
+    to do with this file).
+
+    That made it a cross-test hazard rather than local noise: it landed inside
+    ``tests/unit/test_forms.py``'s ``warnings.catch_warnings(record=True)``
+    window often enough to fail that test's ``assert len(w) == 1`` roughly one
+    run in five, on whichever xdist worker happened to hold both files.
+
+    Closing the coroutine here removes the warning at its source. The
+    assertion in ``test_forms.py`` is narrowed separately, because ANY future
+    stray from anywhere would re-break a count-based assertion — the two fixes
+    are independent and both are wanted.
+    """
+    closed = 0
+    for call in mock_ensure_future.call_args_list:
+        for arg in call.args:
+            if asyncio.iscoroutine(arg):
+                arg.close()
+                closed += 1
+    return closed
+
+
 class AsyncTestView(LiveView):
     """Test view with async operations."""
 
@@ -260,6 +291,11 @@ class TestConsumerAsyncDispatch:
             # Should have called ensure_future twice (once per task)
             assert mock_ensure_future.call_count == 2
 
+            # Asserted, not just performed: the leak's only other symptom is a
+            # warning that surfaces in an unrelated test on an unrelated
+            # worker, which no single-file run can see (#2379 follow-up).
+            assert _close_swallowed_coroutines(mock_ensure_future) == 2
+
         # Tasks should be cleared after dispatch
         assert len(view._async_tasks) == 0
 
@@ -280,6 +316,8 @@ class TestConsumerAsyncDispatch:
 
             # Should dispatch the legacy task
             assert mock_ensure_future.call_count == 1
+
+            assert _close_swallowed_coroutines(mock_ensure_future) == 1
 
         # Should be cleared
         assert view._async_pending is None

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -789,10 +789,45 @@ class TestModelPkSerialization:
         assert view.model_label == "myapp.Thing"
 
 
+def _liveviewform_deprecations(captured):
+    """The LiveViewForm deprecations among `captured`, and only those.
+
+    Selected by MESSAGE alone, deliberately. A category clause here would be
+    redundant — every stray the canary emits is already excluded by the
+    message — and a redundant filter clause cannot be shown to do anything,
+    which is the shape this repo deletes rather than tests around. The
+    category is asserted on the RESULT instead, where it is a real claim
+    about the warning rather than a second way of not selecting it.
+
+    Stated once rather than at each call site: two copies of a filter is the
+    drift this repo keeps retiring.
+    """
+    return [x for x in captured if "liveviewform" in str(x.message).lower()]
+
+
 class TestLiveViewFormDeprecation:
     """Test that LiveViewForm emits deprecation warning."""
 
     def test_subclass_emits_deprecation_warning(self):
+        """Assert on the DeprecationWarning, not on how many warnings arrived.
+
+        This used to end `assert len(w) == 1`, which measures the whole
+        PROCESS rather than the subject: `catch_warnings` mutates the global
+        filter list, so every warning raised anywhere during the window —
+        including one a garbage collection happens to surface — is recorded.
+        It failed roughly one full-suite run in five with `assert 2 == 1`,
+        depending only on which xdist worker held this file.
+
+        The stray was `RuntimeWarning: coroutine
+        'LiveViewConsumer._run_async_work' was never awaited`, from a mocked
+        `asyncio.ensure_future` in `test_async_integration.py`. That leak is
+        fixed at its source in the same change, but the count assertion is
+        narrowed anyway: ANY future stray from anywhere would re-break it,
+        and the number was never what this test is about.
+
+        `tests/integration/test_chunks_overlap.py` already filters its own
+        captured list this way for the same reason.
+        """
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
@@ -800,6 +835,60 @@ class TestLiveViewFormDeprecation:
                 name = forms.CharField()
 
             assert MyForm is not None  # use the class to satisfy linters
-            assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            assert "deprecated" in str(w[0].message).lower()
+
+        deprecations = _liveviewform_deprecations(w)
+        assert len(deprecations) == 1, (
+            "expected exactly one LiveViewForm DeprecationWarning; got "
+            f"{[(x.category.__name__, str(x.message)) for x in w]}"
+        )
+        assert issubclass(deprecations[0].category, DeprecationWarning)
+        assert "deprecated" in str(deprecations[0].message).lower()
+
+    def test_the_narrowing_survives_an_unrelated_warning(self):
+        """The empirical canary for the assertion above.
+
+        Without this, the narrowing is untestable: with no stray present the
+        filtered list and the raw list are identical, so gating the filter off
+        changes nothing and the mutation is a semantic no-op. This test
+        MANUFACTURES the stray, so the filter is the only thing standing
+        between the subject and a wrong answer.
+
+        It also pins, in the same breath, that the OLD assertion would have
+        failed here — which is the whole reason the count was wrong.
+        """
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class MyForm(LiveViewForm):
+                name = forms.CharField()
+
+            assert MyForm is not None
+            # Exactly the shape the real stray had: an unrelated CATEGORY,
+            # raised by something with nothing to do with this subject.
+            warnings.warn(
+                "coroutine 'LiveViewConsumer._run_async_work' was never awaited",
+                RuntimeWarning,
+                stacklevel=1,
+            )
+            # ...and an unrelated warning of the SAME category, so the
+            # category clause alone is not enough to identify the subject.
+            # Without this the message clause would be shadowed by the
+            # category clause and neither the filter nor the identity
+            # assertion could be shown to do anything.
+            warnings.warn(
+                "THEMES is deprecated since djust 0.5",
+                DeprecationWarning,
+                stacklevel=1,
+            )
+
+        deprecations = _liveviewform_deprecations(w)
+        # The subject is still found, unambiguously, among both strays...
+        assert len(deprecations) == 1, [(x.category.__name__, str(x.message)) for x in w]
+        # The warning's own properties (category, wording) are the SUBJECT of
+        # `test_subclass_emits_deprecation_warning` and are asserted there.
+        # Re-asserting them here would be a second copy that shadows the
+        # first: dropping either would leave the property covered, so neither
+        # could be shown to do anything.
+        # ...and the count the old assertion used is NOT 1, which is exactly
+        # how this test failed in CI roughly one run in five.
+        assert len(w) == 3


### PR DESCRIPTION
The flaky test flagged during #2415, finished. Not a blocker for anything —
this is the follow-up.

## The stray, named

`RuntimeWarning: coroutine 'LiveViewConsumer._run_async_work' was never
awaited`, from `test_async_integration.py`, which mocks
`asyncio.ensure_future`. The mock records the coroutine and never schedules
it, so it is never awaited; CPython emits the warning when the collector
eventually reclaims it.

In the run where I reproduced the failure it was attributed to
`_pytest/config/compat.py:49` and `django/utils/translation/trans_real.py:326`
— neither of which has anything to do with `_run_async_work`. That is the
signature of a GC-emitted warning: it surfaces at whatever frame happens to be
executing. When that frame is inside `test_forms.py`'s
`warnings.catch_warnings(record=True)` window — process-global and not
thread-safe — `len(w)` becomes 2.

**The number was the whole diagnosis.** `assert 2 == 1` (a stray ARRIVED) and
`assert 0 == 1` (the warning never fired) have opposite causes, and a count
assertion cannot distinguish them. Getting the assertion detail out of a
1-in-5 failure was the step that turned guessing into knowing.

Worth recording that **three hypotheses were falsified first**, two of them
mine and one of them the obvious one:

| hypothesis | outcome |
|---|---|
| my `importlib.reload` in the #2379 enumeration is the polluter | falsified — 20/20 clean serial pairing |
| an un-awaited coroutine dropped by `del` (refcount) | falsified — collected before the window |
| the same, trapped in a reference cycle needing the cycle collector | falsified — the warning fired outside the recorded window |

The thing that actually settled it was not a synthetic probe but the log from
the failing run itself, plus a scan of the eleven candidate files
(`test_async_integration.py`: 2 warnings; every other: 0).

## Two fixes, because they close different things

**1. The leak, at its source.** `_close_swallowed_coroutines` closes what the
mock swallowed, at both mock sites. Its return count is **asserted**, not just
performed — the leak's only other symptom is a warning in an unrelated test on
an unrelated worker, which no single-file run can observe, so without the
assertion the fix would have had no covering test at all. Measured: that file
emitted 2 such warnings, now 0.

**2. The assertion.** `assert len(w) == 1` measures the whole *process* rather
than the subject, so any future stray from anywhere would re-break it. It now
selects the LiveViewForm deprecation by message and asserts on that.

The repo already does exactly this one file over —
`tests/integration/test_chunks_overlap.py:356` filters its captured list to
`"_wait_for_one" in str(w.message)` and its comment names the same
coroutine-GC mechanism. That was the strongest corroboration available, and it
is in-repo precedent rather than my reasoning.

**Both were wanted.** Fixing only the leak leaves a count assertion that the
next stray re-breaks; narrowing only the assertion leaves a real leak silenced
rather than addressed — which was the trade the count assertion was already
making.

## The canary

`test_the_narrowing_survives_an_unrelated_warning` is what makes the narrowing
testable at all: with no stray present the filtered list and the raw list are
identical, so gating the filter off changes nothing and the mutation is a
semantic no-op. It manufactures **both** stray shapes — an unrelated category,
and an unrelated warning of the *same* category — and pins `len(w) == 3`,
which is exactly how the old assertion failed.

## Gate-off — 6/6, and the survivors were the useful part

| mutation | verdict |
|---|---|
| filter: the message clause dropped | RED (1) |
| canary: the `RuntimeWarning` stray deleted | RED (1) |
| canary: the foreign `DeprecationWarning` stray deleted | RED (1) |
| **production**: `warn_deprecated` emits the wrong category | RED (1) |
| **production**: the message stops naming the subject | RED (2) |
| leak fix: the coroutine-closing helper neutered | RED (2) |

Three rounds of survivors, each a real finding rather than a harness artifact:

* **Selecting by category AND message was belt-and-braces on the same half.**
  Every stray excluded by one clause was excluded by the other, so neither
  could be shown to do anything. The category is now asserted on the *result*,
  where it is a claim about the warning rather than a second way of not
  selecting it.
* **The canary re-asserted the main test's properties**, shadowing them. Each
  test now asserts only its own subject.
* **Two of my mutations recoloured a stray instead of deleting it**, and a
  third deleted a *test assertion* — which can never fail a test. For a
  test-only change the gate-off has to break what the assertion guards, so two
  mutations now target `_deprecation.py`.

The harness also refused to report a number twice ("mutation text matched 2x")
after the canary duplicated a filter — working as intended.

## Verification

* Pollution-class fix, so the 3-clean-run gate (#182/#1174): **16,775 passed**
  on each of three consecutive full-suite runs across all roots — two
  `-n auto`, one `-n 4`. The failure was distribution-dependent, so varying
  the distribution is the part that matters.
* Deterministic reproducer for the original failure, kept as the check:
  `pytest tests/unit/test_forms.py python/djust/tests/test_async_integration.py`.
* No CHANGELOG entry: test-only, no user-visible behaviour change.

## Related

`_rust.pyi`'s `register_tag_handler` example is filed separately as #2417 —
non-functional (`TypeError: Handler must have a 'render' method`), found while
verifying #2379. All 12 stub examples were executed; that one and a top-level
`await` are the two real defects, the other four failures are ordinary
placeholders.
