### PR TITLE
test: the regroup renderer spy patches the REGISTERED handler, not a stale import (#2427)

### DIFF
--- a/python/tests/test_custom_tag_return_escape_2379.py
+++ b/python/tests/test_custom_tag_return_escape_2379.py
@@ -371,6 +371,22 @@ def _registered_handlers() -> dict[str, tuple[str, object]]:
     Not a list: enumerating "the places I know call X" is reliably one short
     (v1.1.1-2 retro), and this repo registers through a decorator, two
     ``register_with_rust_engine`` functions and a component registry.
+
+    **This leaks, irreversibly, and that is not fixable here (#2427).** The
+    ``importlib.reload`` below is what re-triggers registration, and a reload
+    rebinds every class in the module AND registers a NEW instance of it. It
+    cannot be undone — the ``finally`` restores the intercepted ``_rust``
+    functions, not the module state — so from here on, a module-level
+    ``from djust.template_tags.X import SomeHandler`` elsewhere in the suite is
+    a STALE class object that the engine will never call.
+
+    That reddened
+    ``test_regroup_string_source_2385_2394.py::…::test_the_renderer_hands_a_``
+    ``string_source_over_quoted`` intermittently on CI, whenever xdist put this
+    audit on the same worker ahead of it. The cure is on the reading side: a
+    test that patches a handler must resolve the class from
+    ``djust.template_tags._registered_handlers`` rather than from its own
+    import. See ``live_regroup_class()`` in that file.
     """
     import djust
     import djust.template_tags

--- a/python/tests/test_regroup_string_source_2385_2394.py
+++ b/python/tests/test_regroup_string_source_2385_2394.py
@@ -66,6 +66,7 @@ from django.template import Template as DjangoTemplate
 
 from djust import _rust
 from djust.mixins.rust_bridge import _collect_safe_keys
+from djust.template_tags import _registered_handlers as _LIVE_HANDLERS
 from djust.template_tags.regroup import RegroupTagHandler
 
 REPO = pathlib.Path(__file__).resolve().parents[2]
@@ -97,6 +98,51 @@ def render_both(tpl: str, ctx: dict) -> tuple[str, str]:
     djust_ctx = dict(ctx)
     djust_out = _rust.render_template_with_dirs(tpl, djust_ctx, [], _safe_keys(djust_ctx) or None)
     return django_out, djust_out
+
+
+def live_regroup_class() -> type:
+    """The `regroup` handler class the ENGINE will call.
+
+    NOT necessarily the `RegroupTagHandler` imported above, and that difference
+    was CI flake #2427.
+
+    `python/tests/test_custom_tag_return_escape_2379.py`'s handler audit
+    enumerates every registration by `importlib.reload`-ing each
+    `djust.template_tags.*` submodule. Reloading `…regroup` re-executes
+    `@register_assign("regroup")` on a NEW class object and registers a NEW
+    instance — permanently. Nothing restores it and nothing can: a reload is
+    not reversible.
+
+    So a module-level `from … import RegroupTagHandler` goes STALE the moment
+    that audit runs, and the spy below was patching a class the engine would
+    never call. It captured `[]` where it wanted `['"ab"', 'nope']` — an
+    assertion about a class object rather than about the engine's behaviour,
+    which is the shape #2420 had (`assert len(w) == 1` counting every warning
+    in the process).
+
+    Whether it reddens depends on xdist putting the audit on the same worker,
+    ahead of this test. Measured over the full three-root suite: at `-n 4`,
+    what CI's four-core runner gives, **3 of 3 runs failed** and the audit was
+    on the target's worker at line ~7,100 against the target's ~16,500 every
+    time. #2427 records two local `-n auto` runs (12 workers here) that did not
+    reproduce it, and a CI re-run of an unchanged commit that went green — the
+    same scheduler, a different draw.
+
+    `djust.template_tags._registered_handlers` is the Python-side mirror of the
+    Rust registry — `register_assign`'s decorator writes it on the line after
+    `register_assign_tag_handler`, with the SAME instance — and
+    `djust/template_tags/__init__.py` is not itself reloaded, so the dict
+    survives holding whatever was registered last. Reading the class off it is
+    what makes the assertion measure its own subject. (`_rust` exposes
+    `has_assign_tag_handler` but no getter, so this mirror is the closest
+    reachable answer to "what will the engine call".)
+
+    Only the SPY test needs this. `test_the_handler_iterates_with_pythons_own`
+    `_semantics` calls `_decode_source` directly, and a reloaded class runs the
+    same source — its subject is the code, not the wiring, so it is unaffected
+    either way and stays on the import.
+    """
+    return type(_LIVE_HANDLERS["regroup"])
 
 
 def assert_agrees(operand: str, ctx: dict) -> str:
@@ -265,16 +311,21 @@ class TestBothMechanismsAreReachable:
         string there. Asserted through a real render by giving the handler's
         `by` operand no match: what reaches `_decode_source` is what the
         grouping is built from.
+
+        The spy goes on `live_regroup_class()`, not on the `RegroupTagHandler`
+        this module imported — see that helper for the CI flake it closes
+        (#2427).
         """
+        handler_cls = live_regroup_class()
         captured: list[str] = []
-        original = RegroupTagHandler._decode_source
+        original = handler_cls._decode_source
 
         @classmethod  # type: ignore[misc]
         def spy(cls, expr, context):  # type: ignore[no-untyped-def]
             captured.append(expr)
             return original.__func__(cls, expr, context)  # type: ignore[attr-defined]
 
-        RegroupTagHandler._decode_source = spy  # type: ignore[assignment]
+        handler_cls._decode_source = spy  # type: ignore[assignment]
         try:
             _rust.render_template_with_dirs(
                 "{% regroup s by k as g %}[{{ g|length }}]", {"s": "ab"}, [], None
@@ -283,12 +334,55 @@ class TestBothMechanismsAreReachable:
                 "{% regroup nope by k as g %}[{{ g|length }}]", {"s": "ab"}, [], None
             )
         finally:
-            RegroupTagHandler._decode_source = original  # type: ignore[assignment]
+            handler_cls._decode_source = original  # type: ignore[assignment]
 
         assert captured == ['"ab"', "nope"], (
             "the resolved string must arrive JSON-quoted and the unresolved "
             f"token bare — that difference IS the fix's renderer half: {captured!r}"
         )
+
+    def test_the_spy_reaches_a_RE_REGISTERED_handler(self) -> None:
+        """#2427 as a test rather than as a comment.
+
+        The polluter is a real `importlib.reload`, which cannot be undone — a
+        test that performed one would become the next polluter for everything
+        scheduled after it on the same worker. So the shape is simulated by
+        registering an INDEPENDENT class object under `regroup`: same code, own
+        `_decode_source`, and deliberately NOT a subclass, because a subclass
+        would inherit a patch of `RegroupTagHandler` and hide the entire effect
+        — the simulation would then pass while measuring nothing.
+
+        This is the only test that can tell the fix from the bug: in a clean
+        process the imported class and the registered one are the same object,
+        so the method above passes either way. Gating `live_regroup_class` back
+        to `return RegroupTagHandler` reddens THIS one alone.
+        """
+        saved = _LIVE_HANDLERS["regroup"]
+        namespace = {
+            k: v for k, v in vars(RegroupTagHandler).items() if k not in ("__dict__", "__weakref__")
+        }
+        reloaded_cls = type("RegroupTagHandler", RegroupTagHandler.__bases__, namespace)
+        assert reloaded_cls is not RegroupTagHandler
+        assert not issubclass(reloaded_cls, RegroupTagHandler), (
+            "a subclass inherits a patch of the original and would make this "
+            "simulation vacuous — a reload produces a SIBLING"
+        )
+        assert "_decode_source" in vars(reloaded_cls), (
+            "the copy must own `_decode_source`, or patching the original still reaches it"
+        )
+
+        handler = reloaded_cls()
+        _rust.register_assign_tag_handler("regroup", handler)
+        _LIVE_HANDLERS["regroup"] = handler
+        try:
+            assert live_regroup_class() is reloaded_cls
+            # Every assertion of the method above, against the class the
+            # registry now holds.
+            self.test_the_renderer_hands_a_string_source_over_quoted()
+        finally:
+            _rust.register_assign_tag_handler("regroup", saved)
+            _LIVE_HANDLERS["regroup"] = saved
+        assert live_regroup_class() is type(saved), "the registry was not restored"
 
     @pytest.mark.parametrize(
         "expr,expected",


### PR DESCRIPTION
Closes #2427.

## The measured distribution, first

The issue asked not to start by re-reading the test. Reproducing it under CI's
distribution took one loop: the full three-root suite at **`-n 4`**, what the
four-core GitHub runner gives.

| where | runs | target failed |
|---|---|---|
| local, full three roots, **`-n 4`** | 3 | **3** |
| local, full three roots, `-n auto` (12 workers here) | 2 (per #2427) | 0 |
| CI `python-tests (py3.12)`, PR #2420 / #2424 | 2 | 2 |
| CI, no-change re-run of PR #2420 | 1 | 0 |

The `-v` logs also record *where* each test ran, and the answer was the same
every time:

```
run 1: target gw2 (line 16676)   polluter gw2 (line 7114)   FAILED
run 2: target gw2 (line 17212)   polluter gw2 (line 7114)   FAILED
run 3: target gw2 (line 16328)   polluter gw2 (line 7112)   FAILED
```

Same worker, polluter ~9,000 lines ahead. Worker count is the whole variable:
xdist's `load` scheduler has to put the two on one worker in that order, which
is much likelier across 4 workers than across 12 — which is why CI saw it and
#2427's local runs did not.

## The observed value was the diagnosis

`assert captured == ['"ab"', "nope"]` failed with `captured == []`. Not a wrong
pair — the spy **never fired**.

```python
original = RegroupTagHandler._decode_source
RegroupTagHandler._decode_source = spy       # ...on WHICH class object?
```

`python/tests/test_custom_tag_return_escape_2379.py`'s handler audit
(`_registered_handlers()`, the fixture behind `TestEveryRegisteredHandlerIs`
`AccountedFor`) enumerates registrations by re-triggering them:

```python
for mod in pkgutil.iter_modules(djust.template_tags.__path__):
    importlib.reload(importlib.import_module(f"djust.template_tags.{mod.name}"))
```

Reloading `djust.template_tags.regroup` re-executes
`@register_assign("regroup")` on a **new class object** and registers a **new
instance** with the Rust engine. Its `finally` restores the intercepted
`_rust.register_*` functions — not the module state, which a reload cannot
restore. So from that point on, this file's module-level
`from djust.template_tags.regroup import RegroupTagHandler` is a stale class the
engine will never call, and the spy went onto it.

Confirmed directly rather than inferred:

```
before: type(_registered_handlers['regroup']) is RegroupTagHandler -> True
after : type(_registered_handlers['regroup']) is RegroupTagHandler -> False
```

and deterministically, in one process:

```
$ pytest python/tests/test_custom_tag_return_escape_2379.py \
         python/tests/test_regroup_string_source_2385_2394.py::...::test_the_renderer_hands_a_string_source_over_quoted
1 failed, 26 passed          # captured == []
```

## The fix: make the assertion measure its subject

The subject is *what `_decode_source` the engine calls*, so the class is now
resolved from the registry rather than from an import:

```python
def live_regroup_class() -> type:
    return type(_LIVE_HANDLERS["regroup"])
```

`djust.template_tags._registered_handlers` is the Python-side mirror of the Rust
registry — `register_assign`'s decorator writes it on the line after
`register_assign_tag_handler`, with the *same instance* — and
`djust/template_tags/__init__.py` is not itself reloaded, so it survives holding
whatever was registered last. `_rust` exposes `has_assign_tag_handler` but no
getter, so that mirror is the closest reachable answer.

This is the same shape as #2420, whose `assert len(w) == 1` counted every
warning in the process instead of its own.

**One mechanism, not two.** Making the audit restore the registry afterwards
would ALSO make this test pass, and the two would then shadow each other — no
gate-off could separate them (#2233). The audit's reload is deliberate and
genuinely irreversible, so the cure belongs on the reading side; the leak is
named in the audit's own docstring instead of being papered over, pointing the
next reader at `live_regroup_class()`.

`test_the_handler_iterates_with_pythons_own_semantics` deliberately stays on the
import: it calls `_decode_source` directly, its subject is the code rather than
the wiring, and a reloaded class runs the same source.

## The regression test

`test_the_spy_reaches_a_RE_REGISTERED_handler` is the **only** test that can
tell the fix from the bug — in a clean process the imported class and the
registered one are the same object, so the spy test passes either way. That is
stated in its docstring rather than left for a reviewer to discover.

It simulates the reload by registering an **independent class object** built
from `RegroupTagHandler`'s own namespace, because:

- a real `importlib.reload` cannot be undone, so the test would become the next
  polluter for everything scheduled after it on the same worker;
- a **subclass** would inherit a patch of `RegroupTagHandler` and make the
  simulation vacuous — it would pass while measuring nothing. A reload produces
  a *sibling*, and `assert not issubclass(...)` plus
  `assert "_decode_source" in vars(reloaded_cls)` pin that mechanically.

The registry is restored in a `finally`, and the restore is asserted.

### Gate-off

`live_regroup_class` → `return RegroupTagHandler` (i.e. the bug, restored):

| scenario | with fix | gated off |
|---|---|---|
| target file alone | 0 failed, 34 passed | **1 failed** (`test_the_spy_reaches_a_RE_REGISTERED_handler`) |
| polluter file then target file | 0 failed, 60 passed | **2 failed** (+ the original flake) |

The harness asserts the mutation matched exactly once, that the source changed,
clears `__pycache__` between runs, and counts pytest's `N error` apart from
`N failed`. No crate rebuild needed — the fix is Python-only.

## Verification

Three consecutive full `-n 4` runs (the pollution-class gate), and in **all
three** the audit was on the target's worker, ahead of it — the exact condition
that reddened it 3/3 before:

```
postfix run 1: target gw2 (16266)  polluter gw2 (7100)  16926 passed, 0 failed
postfix run 2: target gw2 (16338)  polluter gw2 (7100)  16926 passed, 0 failed
postfix run 3: target gw2 (16892)  polluter gw2 (7098)  16926 passed, 0 failed
```

`ruff check` / `ruff format --check` clean.

No CHANGELOG entry: test-only, matching #2420 (`f855b4c8`), the immediately
preceding fix of this same class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
