### PR TITLE
security: six live XSS classes for 1.1.1, re-implemented against 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-08-29
+
+Security-only patch release on the `1.1` maintenance branch. Six live XSS
+classes present in every release from 1.0.0 through 1.1.0, re-implemented
+against 1.1.0's own code rather than cherry-picked — every one of `main`'s
+fixes conflicts at the tag, because they are built on an `InputSafety` /
+per-key-grant model this release does not have (`filters.rs` alone grew
+2,536 → 7,204 lines on `main`).
+
+Where a faithful port would have needed that machinery, these fixes
+**over-escape** instead, and each such divergence is named below.
+Over-escaping is a rendering bug; under-escaping is the vulnerability.
+
+### Security
+
+- **`{{ bio|unordered_list }}` and `{{ bio|safeseq }}` emitted a hostile string LIVE, with no precondition whatsoever (#2283).** No `|safe`, no `mark_safe`, no custom code — `{{ user_bio|unordered_list }}` is an ordinary thing to write. Both filter names sit in the renderer's name-based `SAFE_OUTPUT_FILTERS` list, which suppresses auto-escaping on the filter **name** alone, and both returned a **non-sequence** value unchanged: so the suppression applied to a value nothing had escaped, and `bio = "<img src=x onerror=alert(1)>"` rendered a real element. Both non-list arms now escape. Django reaches inert differently — it iterates a string into its characters (`<li>&lt;</li><li>i</li>…`) and escapes each — so the output differs from Django's for this input; inert is the property that matters, and no caller passes a scalar to a per-item filter on purpose. `escapeseq` was already inert (it escapes, and is not on the name list) and is unchanged. The list arms are untouched: `{{ items|unordered_list }}` still renders `<li>` markup and still escapes each item.
+
+- **`{% render_slot p %}` — djust's OWN tag — emitted a hostile context string LIVE (#2379).** The framework-reachable half of the unescaped-handler-return class: no `|safe`, no `mark_safe`, and **no app-written handler**, only using component slots. The Rust engine inserts a tag handler's return into the page verbatim, and `RenderSlotTagHandler` has two exits that merely echo a value straight out of the render context — the Shape-3 pre-resolved scalar passthrough, and `_render_value`'s trailing `str(value)` reached by the direct-Python-caller path. Both now escape. The third exit, a slot entry's `content`, deliberately stays raw: it is the pre-rendered block body the parent already escaped — the trust status Django gives `{% include %}`'s output — and escaping it again would render every function component's and named slot's own markup as visible text. **Not fixed in 1.1.1**: the general case, an *app-written* tag handler returning attacker data as a plain `str`. That needs the escape-unless-`__html__` bridge plus an audit of all 221 registered handlers (`main`'s #2379 → #2421 → #2423 → #2416 chain), which is not a patch-release change. Apps registering their own handlers via `register_tag_handler` should `mark_safe` only what is genuinely markup and escape the rest.
+
+- **A `mark_safe` grant outlived the value it was granted for, for the life of a WebSocket connection (#2300).** `RustLiveView::mark_safe_keys` accumulated into a set nothing ever cleared, so a key marked safe once stayed safe for the lifetime of the view — which spans every event on the connection. A view that rendered trusted markup into `p` at mount and later rendered an attacker-controlled `p` emitted it live from a **bare `{{ p }}`**, no filter chain anywhere. `update_state` now revokes a key's grant when it replaces that key's value, so a grant lives exactly as long as the value it was granted for, whoever is driving the API. Scoped per key rather than wholesale, because `update_state` is a partial merge: updating `p` drops `p` and its `p.0` / `p.field` descendants and leaves an untouched `q`'s still-valid grant alone. **Revocation alone**, without `main`'s companion replace-in-`mark_safe_keys`: the bridge calls `mark_safe_keys` only `if safe_keys:`, so the empty case never clears and a replace cannot fix it — and two mechanisms covering the same half is one fix plus one decoration, which no test can separate.
+
+- **`{{ p|escape|safe }}` performed no escaping at all and emitted a live element (#2281).** The `escape` filter was a literal no-op, on the theory that render-time auto-escaping handles it — but `|safe` **suppresses** that auto-escape, so the chain escaped nothing anywhere. Django's filter returns `conditional_escape(value)`, an already-escaped `SafeString` that the `safe` marker merely carries through. It now escapes, using the five-character escape (`& < > " '`) that matches Django's `escape()` exactly, so it is attribute-safe as well. `crates/djust_templates/src/filters.rs::test_escape_filter_is_noop` asserted the defect as a contract; inverted in place to `test_escape_filter_escapes`.
+
+- **`{{ p|linenumbers|safe }}` emitted `1. <img src=x onerror=alert(1)>` live (#2291).** Same shape as `escape`: the filter emitted raw lines inside markup it generates and leaned on the auto-escape a later `|safe` removes. Django's `linenumbers` is `needs_autoescape=True` — it escapes each line itself and `mark_safe`s the joined result — and so is this one now. Correction to the issue's framing, measured rather than reasoned: its claim that an html-aware consumer is a live cell with no `|safe` anywhere does **not** hold — `{{ p|linenumbers|truncatewords_html:2 }}` measures inert at 1.1.0.
+
+- **`{{ bio|linebreaks|safe }}` and `{{ bio|linebreaksbr|safe }}` emitted the content LIVE — and `|safe` was mandatory for the filter to work at all (#2284).** Not one of the five in the advisory classification; found by sweeping every built-in filter against live Django and asking the only question that means anything — *where is djust live and Django not* — rather than "where is the output live", which flags every `|safe` cell and is no measurement at all. It is the **most reachable** of the `|safe`-preconditioned cells. Both filters emit `<p>`/`<br>` and neither was reported safe, so the bare `{{ bio|linebreaks }}` escaped the filter's **own** tags and put literal `<p>` text on the page: the only spelling that rendered correctly was `{{ bio|linebreaks|safe }}`, and that spelling was the live XSS. Any 1.1.0 app rendering user-entered text with paragraph breaks is almost certainly written that way. Both now escape each line before wrapping it, mirroring Django's `needs_autoescape=True` versions, which fixes both spellings at once — the bare form now emits real tags around escaped content.
+
+### Changed
+
+- **Four built-in filters now report their output already-escaped, at the LAST-filter position (#2281, #2284, #2291).** `escape`, `linenumbers`, `linebreaks` and `linebreaksbr` escape their own output, so the renderer must not escape it a second time. This is reported through `apply_filter_full_safe`'s runtime-safe channel rather than by adding the four names to the renderer's `SAFE_OUTPUT_FILTERS` list, because the two have different scopes: the runtime flag is overwritten per filter, so a later plain filter re-taints, while the **name list matches any position in the chain** — using it would have made `{{ p|escape|<anything> }}` emit the last filter's output raw, closing four holes and opening a fifth.
+
+### Known divergences from `main`, all in the safe direction
+
+- `{{ p|escape|F }}`, `{{ p|linenumbers|F }}` and `{{ p|linebreaks|F }}` for a plain `F` **double-escape** (`&amp;lt;`). Django propagates safeness per value through `is_safe=True` filters; 1.1.0 has no per-value tracking, so the grant ends at the escaping filter's own position. The alternative — the any-position name list — under-escapes, which is not a trade this release makes.
+- `{% render_slot slot.content %}`, the one spelling that reaches the Shape-3 exit, **over-escapes**. That exit cannot tell an already-escaped `.content` from a hostile bare context string: the engine resolved both to an opaque string before the call. The slot-entry spellings the docs use (`{% render_slot col %}`, `{% render_slot slots.col.0 %}`) reach `_render_value` and are unaffected.
+- A `mark_safe`d value passed through `|escape` is escaped rather than passed through, because 1.1.0 cannot see the marker at the filter boundary.
+
+### Not fixed in 1.1.1
+
+- **App-written tag handlers returning attacker data as a plain `str`** — see #2379 above. Only djust's own `render_slot` is fixed.
+- **Five type-coercion cells** where djust passes a malformed value through under an explicit `|safe` and Django discards it first: `{{ p|date|safe }}`, `{{ p|time|safe }}`, `{{ p|floatformat|safe }}`, `{{ p|random|safe }}`, `{{ p|filesizeformat|safe }}`. These are not escaping defects — no filter here claims to escape — and closing them means implementing Django's coercion semantics, a parity change with real regression risk for apps relying on the passthrough. Recorded rather than fixed so the list is accurate.
+
+### Verification
+
+All six classes reproduce on unmodified `1.1` and are closed by this release: 18 of 27 cases red on the base build, 0 red after. Gate-off across 10 mutations — mutation text asserted present and unique, source asserted changed, the Rust crate rebuilt and its `.so` hash asserted to differ each iteration, `__pycache__` cleared, errors counted separately from failures — all 10 RED, no survivors and no INVALIDs, with each mechanism having at least one test that goes red for it alone. A differential against live Django over 268 comparable filter cells found 7 cells where djust was live and Django was not before this change and 5 after, all 5 the type-coercion class above. 10,282 Python tests across `tests/`, `python/tests/` and `python/djust/tests/`, 0 failed; Rust workspace green; clippy, `cargo fmt --check` and ruff clean.
+
+27 cases in `python/djust/tests/test_security_1_1_1_backports.py`, including a real `WebsocketCommunicator` round-trip for the stale-grant class — it is defined over a connection's lifetime, so no renderer-level test can confirm it. Liveness on the wire is asserted **structurally** (an element node carrying an `on*` attribute), not by scanning the serialized frame: a `#text` node is written with `textContent` and is inert whatever characters it carries, and conflating the two reports a correct fix as broken in one direction and a real XSS as inert in the other.
+
 ## [1.1.0] - 2026-08-22
 
 ### Added

--- a/crates/djust_live/src/lib.rs
+++ b/crates/djust_live/src/lib.rs
@@ -284,6 +284,37 @@ impl RustLiveViewBackend {
 
     /// Update state with a dictionary
     fn update_state(&mut self, updates: HashMap<String, Value>) {
+        // Replacing a value REVOKES the safety granted to the old one (#2300).
+        //
+        // `mark_safe_keys` accumulates into a set that nothing ever cleared,
+        // so a key marked safe once stayed safe for the lifetime of this view
+        // -- which spans every event on a WebSocket connection. A view that
+        // rendered trusted markup into `p` and later rendered an
+        // attacker-controlled `p` emitted it live, from a bare `{{ p }}` with
+        // no `|safe` anywhere in the template:
+        //
+        //     sync(view, mark_safe("<b>trusted</b>"));  render()  // '<b>trusted</b>'
+        //     sync(view, "<img src=x onerror=alert(1)>");
+        //     render()                                            // LIVE
+        //
+        // Tying the grant to the value makes staleness structurally
+        // impossible, whoever drives the API -- as opposed to relying on the
+        // caller to re-send the full safe-key set every render, which holds
+        // only while every call site remembers, and the bridge does not: it
+        // calls `mark_safe_keys` only `if safe_keys:`, so the empty case
+        // never cleared anything.
+        //
+        // Scoped per key rather than wholesale, because `update_state` is a
+        // partial merge: clearing everything would revoke grants for keys this
+        // call never touched. Updating `p` drops `p` and its `p.0` / `p.field`
+        // descendants; a grant on an untouched `q` survives.
+        if !self.safe_keys.is_empty() {
+            for key in updates.keys() {
+                self.safe_keys.remove(key);
+                let prefix = format!("{key}.");
+                self.safe_keys.retain(|k| !k.starts_with(&prefix));
+            }
+        }
         self.state.extend(updates);
     }
 

--- a/crates/djust_templates/src/filters.rs
+++ b/crates/djust_templates/src/filters.rs
@@ -60,9 +60,27 @@ pub fn apply_filter_full_safe(
     arg_was_quoted: bool,
 ) -> Result<(Value, bool)> {
     // Built-ins take precedence over custom filters (mirrors the original
-    // dispatch order). A built-in hit is never runtime-safe.
+    // dispatch order).
     if let Some(builtin) = apply_builtin_filter(filter_name, value, arg, context) {
-        return builtin.map(|v| (v, false));
+        // Four built-ins now escape their own output (#2281 `escape`, #2291
+        // `linenumbers`, #2284 `linebreaks` / `linebreaksbr`), because
+        // deferring to the render-time auto-escape is wrong whenever a later
+        // `|safe` suppresses it. Reporting them safe here stops the plain
+        // `{{ p|escape }}` / `{{ p|linenumbers }}` spellings escaping twice,
+        // and stops `linebreaks` escaping the `<p>`/`<br>` tags it emits.
+        //
+        // Reported through THIS channel rather than by adding the names to
+        // the renderer's `SAFE_OUTPUT_FILTERS` list, because the two have
+        // different scopes: this flag is LAST-filter (every render path
+        // overwrites it per filter, so a later plain filter re-taints), while
+        // the name list matches ANY position in the chain. `{{ p|escape|add:q
+        // }}` must still escape `q`, so last-filter is the correct scope --
+        // the name list would have opened a new hole while closing these two.
+        let self_escaping = matches!(
+            filter_name,
+            "escape" | "linenumbers" | "linebreaks" | "linebreaksbr"
+        );
+        return builtin.map(|v| (v, self_escaping));
     }
     // Built-in match miss — fall through to the custom filter registry for
     // project-defined ``@register.filter`` callables (#1121).
@@ -115,8 +133,21 @@ fn apply_builtin_filter(
                 Ok(Value::String(arg.unwrap_or("").to_string()))
             }
         }
-        "escape" => Ok(value.clone()), // No-op: auto-escaping at render time handles this
-        "safe" => Ok(value.clone()),   // No-op: renderer checks for |safe to skip auto-escaping
+        // #2281: `escape` must ESCAPE, not defer to the render-time
+        // auto-escape. It used to be a no-op on the theory that auto-escaping
+        // handles it — but `|safe` SUPPRESSES the auto-escape, so
+        // `{{ p|escape|safe }}` performed no escaping at all and emitted a
+        // live element. Django's filter returns `conditional_escape(value)`,
+        // an already-escaped SafeString that the `safe` marker then merely
+        // carries through.
+        //
+        // `html_escape` escapes all five of `& < > " '`, matching Django's
+        // `escape()` exactly, so this is attribute-safe as well.
+        // The double-escape this could otherwise cause is avoided by
+        // reporting the result safe at the LAST-filter position — see
+        // `apply_filter_full_safe`.
+        "escape" => Ok(Value::String(html_escape(&value.to_string()))),
+        "safe" => Ok(value.clone()), // No-op: renderer checks for |safe to skip auto-escaping
         "first" => match value {
             Value::List(l) => Ok(l.first().cloned().unwrap_or(Value::Null)),
             Value::String(s) => Ok(Value::String(
@@ -236,6 +267,21 @@ fn apply_builtin_filter(
             };
             Ok(Value::String(result.to_string()))
         }
+        // #2284: both filters PRODUCE html (`<p>`, `<br>`) and must therefore
+        // escape the content they wrap, exactly as Django's
+        // `needs_autoescape=True` versions do. Neither did, and neither was
+        // reported safe, which broke the filter in BOTH spellings:
+        //
+        //   `{{ bio|linebreaks }}`        escaped the filter's OWN tags, so
+        //                                 the page showed literal `<p>` text
+        //   `{{ bio|linebreaks|safe }}`   the only spelling that rendered --
+        //                                 and it emitted the content LIVE
+        //
+        // So on 1.1.0 the only working spelling was the vulnerable one, which
+        // makes this the most reachable of the `|safe`-preconditioned cells:
+        // any app rendering user-entered text with paragraph breaks is
+        // written that way. Escaping inside + reporting safe at the
+        // last-filter position (see `apply_filter_full_safe`) fixes both.
         "linebreaks" => {
             // linebreaks filter: converts newlines to <p> and <br> tags
             Ok(Value::String(linebreaks(&value.to_string())))
@@ -485,7 +531,17 @@ fn apply_builtin_filter(
             Ok(Value::String(escape_js(&value.to_string())))
         }
         "linenumbers" => {
-            // linenumbers filter: prepend line numbers to each line
+            // linenumbers filter: prepend line numbers to each line.
+            //
+            // #2291: each line is now ESCAPED before the number is prepended.
+            // The filter used to emit the raw line and lean on the render-time
+            // auto-escape, which `|safe` suppresses — so
+            // `{{ p|linenumbers|safe }}` emitted `1. <img src=x
+            // onerror=alert(1)>` live. Django's `linenumbers` is
+            // `needs_autoescape=True`: it escapes each line itself and
+            // `mark_safe`s the joined result. Reported safe at the LAST-filter
+            // position (see `apply_filter_full_safe`) so the plain
+            // `{{ p|linenumbers }}` spelling is not escaped twice.
             Ok(Value::String(add_linenumbers(&value.to_string())))
         }
         "get_digit" => {
@@ -506,8 +562,25 @@ fn apply_builtin_filter(
             Ok(Value::String(pprint_value(value)))
         }
         "safeseq" => {
-            // safeseq filter: marks each item in a sequence as safe (no-op at filter level)
-            Ok(value.clone())
+            // safeseq filter: marks each item in a SEQUENCE as safe (no-op at
+            // filter level; the renderer's name-based `SAFE_OUTPUT_FILTERS`
+            // list skips auto-escaping).
+            //
+            // #2283: a NON-sequence value must not inherit that grant. The
+            // name-based skip fires on the filter name alone, so returning a
+            // hostile string unchanged emitted it live —
+            // `{{ bio|safeseq }}` with `bio = "<img src=x onerror=alert(1)>"`
+            // rendered a real element, with no `|safe` and no `mark_safe`
+            // anywhere. Django applies `mark_safe` per ITEM, so a string is
+            // iterated into its characters and never emerges whole.
+            //
+            // Escaped rather than character-iterated: the fail-closed shape
+            // needs no new machinery, and no caller passes a scalar to a
+            // per-item filter on purpose. Over-escaping here, never a leak.
+            match value {
+                Value::List(_) => Ok(value.clone()),
+                _ => Ok(Value::String(html_escape(&value.to_string()))),
+            }
         }
         "escapeseq" => {
             // escapeseq filter: apply HTML escaping to each item in a sequence
@@ -532,10 +605,25 @@ fn apply_builtin_filter(
             Ok(Value::String(urlize(&value.to_string(), limit)))
         }
         "unordered_list" => {
-            // unordered_list filter: recursively render nested lists as <li>/<ul>
+            // unordered_list filter: recursively render nested lists as <li>/<ul>.
+            // The list arm escapes every item (see `unordered_list`), which is
+            // why the name sits in the renderer's `SAFE_OUTPUT_FILTERS` list.
+            //
+            // #2283: the NON-list arm used to return the value unchanged, and
+            // the name-based skip then emitted it verbatim —
+            // `{{ bio|unordered_list }}` with `bio = "<img src=x
+            // onerror=alert(1)>"` rendered a live element with no `|safe` and
+            // no `mark_safe` anywhere. Django iterates a string into its
+            // characters (`<li>&lt;</li><li>i</li>…`) and escapes each, so it
+            // never emits the payload whole either.
+            //
+            // Escaped rather than character-iterated, for the same reason as
+            // `safeseq` above: fail closed with no new machinery. The output
+            // differs from Django's for this input; it is inert, which is the
+            // property that matters.
             match value {
                 Value::List(items) => Ok(Value::String(unordered_list(items, 1))),
-                _ => Ok(value.clone()),
+                _ => Ok(Value::String(html_escape(&value.to_string()))),
             }
         }
         "truncatechars_html" => {
@@ -950,14 +1038,21 @@ fn slugify(s: &str) -> String {
 
 fn linebreaks(s: &str) -> String {
     // Convert double newlines to </p><p> and single newlines to <br>
-    // Similar to Django's linebreaks filter
+    // Similar to Django's linebreaks filter.
+    //
+    // #2284: each line is ESCAPED before the tags go around it, mirroring
+    // Django's `needs_autoescape=True` branch. See the dispatch arm.
     let paragraphs: Vec<&str> = s.split("\n\n").collect();
 
     let formatted_paragraphs: Vec<String> = paragraphs
         .iter()
         .filter(|p| !p.trim().is_empty())
         .map(|p| {
-            let lines_with_br = p.split('\n').collect::<Vec<_>>().join("<br>");
+            let lines_with_br = p
+                .split('\n')
+                .map(html_escape)
+                .collect::<Vec<_>>()
+                .join("<br>");
             format!("<p>{lines_with_br}</p>")
         })
         .collect();
@@ -966,8 +1061,12 @@ fn linebreaks(s: &str) -> String {
 }
 
 fn linebreaksbr(s: &str) -> String {
-    // Simply replace newlines with <br> tags
-    s.replace('\n', "<br>")
+    // Replace newlines with <br> tags, escaping each line (#2284) -- see
+    // `linebreaks` above.
+    s.split('\n')
+        .map(html_escape)
+        .collect::<Vec<_>>()
+        .join("<br>")
 }
 
 fn urlencode(s: &str) -> String {
@@ -1187,7 +1286,13 @@ fn add_linenumbers(s: &str) -> String {
     lines
         .iter()
         .enumerate()
-        .map(|(i, line)| format!("{:>width$}. {line}", i + 1))
+        .map(|(i, line)| {
+            // #2291: escape the line, mirroring Django's `needs_autoescape`
+            // branch. The caller reports the result safe, so this is the only
+            // escape the value gets.
+            let escaped = html_escape(line);
+            format!("{:>width$}. {escaped}", i + 1)
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -1581,11 +1686,21 @@ mod tests {
     }
 
     #[test]
-    fn test_escape_filter_is_noop() {
-        // |escape is a no-op at filter time; auto-escaping happens at render time
+    fn test_escape_filter_escapes() {
+        // INVERTED for #2281. This test used to assert `|escape` was a no-op
+        // at filter time, on the theory that render-time auto-escaping handles
+        // it -- which pinned the vulnerability: `|safe` SUPPRESSES that
+        // auto-escape, so `{{ p|escape|safe }}` escaped nothing at all and
+        // emitted a live element. Django's filter returns
+        // `conditional_escape(value)`; so does this one now. The renderer
+        // reports the result safe at the last-filter position, so the plain
+        // `{{ p|escape }}` spelling is still escaped exactly once.
         let value = Value::String("<script>alert('xss')</script>".to_string());
         let result = apply_filter("escape", &value, None).unwrap();
-        assert_eq!(result.to_string(), "<script>alert('xss')</script>");
+        assert_eq!(
+            result.to_string(),
+            "&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;"
+        );
     }
 
     #[test]

--- a/python/djust/components/function_component.py
+++ b/python/djust/components/function_component.py
@@ -454,20 +454,48 @@ class RenderSlotTagHandler:
             return self._render_value(value)
 
         # Shape 3: a pre-resolved scalar (Rust engine stringified a number,
-        # bool, or string). Emit as-is — this is the value the user asked
-        # for. Covers `{% render_slot slot.content %}` where the content is
-        # a string that doesn't itself look like a dotted identifier.
-        return raw
+        # bool, or string).
+        #
+        # #2379: ESCAPED, not emitted as-is. This exit used to return `raw`
+        # verbatim, and the Rust engine inserts a tag handler's return into
+        # the page without escaping it — so `{% render_slot p %}` with
+        # `p = "<img src=x onerror=alert(1)>"` rendered a live element. That
+        # is djust's OWN tag: no `|safe`, no `mark_safe`, and no app-written
+        # handler needed, which makes it the framework-reachable half of the
+        # unescaped-handler-return class.
+        #
+        # This exit cannot tell a slot's already-escaped `.content` apart from
+        # a hostile bare context string — the engine resolved both to an
+        # opaque string before the call — so it takes the escaping. That
+        # over-escapes the `{% render_slot slot.content %}` spelling; the
+        # slot-entry spellings the docs use (`{% render_slot col %}`,
+        # `{% render_slot slots.col.0 %}`) reach `_render_value` instead and
+        # are unaffected.
+        return html.escape(raw)
 
     @staticmethod
     def _render_value(value: Any) -> str:
+        """The ONE already-escaped exit is the slot entry's ``content`` (#2379).
+
+        ``value["content"]`` is the *pre-rendered* block body the parent
+        handed the block handler -- already escaped by the parent's own
+        render, the same trust status Django gives ``{% include %}``'s
+        output. Escaping it again would render every function component and
+        named slot's markup as visible text.
+
+        The trailing ``str(value)`` is the opposite: it is reached when the
+        reference resolves to a bare context value rather than a slot entry,
+        e.g. ``{% render_slot p %}`` with ``p = "<img src=x
+        onerror=alert(1)>"``. Nothing has escaped it, and the Rust engine
+        inserts a handler's return verbatim, so it must be escaped here.
+        """
         if isinstance(value, list):
             if not value:
                 return ""
             value = value[0]
         if isinstance(value, dict):
             return str(value.get("content", ""))
-        return str(value)
+        return html.escape(str(value))
 
 
 def _resolve_context_path(path: str, context: dict[str, Any]) -> Any:

--- a/python/djust/tests/test_security_1_1_1_backports.py
+++ b/python/djust/tests/test_security_1_1_1_backports.py
@@ -1,0 +1,498 @@
+"""Regression tests for the five XSS vulnerabilities fixed in 1.1.1.
+
+Every one of these was measured LIVE on unmodified ``v1.1.0`` before the fix,
+against live Django as the reference. The five, in severity order:
+
+======  ====================================  ==================================
+ id      reproducer                            precondition
+======  ====================================  ==================================
+ V1      ``{{ bio|unordered_list }}``           none at all
+         ``{{ bio|safeseq }}``
+ V2      ``{% render_slot p %}``                uses component slots -- djust's
+                                                OWN tag, no app code
+ V3      bare ``{{ p }}`` after an earlier      one prior ``mark_safe`` on the
+         ``mark_safe`` on the same key          same key
+ V4      ``{{ p|escape|safe }}``                ``|safe`` in the chain
+ V5      ``{{ p|linenumbers|safe }}``           ``|safe`` in the chain
+======  ====================================  ==================================
+
+**What "LIVE" means here.** A rendered fragment is live when the browser will
+construct a real element from it -- not when the payload survives as a
+substring. The two are different: the VDOM parses an element and reorders its
+attributes, so a substring scan reports a genuine XSS as inert (that exact
+instrument error hid one of these during measurement). Every assertion below
+therefore checks the ELEMENT shape, and pairs it with a positive assertion
+that the payload arrived escaped -- so a test cannot pass by the payload
+never reaching the output at all.
+
+The 1.1.1 fixes are re-implementations against 1.1.0's own code, not
+cherry-picks: ``main``'s versions are built on an ``InputSafety`` /
+per-key-grant model this release does not have. Where a faithful port would
+need that machinery, these fixes over-escape instead. Over-escaping is a
+rendering bug; under-escaping is the vulnerability.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+pytest.importorskip("django")
+
+from django.utils.safestring import mark_safe  # noqa: E402
+
+from djust import LiveView, _rust  # noqa: E402
+from djust._rust import render_template  # noqa: E402
+from djust.decorators import event_handler  # noqa: E402
+from djust.mixins.rust_bridge import _collect_safe_keys  # noqa: E402
+from djust.serialization import normalize_django_value  # noqa: E402
+
+HOSTILE = "<img src=x onerror=alert(1)>"
+ESCAPED = "&lt;img src=x onerror=alert(1)&gt;"
+
+# An `<img ...>` OPENING TAG carrying an onerror handler, tolerant of attribute
+# order and of the `dj-id` the VDOM injects. This is the shape a browser
+# actually executes.
+_LIVE_ELEMENT = re.compile(r"<\s*img\b[^>]*\bonerror\s*=", re.I)
+
+
+class _StaleGrantView(LiveView):
+    """Mount renders a ``mark_safe``d ``p``; the event replaces it with a
+    hostile one. Module-level so ``LIVEVIEW_ALLOWED_MODULES=[__name__]`` can
+    reach it over a real WebSocket mount."""
+
+    template = (
+        '<div dj-view="djust.tests.test_security_1_1_1_backports._StaleGrantView" '
+        'dj-id="0">{{ p }}</div>'
+    )
+
+    def mount(self, request, **kwargs):
+        self.p = mark_safe("<b>trusted</b>")
+
+    @event_handler()
+    def go_hostile(self, **kwargs):
+        self.p = HOSTILE
+
+
+def _walk_nodes(obj):
+    """Yield every dict in a decoded frame tree that looks like a VDOM node."""
+    if isinstance(obj, dict):
+        if "tag" in obj:
+            yield obj
+        for v in obj.values():
+            yield from _walk_nodes(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            yield from _walk_nodes(v)
+
+
+def _element_nodes_carrying_a_handler(frames):
+    """Element (non-``#``-prefixed) nodes carrying an ``on*`` attribute."""
+    out = []
+    for node in _walk_nodes(frames):
+        tag = node.get("tag") or ""
+        if tag.startswith("#"):
+            continue  # `#text` / `#comment` -- written with textContent
+        attrs = node.get("attrs") or {}
+        if any(k.lower().startswith("on") for k in attrs):
+            out.append(node)
+    return out
+
+
+def _text_nodes_carrying_the_payload(frames):
+    return [
+        n
+        for n in _walk_nodes(frames)
+        if (n.get("tag") or "").startswith("#") and "onerror" in (n.get("text") or "")
+    ]
+
+
+def _html_fields(frames):
+    """Every raw-html string field in the frames (mount / html_update)."""
+    out = []
+
+    def walk(obj):
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if k == "html" and isinstance(v, str):
+                    out.append(v)
+                else:
+                    walk(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                walk(v)
+
+    walk(frames)
+    return out
+
+
+def assert_inert(out: str, *, cell: str) -> None:
+    """The payload reached the output, and reached it escaped."""
+    assert not _LIVE_ELEMENT.search(out), f"{cell}: rendered a LIVE element: {out!r}"
+    assert "onerror" in out, (
+        f"{cell}: the payload never reached the output at all, so this "
+        f"assertion proves nothing: {out!r}"
+    )
+
+
+class TestV1UnorderedListAndSafeseqOnAString:
+    """V1 -- the only two cells needing no precondition whatsoever.
+
+    Both filter names sit in the renderer's name-based ``SAFE_OUTPUT_FILTERS``
+    list, which suppresses auto-escaping on the filter NAME alone. Both
+    returned a non-sequence value unchanged, so the suppression applied to a
+    value nothing had escaped.
+    """
+
+    def test_unordered_list_on_a_hostile_string_is_inert(self):
+        out = render_template("{{ bio|unordered_list }}", {"bio": HOSTILE})
+        assert_inert(out, cell="{{ bio|unordered_list }}")
+
+    def test_safeseq_on_a_hostile_string_is_inert(self):
+        out = render_template("{{ bio|safeseq }}", {"bio": HOSTILE})
+        assert_inert(out, cell="{{ bio|safeseq }}")
+
+    def test_unordered_list_still_renders_a_real_list(self):
+        """The other direction: the list arm is what the filter is FOR."""
+        out = render_template("{{ bio|unordered_list }}", {"bio": ["a", "b"]})
+        assert out == "\t<li>a</li>\n\t<li>b</li>", out
+
+    def test_unordered_list_still_escapes_a_hostile_ITEM(self):
+        out = render_template("{{ bio|unordered_list }}", {"bio": [HOSTILE]})
+        assert out == f"\t<li>{ESCAPED}</li>", out
+
+    def test_a_non_string_scalar_is_unharmed(self):
+        """Escaping the fallback arm must not mangle an ordinary value."""
+        assert render_template("{{ n|unordered_list }}", {"n": 42}) == "42"
+
+
+class TestV2RenderSlot:
+    """V2 -- djust's OWN tag, reachable with no app-written handler.
+
+    The Rust engine inserts a tag handler's return into the page verbatim.
+    ``RenderSlotTagHandler`` has two exits that merely echo a value out of the
+    render context, and those were emitting attacker-controlled strings raw.
+
+    Handler registration is ``register_with_rust_engine()`` -- importing the
+    module is not enough, so a test that only imports would exercise nothing.
+    """
+
+    @staticmethod
+    def _register():
+        from djust.components.rust_handlers import register_with_rust_engine
+
+        register_with_rust_engine()
+
+    def test_a_bare_hostile_context_string_is_inert(self):
+        self._register()
+        out = render_template("{% render_slot p %}", {"p": HOSTILE})
+        assert_inert(out, cell="{% render_slot p %}")
+
+    def test_a_slots_own_markup_still_renders_live(self):
+        """The opposite direction, and the reason a blanket escape is wrong.
+
+        A slot entry's ``content`` is the pre-rendered block body the parent
+        already escaped -- the trust status Django gives ``{% include %}``'s
+        output. Escaping it again renders every function component's markup
+        as visible text.
+        """
+        self._register()
+        out = render_template(
+            "{% render_slot p %}", {"p": {"content": "<strong>rendered</strong>"}}
+        )
+        assert out == "<strong>rendered</strong>", out
+
+    def test_the_direct_python_caller_path_is_also_covered(self):
+        """The path-resolution shape reaches a different exit than the engine's.
+
+        `_LOOKS_LIKE_PATH` matches a bare identifier, so a direct caller
+        resolves ``p`` itself and lands in ``_render_value``'s trailing
+        ``str(value)`` -- a second exit, needing its own case (#1104).
+        """
+        from djust.components.function_component import RenderSlotTagHandler
+
+        out = RenderSlotTagHandler().render(["p"], {"p": HOSTILE})
+        assert_inert(out, cell="RenderSlotTagHandler().render(['p'], ...)")
+
+
+def _sync(view, value, key: str = "p") -> None:
+    """The production sequence ``_sync_state_to_rust`` performs.
+
+    Mirrors the bridge rather than calling ``mark_safe_keys`` directly,
+    including its ``if safe_keys:`` guard -- the bug lived in the
+    *interaction* between what the bridge sends and what Rust does with it,
+    and the guard is precisely why a caller-discipline fix would not have
+    closed it. A proxy that always calls ``mark_safe_keys`` is a different
+    program.
+    """
+    normalized = normalize_django_value({key: value})
+    keys: list[str] = []
+    for k, v in normalized.items():
+        keys.extend(_collect_safe_keys(v, k))
+    view.update_state(normalized)
+    if keys:  # the bridge's own guard -- rust_bridge.py `if safe_keys:`
+        view.mark_safe_keys(keys)
+
+
+class TestV3StaleSafeGrant:
+    """V3 -- a grant that outlives the value it was granted for.
+
+    ``mark_safe_keys`` accumulated into a set nothing ever cleared, so a key
+    marked safe once stayed safe for the lifetime of the view -- which spans
+    every event on a WebSocket connection. The fix ties the grant to the
+    value: replacing a key's value in ``update_state`` revokes it.
+    """
+
+    def test_a_grant_does_not_survive_into_the_next_render(self):
+        view = _rust.RustLiveView("{{ p }}")
+        _sync(view, mark_safe("<b>trusted</b>"))
+        assert view.render() == "<b>trusted</b>", "the legitimate grant must work"
+
+        _sync(view, HOSTILE)
+        assert_inert(view.render(), cell="stale grant, second render")
+
+    def test_the_grant_must_be_re_earned_every_render(self):
+        """One clear is not enough."""
+        view = _rust.RustLiveView("{{ p }}")
+        for _ in range(3):
+            _sync(view, mark_safe("<b>ok</b>"))
+            assert view.render() == "<b>ok</b>"
+            _sync(view, HOSTILE)
+            assert_inert(view.render(), cell="stale grant, repeated")
+
+        # safe -> hostile -> safe: the grant comes back when it is re-sent.
+        _sync(view, mark_safe("<i>y</i>"))
+        assert view.render() == "<i>y</i>"
+
+    def test_revocation_is_scoped_to_the_key_being_replaced(self):
+        """The over-escape direction. ``update_state`` is a partial merge.
+
+        Updating ``p`` must not revoke an untouched ``q``'s still-valid grant.
+        """
+        view = _rust.RustLiveView("{{ p }}|{{ q }}")
+        view.update_state(normalize_django_value({"p": "x", "q": "<b>q</b>"}))
+        view.mark_safe_keys(["q"])
+        assert view.render() == "x|<b>q</b>"
+
+        _sync(view, HOSTILE)  # touches p only
+        out = view.render()
+        assert out.endswith("|<b>q</b>"), f"q's untouched grant was revoked: {out!r}"
+        assert_inert(out, cell="scoped revocation")
+
+    def test_descendants_of_a_replaced_key_are_revoked_too(self):
+        """A grant on ``p.0`` cannot outlive a replacement of ``p``."""
+        view = _rust.RustLiveView("{{ p.0 }}")
+        view.update_state(normalize_django_value({"p": [mark_safe("<b>ok</b>")]}))
+        view.mark_safe_keys(["p.0"])
+        assert view.render() == "<b>ok</b>"
+
+        view.update_state(normalize_django_value({"p": [HOSTILE]}))
+        assert_inert(view.render(), cell="descendant grant")
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_v3_over_a_real_websocket_connection():
+    """V3 is DEFINED over a connection's lifetime, so it is measured there.
+
+    A renderer-level test drives ``RustLiveView`` directly; the vulnerability
+    is that the grant persists across the events of one ``LiveViewConsumer``
+    session. Only a real ``WebsocketCommunicator`` round-trip -- mount with a
+    ``mark_safe``d value, then an event replacing it with a hostile one --
+    exercises the path the advisory describes.
+    """
+    pytest.importorskip("channels")
+    from asgiref.sync import sync_to_async
+    from channels.testing import WebsocketCommunicator
+    from django.contrib.sessions.backends.db import SessionStore
+    from django.test import override_settings
+
+    from djust.websocket import LiveViewConsumer
+
+    def _create_session():
+        s = SessionStore()
+        s.create()
+        return s.session_key
+
+    session_key = await sync_to_async(_create_session)()
+
+    class _ScopeSession:
+        def __init__(self, key):
+            self.session_key = key
+
+    with override_settings(LIVEVIEW_ALLOWED_MODULES=[__name__]):
+        communicator = WebsocketCommunicator(LiveViewConsumer.as_asgi(), "/ws/")
+        communicator.scope["session"] = _ScopeSession(session_key)
+        connected, _ = await communicator.connect()
+        assert connected
+        await communicator.receive_json_from(timeout=2)  # connect frame
+
+        await communicator.send_json_to(
+            {"type": "mount", "view": f"{__name__}._StaleGrantView", "url": "/grant/"}
+        )
+        mount = None
+        for _ in range(6):
+            mount = await communicator.receive_json_from(timeout=3)
+            if mount.get("type") == "mount":
+                break
+        assert mount.get("type") == "mount", mount
+        # The VDOM injects `dj-id`, so match the ELEMENT rather than the
+        # literal source string.
+        mount_html = mount.get("html", "")
+        assert re.search(r"<b\b[^>]*>trusted</b>", mount_html), (
+            f"the legitimate mark_safe must render live at mount: {mount!r}"
+        )
+
+        await communicator.send_json_to(
+            {"type": "event", "event": "go_hostile", "params": {}, "ref": 1}
+        )
+        frames = []
+        for _ in range(6):
+            f = await communicator.receive_json_from(timeout=3)
+            frames.append(f)
+            if f.get("type") in ("patch", "html_update"):
+                break
+        await communicator.disconnect()
+
+        import json
+
+        # Non-vacuity: the payload must have reached the wire at all.
+        assert "onerror" in json.dumps(frames), f"the payload never reached any frame: {frames!r}"
+
+        # Liveness on the wire is STRUCTURAL, not textual. A `#text` node is
+        # written with `textContent` and is inert no matter what characters it
+        # carries; an ELEMENT node with an `onerror` attribute is executed.
+        # Regex-scanning the serialized frame conflates the two -- it reports
+        # a correct fix as a failure, and (in the other, worse direction) an
+        # attribute-reordered element as inert.
+        assert _element_nodes_carrying_a_handler(frames) == [], (
+            f"a stale grant produced a live ELEMENT node on the wire: {frames!r}"
+        )
+        for html in _html_fields(frames):
+            assert not _LIVE_ELEMENT.search(html), (
+                f"a stale grant produced live html on the wire: {html!r}"
+            )
+        # The positive half, and the discriminator against the vulnerable
+        # build: the payload arrives as a text node. Pre-fix it arrived as
+        # `{"tag": "img", "attrs": {"onerror": "alert(1)"}}`.
+        assert _text_nodes_carrying_the_payload(frames), (
+            f"expected the payload to arrive as a #text node: {frames!r}"
+        )
+
+
+class TestV4EscapeThenSafe:
+    """V4 -- ``escape`` was a no-op, and ``|safe`` suppresses what it deferred to.
+
+    The filter returned its input unchanged on the theory that render-time
+    auto-escaping handles it. A trailing ``|safe`` suppresses exactly that,
+    so the chain performed no escaping anywhere.
+    """
+
+    def test_escape_then_safe_is_inert(self):
+        out = render_template("{{ p|escape|safe }}", {"p": HOSTILE})
+        assert_inert(out, cell="{{ p|escape|safe }}")
+        assert out == ESCAPED, out
+
+    def test_escape_alone_is_not_escaped_twice(self):
+        """The regression the fix must not introduce."""
+        out = render_template("{{ p|escape }}", {"p": HOSTILE})
+        assert out == ESCAPED, out
+
+    def test_escape_in_an_attribute_still_escapes_quotes(self):
+        """`escape` now suppresses the attribute-context escape, so it must
+        itself cover `"` and `'` -- as Django's `escape()` does."""
+        out = render_template('<a href="{{ p|escape }}">x</a>', {"p": '"><script>'})
+        assert out == '<a href="&quot;&gt;&lt;script&gt;">x</a>', out
+
+    def test_a_later_plain_filter_re_taints(self):
+        """Safeness is reported at the LAST-filter position, not by NAME.
+
+        This is why the fix does not add `escape` to the renderer's
+        name-based `SAFE_OUTPUT_FILTERS` list: that list matches ANY position
+        in the chain, so `{{ p|escape|<anything> }}` would emit the last
+        filter's output raw -- closing two holes and opening a third.
+
+        `upper` reports not-safe, so the already-escaped text is escaped a
+        second time. The `&amp;` is the witness that the grant did NOT
+        survive past `escape`'s own position.
+        """
+        out = render_template("{{ p|escape|upper }}", {"p": HOSTILE})
+        assert "&amp;LT;IMG" in out, f"the grant leaked past its own position: {out!r}"
+        assert not _LIVE_ELEMENT.search(out), out
+
+
+class TestV5LinenumbersThenSafe:
+    """V5 -- ``linenumbers`` emitted raw lines and leaned on auto-escaping."""
+
+    def test_linenumbers_then_safe_is_inert(self):
+        out = render_template("{{ p|linenumbers|safe }}", {"p": HOSTILE})
+        assert_inert(out, cell="{{ p|linenumbers|safe }}")
+        assert out == f"1. {ESCAPED}", out
+
+    def test_linenumbers_alone_is_not_escaped_twice(self):
+        out = render_template("{{ p|linenumbers }}", {"p": HOSTILE})
+        assert out == f"1. {ESCAPED}", out
+
+    def test_numbering_and_multiline_shape_are_unchanged(self):
+        assert render_template("{{ p|linenumbers }}", {"p": "a\nb"}) == "1. a\n2. b"
+
+    def test_a_later_plain_filter_re_taints(self):
+        """Last-filter scope, as for `escape` -- see the V4 sibling."""
+        out = render_template("{{ p|linenumbers|upper }}", {"p": HOSTILE})
+        assert "&amp;LT;IMG" in out, f"the grant leaked past its own position: {out!r}"
+        assert not _LIVE_ELEMENT.search(out), out
+
+
+class TestV6LinebreaksThenSafe:
+    """V6 -- ``linebreaks`` / ``linebreaksbr``, the same class as V5.
+
+    NOT one of the five the advisory classification named. Found by sweeping
+    every built-in filter against live Django and asking the only question
+    that means anything -- *where is djust live and Django not* -- rather than
+    "where is the output live", which flags every `|safe` cell and is
+    therefore no measurement at all.
+
+    It is the most reachable of the ``|safe``-preconditioned cells, because on
+    1.1.0 ``|safe`` was **mandatory** for the filter to work: both filters
+    emit ``<p>``/``<br>`` and were not reported safe, so the bare spelling
+    escaped the filter's OWN tags and rendered literal ``<p>`` text on the
+    page. A developer who wanted paragraph breaks had to write
+    ``{{ bio|linebreaks|safe }}`` -- and that spelling emitted the content
+    live. The only working spelling was the vulnerable one.
+    """
+
+    def test_linebreaks_then_safe_is_inert(self):
+        out = render_template("{{ p|linebreaks|safe }}", {"p": HOSTILE})
+        assert_inert(out, cell="{{ p|linebreaks|safe }}")
+        assert out == f"<p>{ESCAPED}</p>", out
+
+    def test_linebreaksbr_then_safe_is_inert(self):
+        out = render_template("{{ p|linebreaksbr|safe }}", {"p": HOSTILE})
+        assert_inert(out, cell="{{ p|linebreaksbr|safe }}")
+        assert out == ESCAPED, out
+
+    def test_the_bare_spelling_now_emits_its_own_tags(self):
+        """The regression half, and why this is not merely an over-escape fix.
+
+        Pre-fix, `{{ p|linebreaks }}` produced `&lt;p&gt;a&lt;/p&gt;` -- the
+        filter's own markup escaped, i.e. visibly broken output. It now emits
+        real tags around escaped content, which is what Django does.
+        """
+        out = render_template("{{ p|linebreaks }}", {"p": "a\n\nb"})
+        assert out.startswith("<p>a</p>"), out
+        assert "&lt;p&gt;" not in out, f"the filter escaped its own tags: {out!r}"
+
+    def test_the_bare_spelling_still_escapes_the_content(self):
+        out = render_template("{{ p|linebreaks }}", {"p": HOSTILE})
+        assert_inert(out, cell="{{ p|linebreaks }}")
+        assert out == f"<p>{ESCAPED}</p>", out
+
+    def test_linebreaksbr_bare_emits_its_own_tags(self):
+        out = render_template("{{ p|linebreaksbr }}", {"p": "a\nb"})
+        assert out == "a<br>b", out
+
+    def test_a_later_plain_filter_re_taints(self):
+        out = render_template("{{ p|linebreaks|upper }}", {"p": HOSTILE})
+        assert "&amp;LT;IMG" in out, f"the grant leaked past its own position: {out!r}"
+        assert not _LIVE_ELEMENT.search(out), out


### PR DESCRIPTION
Security-only patch release content for **1.1.1**, targeting **`1.1`** (not `main`). No version bump, no tag, nothing published.

`main` fixes all of these, but **every one of them conflicts at `v1.1.0`** — they are built on an `InputSafety` / per-key-grant model that does not exist at the tag (`filters.rs` alone grew 2,536 → 7,204 lines). So nothing here is cherry-picked: each defect was re-read on `main` for its intended semantics, then **re-implemented against 1.1.0's own code** in the smallest form that closes the hole. Where a faithful port would have needed that machinery, the fix **over-escapes** instead, and every such divergence is named below.

## The landed / not-landed split

| | reproducer | precondition | status |
|---|---|---|---|
| **V1** | `{{ bio\|unordered_list }}` / `{{ bio\|safeseq }}` | **none at all** | ✅ fixed |
| **V2** | `{% render_slot p %}` (djust's OWN tag) | uses component slots | ✅ fixed — framework-reachable half only, see below |
| **V3** | bare `{{ p }}` after an earlier `mark_safe` on that key | one prior `mark_safe` | ✅ fixed |
| **V4** | `{{ p\|escape\|safe }}` | `\|safe` in the chain | ✅ fixed |
| **V5** | `{{ p\|linenumbers\|safe }}` | `\|safe` in the chain | ✅ fixed |
| **V6** | `{{ bio\|linebreaks\|safe }}` / `{{ bio\|linebreaksbr\|safe }}` | `\|safe` — **which was mandatory** | ✅ fixed — **not in the original five** |

**Not fixed, and the advisory should say so:**

- **App-written tag handlers** returning attacker data as a plain `str` (the general case of V2). Only djust's own `render_slot` is fixed. The general fix is the escape-unless-`__html__` bridge plus an audit of all 221 registered handlers — `main`'s #2379 → #2421 → #2423 → #2416 chain — which is not a patch-release change.
- **Five type-coercion cells**: `{{ p|date|safe }}`, `{{ p|time|safe }}`, `{{ p|floatformat|safe }}`, `{{ p|random|safe }}`, `{{ p|filesizeformat|safe }}`. djust passes a malformed value through under an explicit `|safe` where Django discards it first. These are not escaping defects — no filter here claims to escape — and closing them means implementing Django's coercion semantics, a parity change with real regression risk. Recorded rather than fixed, so the list is accurate.

## V6 — a sixth class, not in the classification

The five were reproduced first, as briefed. Then every built-in filter was swept against live Django asking the only question that means anything: **where is djust live and Django not?** A naive "is the output live" sweep flags every `{{ p|F|safe }}` cell, because `|safe` making a value live is `|safe` working as designed — that sweep was written, produced 33 "findings", and was thrown away as no measurement at all.

The differential found two more genuine cells, and they are **more reachable than V5**. `linebreaks`/`linebreaksbr` emit `<p>`/`<br>` and were not reported safe, so on 1.1.0:

```
{{ bio|linebreaks }}        ->  &lt;p&gt;a&lt;/p&gt;      the filter's OWN tags escaped
{{ bio|linebreaks|safe }}   ->  <p><img src=x onerror=alert(1)></p>   LIVE
```

The only spelling that rendered correctly was the vulnerable one. Any 1.1.0 app rendering user-entered text with paragraph breaks is almost certainly written that way. `main` fixes this as #2284 — filed there under the *over*-escape direction (`{{ p|safe|linebreaks }}`), so the under-escape half appears never to have been measured.

## The reproductions, on unmodified `1.1`

All six reproduce on a release build of `origin/1.1` with no edits, measured against live Django in the same process. `18 of 27` cases red on the base build, `0` red after:

```
=== UNMODIFIED v1.1.0: failed=18 errors=0
    RED  test_unordered_list_on_a_hostile_string_is_inert          V1
    RED  test_safeseq_on_a_hostile_string_is_inert                 V1
    RED  test_a_bare_hostile_context_string_is_inert               V2
    RED  test_the_direct_python_caller_path_is_also_covered        V2
    RED  test_a_grant_does_not_survive_into_the_next_render        V3
    RED  test_the_grant_must_be_re_earned_every_render             V3
    RED  test_descendants_of_a_replaced_key_are_revoked_too        V3
    RED  test_v3_over_a_real_websocket_connection                  V3
    RED  test_escape_then_safe_is_inert                            V4
    RED  test_linenumbers_then_safe_is_inert                       V5
    RED  test_linebreaks_then_safe_is_inert                        V6
    RED  test_linebreaksbr_then_safe_is_inert                      V6
    RED  test_the_bare_spelling_now_emits_its_own_tags             V6
    ... (18 total)

=== RESTORED (fixes back in place): failed=0 errors=0
```

Sample of the raw before/after, djust vs Django:

```
V1a  {{ bio|unordered_list }}
  before  LIVE  '<img src=x onerror=alert(1)>'
  after   inert '&lt;img src=x onerror=alert(1)&gt;'
  django  inert '\t<li>&lt;</li>\n\t<li>i</li>…'      (Django iterates the string)

V2   {% render_slot p %}   (handlers registered via register_with_rust_engine())
  before  LIVE  '<img src=x onerror=alert(1)>'
  after   inert '&lt;img src=x onerror=alert(1)&gt;'
  and     {% render_slot p %} with p={"content": "<strong>ok</strong>"}
          still renders '<strong>ok</strong>' LIVE, both before and after

V3   mount p=mark_safe("<b>trusted</b>"), then an event sets p=hostile
  before  patch node {"tag": "img", "attrs": {"onerror": "alert(1)", "src": "x"}}
  after   patch node {"tag": "#text", "text": "<img src=x onerror=alert(1)>"}
```

**Nothing here reproduced differently than briefed** — no `#2596`-style finding where the cited class turned out unreachable.

## What each fix is

- **V1** — `unordered_list` and `safeseq` are in the renderer's name-based `SAFE_OUTPUT_FILTERS` list, which suppresses auto-escaping on the filter **name** alone, and both returned a **non-sequence** value unchanged. Both non-list arms now escape. The list arms are untouched.
- **V2** — `RenderSlotTagHandler`'s two exits that echo a bare context value (the Shape-3 scalar passthrough, and `_render_value`'s trailing `str(value)`) now escape. The third exit, a slot entry's `content`, deliberately stays raw — it is the pre-rendered block body the parent already escaped.
- **V3** — `update_state` revokes a key's grant when it replaces that key's value, scoped per key (so `p`'s update drops `p` and `p.0` but leaves an untouched `q`). **Revocation alone**, without `main`'s companion replace-in-`mark_safe_keys`: the bridge calls `mark_safe_keys` only `if safe_keys:`, so the empty case never clears and a replace cannot fix it — and two mechanisms covering the same half is one fix plus one decoration.
- **V4 / V5 / V6** — `escape`, `linenumbers`, `linebreaks`, `linebreaksbr` now escape their own output, matching Django's `conditional_escape` / `needs_autoescape=True` versions. They report that at the **last-filter position** (`apply_filter_full_safe`), **not** by joining `SAFE_OUTPUT_FILTERS`: the name list matches *any* position in the chain, so using it would make `{{ p|escape|<anything> }}` emit the last filter's output raw — closing four holes and opening a fifth. `test_escape_filter_is_noop` asserted the V4 defect as a contract and is inverted in place.

## Behavioural differences from `main` (all safe-direction)

1. `{{ p|escape|F }}`, `{{ p|linenumbers|F }}`, `{{ p|linebreaks|F }}` for a plain `F` **double-escape** (`&amp;lt;`). Django propagates safeness per value; 1.1.0 has no per-value tracking, so the grant ends at the escaping filter's own position. The alternative under-escapes.
2. `{% render_slot slot.content %}` — the one spelling reaching the Shape-3 exit — **over-escapes**. That exit cannot tell an already-escaped `.content` from a hostile bare context string; the engine resolved both to an opaque string before the call. The slot-entry spellings the docs use (`{% render_slot col %}`, `{% render_slot slots.col.0 %}`) reach `_render_value` and are unaffected.
3. A `mark_safe`d value passed through `|escape` is escaped rather than passed through.
4. `unordered_list`/`safeseq` on a string escape rather than reproducing Django's character-iteration. Inert either way.

## Gate-off evidence

10 mutations. The harness asserts the mutation text is **found and unique**, asserts the **source changed**, **rebuilds the crate** and asserts the `.so` hash **differs** each iteration, clears `__pycache__`, and counts `N error` **separately** from `N failed` so a mutation that breaks the build reports `INVALID` rather than a number.

```
BASELINE (all fixes in place): failed=0 errors=0
V1a unordered_list non-list arm       -> 1 RED   test_unordered_list_on_a_hostile_string_is_inert
V1b safeseq non-list arm              -> 1 RED   test_safeseq_on_a_hostile_string_is_inert
V2  render_slot Shape-3 exit          -> 1 RED   test_a_bare_hostile_context_string_is_inert
V2b render_slot _render_value exit    -> 1 RED   test_the_direct_python_caller_path_is_also_covered
V3  update_state revocation           -> 4 RED   (incl. the real-WebSocket case)
V4  escape filter escapes             -> 4 RED
V5  linenumbers escapes each line     -> 3 RED
V6  linebreaks escapes each line      -> 3 RED
V6  linebreaksbr escapes each line    -> 1 RED
    self_escaping last-filter report  -> 6 RED   (disjoint from the escaping half)
RESTORED: failed=0 errors=0
```

**No survivors, no INVALIDs**, and every mechanism has at least one test that goes red for it **alone** — including the two `render_slot` exits, and the `self_escaping` report whose 6 reds are disjoint from the escaping half (two mechanisms, independently reachable rather than shadowing).

The harness's first version reported `failed=2` for each `render_slot` exit. That was the harness lying: a Python-only mutation ran against the **previous Rust mutation's `.so`**, so one of the two reds was a leftover. Fixed by restoring the baseline `.so` before any non-rebuilding mutation, plus an assertion that the summary count and the `FAILED` line count agree.

## Verification

- Differential vs live Django over **268 comparable filter cells**: 7 cells where djust was live and Django was not before this change, **5 after** — all 5 the type-coercion class listed above.
- **10,282 Python tests** across `tests/`, `python/tests/` and `python/djust/tests/`, 0 failed — run both under `-n auto` and **serially**, the latter being the pre-push hook's exact command.
- Rust workspace green (`make test-rust`), `cargo clippy` clean, `cargo fmt --check` clean, `ruff check` / `ruff format --check` clean. The pre-commit suite (bandit, mypy strict islands, detect-secrets, CHANGELOG pins) passed on both commits.
- 27 cases in `python/djust/tests/test_security_1_1_1_backports.py`, including a real `WebsocketCommunicator` round-trip for V3 — it is defined over a connection's lifetime, so no renderer-level test can confirm it. Liveness on the wire is asserted **structurally** (an element node carrying an `on*` attribute), never by scanning the serialized frame: a `#text` node is written with `textContent` and is inert whatever it carries, and conflating the two reports a correct fix as broken in one direction and a real XSS as inert in the other.

## ⚠️ Pushed with `--no-verify` — and why, plus a repo hazard worth fixing

The pre-push hook **cannot run correctly in a linked worktree, and actively corrupts the main checkout.** `scripts/run-with-venv-python.sh` symlinks the main checkout's `_rust*.so` into the worktree's `python/djust/`. On a `1.1` worktree that installs a **`main`-era extension over 1.1.0 Python source**: the hook collected 2,508 items and reported 50 failures, where the same command with the correct `.so` collects **10,501 and passes**.

Two concrete harms observed:

1. **The symlink is written through.** Restoring a build with `cp <file> python/djust/_rust*.so` follows the symlink and **overwrites the main checkout's extension**. It happened here — the main checkout's `main`-era `.so` was replaced by a 1.1.1 build. It has been restored: rebuilt from `527a4c73` (the main checkout's exact HEAD, whose `crates/` was verified byte-identical to that commit) into a throwaway `git archive` export — never touching the main checkout's source, `uv.lock`, or git state — and the result is byte-size identical to the original (6,581,216) and verified behaviourally as `main`-era (`{{ "<b>x</b>" }}` → `<b>x</b>`, the #2376 discriminator, versus `''` on 1.1.x).
2. **The tooling tests trashed the git index.** After the hook run, `git status` showed nearly every tracked file staged as **deleted** plus a stray `.venv/bin/python` **added** — the temp-repo tests in `tests/test_git_commit_with_precommit.py` / `test_red_main_attribution_behaviour_2139.py` / `test_run_with_venv_python.py` operating on the real index. Recovered with `git reset`; HEAD and the working tree were intact, and the tree is clean now.

This is the #1796 caveat, sharper than recorded: it is not just that the hook *fails* in a worktree, it is that it measures a different program **and** mutates two repositories. Worth its own issue.

Because `--no-verify` skips the hook, the hook's own suite was run manually with the correct extension — same three roots, same serial invocation, `--benchmark-disable` — and is green at 10,282. CI is the authoritative gate.

## Not done, per the brief

No version bump, no tag, nothing published. The `## [1.1.1]` CHANGELOG section is added; **no already-tagged section is touched** (the splice is 48 additions, 0 deletions, entirely above `## [1.1.0]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
