### PR TITLE
ci: gate maintenance branches, not only main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,13 +2,13 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: [main, '1.*']
     paths-ignore:
       - '**.md'
       - 'docs/**'
       - 'CHANGELOG.md'
   pull_request:
-    branches: [main]
+    branches: [main, '1.*']
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,13 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, '1.*' ]
     paths-ignore:
       - '**.md'
       - 'docs/**'
       - 'CHANGELOG.md'
   pull_request:
-    branches: [ main ]
+    branches: [ main, '1.*' ]
     paths-ignore:
       - '**.md'
       - 'docs/**'


### PR DESCRIPTION
`test.yml` and `codeql.yml` both trigger on `branches: [main]` for push and pull_request. **Every other long-lived branch has no CI at all** — a PR into `1.0`, `1.1` or `1.2` runs no test suite, no clippy/ruff/mypy, and no CodeQL. Only the two unfiltered workflows (external-PR gate, security hot-spot check) fire.

Found while opening the 1.1.1 security backport (#2439) into the freshly cut `1.1` branch: a **security patch release** was about to be validated entirely by hand, with the merge button green because almost nothing had run. Same failure shape as a check list that is empty rather than passing — absence reading as success.

Widened both to `[main, '1.*']`, covering the existing `1.0`, `1.1`, `1.2` branches and any future `1.x`. Deliberately narrow: feature branches are still gated by their PR into `main`, so this adds no runs for them.

Note the trigger must also exist on the **base** branch for a PR into it to be gated, so this is being applied to `1.1` as well as landing here.