### PR TITLE
ci: gate maintenance branches, not only main (1.1)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,13 +2,13 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: [main, '1.*']
     paths-ignore:
       - '**.md'
       - 'docs/**'
       - 'CHANGELOG.md'
   pull_request:
-    branches: [main]
+    branches: [main, '1.*']
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,13 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, '1.*' ]
     paths-ignore:
       - '**.md'
       - 'docs/**'
       - 'CHANGELOG.md'
   pull_request:
-    branches: [ main ]
+    branches: [ main, '1.*' ]
     paths-ignore:
       - '**.md'
       - 'docs/**'


### PR DESCRIPTION
Cherry-pick of `e34084e2` (PR #2440 into `main`) onto the `1.1` maintenance branch.

## Why this must land on `1.1` specifically, before #2439

A `pull_request` workflow is selected using the **base** branch's trigger filter. `1.1` was cut from `v1.1.0`, whose `test.yml` and `codeql.yml` read `branches: [main]` — so **PR #2439, the 1.1.1 security backport, currently gets no test suite, no lint and no CodeQL.** Landing the fix on `main` alone would not change that.

This PR is also the first live check of the fix: if the widened filter works, this PR itself will be gated by `test.yml`/`codeql.yml`, where a PR into `1.1` previously ran neither. If it runs only the two unfiltered checks, the filter did not take effect and that is the signal to look again — a green result here means something either way, which a PR that could not fail would not.

After this merges, #2439 needs a merge-forward from `1.1` so its CI re-evaluates with the trigger present.