### PR TITLE
chore(release): bump to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bincode",
  "criterion",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "ahash",
  "chrono",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "ahash",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 authors = ["djust contributors"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "djust"
-version = "1.1.0"
+version = "1.1.1"
 description = "Phoenix LiveView-style reactive components for Django with Rust-powered performance. Real-time UI updates over WebSocket, no JavaScript build step required."
 authors = [{name = "djust contributors"}]
 readme = "README.md"

--- a/python/djust/__init__.py
+++ b/python/djust/__init__.py
@@ -75,7 +75,7 @@ except ImportError:
     # Rust components not yet built - this is optional
     rust_components = None  # noqa: F841 — accessed as djust.rust_components by user code
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 
 def enable_hot_reload():

--- a/python/djust/components/__init__.py
+++ b/python/djust/components/__init__.py
@@ -33,7 +33,7 @@ descriptors, mixins, rust handlers, gallery).
     python manage.py component_gallery
 """
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 # ---------------------------------------------------------------------------
 # Core component classes (original djust.components)

--- a/uv.lock
+++ b/uv.lock
@@ -591,7 +591,7 @@ wheels = [
 
 [[package]]
 name = "djust"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "channels", extra = ["daphne"] },


### PR DESCRIPTION
Version bump for the 1.1.1 security patch release. **No tag, nothing published.**

## Contents

Six files, one line each (five for `Cargo.lock`'s workspace crates):

```
pyproject.toml  Cargo.toml  python/djust/__init__.py
python/djust/components/__init__.py  uv.lock  Cargo.lock       -> 1.1.1
```

`make version-check` reports all six agreeing at `1.1.1`.

## One thing worth knowing

`make version` runs `uv lock`, which rewrote **all 125** package sources in `uv.lock` from `https://pypi.org/simple` to `http://127.0.0.1:8418/pypi/simple/` — a local index mirror configured on this machine. Committing that would point every install, CI included, at a loopback address that exists nowhere else.

Reverted; `uv.lock`'s diff is now the single `djust` self-entry line. The repo's `check uv.lock records a public index` hook passed, and would have blocked it — but the rewrite recurs on every `uv lock` / `make build` here, so it is worth knowing rather than rediscovering each release.

## What this release contains

`#2439` closed **six live XSS classes** present since 1.0.0, re-implemented against 1.1.0's own code rather than cherry-picked (every fix on `main` conflicts at the tag — `filters.rs` alone grew 2,536 → 7,204 lines).

The `[1.1.1]` CHANGELOG section states, deliberately:

- the six fixed, with reproducers
- **three known divergences from `main`, all over-escaping** — `{{ p|escape|F }}` double-escapes for plain `F`; `{% render_slot slot.content %}` over-escapes; a `mark_safe`d value through `|escape` is escaped. 1.1.0 has no per-value safety model, so these are the fail-closed cost of a faithful-enough fix.
- **two classes 1.1.1 does NOT fix** — app-written tag handlers returning attacker data as a plain `str` (only djust's own `render_slot` is covered), and five type-coercion cells under an explicit `|safe`.

The advisory should name that last group.

## Verification

`#2439` was green on 17 CI checks — its first real CI run ever, since `test.yml`/`codeql.yml` had filtered `branches: [main]` and a PR into `1.1` previously ran **two** checks. Fixed in #2440/#2441 before this landed.

I also verified all seven vulnerable cells inert independently, and probed the load-bearing design choice (last-filter safety scope rather than an any-position name list) for a re-taint hole. There isn't one.