### PR TITLE
fix(make): let `make release` run from an X.Y maintenance branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -580,10 +580,11 @@ endif
 	@echo "$(YELLOW)Creating release v$(VERSION)...$(NC)"
 	@# Verify we're on main or release branch
 	@BRANCH=$$(git branch --show-current); \
-	if [ "$$BRANCH" != "main" ] && [[ "$$BRANCH" != release/* ]]; then \
-		echo "$(RED)ERROR: Must be on main or release/* branch$(NC)"; \
-		exit 1; \
-	fi
+	case "$$BRANCH" in \
+		main|release/*) ;; \
+		[0-9].[0-9]|[0-9].[0-9][0-9]|[0-9][0-9].[0-9]|[0-9][0-9].[0-9][0-9]) ;; \
+		*) echo "$(RED)ERROR: Must be on main, release/*, or an X.Y maintenance branch (got '$$BRANCH')$(NC)"; exit 1 ;; \
+	esac
 	@# Verify working directory is clean
 	@if [ -n "$$(git status --porcelain)" ]; then \
 		echo "$(RED)ERROR: Working directory not clean$(NC)"; \


### PR DESCRIPTION
Blocks the 1.1.1 tag. `make release` refuses any branch that is not `main` or `release/*`, so tagging from `1.1` fails.

The guard's intent is *"do not tag from a feature branch."* `1.1` satisfies the intent but not the letter. Bypassing it by hand would be the wrong fix for a guard that is merely too narrow — same reasoning as `git add -f` on a gitignored path being a STOP rather than a workaround.

Same class as the CI branch filter widened in #2440/#2441: tooling written when `main` was the only long-lived branch, now that maintenance branches exist.

## The pattern is exact-`X.Y`, and a canary is why

The first version used `[0-9]*.[0-9]*`. A canary against real branch names caught it **accepting `1.1-wip`**, because the glob is greedy. Tightened and re-verified:

```
ACCEPT  main  release/1.1.1  1.0  1.1  1.2  2.0  1.10  10.1
REFUSE  1.1-wip  1.1.1  v1.1  fix/foo  feat/bar  worktree-agent-abc
```

Every other release guard is untouched and still runs: clean working tree, version match against `pyproject.toml`, lockfile self-entry sync (#1498), and the local **and** origin tag-exists checks added after the v1.1.0rc4 incident.

Needs the same change on `main` for future `1.2.x` releases — following separately.