### PR TITLE
security(templates): a bind REPLACES the safety grant, it does not inherit one (1.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-08-30
+
+Security-only patch release on the `1.1` maintenance branch, closing one XSS
+class 1.1.1 left open: a template **binding** carried a safety grant it had not
+earned. Present in every release from 1.0.0 through 1.1.1.
+
+### Security
+
+- **A `{% with %}`, `{% for %}`, `{% include … with %}` or `{% … as x %}` bind that shadowed a `mark_safe`d name emitted the NEW, attacker-controlled value LIVE (#2361, #2363).** djust's context safety channel is keyed BY NAME — `Context::safe_keys` holds dotted paths written by `rust_bridge._collect_safe_keys`, and `Context::is_safe` answers by looking a NAME up in it. Every construct that binds a resolved value to a name copied the VALUE and left the GRANT attached, so with `p` marked safe anywhere in the view's context, `{% with p=hostile %}{{ p }}{% endwith %}` rendered `<img src=x onerror=alert(1)>` as a real element where Django escapes it. No `|safe`, no custom filter: one prior `mark_safe` on a name, and any template that later binds that name. Eight bind shapes reproduce, each measured on unmodified `1.1` against its own `safe_keys=None` control: `{% with %}` rebinding the granted name and its `p.a` descendant, `{% with %}` binding any other name the context had marked, the `{% for %}` loop variable and its `p.a` descendant, `{% for k, v in … %}` tuple unpacking, `{% include … with %}`, and an assign tag's `{% … as x %}` merge. `{% include … with … only %}` was already inert (the fresh context carries no grants) and is pinned so a future change cannot quietly reintroduce it.
+
+  The cure is a rule about the **operation**, not the values: **a bind REPLACES the grant.** `Context::bind` revokes `name` and every `name.…` beneath it before attaching the new value; the `{% for %}` arm hoists that same revoke out of its iteration — identical in effect, since every iteration binds the same names, and `O(len(safe_keys))` once instead of per item. The descendants go because they described the value being SHADOWED: with `p.a` marked, leaving them makes `{% with p=hostile %}{{ p.a }}{% endwith %}` emit raw. Stating the rule the other way round — "a bind also CARRIES a grant", which is what the two issues above asked for, both being **over**-escapes — would have left this leak open. Both directions are the same rule, and `main` states it the same way (PR #2378).
+
+  **Both directions are tested.** The two channels that legitimately carry a grant across a bind on this branch are asserted still live: the `{% for %}` positional loop mapping (`x` → `items.<index>`, including dotted `r.body` paths), and a plain `{% include %}`'s inherited parent context. So are unrelated and prefix-sharing sibling names (`pp` is not beneath `p`), and the parent context's own grant after the block ends.
+
+### Known divergences from Django, unchanged by this release
+
+- `{% with q=p %}` over a marked `p` binds a NEW name and stays **escaped** where Django renders it live. This arm resolves its operand with a bare `Context::get`, so there is no runtime-safe bool to attach and the honest replacement grant is "none". Over-escaping, and `main` behaves the same way — its `Context::bind` takes a `safe` bool from `get_value_safe`, which returns `false` for a bare context name there too. Pinned rather than silently accepted.
+- `{% with q=p|filter %}` does not resolve the filter at all on 1.1.x; it binds the literal token `p|filter`. A pre-existing resolution gap (`main`'s #2325), not an escaping defect. Pinned so the fix cannot be read as having caused it.
+
+### Not fixed in 1.1.2
+
+- The **over-escape** half of this defect — `main`'s #2363 (`{% with body=post.text|linebreaks %}` renders escaped tag text) and #2361 (a `mark_safe` value reached through `d.values` / `d.items` loses its mark). Both need machinery this branch does not have: a filter pipeline in the `{% with %}` arm, and the `Value::DictView` normalisation the `{% for %}` arm gained on `main`. Backporting either is a feature change, not a patch. Neither is a leak — both escape more than Django, which is the direction to fail in.
+
+### Verification
+
+All eight leaking shapes reproduce on unmodified `1.1` and are closed here, with the two legitimate-grant shapes and the `only` case unchanged. Gate-off across 7 mutations — mutation text asserted present at its declared count, source asserted changed, the Rust crate rebuilt and its `.so` mtime asserted to advance each iteration, `__pycache__` cleared, `N error` counted separately from `N failed` — all 7 RED, 0 survivors, 0 INVALIDs, and every mechanism has at least one test that goes red for it alone: neutering only the descendant sweep fails exactly the two `p.a` cases and nothing else. Both sources restored byte-identical. 10,302 Python tests across `tests/`, `python/tests/` and `python/djust/tests/`, 0 failed; `make test-rust` green across 44 test binaries; clippy, `cargo fmt --check` and ruff clean.
+
+New cases in `TestABindRevokesAStaleGrant`, `TestALegitimateGrantStillReachesItsValue`, `TestTheAcceptedDivergences` and `TestEveryAssignTagMergeSiteUsesTheBind`, plus `context::tests` in `crates/djust_core/src/context.rs`. Every Python case runs through `_rust.render_template_with_dirs` — the only entry point carrying `safe_keys` — with keys from the **production** collector, renders the same template twice (channel off, then on) so a green cell cannot mean the channel was never engaged, and asserts liveness **structurally** (an `<img>` opening tag carrying an `onerror` attribute) rather than by substring, paired with a positive assertion that the payload arrived escaped so no case can pass by the payload never reaching the output. The three assign-tag merge sites are pinned as a **set**, not a floor, so a fourth added with a bare `set` fails.
+
 ## [1.1.1] - 2026-08-29
 
 Security-only patch release on the `1.1` maintenance branch. Six live XSS

--- a/crates/djust_core/src/context.rs
+++ b/crates/djust_core/src/context.rs
@@ -138,6 +138,88 @@ impl Context {
         self.safe_keys.insert(key);
     }
 
+    /// Bind `name` to `value`, **REPLACING** whatever safety grant `name`
+    /// carried.
+    ///
+    /// This is the one door for every template construct that binds a
+    /// resolved value to a NEW NAME — `{% with %}`, `{% include … with %}`
+    /// and the `{% … as x %}` assign-tag merge. [`Context::set`] moves the
+    /// VALUE; this moves the value AND revokes the grant that described the
+    /// value being SHADOWED.
+    ///
+    /// # Why the grant must be REPLACED, not merely carried
+    ///
+    /// djust's safety channel is keyed BY NAME: `safe_keys` holds dotted
+    /// paths written by `rust_bridge._collect_safe_keys`, and
+    /// [`Context::is_safe`] answers by looking a name up in it. A bind copies
+    /// the value, so without this the grant stays attached to a name that now
+    /// holds a DIFFERENT — possibly attacker-controlled — value:
+    ///
+    /// ```text
+    /// safe_keys = ["p"],  p = mark_safe("<b>trusted</b>")
+    /// {% with p=hostile %}{{ p }}{% endwith %}   ->  hostile emitted RAW
+    /// ```
+    ///
+    /// That is an UNDER-escape — djust MORE permissive than Django, the one
+    /// direction this machinery must never move in.
+    ///
+    /// # The paths BENEATH the name go too
+    ///
+    /// `safe_keys` holds `p.a` as readily as `p`, and those descendants
+    /// described the value being SHADOWED. Leaving them makes
+    /// `{% with p=hostile_dict %}{{ p.a }}{% endwith %}` emit raw. So a bind
+    /// revokes `name` and every `name.…` beneath it.
+    ///
+    /// # Why no `safe` argument on this branch
+    ///
+    /// None of the 1.1.x bind sinks has a runtime-safe channel to carry: the
+    /// `{% with %}` / `{% include … with %}` arms resolve their operand with a
+    /// bare `Context::get` (no filter pipeline, so no `filter_output_is_safe`
+    /// bool exists to thread), and an assign tag's handler returns plain
+    /// `Value`s across the PyO3 boundary with no safety information at all.
+    /// The honest replacement grant is therefore always "none", and taking a
+    /// `bool` that every call site passes `false` would be dead config. When a
+    /// sink gains a genuine runtime-safe bool, widen this signature then — the
+    /// revoke half is what closes the leak and is unaffected either way.
+    ///
+    /// The `{% for %}` loop variable is the fourth bind sink and hoists the
+    /// [`Context::revoke_safe_subtree`] half OUT of its iteration rather than
+    /// calling this per item — see that method's docs.
+    pub fn bind(&mut self, name: String, value: Value) {
+        self.revoke_safe_subtree(&name);
+        self.set(name, value);
+    }
+
+    /// The SUBTREE half of a [`Context::bind`]: drop the grant on `key` and on
+    /// every dotted path beneath it. `O(len(safe_keys))`.
+    ///
+    /// The descendants go because they described the value being SHADOWED.
+    /// With `p.a` marked, leaving them makes
+    /// `{% with p=hostile_dict %}{{ p.a }}{% endwith %}` emit raw.
+    ///
+    /// A `{% for %}` binds the same names once per iteration, so it calls this
+    /// ONCE before the loop instead of `bind` per item: the shadowed outer
+    /// grants every iteration would clear are the same ones, so clearing them
+    /// once is identical in effect and turns an `O(N·len(safe_keys))` scan
+    /// into one. `context::tests::the_loop_decomposition_of_bind_agrees_with_bind`
+    /// pins that the two spellings agree so the split cannot drift.
+    ///
+    /// The scan is skipped entirely when the set is empty — the common case
+    /// for a render with no context marks at all.
+    ///
+    /// This deliberately does NOT touch [`Context::set_loop_mapping`]'s
+    /// aliases: that mapping is how a real list's per-item marks resolve
+    /// (`{% for x in p %}` → `p.<index>`), which is a grant the bound value
+    /// genuinely carries rather than a stale one it inherited.
+    pub fn revoke_safe_subtree(&mut self, key: &str) {
+        if self.safe_keys.is_empty() {
+            return;
+        }
+        self.safe_keys.remove(key);
+        let prefix = format!("{key}.");
+        self.safe_keys.retain(|k| !k.starts_with(&prefix));
+    }
+
     /// Check if a variable name is marked safe.
     pub fn is_safe(&self, key: &str) -> bool {
         // First check directly
@@ -577,5 +659,108 @@ mod tests {
 
         ctx.pop();
         assert!(matches!(ctx.get("a"), Some(Value::Integer(1))));
+    }
+
+    // ---- `Context::bind` — a binding REPLACES the grant ----
+
+    /// The three-key fixture every bind test below shadows one name of.
+    fn ctx_with_a_marked_name() -> Context {
+        let mut ctx = Context::new();
+        ctx.set("p".to_string(), Value::String("<b>x</b>".into()));
+        ctx.mark_safe("p".to_string());
+        ctx.mark_safe("p.a".to_string());
+        ctx.mark_safe("q".to_string());
+        ctx
+    }
+
+    #[test]
+    fn bind_revokes_a_stale_grant_on_the_shadowed_name() {
+        let mut ctx = ctx_with_a_marked_name();
+        ctx.bind("p".to_string(), Value::String("<img>".into()));
+        assert!(!ctx.is_safe("p"), "the shadowed name kept its grant");
+    }
+
+    #[test]
+    fn bind_revokes_the_grants_beneath_the_shadowed_name() {
+        let mut ctx = ctx_with_a_marked_name();
+        ctx.bind("p".to_string(), Value::String("<img>".into()));
+        assert!(
+            !ctx.is_safe("p.a"),
+            "a descendant of the shadowed name survived"
+        );
+    }
+
+    #[test]
+    fn bind_leaves_every_other_name_alone() {
+        let mut ctx = ctx_with_a_marked_name();
+        ctx.bind("p".to_string(), Value::String("<img>".into()));
+        assert!(ctx.is_safe("q"), "bind revoked an unrelated name");
+    }
+
+    #[test]
+    fn bind_still_moves_the_value() {
+        let mut ctx = ctx_with_a_marked_name();
+        ctx.bind("p".to_string(), Value::String("<img>".into()));
+        assert!(matches!(ctx.get("p"), Some(Value::String(s)) if s == "<img>"));
+    }
+
+    /// The `{% for %}` arm hoists `revoke_safe_subtree` out of its iteration
+    /// and calls plain `set` per item. That decomposition is a COST decision,
+    /// so it must be observationally identical to calling `bind` each time, or
+    /// the split has drifted.
+    #[test]
+    fn the_loop_decomposition_of_bind_agrees_with_bind() {
+        let items = [
+            Value::String("<b>0</b>".into()),
+            Value::String("<i>1</i>".into()),
+            Value::String("<u>2</u>".into()),
+        ];
+
+        // Spelling A — `bind` per iteration.
+        let mut a = ctx_with_a_marked_name();
+        // Spelling B — one subtree revoke, then `set` per item.
+        let mut b = ctx_with_a_marked_name();
+        b.revoke_safe_subtree("p");
+
+        for value in items.iter() {
+            a.bind("p".to_string(), value.clone());
+            b.set("p".to_string(), value.clone());
+
+            assert_eq!(
+                a.is_safe("p"),
+                b.is_safe("p"),
+                "bind and its loop decomposition disagree on `p` at {value:?}"
+            );
+            assert_eq!(a.is_safe("p.a"), b.is_safe("p.a"), "…and on `p.a`");
+            assert_eq!(a.is_safe("q"), b.is_safe("q"), "…and on the untouched `q`");
+        }
+    }
+
+    #[test]
+    fn revoke_safe_subtree_does_not_touch_a_sibling_sharing_a_prefix() {
+        // `pp` starts with `p` but is not beneath it — only `p.` is.
+        let mut ctx = Context::new();
+        ctx.mark_safe("p".to_string());
+        ctx.mark_safe("pp".to_string());
+        ctx.mark_safe("p.a".to_string());
+        ctx.revoke_safe_subtree("p");
+        assert!(!ctx.is_safe("p"));
+        assert!(!ctx.is_safe("p.a"));
+        assert!(ctx.is_safe("pp"), "a prefix-sharing SIBLING was revoked");
+    }
+
+    /// The revoke must not disturb the loop-mapping alias, which is how a real
+    /// list's per-item marks reach the loop variable. That grant is one the
+    /// bound value genuinely carries, not a stale one it inherited.
+    #[test]
+    fn revoke_safe_subtree_leaves_the_loop_mapping_channel_intact() {
+        let mut ctx = Context::new();
+        ctx.mark_safe("items.0".to_string());
+        ctx.set_loop_mapping("x".to_string(), "items".to_string(), 0);
+        ctx.revoke_safe_subtree("x");
+        assert!(
+            ctx.is_safe("x"),
+            "revoking the loop variable's name dropped its per-item mark"
+        );
     }
 }

--- a/crates/djust_templates/src/renderer.rs
+++ b/crates/djust_templates/src/renderer.rs
@@ -191,7 +191,13 @@ pub fn render_nodes_with_loader<L: TemplateLoader>(
                 }
                 if let Some(ctx) = mutated.as_mut() {
                     for (k, v) in updates {
-                        ctx.set(k, v);
+                        // `bind`, not `set`: an assign tag's handler returns
+                        // plain `Value`s across the PyO3 boundary with no
+                        // safety channel at all, so the honest grant is NONE
+                        // -- and a `{% ... as x %}` that lands on a name the
+                        // context had marked must not inherit that stale grant
+                        // and emit the handler's output RAW.
+                        ctx.bind(k, v);
                     }
                 }
                 // Assign tags emit no HTML.
@@ -357,7 +363,13 @@ pub fn render_nodes_collecting<L: TemplateLoader>(
                 }
                 if let Some(ctx) = mutated.as_mut() {
                     for (k, v) in updates {
-                        ctx.set(k, v);
+                        // `bind`, not `set`: an assign tag's handler returns
+                        // plain `Value`s across the PyO3 boundary with no
+                        // safety channel at all, so the honest grant is NONE
+                        // -- and a `{% ... as x %}` that lands on a name the
+                        // context had marked must not inherit that stale grant
+                        // and emit the handler's output RAW.
+                        ctx.bind(k, v);
                     }
                 }
                 String::new()
@@ -427,7 +439,13 @@ pub fn render_nodes_partial<L: TemplateLoader>(
                     }
                     if let Some(ctx) = mutated.as_mut() {
                         for (k, v) in updates {
-                            ctx.set(k, v);
+                            // `bind`, not `set`: an assign tag's handler returns
+                            // plain `Value`s across the PyO3 boundary with no
+                            // safety channel at all, so the honest grant is NONE
+                            // -- and a `{% ... as x %}` that lands on a name the
+                            // context had marked must not inherit that stale grant
+                            // and emit the handler's output RAW.
+                            ctx.bind(k, v);
                         }
                     }
                     String::new()
@@ -688,6 +706,25 @@ pub fn render_node_with_loader<L: TemplateLoader>(
 
                     let mut output = String::new();
                     let mut ctx = context.clone();
+
+                    // The SUBTREE half of `Context::bind`, hoisted out of the
+                    // iteration. Every iteration binds the SAME names, so the
+                    // shadowed outer grants each would clear are the same ones
+                    // -- clearing them once is identical in effect (pinned by
+                    // `context::tests::the_loop_decomposition_of_bind_agrees_with_bind`)
+                    // and turns an O(N*len(safe_keys)) scan into one.
+                    //
+                    // Without this, `{% for p in hostile %}{{ p }}{% endfor %}`
+                    // with `p` marked in the context emitted the hostile items
+                    // RAW: the loop bound the value and inherited the stale
+                    // by-name grant.
+                    //
+                    // This does NOT disturb `set_loop_mapping` below, which is
+                    // the LEGITIMATE per-item channel (`x` -> `items.<index>`)
+                    // -- a grant the bound item genuinely carries.
+                    for var_name in var_names {
+                        ctx.revoke_safe_subtree(var_name);
+                    }
 
                     // Create an iterator with indices, reversing if needed
                     let items_vec = items;
@@ -962,7 +999,14 @@ pub fn render_node_with_loader<L: TemplateLoader>(
                             Value::String(value_expr.clone())
                         }
                     });
-                    include_context.set(key.clone(), value);
+                    // `bind`, not `set`: this is the third spelling of one
+                    // binding, and a fix that reached only `{% with %}` would
+                    // be the parallel-path drift CLAUDE.md #1646 describes.
+                    // With `only`, `include_context` is fresh and carries no
+                    // grants, so the revoke is a no-op there; WITHOUT `only`
+                    // it inherits every grant the parent context holds, which
+                    // is exactly where the stale one would have leaked.
+                    include_context.bind(key.clone(), value);
                 }
 
                 render_nodes_with_loader(&nodes, &include_context, Some(loader))
@@ -1076,7 +1120,18 @@ pub fn render_node_with_loader<L: TemplateLoader>(
                     .get(expression)
                     .cloned()
                     .unwrap_or_else(|| Value::String(expression.clone()));
-                new_context.set(var_name.clone(), value);
+                // `bind`, not `set`: `Context::bind` REVOKES whatever grant
+                // `var_name` carried before attaching the new value. Without
+                // it, `{% with p=hostile %}{{ p }}{% endwith %}` over a
+                // context that marked `p` safe emitted the hostile value RAW
+                // -- djust MORE permissive than Django, an UNDER-escape.
+                //
+                // No grant is attached in its place: this arm resolves its
+                // operand with a bare `Context::get`, which carries no
+                // runtime-safe bool. `{% with q=p %}` over a marked `p`
+                // therefore stays escaped, as it was before this change and as
+                // it is on `main`.
+                new_context.bind(var_name.clone(), value);
             }
 
             // Render children with new context

--- a/python/djust/tests/test_security_1_1_2_binding_grant.py
+++ b/python/djust/tests/test_security_1_1_2_binding_grant.py
@@ -1,0 +1,350 @@
+"""A template BINDING must not carry a stale safety grant (1.1.2).
+
+The defect
+----------
+djust's context safety channel is keyed BY NAME: ``Context::safe_keys`` holds
+dotted paths written by ``rust_bridge._collect_safe_keys``, and
+``Context::is_safe`` answers by looking a NAME up in it. Every construct that
+binds a resolved value to a name — ``{% with %}``, ``{% include … with %}``,
+the ``{% for %}`` loop variable, and an assign tag's ``{% … as x %}`` merge —
+copied the VALUE and left the GRANT attached. Rebinding a name the view had
+marked safe therefore emitted the NEW, attacker-controlled value RAW::
+
+    safe_keys = ["p"],  p = mark_safe("<b>trusted</b>")
+    {% with p=hostile %}{{ p }}{% endwith %}   ->  hostile emitted LIVE
+
+That is an UNDER-escape — djust MORE permissive than Django, the one direction
+this machinery must never move in.
+
+The cure is a rule about the OPERATION, not the values: **a bind REPLACES the
+grant**. ``Context::bind`` revokes ``name`` and every ``name.…`` beneath it
+before attaching the new value. Stating it as "a bind also CARRIES a grant"
+would have fixed only the over-escape half that ``main``'s #2361/#2363 reported
+and left this leak open; both directions are the same rule.
+
+Both directions are asserted here
+---------------------------------
+* ``TestABindRevokesAStaleGrant`` — the leak. Each case emitted the payload
+  LIVE on unmodified 1.1.1.
+* ``TestALegitimateGrantStillReachesItsValue`` — the inverse. The fix must not
+  start silently dropping grants a value genuinely carries; the ``{% for %}``
+  per-item channel (``set_loop_mapping``) and a plain ``{% include %}``'s
+  inherited context are the two that exist on this branch, and both stay live.
+
+The control pair
+----------------
+``render_template_with_dirs``'s fourth argument IS the safe-key channel, and a
+probe that never engages it proves nothing. Every assertion here therefore runs
+the SAME template twice — once with ``safe_keys=None`` and once with the keys
+the PRODUCTION collector emits — and pins both outputs. Without that pairing a
+green cell can mean "the channel was never engaged", which is how a whole test
+file in this repo turned out to be measuring nothing.
+
+Known divergences from Django, unchanged by this fix
+----------------------------------------------------
+* ``{% with q=p %}`` over a marked ``p`` binds a NEW name and stays ESCAPED
+  where Django renders it live. This arm resolves its operand with a bare
+  ``Context::get``, which carries no runtime-safe bool to attach, so the
+  honest replacement grant is "none". Over-escaping, and ``main`` behaves the
+  same way. Pinned by ``test_a_new_name_binding_carries_no_grant_either_way``.
+* ``{% with q=p|filter %}`` does not resolve the filter at all on 1.1.x (it
+  binds the literal token) — a separate pre-existing gap, not an escaping
+  defect. Pinned by ``test_a_filtered_with_operand_is_unresolved_not_leaked``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+pytest.importorskip("django")
+
+from django.template import Context as DjangoContext  # noqa: E402
+from django.template import Engine  # noqa: E402
+from django.template import Template as DjangoTemplate  # noqa: E402
+from django.utils.safestring import mark_safe  # noqa: E402
+
+from djust import _rust  # noqa: E402
+from djust.mixins.rust_bridge import _collect_safe_keys  # noqa: E402
+
+MARKED = mark_safe("<b>ok</b>")
+HOSTILE = "<img src=x onerror=alert(1)>"
+ESCAPED = "&lt;img src=x onerror=alert(1)&gt;"
+
+# An `<img …>` OPENING TAG carrying an onerror handler, tolerant of attribute
+# order. This is the shape a browser actually executes; a bare substring scan
+# reports a genuine XSS as inert once anything reorders attributes.
+_LIVE_ELEMENT = re.compile(r"<\s*img\b[^>]*\bonerror\s*=", re.I)
+
+
+def _safe_keys(ctx: dict) -> list[str]:
+    """The keys the PRODUCTION collector emits for this context."""
+    keys: list[str] = []
+    for key, value in ctx.items():
+        keys.extend(_collect_safe_keys(value, key))
+    return keys
+
+
+def render_pair(tpl: str, ctx: dict, dirs: list[str] | None = None) -> tuple[str, str]:
+    """Render `tpl` with the safe-key channel OFF and then ON.
+
+    The pair is the control: a difference proves the channel was engaged, and
+    an assertion about the ON output means nothing without knowing the OFF one.
+    """
+    dirs = dirs or []
+    off = _rust.render_template_with_dirs(tpl, ctx, dirs, None)
+    on = _rust.render_template_with_dirs(tpl, ctx, dirs, _safe_keys(ctx) or None)
+    return off, on
+
+
+def django_render(tpl: str, ctx: dict, dirs: list[str] | None = None) -> str:
+    if dirs:
+        return DjangoTemplate(tpl, engine=Engine(dirs=dirs, libraries={})).render(
+            DjangoContext(ctx)
+        )
+    return DjangoTemplate(tpl).render(DjangoContext(ctx))
+
+
+def assert_inert_both_ways(tpl: str, ctx: dict, dirs: list[str] | None = None) -> None:
+    """The payload is escaped whether or not the safe-key channel is engaged.
+
+    Also pins that the safe keys really do name the shadowed variable — a probe
+    whose ``safe_keys`` came out empty would pass this vacuously.
+    """
+    assert _safe_keys(ctx), f"the probe engaged NO safe keys, so it proves nothing: {ctx!r}"
+    off, on = render_pair(tpl, ctx, dirs)
+    assert not _LIVE_ELEMENT.search(off), f"{tpl!r} was live even with the channel OFF: {off!r}"
+    assert not _LIVE_ELEMENT.search(on), f"{tpl!r} leaked a stale grant: {on!r}"
+    assert ESCAPED in on, f"{tpl!r} never emitted the payload at all: {on!r}"
+    assert on == django_render(tpl, ctx, dirs), (
+        f"{tpl!r}\n  django {django_render(tpl, ctx, dirs)!r}\n  djust  {on!r}"
+    )
+
+
+class TestABindRevokesAStaleGrant:
+    """The leak. Each of these emitted the payload LIVE on unmodified 1.1.1."""
+
+    def test_with_rebinding_a_marked_name_drops_the_stale_grant(self):
+        assert_inert_both_ways(
+            "{% with p=hostile %}{{ p }}{% endwith %}",
+            {"p": MARKED, "hostile": HOSTILE},
+        )
+
+    def test_with_rebinding_drops_the_grants_BENEATH_the_name_too(self):
+        """``p.a`` belonged to the SHADOWED ``p``; it must not survive the bind."""
+        assert_inert_both_ways(
+            "{% with p=hostile %}{{ p.a }}{% endwith %}",
+            {"p": {"a": MARKED}, "hostile": {"a": HOSTILE}},
+        )
+
+    def test_with_binding_a_new_name_that_the_context_marked(self):
+        """The bound name need not be the operand's — any marked name shadows."""
+        assert_inert_both_ways(
+            "{% with q=hostile %}{{ q }}{% endwith %}",
+            {"q": MARKED, "hostile": HOSTILE},
+        )
+
+    def test_for_rebinding_a_marked_name_drops_the_stale_grant(self):
+        assert_inert_both_ways(
+            "{% for p in hs %}{{ p }}{% endfor %}",
+            {"p": MARKED, "hs": [HOSTILE]},
+        )
+
+    def test_for_rebinding_drops_the_grants_beneath_the_name_too(self):
+        assert_inert_both_ways(
+            "{% for p in hs %}{{ p.a }}{% endfor %}",
+            {"p": {"a": MARKED}, "hs": [{"a": HOSTILE}]},
+        )
+
+    def test_for_tuple_unpacking_revokes_each_bound_name_independently(self):
+        """Both halves of ``{% for k, v in rows %}`` are binds, so both revoke."""
+        assert_inert_both_ways(
+            "{% for k, v in rows %}{{ k }}|{{ v }}{% endfor %}",
+            {"k": MARKED, "v": MARKED, "rows": [[HOSTILE, HOSTILE]]},
+        )
+
+    def test_include_with_rebinding_a_marked_name_drops_the_stale_grant(self, dirs):
+        assert_inert_both_ways(
+            '{% include "child.html" with q=hostile %}',
+            {"q": MARKED, "hostile": HOSTILE},
+            dirs,
+        )
+
+    def test_include_with_only_never_carried_a_grant_and_still_does_not(self, dirs):
+        """``only`` builds a FRESH context, so the revoke is a no-op here.
+
+        Kept as its own case so a future change that starts seeding the fresh
+        context from the parent cannot reintroduce the leak unnoticed.
+        """
+        assert_inert_both_ways(
+            '{% include "child.html" with q=hostile only %}',
+            {"q": MARKED, "hostile": HOSTILE},
+            dirs,
+        )
+
+    def test_an_assign_tag_binding_a_marked_name_drops_the_stale_grant(self, leak_probe_tag):
+        """``{% … as x %}`` is the fourth bind sink.
+
+        An assign handler returns plain ``Value``s across the PyO3 boundary
+        with no safety channel at all, so a handler's output landing on a
+        marked name was emitted RAW.
+
+        No Django comparison: the tag is djust-registry-only, so there is no
+        live-Django rendering of it to agree with. The control pair still
+        applies, and the escaped-payload assertion keeps the case from passing
+        by the payload never reaching the output.
+        """
+        ctx = {"p": MARKED}
+        assert _safe_keys(ctx) == ["p"]
+        off, on = render_pair("{% leakprobe112 as p %}{{ p }}", ctx)
+        assert not _LIVE_ELEMENT.search(off), f"live with the channel OFF: {off!r}"
+        assert not _LIVE_ELEMENT.search(on), f"the assign merge leaked a stale grant: {on!r}"
+        assert off == on == ESCAPED
+
+    def test_the_outer_grant_is_intact_after_the_block(self):
+        """The revoke is scoped to the bind's own context, not the parent's."""
+        off, on = render_pair("{% with p=h %}{% endwith %}{{ p }}", {"p": MARKED, "h": HOSTILE})
+        assert off == "&lt;b&gt;ok&lt;/b&gt;"
+        assert on == "<b>ok</b>", "the block's revoke escaped into the parent context"
+
+
+class TestALegitimateGrantStillReachesItsValue:
+    """The inverse direction: the fix must not start DROPPING earned grants.
+
+    Two channels on this branch legitimately carry a grant across a bind, and
+    both must survive: the ``{% for %}`` positional loop mapping, and a plain
+    ``{% include %}``'s inherited parent context.
+    """
+
+    def test_a_for_loop_still_resolves_its_per_item_mark(self):
+        """``set_loop_mapping`` resolves ``x`` -> ``p.<index>``; untouched."""
+        off, on = render_pair("{% for x in p %}{{ x }}{% endfor %}", {"p": [MARKED]})
+        assert off == "&lt;b&gt;ok&lt;/b&gt;"
+        assert on == "<b>ok</b>", "the loop variable lost its genuine per-item mark"
+        assert on == django_render("{% for x in p %}{{ x }}{% endfor %}", {"p": [MARKED]})
+
+    def test_a_for_loop_marks_only_the_marked_item(self):
+        ctx = {"p": [MARKED, HOSTILE]}
+        off, on = render_pair("{% for x in p %}[{{ x }}]{% endfor %}", ctx)
+        assert off == "[&lt;b&gt;ok&lt;/b&gt;][" + ESCAPED + "]"
+        assert on == "[<b>ok</b>][" + ESCAPED + "]"
+        assert not _LIVE_ELEMENT.search(on)
+
+    def test_a_nested_dotted_per_item_mark_still_resolves(self):
+        ctx = {"rows": [{"body": MARKED}]}
+        tpl = "{% for r in rows %}{{ r.body }}{% endfor %}"
+        off, on = render_pair(tpl, ctx)
+        assert off == "&lt;b&gt;ok&lt;/b&gt;"
+        assert on == "<b>ok</b>", "a dotted per-item mark was revoked"
+
+    def test_a_plain_include_still_inherits_the_parent_grant(self, dirs):
+        """No ``with``, so no bind — the inherited grant must survive."""
+        off, on = render_pair('{% include "child.html" %}', {"q": MARKED}, dirs)
+        assert off == "[&lt;b&gt;ok&lt;/b&gt;]"
+        assert on == "[<b>ok</b>]", "a plain include lost the parent's grant"
+
+    def test_an_unrelated_name_keeps_its_grant_across_a_bind(self):
+        """The revoke is scoped to the bound name's own subtree."""
+        ctx = {"p": MARKED, "other": MARKED, "h": HOSTILE}
+        off, on = render_pair("{% with p=h %}{{ other }}{% endwith %}", ctx)
+        assert off == "&lt;b&gt;ok&lt;/b&gt;"
+        assert on == "<b>ok</b>", "the bind revoked an unrelated name"
+
+    def test_a_prefix_sharing_sibling_keeps_its_grant(self):
+        """``pp`` starts with ``p`` but is not beneath it — only ``p.`` is."""
+        ctx = {"p": MARKED, "pp": MARKED, "h": HOSTILE}
+        off, on = render_pair("{% with p=h %}{{ pp }}{% endwith %}", ctx)
+        assert off == "&lt;b&gt;ok&lt;/b&gt;"
+        assert on == "<b>ok</b>", "a prefix-sharing SIBLING was revoked"
+
+
+class TestTheAcceptedDivergences:
+    """Shapes that do NOT reproduce the leak, pinned so a change is visible."""
+
+    def test_a_new_name_binding_carries_no_grant_either_way(self):
+        """``{% with q=p %}`` over a marked ``p``: escaped, where Django is live.
+
+        This arm has no runtime-safe bool to attach, so the honest grant is
+        none. Over-escaping — a rendering divergence, not a leak — and ``main``
+        behaves identically. Unchanged by this fix.
+        """
+        tpl = "{% with q=p %}{{ q }}{% endwith %}"
+        off, on = render_pair(tpl, {"p": MARKED})
+        assert off == on == "&lt;b&gt;ok&lt;/b&gt;"
+        assert django_render(tpl, {"p": MARKED}) == "<b>ok</b>"
+
+    def test_a_filtered_with_operand_is_unresolved_not_leaked(self):
+        """``{% with p=h|upper %}`` binds the literal token on 1.1.x.
+
+        A separate pre-existing resolution gap; what matters here is that the
+        marked name ``p`` does not make the bound token live.
+        """
+        tpl = "{% with p=h|upper %}{{ p }}{% endwith %}"
+        off, on = render_pair(tpl, {"p": MARKED, "h": HOSTILE})
+        assert off == on == "h|upper"
+
+
+class TestEveryAssignTagMergeSiteUsesTheBind:
+    """The mechanical-replacement pin (CLAUDE.md #1104 / #1125).
+
+    Only ``render_nodes_with_loader``'s assign-merge is reachable through
+    ``render_template_with_dirs``; the ``_collecting`` and ``_partial`` render
+    functions carry the SAME merge loop and are exercised by the streaming /
+    partial paths. A behavioural test cannot reach them from here, so the set
+    is pinned structurally: a fourth site added with a bare ``set`` fails this.
+    """
+
+    RENDERER = (
+        pathlib.Path(__file__).resolve().parents[3]
+        / "crates"
+        / "djust_templates"
+        / "src"
+        / "renderer.rs"
+    )
+
+    def test_no_assign_merge_site_still_uses_a_bare_set(self):
+        src = self.RENDERER.read_text()
+        assert "ctx.set(k, v);" not in src, (
+            "an assign-tag merge site still binds with a bare `set`, which "
+            "leaves a stale by-name safety grant attached"
+        )
+
+    def test_all_three_assign_merge_sites_are_present(self):
+        src = self.RENDERER.read_text()
+        assert src.count("ctx.bind(k, v);") == 3, (
+            "expected exactly 3 assign-tag merge sites (with_loader / "
+            "collecting / partial); the set changed — decide the new one "
+            "explicitly rather than letting it default to `set`"
+        )
+
+
+@pytest.fixture
+def dirs(tmp_path: pathlib.Path) -> list[str]:
+    """A one-template directory for the ``{% include %}`` cases."""
+    (tmp_path / "child.html").write_text("[{{ q }}]")
+    return [str(tmp_path)]
+
+
+@pytest.fixture
+def leak_probe_tag():
+    """Register an assign tag whose handler returns an attacker-controlled str.
+
+    Registered and unregistered around the test so the process-global Rust
+    assign registry is left exactly as it was found.
+    """
+    from djust._rust import register_assign_tag_handler, unregister_assign_tag_handler
+    from djust.template_tags import AssignTagHandler
+
+    class _LeakProbe(AssignTagHandler):
+        RESOLVE_ARG_POSITIONS: set[int] = set()
+
+        def render(self, args, context):
+            return {args[-1]: HOSTILE}
+
+    register_assign_tag_handler("leakprobe112", _LeakProbe())
+    try:
+        yield
+    finally:
+        unregister_assign_tag_handler("leakprobe112")


### PR DESCRIPTION
Security patch for the `1.1` maintenance line, closing one XSS class 1.1.1 left open. **Base: `1.1`, not `main`.** No version bump, no tag — the release is cut separately.

## The defect

djust's context safety channel is keyed **by name**: `Context::safe_keys` holds dotted paths written by `rust_bridge._collect_safe_keys`, and `Context::is_safe` answers by looking a name up in it. Every construct that binds a resolved value to a name copied the **value** and left the **grant** attached — so rebinding a name the view had marked safe emitted the new, attacker-controlled value live where Django escapes it.

```
safe_keys = ["p"],  p = mark_safe("<b>trusted</b>")
{% with p=hostile %}{{ p }}{% endwith %}   ->  <img src=x onerror=alert(1)>   LIVE
```

No `|safe`, no custom filter: one prior `mark_safe` on a name, and any template that later binds that name.

## Per-shape reproduction on unmodified `1.1`

Measured through `_rust.render_template_with_dirs` — the only entry point carrying `safe_keys` — with keys from the production collector, each probe paired with its `safe_keys=None` **control** so a green cell cannot mean the channel was never engaged.

| # | shape | `safe_keys=None` | `safe_keys=[…]` on 1.1.1 | after | Django |
|---|---|---|---|---|---|
| A1 | `{% with p=hostile %}{{ p }}` | escaped | **LIVE** | escaped | escaped |
| A2 | `{% with p=hostile %}{{ p.a }}` | escaped | **LIVE** | escaped | escaped |
| B2 | `{% with q=hostile %}{{ q }}`, `q` marked | escaped | **LIVE** | escaped | escaped |
| C1 | `{% for p in hs %}{{ p }}` | escaped | **LIVE** | escaped | escaped |
| C2 | `{% for p in hs %}{{ p.a }}` | escaped | **LIVE** | escaped | escaped |
| C3 | `{% for k, v in rows %}` tuple unpack | escaped | **LIVE** | escaped | escaped |
| D1 | `{% include "c" with q=hostile %}` | escaped | **LIVE** | escaped | escaped |
| E1 | `{% leakprobe as p %}{{ p }}` (assign tag) | escaped | **LIVE** | escaped | n/a |
| D2 | `{% include "c" with q=hostile only %}` | escaped | inert | inert | escaped |
| C4 | `{% for x in p %}{{ x }}`, `p.0` marked | escaped | **live (correct)** | live | live |
| D3 | `{% include "c" %}`, `q` marked, no `with` | escaped | **live (correct)** | live | live |

Eight shapes leak; D2 already did not (the `only` context is fresh) and is pinned so a future change cannot quietly reintroduce it. C4 and D3 are the two channels that **legitimately** carry a grant across a bind and must not be dropped.

Two shapes named in the brief did **not** reproduce, which is a finding rather than something to "fix":

- `{% with q=p %}` binding a **new, unmarked** name over a marked `p` — already escaped, where Django is live. This arm has no runtime-safe bool to attach; `main` behaves identically. Over-escape, pinned.
- `{% with p=h|upper %}` — 1.1.x does not resolve filters in `{% with %}` at all; it binds the literal token `h|upper`. Pre-existing resolution gap (`main`'s #2325), not an escaping defect. Pinned.

## The fix

The cure is a rule about the **operation**, not the values: **a bind REPLACES the grant.** `Context::bind` revokes `name` and every `name.…` beneath it, then sets the value. The descendants go because they described the value being *shadowed* — with `p.a` marked, leaving them makes A2 emit raw.

Stating it the other way round — "a bind also *carries* a grant", which is what `main`'s #2361/#2363 asked for, both being **over**-escapes — would have left this leak open. Both directions are the same rule, and `main` (PR #2378, `1f2761d8`) states it the same way for the same reason.

Sinks, each decided explicitly (#1646):

| sink | before | after |
|---|---|---|
| `{% with %}` | stale grant kept | revoked |
| `{% include … with %}` | stale grant kept | revoked |
| `{% include … with … only %}` | fresh context, no grant | unchanged |
| `{% for %}` loop var + tuple unpack | stale grant kept | revoked (hoisted out of the iteration) |
| `{% for %}` positional loop mapping | legitimate per-item channel | **unchanged** |
| `{% … as x %}` assign merge, all 3 render fns | stale grant kept | revoked |

### Re-implemented against 1.1, not cherry-picked

`main`'s `Context::bind` takes a `safe: bool` threaded from `get_value_safe`. This branch has nothing to supply it: the `{% with %}` / `{% include … with %}` arms resolve with a bare `Context::get` (no filter pipeline), and an assign handler returns plain `Value`s across the PyO3 boundary with no safety information. So `bind` takes no `safe` argument here — a bool every call site passes `false` is dead config — and the replacement grant is always none. `main`'s `{% for %}` machinery (`Value::DictView` normalisation, per-item `derived_grants`) is likewise absent and is not backported; it only ever *adds* grants, i.e. fixes the over-escape half.

## Both directions tested

`TestALegitimateGrantStillReachesItsValue` asserts the fix does not start dropping earned grants: the `{% for %}` positional loop mapping (including a dotted `r.body` path), a plain `{% include %}`'s inherited context, an unrelated name, a prefix-sharing sibling (`pp` is not beneath `p`), and the parent's own grant after the block ends.

## Gate-off

7 mutations. Each asserted present at its declared count, asserted to change the source, the Rust crate **rebuilt** with its `.so` mtime asserted to advance, `__pycache__` cleared, and `N error` counted separately from `N failed` so a mutation that broke the build cannot report as evidence.

| mutation | red |
|---|---|
| M1 `Context::bind` stops revoking | 5 |
| M2 `revoke_safe_subtree` stops removing the exact name | 6 |
| M3 `revoke_safe_subtree` stops sweeping descendants | 2 — exactly the two `.a` cases |
| M4 `{% with %}` binds with a bare `set` | 3 |
| M5 `{% include … with %}` binds with a bare `set` | 1 |
| M6 the `{% for %}` hoisted revoke removed | 3 |
| M7 all three assign merges bind with a bare `set` | 3 |

**0 survivors, 0 INVALIDs**, and every mechanism has at least one test that goes red for it alone — so no two mechanisms are shadowing each other. Both sources restored byte-identical (sha256).

## Verification

- **10,302 Python tests** across `tests/`, `python/tests/`, `python/djust/tests/` — 0 failed, 219 skipped.
- `make test-rust` green across 44 test binaries (includes 6 new `context::tests` cases).
- `cargo clippy --workspace --all-targets`, `cargo fmt --check`, ruff: clean.
- Branch is 0 commits behind `origin/1.1`.

## Not fixed here

The **over-escape** half — `main`'s #2363 (`{% with body=post.text|linebreaks %}` renders escaped tag text) and #2361 (a `mark_safe` value through `d.values` / `d.items` loses its mark). Both need machinery this branch lacks and are feature changes, not patches. Neither is a leak: both escape *more* than Django, which is the direction to fail in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
