### PR TITLE
chore(release): bump to 1.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "djust_components"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "ahash",
  "criterion",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "djust_core"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "ahash",
  "criterion",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "djust_live"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "bincode",
  "criterion",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "djust_templates"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "ahash",
  "chrono",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "djust_vdom"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "ahash",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 authors = ["djust contributors"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "djust"
-version = "1.1.1"
+version = "1.1.2"
 description = "Phoenix LiveView-style reactive components for Django with Rust-powered performance. Real-time UI updates over WebSocket, no JavaScript build step required."
 authors = [{name = "djust contributors"}]
 readme = "README.md"

--- a/python/djust/__init__.py
+++ b/python/djust/__init__.py
@@ -75,7 +75,7 @@ except ImportError:
     # Rust components not yet built - this is optional
     rust_components = None  # noqa: F841 — accessed as djust.rust_components by user code
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 
 def enable_hot_reload():

--- a/python/djust/components/__init__.py
+++ b/python/djust/components/__init__.py
@@ -33,7 +33,7 @@ descriptors, mixins, rust handlers, gallery).
     python manage.py component_gallery
 """
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 # ---------------------------------------------------------------------------
 # Core component classes (original djust.components)

--- a/uv.lock
+++ b/uv.lock
@@ -591,7 +591,7 @@ wheels = [
 
 [[package]]
 name = "djust"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "channels", extra = ["daphne"] },


### PR DESCRIPTION
Version bump for the 1.1.2 security patch. No tag, nothing published by this PR.

Closes the safety-grant-inheritance XSS left open by 1.1.1 (#2444). Eight live bind shapes were found and fixed — five more than the brief named:

`{% with %}` rebind · `{% with %}` descendant (`{{ p.a }}`) · `{% with %}` over a marked name · `{% for %}` loop var · `{% for %}` descendant · `{% for k, v %}` tuple unpack · `{% include ... with %}` · `{% ... as x %}`

All six version files at 1.1.2. `uv lock` again rewrote all 125 package sources to `127.0.0.1:8418`; reverted, so uv.lock's diff is the single self-entry line.