### PR TITLE
fix(templates): a Value::Encoded carries its attributes, so {{ dt.year }} resolves (#2481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`{{ post.published.year }}` renders `2026` instead of nothing — a `Value::Encoded` carries its attributes (#2481).** Django's `Variable._resolve_lookup` tries three things at every dotted segment: mapping item access, then `getattr`, then an integer index. `context::lookup_segment` implemented steps 1 and 3, and said so in as many words — *"attribute access — see the note above; a `Value` has none"*. So every dotted lookup on a `datetime` / `date` / `time` / `timedelta` resolved to **nothing**, on every path with no raw-Python sidecar — which is every `DjustTemplateBackend` render:
+
+  ```
+  {{ p.year }}    datetime(2026, 3, 4, 5, 6, 7)   django 2026   djust ''
+  {{ p.days }}    timedelta(days=3)               django 3      djust ''
+  ```
+
+  It predates the variant: before #2448 a `datetime` was `Value::String(str(o))`, which has no attributes either. The LiveView path had a partial escape — `crates/djust_live/src/lib.rs` attaches a `raw_py_objects` sidecar, so `{{ dt.year }}` could resolve through `getattr` *there* — and a fallback on one path is not the rule (#1646), which is why the fix is at the carrier rather than at one caller and why `TestBothPathsAgree` asserts the two now answer the same.
+
+  **21 cells, measured against live Django**, through BOTH entry points `python/djust/template/backend.py` binds. `lookup_segment` is the ONE reader of the map, pinned as an equality in both directions so a second dotted-path walker that does not consult it reddens as loudly as a deleted arm (#1125/#1646); `lookup_segment` itself has exactly one caller, pinned the same way. Over the swept attribute surface the mismatch count goes **64 → 41**, and nothing moves into `djust REFUSES & Django RENDERS`.
+
+  **What the map carries is a rule, not a list.** It holds what Python answers WITHOUT a call and WITHOUT recursing. `min` / `max` / `resolution` look like they belong and cannot: their values are values of the same family, and `datetime.min.min is datetime.min` — measured, in `test_the_class_attributes_would_not_terminate` — so a collector that carried them would not terminate. `test_the_name_list_is_the_whole_of_the_policy` fails if they ever enter the table. The nullary methods (`isoformat`, `weekday`, `ctime`, `total_seconds`, `date`, `time`, …) are absent because Django reaches them through its auto-call (ADR-024), which turns a LOOKUP into an EVALUATION — eager at conversion time, paid whether or not a template asks, and inheriting whatever the call raises. Both families are pinned in the DIVERGING direction and filed as #2485; `Decimal` is `Value::Decimal`, a different carrier with no attribute slot, and is filed as #2486.
+
+  **Wire.** The `ENCODED_TAG` payload grows to a **ninth** positional slot, appended, written unconditionally as a map — an empty one costs a byte and the slots stay aligned, which is the choice `cmp_key` makes one slot over and for the same reason (#1541). The reader accepts 9 / 8 / 6 / 4 / 3, and an older width restores NO attributes: the answer that entry was written with. Carrying it is what makes the fix survive a cache hit — `SerializableViewState.state` round-trips through msgpack on every read of the default `InMemoryStateBackend`, so without the slot `{{ dt.year }}` would answer once and go empty afterwards, the reopening `ENCODED_TAG` has now prevented four times. `crates/djust_core/tests/test_encoded_wire_positions_2471_2472.rs` grows the slot-9 pins: a 13-shape sweep of what the map can hold, order, the empty map, a malformed slot, and a key↔attrs SWAP — which neither changes the payload's width nor trips any type check, so only the values can catch it.
+
+  **`Encoded`'s derived `PartialEq` becomes a hand-written one.** The map holds `Value`s and `Value` deliberately has no `PartialEq`: Django's `==` for a template value is `renderer::values_equal`, which equates `1` with `1.0` and asks `python_partial_cmp` for this family. Deriving a second `==` onto `Value` would put a structural answer one keystroke from every site that wants the Django one — two mechanisms for one question (#1646) — so the structural comparison is reachable by NAME only, as `values_structurally_equal`, with `test_every_variant_is_structurally_equal_to_its_own_clone` so a new variant cannot land on its wildcard unnoticed.
+
+  **Surfaced rather than folded in (#1079).** `Value::None` and `Value::Missing` are deliberately distinct (#2203) and share ONE msgpack `nil`, so every `None` in state comes back as `Missing` and renders `''` after one cache hit. Pre-existing and general — pinned with a plain `Value::Object` losing it too, which is what makes "pre-existing" a measurement — and filed as #2484.
+
+  Regression coverage: 143 cases in `python/tests/test_encoded_attributes_2481.py`; new cases in `test_encoded_wire_positions_2471_2472.rs`. Gate-off verified against four independent reverts (the reader, the producer, the wire write, the wire read), each asserting the mutation matched exactly once, the source changed, the `.so` mtime advanced and `__pycache__` was cleared, and counting collection errors apart from failures.
 
 
 ### Changed

--- a/crates/djust_core/src/context.rs
+++ b/crates/djust_core/src/context.rs
@@ -64,12 +64,20 @@ pub fn template_builtin(name: &str) -> Option<Value> {
 /// runs first. Reversing these two arms passes every single-key test and
 /// fails that one.
 ///
-/// **Step 2 has no counterpart here and needs none.** A [`Value`] is inert
-/// data with no attributes; the attribute step belongs to the raw-Python
-/// sidecar walk in [`Context::resolve`], which has done all three in this
-/// order since #1997. That walk is this one's parallel path (CLAUDE.md
-/// #1646) — one had Django's rule and its twin did not, which is the drift
-/// this helper exists to end. State it once, call it from both spellings.
+/// **Step 2 reaches exactly one variant, and used to reach none** (#2481).
+/// A [`Value`] is inert data with no attributes — except a
+/// [`Value::Encoded`], which exists precisely because a Python object could
+/// not cross, and which since #2481 carries the object's attributes by name
+/// alongside its `display` / `json` / `truthy` spellings. So
+/// `{{ dt.year }}` resolves here rather than only on the paths that happen to
+/// have a raw-Python sidecar.
+///
+/// That sidecar walk in [`Context::resolve`] is this one's parallel path
+/// (CLAUDE.md #1646) — it has done all three steps in this order since #1997,
+/// and it is attached only when a top-level context key holds a raw Python
+/// object, which no `DjustTemplateBackend` render does. One walk had Django's
+/// attribute step and its twin did not; that is the drift #2481 closes, in
+/// the same helper #2371 wrote to close the SPELLING half of it.
 ///
 /// A [`Value::DictView`] is deliberately absent from step 3: Python's
 /// `dict_items` is not subscriptable, Django's `current[int(bit)]` raises on
@@ -94,7 +102,28 @@ fn lookup_segment<'a>(current: &'a Value, part: &str) -> Option<&'a Value> {
         }
     }
 
-    // (2) attribute access — see the note above; a `Value` has none.
+    // (2) attribute access. ONE variant carries attributes — a
+    //     `Value::Encoded`, which holds a Python object by the spellings
+    //     measured at the PyO3 boundary and, since #2481, by its attribute map
+    //     as well. `{{ post.published.year }}` is an ordinary Django idiom and
+    //     rendered the EMPTY STRING on every path with no raw-Python sidecar,
+    //     which is every `DjustTemplateBackend` render.
+    //
+    //     This is the ONE reader of `Encoded::attrs`. Every other variant is
+    //     inert data with no attributes, so the step is genuinely absent for
+    //     them rather than unimplemented — a `Value::Object` answers the same
+    //     names through step 1 above, which is Django's own order.
+    //
+    //     BEFORE step 3, which is Django's order: `_resolve_lookup` tries
+    //     `getattr` before `current[int(bit)]`. Unobservable for an `Encoded`
+    //     today (it has no index arm below, and none of the carried names
+    //     parses as an integer) and correct anyway, so the two cannot come
+    //     apart if either set grows.
+    if let Value::Encoded(encoded) = current {
+        if let Some(found) = encoded.attrs.get(part) {
+            return Some(found);
+        }
+    }
 
     // (3) integer index. `int(bit)`, so `"007"` is the index 7, and a segment
     //     that is not an integer at all stops the walk here as Django's

--- a/crates/djust_core/src/lib.rs
+++ b/crates/djust_core/src/lib.rs
@@ -317,7 +317,7 @@ pub enum Value {
 
 /// The payload of [`Value::Encoded`] (#2448). Boxed there to keep `Value`'s
 /// size unchanged — a `Value` is cloned per context entry per render.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Encoded {
     /// CPython's `tp_name` for the type, as it appears in a `TypeError`
     /// message: `datetime.datetime`, `datetime.date`, `datetime.time`,
@@ -393,7 +393,78 @@ pub struct Encoded {
     /// (#2471). `None` only where Python could not be asked — see
     /// [`Encoded::python_partial_cmp`], which is the ONE place this is read.
     pub cmp_key: Option<CmpKey>,
+    /// The object's ATTRIBUTES, by name, measured at the conversion (#2481).
+    ///
+    /// Django's `Variable._resolve_lookup` tries mapping access, then
+    /// `getattr`, then an integer index at every dotted segment. A `Value` is
+    /// inert data with no attributes, so djust's `context::lookup_segment` had
+    /// no step 2 at all and `{{ post.published.year }}` — an ordinary Django
+    /// idiom — rendered the EMPTY STRING on every path with no raw-Python
+    /// sidecar, which is every `DjustTemplateBackend` render. This map is that
+    /// step's answer: `lookup_segment` reads it, and it is the ONE reader.
+    ///
+    /// **Collected by NAME, not by bulk dump.** A `datetime` is a C type: it
+    /// has no `__dict__`, so the `__dict__` arm of `FromPyObject` never reached
+    /// `.year` and never could. [`ENCODED_ATTR_NAMES`] states the per-type list
+    /// and is the whole of the policy.
+    ///
+    /// **`min` / `max` / `resolution` are deliberately absent, and the reason
+    /// is not taste.** They are class attributes whose values are themselves
+    /// `datetime`s, so collecting them would convert a `datetime` whose own
+    /// `min` is a `datetime` — `datetime.min.min is datetime.min` is `True` —
+    /// and the conversion would not terminate. Measured, not reasoned about.
+    /// So `{{ p.max }}` stays empty where Django renders it; that cell is
+    /// unchanged by this field rather than closed by it, and is recorded as
+    /// such rather than quietly widened.
+    ///
+    /// **Nullary METHODS are absent too** — `isoformat`, `weekday`, `ctime`,
+    /// `total_seconds`, `date`, `time`. Django reaches them through its
+    /// auto-call (ADR-024), which turns a lookup into an EVALUATION; putting a
+    /// call's result in this map would make the whole family eager at
+    /// conversion time, pay for it on every render whether or not a template
+    /// asks, and inherit whatever the call raises. A different mechanism, so a
+    /// different decision — filed rather than folded in.
+    ///
+    /// Keyed by [`ObjectKey`] rather than `String` so the map IS a
+    /// [`Value::Object`]'s map: the same `get(part)` `lookup_segment` already
+    /// makes for step 1, and the same thing on the wire.
+    pub attrs: IndexMap<ObjectKey, Value>,
 }
+
+/// The attribute names carried on a [`Value::Encoded`] for each of the four
+/// `DjangoJSONEncoder` types (#2481).
+///
+/// The per-type lists Python answers WITHOUT being called and WITHOUT
+/// recursing — see the [`Encoded::attrs`] doc for why `min` / `max` /
+/// `resolution` and the nullary methods are not here. Keyed by the `tp_name`
+/// [`django_json_encoded`] has already resolved, so the lookup is one string
+/// compare over four entries rather than a second `isinstance` sweep.
+///
+/// `datetime.datetime` is a `datetime.date` SUBCLASS and gets the longer list,
+/// because [`django_json_encoded`] matches `datetime` first — the same
+/// ordering, in the same order, for the same reason.
+pub const ENCODED_ATTR_NAMES: &[(&str, &[&str])] = &[
+    (
+        "datetime.datetime",
+        &[
+            "year",
+            "month",
+            "day",
+            "hour",
+            "minute",
+            "second",
+            "microsecond",
+            "fold",
+            "tzinfo",
+        ],
+    ),
+    ("datetime.date", &["year", "month", "day"]),
+    (
+        "datetime.time",
+        &["hour", "minute", "second", "microsecond", "fold", "tzinfo"],
+    ),
+    ("datetime.timedelta", &["days", "seconds", "microseconds"]),
+];
 
 /// A [`Encoded`] value's position in Python's ordering (#2471).
 ///
@@ -459,6 +530,102 @@ pub const CMP_DOMAIN_DATETIME_AWARE: u8 = 4;
 /// A `time` whose `utcoffset()` is `None`. There is deliberately no aware-time
 /// domain — see the `datetime.time` arm of [`comparison_key`].
 pub const CMP_DOMAIN_TIME_NAIVE: u8 = 5;
+
+/// STRUCTURAL equality for two [`Encoded`]s — every carried spelling, plus the
+/// attribute map (#2481).
+///
+/// Hand-written rather than derived because [`Encoded::attrs`] holds `Value`s
+/// and [`Value`] deliberately has NO `PartialEq`: Django's `==` for a template
+/// value is `renderer::values_equal`, which equates `1` with `1.0` and asks
+/// [`Encoded::python_partial_cmp`] for this family. Deriving a second `==` onto
+/// `Value` would put a structural answer one keystroke away from every site
+/// that wants the Django one — two mechanisms for one question, which is the
+/// #1646 shape. So the structural comparison is reachable by NAME only, through
+/// [`values_structurally_equal`], and this impl is its one caller.
+///
+/// What this is for: pinning that a value survived a round trip unchanged. It
+/// is NOT `{% if a == b %}`.
+impl PartialEq for Encoded {
+    fn eq(&self, other: &Self) -> bool {
+        self.type_name == other.type_name
+            && self.display == other.display
+            && self.json == other.json
+            && self.truthy == other.truthy
+            && self.sized_empty == other.sized_empty
+            && self.iterable == other.iterable
+            && self.repr == other.repr
+            && self.cmp_key == other.cmp_key
+            && self.attrs.len() == other.attrs.len()
+            && self
+                .attrs
+                .iter()
+                .zip(other.attrs.iter())
+                .all(|((ka, va), (kb, vb))| ka == kb && values_structurally_equal(va, vb))
+    }
+}
+
+/// Are these two [`Value`]s the SAME VALUE — same variant, same payload?
+///
+/// **Not Django's `==`.** `renderer::values_equal` is that, and it deliberately
+/// answers differently: `1 == 1.0` is true there and false here, a `Decimal`
+/// compares against an `Integer` there and not here, and two `Encoded`s go
+/// through Python's own ordering. This function answers the round-trip
+/// question instead — "did anything change on the way through the codec" — and
+/// exists because [`Encoded`] carries a map of `Value`s that a wire pin has to
+/// compare.
+///
+/// Every pair is spelled explicitly and the wildcard is LAST, so the distinct
+/// pairs stay distinct: `Missing` is not `None` (#2203), a `List` is not a
+/// `Tuple` (#2276), and a `DictView` is not the `List` of its items (#2340). A
+/// new `Value` variant lands on the wildcard and compares unequal to itself —
+/// which `test_every_variant_is_structurally_equal_to_its_own_clone` turns into
+/// a failure rather than a silent wrong answer.
+///
+/// Float NaN is not equal to itself, as `f64`'s own `==` says. No `Encoded`
+/// attribute is a NaN today; the note is here so the answer is not a surprise.
+pub fn values_structurally_equal(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::Missing, Value::Missing) => true,
+        (Value::None, Value::None) => true,
+        (Value::Bool(a), Value::Bool(b)) => a == b,
+        (Value::Integer(a), Value::Integer(b)) => a == b,
+        (Value::Float(a), Value::Float(b)) => a == b,
+        (Value::String(a), Value::String(b)) => a == b,
+        (Value::Decimal(a), Value::Decimal(b)) => a == b,
+        (Value::BigInt(a), Value::BigInt(b)) => a == b,
+        (Value::List(a), Value::List(b)) | (Value::Tuple(a), Value::Tuple(b)) => {
+            a.len() == b.len()
+                && a.iter()
+                    .zip(b.iter())
+                    .all(|(x, y)| values_structurally_equal(x, y))
+        }
+        (Value::Object(a), Value::Object(b)) => {
+            a.len() == b.len()
+                && a.iter()
+                    .zip(b.iter())
+                    .all(|((ka, va), (kb, vb))| ka == kb && values_structurally_equal(va, vb))
+        }
+        (
+            Value::DictView {
+                kind: ka,
+                items: ia,
+            },
+            Value::DictView {
+                kind: kb,
+                items: ib,
+            },
+        ) => {
+            ka == kb
+                && ia.len() == ib.len()
+                && ia
+                    .iter()
+                    .zip(ib.iter())
+                    .all(|(x, y)| values_structurally_equal(x, y))
+        }
+        (Value::Encoded(a), Value::Encoded(b)) => a == b,
+        _ => false,
+    }
+}
 
 impl Encoded {
     /// Python's answer for `a <op> b`, or `None` where Python refuses (#2471).
@@ -586,6 +753,19 @@ impl Serialize for Value {
                         e.iterable,
                         e.repr.as_str(),
                         e.cmp_key.map(|k| (k.domain, k.hi, k.lo)),
+                        // Slot 9, appended (#2481). A MAP, written
+                        // unconditionally — an empty one costs a byte and the
+                        // slots stay aligned, which is the same choice
+                        // `cmp_key` makes one slot over and for the same
+                        // reason. Carried rather than rebuilt on read because
+                        // `SerializableViewState.state` round-trips through
+                        // msgpack on EVERY read of the state backend and there
+                        // is no interpreter there to re-ask the object: without
+                        // this, `{{ dt.year }}` would answer on the first
+                        // render and go empty again after one cache hit. That
+                        // is the exact reopening `ENCODED_TAG` exists to
+                        // prevent, now for the fourth time.
+                        &e.attrs,
                     ),
                 )?;
                 m.end()
@@ -621,6 +801,32 @@ impl Serialize for Value {
             // encoding to mirror (#2340).
             Value::DictView { items, .. } => items.serialize(serializer),
         }
+    }
+}
+
+/// One [`CmpKey`] slot, read back off the wire (#2471).
+///
+/// `nil` or a three-integer array; anything else is not a payload this crate
+/// wrote, so it reads as ABSENT rather than being guessed at — a value with no
+/// key keeps the pre-#2471 comparison answer, which is the direction to fail
+/// in.
+///
+/// Extracted when #2481 added the ninth slot, so the eight- and nine-element
+/// arms cannot drift apart on how a key is read (#1646). Two copies of this
+/// `match` is the shape where one arm gains a case and the other does not.
+fn decode_cmp_key(key: &Value) -> Option<CmpKey> {
+    let (Value::List(limbs) | Value::Tuple(limbs)) = key else {
+        return None;
+    };
+    match limbs.as_slice() {
+        [Value::Integer(domain), Value::Integer(hi), Value::Integer(lo)] => {
+            u8::try_from(*domain).ok().map(|domain| CmpKey {
+                domain,
+                hi: *hi,
+                lo: *lo,
+            })
+        }
+        _ => None,
     }
 }
 
@@ -746,29 +952,19 @@ impl<'de> Deserialize<'de> for Value {
                     // anything else is a real dict and falls through, so a
                     // user dict under this key cannot forge one.
                     if let Some(Value::List(parts)) = obj.get(ENCODED_TAG) {
-                        // Eight elements: the #2471/#2472 shape, `repr` and
-                        // the comparison key carried after #2466's two bits.
-                        // The key is `nil` or a three-integer array; anything
-                        // else is not one this crate wrote, so it reads as
-                        // absent rather than being guessed at.
-                        if let [Value::String(type_name), Value::String(display), Value::String(json), Value::Bool(truthy), Value::Bool(sized_empty), Value::Bool(iterable), Value::String(repr), key] =
+                        // NINE elements: the #2481 shape, the attribute map
+                        // appended after the comparison key. The map is a real
+                        // msgpack map, so it reads back as a `Value::Object`;
+                        // anything else in that slot reads as NO attributes
+                        // rather than as a guess, which is the same
+                        // fail-to-absent `cmp_key` takes one slot over.
+                        //
+                        // A user dict cannot forge one through this arm: the
+                        // four `_TAG` constants all start with `_`, and every
+                        // producer of this map skips `_`-prefixed names.
+                        if let [Value::String(type_name), Value::String(display), Value::String(json), Value::Bool(truthy), Value::Bool(sized_empty), Value::Bool(iterable), Value::String(repr), key, attrs] =
                             parts.as_slice()
                         {
-                            let cmp_key = match key {
-                                Value::List(limbs) | Value::Tuple(limbs) => {
-                                    match limbs.as_slice() {
-                                        [Value::Integer(domain), Value::Integer(hi), Value::Integer(lo)] => {
-                                            u8::try_from(*domain).ok().map(|domain| CmpKey {
-                                                domain,
-                                                hi: *hi,
-                                                lo: *lo,
-                                            })
-                                        }
-                                        _ => None,
-                                    }
-                                }
-                                _ => None,
-                            };
                             return Ok(Value::Encoded(Box::new(Encoded {
                                 type_name: type_name.clone(),
                                 display: display.clone(),
@@ -777,7 +973,37 @@ impl<'de> Deserialize<'de> for Value {
                                 sized_empty: *sized_empty,
                                 iterable: *iterable,
                                 repr: repr.clone(),
-                                cmp_key,
+                                cmp_key: decode_cmp_key(key),
+                                attrs: match attrs {
+                                    Value::Object(map) => map.clone(),
+                                    _ => IndexMap::new(),
+                                },
+                            })));
+                        }
+                        // Eight elements: the #2471/#2472 shape, `repr` and
+                        // the comparison key carried after #2466's two bits.
+                        // The key is `nil` or a three-integer array; anything
+                        // else is not one this crate wrote, so it reads as
+                        // absent rather than being guessed at.
+                        if let [Value::String(type_name), Value::String(display), Value::String(json), Value::Bool(truthy), Value::Bool(sized_empty), Value::Bool(iterable), Value::String(repr), key] =
+                            parts.as_slice()
+                        {
+                            return Ok(Value::Encoded(Box::new(Encoded {
+                                type_name: type_name.clone(),
+                                display: display.clone(),
+                                json: json.clone(),
+                                truthy: *truthy,
+                                sized_empty: *sized_empty,
+                                iterable: *iterable,
+                                repr: repr.clone(),
+                                cmp_key: decode_cmp_key(key),
+                                // The field THIS width does not carry restores
+                                // to the answer the entry was WRITTEN with: no
+                                // attributes, which is what `{{ dt.year }}`
+                                // resolved to before #2481. A stale entry
+                                // behaves exactly as it did rather than
+                                // half-way between.
+                                attrs: IndexMap::new(),
                             })));
                         }
                         // Six elements: the #2466 shape, `sized_empty` and
@@ -801,6 +1027,7 @@ impl<'de> Deserialize<'de> for Value {
                                 // half-way between.
                                 repr: display.clone(),
                                 cmp_key: None,
+                                attrs: IndexMap::new(),
                             })));
                         }
                         // Four elements: the #2458 shape, `truthy` carried and
@@ -821,6 +1048,7 @@ impl<'de> Deserialize<'de> for Value {
                                 iterable: false,
                                 repr: display.clone(),
                                 cmp_key: None,
+                                attrs: IndexMap::new(),
                             })));
                         }
                         // Three elements: the #2448 shape, still readable
@@ -839,6 +1067,7 @@ impl<'de> Deserialize<'de> for Value {
                                 iterable: false,
                                 repr: display.clone(),
                                 cmp_key: None,
+                                attrs: IndexMap::new(),
                             })));
                         }
                     }
@@ -1003,6 +1232,20 @@ pub fn django_json_encoded(ob: &Bound<'_, PyAny>) -> Option<Encoded> {
     // where a value with no `display` would have nothing to render.
     let cmp_key = comparison_key(ob, tp_name);
 
+    // The attributes Django's lookup step 2 reaches (#2481). Keyed off the
+    // `tp_name` already resolved above rather than a second `isinstance`
+    // sweep — the same value, one string compare over four entries.
+    //
+    // NOT the `type_name` computed just above: that is the SUBCLASS's
+    // `__name__` for a Python-level subclass (`MyDT`), which is right for a
+    // `TypeError` message and wrong as a lookup key here. A `datetime`
+    // subclass has a `datetime`'s attributes.
+    let attrs = ENCODED_ATTR_NAMES
+        .iter()
+        .find(|(name, _)| *name == tp_name)
+        .map(|(_, names)| collect_named_attrs(ob, names))
+        .unwrap_or_default();
+
     Some(Encoded {
         type_name,
         display,
@@ -1015,7 +1258,42 @@ pub fn django_json_encoded(ob: &Bound<'_, PyAny>) -> Option<Encoded> {
         iterable: false,
         repr,
         cmp_key,
+        attrs,
     })
+}
+
+/// `getattr(o, name)` for each `name`, as a [`Value::Object`]'s map (#2481).
+///
+/// The ONE producer of [`Encoded::attrs`]. A name the object does not have, or
+/// whose value will not convert, is SKIPPED rather than stored as `Missing` —
+/// an absent key is what makes `lookup_segment` answer `None` and the render
+/// fall through to the raw-Python sidecar (where there is one) exactly as it
+/// did before this map existed.
+///
+/// Every value is MEASURED off the live object. Not one of these is derivable
+/// from the strings `Encoded` already carries — `str(timedelta(days=3,
+/// seconds=90))` is `"3 days, 0:01:30"` and parsing `.days` back out of it
+/// would be a transcription with a per-value branch, which is the shape #2472
+/// nearly shipped by cloning `display` into `repr`.
+///
+/// The caller decides the names, and that is the whole of the recursion
+/// argument: [`ENCODED_ATTR_NAMES`] lists no attribute whose value is another
+/// object of the same family, so `v.extract::<Value>()` below cannot re-enter
+/// [`django_json_encoded`] on a value that would ask for the same names again.
+/// `datetime.min.min is datetime.min`, so a list containing `min` would not
+/// terminate.
+fn collect_named_attrs(ob: &Bound<'_, PyAny>, names: &[&str]) -> IndexMap<ObjectKey, Value> {
+    let mut map = IndexMap::with_capacity(names.len());
+    for name in names {
+        let Ok(attr) = ob.getattr(*name) else {
+            continue;
+        };
+        let Ok(value) = attr.extract::<Value>() else {
+            continue;
+        };
+        map.insert(ObjectKey::Str((*name).to_string()), value);
+    }
+    map
 }
 
 /// `(days, microseconds-within-the-day)` for a `datetime.timedelta`.
@@ -2147,6 +2425,14 @@ pub fn falsy_opaque(ob: &Bound<'_, PyAny>) -> Option<Encoded> {
         // names and `LenZero() == LenZero()` is False WITHIN one — so no
         // carried spelling decides it. Filed as #2480.
         cmp_key: None,
+        // EMPTY, and that is this arm's gate rather than an omission (#2481).
+        // The values that reach here are the ones the `__dict__` bulk-dump arm
+        // above declined — an object WITH attributes keeps its `Value::Object`,
+        // because moving it to this carrier would take `{{ obj.a }}` with it.
+        // Now that `Encoded` HAS an attribute map that objection is answerable,
+        // and answering it is #2478 — a different decision about a different
+        // set of objects, filed rather than folded in.
+        attrs: IndexMap::new(),
     })
 }
 

--- a/crates/djust_core/tests/test_encoded_wire_positions_2471_2472.rs
+++ b/crates/djust_core/tests/test_encoded_wire_positions_2471_2472.rs
@@ -49,11 +49,13 @@
 //!   5 iterable     #2466
 //!   6 repr         #2472
 //!   7 cmp_key      #2471   nil, or [domain, hi, lo]
+//!   8 attrs        #2481   a MAP of attribute name -> Value
 //! ```
 //!
-//! Every widening APPENDS. That is what lets the reader accept 8, 6, 4 and 3
+//! Every widening APPENDS. That is what lets the reader accept 9, 8, 6, 4 and 3
 //! elements from older writers, and it is why this merge put #2471/#2472's two
-//! fields AFTER #2466's rather than in struct-declaration order.
+//! fields AFTER #2466's rather than in struct-declaration order — and #2481's
+//! after those.
 //!
 //! # Non-vacuity
 //!
@@ -62,6 +64,22 @@
 //! fixture below therefore gives them DISTINCT values, and
 //! `test_a_one_slot_shift_is_detectable` proves the assertions can actually see
 //! a shift rather than merely passing over one.
+//!
+//! Slots 7 and 8 need the same treatment for a different reason: both are
+//! "structured or nil", so a swap between them does NOT change the payload's
+//! width or trip any type check — it silently loses both. The sample therefore
+//! carries a non-empty attribute map AND a key, and
+//! `test_a_swap_of_the_key_and_attribute_slots_is_detectable` proves the
+//! assertions see it.
+//!
+//! # The attribute map's own shape
+//!
+//! It is a msgpack MAP, so it reads back through the same `visit_map` every
+//! other value takes and arrives as a `Value::Object` — which is exactly what
+//! `Encoded::attrs` holds, so there is no second decoding to keep in step. A
+//! user dict cannot forge an `Encoded` through it: the four `_TAG` constants
+//! all begin with `_`, and every producer of this map skips `_`-prefixed
+//! names.
 
 use djust_core::{Encoded, Value};
 
@@ -85,7 +103,28 @@ fn sample() -> Encoded {
             hi: -7,
             lo: 90_000_000,
         }),
+        // NON-EMPTY, and heterogeneous. An empty map is the default every
+        // older width restores to, so a fixture carrying one could not tell
+        // "slot 9 round-tripped" from "slot 9 was dropped" (#2481).
+        attrs: attrs_of(&[
+            ("days", Value::Integer(-7)),
+            ("seconds", Value::Integer(90)),
+            ("microseconds", Value::Integer(0)),
+        ]),
     }
+}
+
+/// An attribute map from `(name, value)` pairs.
+fn attrs_of(pairs: &[(&str, Value)]) -> indexmap::IndexMap<djust_core::ObjectKey, Value> {
+    pairs
+        .iter()
+        .map(|(k, v)| {
+            (
+                djust_core::object_key::ObjectKey::Str((*k).to_string()),
+                v.clone(),
+            )
+        })
+        .collect()
 }
 
 fn round_trip(e: &Encoded) -> Encoded {
@@ -125,17 +164,267 @@ fn parts_of(e: &Encoded) -> Vec<Value> {
         ]),
         None => Value::None,
     });
+    v.push(Value::Object(e.attrs.clone()));
     v
 }
 
 #[test]
-fn the_payload_is_eight_slots_in_the_documented_order() {
+fn the_payload_is_nine_slots_in_the_documented_order() {
     let e = sample();
     // `Value` has no `PartialEq` (the renderer's own tests note it), so match
     // the variant and compare the `Encoded`, which does derive one.
+    assert_eq!(parts_of(&e).len(), 9, "the payload width moved");
     match decode_parts(parts_of(&e)) {
         Value::Encoded(back) => assert_eq!(*back, e),
-        other => panic!("the eight-slot payload did not read as an Encoded: {other:?}"),
+        other => panic!("the nine-slot payload did not read as an Encoded: {other:?}"),
+    }
+}
+
+#[test]
+fn the_attribute_map_carries_every_value_shape_it_can_hold() {
+    // `Encoded::attrs` holds whatever `Value::extract` made of the attribute,
+    // so the codec has to carry every shape a `Value` can be — not just the
+    // integers a `timedelta` happens to produce. #2478 widens the producers to
+    // arbitrary `__dict__` values, which is when the rest of these arrive.
+    //
+    // Sweeping the shapes is what pins that a `Tuple` inside the map keeps its
+    // own tag (#2276) and that `Missing` and `None` stay distinct (#2203) —
+    // both are one `Value` arm away from collapsing.
+    let shapes: Vec<(&str, Value)> = vec![
+        ("int", Value::Integer(-2026)),
+        ("float", Value::Float(1.5)),
+        ("bool", Value::Bool(true)),
+        ("str", Value::String("UTC".to_string())),
+        // `Value::None` is deliberately NOT here — see
+        // `a_none_attribute_comes_back_as_missing_a_pre_existing_codec_gap`.
+        ("missing", Value::Missing),
+        ("decimal", Value::Decimal("1.50".to_string())),
+        (
+            "bigint",
+            Value::BigInt("123456789012345678901234567890".to_string()),
+        ),
+        // The nested elements avoid `Value::None` for the reason
+        // `a_none_attribute_comes_back_as_missing_a_pre_existing_codec_gap`
+        // records — the gap is the CODEC's, not this slot's, and pinning it
+        // once is enough.
+        ("list", Value::List(vec![Value::Integer(1), Value::Missing])),
+        (
+            "tuple",
+            Value::Tuple(vec![Value::Integer(1), Value::Bool(false)]),
+        ),
+        (
+            "object",
+            Value::Object(attrs_of(&[("a", Value::Integer(1))])),
+        ),
+        ("nested_encoded", Value::Encoded(Box::new(sample()))),
+        ("empty_list", Value::List(vec![])),
+        ("empty_object", Value::Object(attrs_of(&[]))),
+    ];
+    let mut checked = 0;
+    for (name, shape) in &shapes {
+        let e = Encoded {
+            attrs: attrs_of(&[(name, shape.clone())]),
+            ..sample()
+        };
+        assert_eq!(round_trip(&e), e, "the {name} attribute did not survive");
+        checked += 1;
+    }
+    assert_eq!(checked, 13, "the shape sweep shrank");
+
+    // And all of them at once, so ORDER is pinned too — the map is an
+    // `IndexMap` because Python's attribute order is what a caller sees, and a
+    // `HashMap` here would reorder per process.
+    let all = Encoded {
+        attrs: attrs_of(
+            &shapes
+                .iter()
+                .map(|(k, v)| (*k, v.clone()))
+                .collect::<Vec<_>>(),
+        ),
+        ..sample()
+    };
+    let back = round_trip(&all);
+    assert_eq!(back, all);
+    assert_eq!(
+        back.attrs.keys().collect::<Vec<_>>(),
+        all.attrs.keys().collect::<Vec<_>>(),
+        "the attribute map came back reordered",
+    );
+}
+
+#[test]
+fn a_none_attribute_comes_back_as_missing_a_pre_existing_codec_gap() {
+    // Pinned in the DIVERGING direction, because it is not this slot's bug and
+    // is not fixed here.
+    //
+    // `impl Serialize for Value` writes `Missing | None` as ONE msgpack `nil`
+    // and `visit_unit` reads every `nil` back as `Missing`. The two variants
+    // are deliberately DISTINCT (#2203) — `None` renders `"None"` and `Missing`
+    // renders `""` — so a `None` anywhere in a value that round-trips through
+    // the state backend comes back rendering the empty string.
+    //
+    // It predates the attribute map and is not reached through it alone: the
+    // second half of this test shows a PLAIN `Value::Object` losing it too, so
+    // `{{ d.a }}` on `{"a": None}` has always answered `None` on the first
+    // render and `""` after one cache hit. #2481 adds one more reachable
+    // instance (`{{ dt.tzinfo }}` on a NAIVE datetime) and improves the
+    // pre-round-trip answer there from `""` to Django's `"None"`; it neither
+    // causes nor worsens the round-trip half. Filed separately.
+    let e = Encoded {
+        attrs: attrs_of(&[("tzinfo", Value::None)]),
+        ..sample()
+    };
+    let back = round_trip(&e);
+    assert!(
+        matches!(back.attrs.get("tzinfo"), Some(Value::Missing)),
+        "the codec gap moved — a None attribute now reads as {:?}",
+        back.attrs.get("tzinfo"),
+    );
+
+    // The same loss, with no `Encoded` involved at all — which is what makes
+    // "pre-existing" a measurement rather than a claim.
+    let plain = Value::Object(attrs_of(&[("a", Value::None)]));
+    let bytes = rmp_serde::to_vec(&plain).expect("encode");
+    match rmp_serde::from_slice::<Value>(&bytes).expect("decode") {
+        Value::Object(map) => assert!(
+            matches!(map.get("a"), Some(Value::Missing)),
+            "a plain Object's None survived — the gap this pins is closed, so \
+             the `none` case belongs back in the shape sweep above",
+        ),
+        other => panic!("expected an Object: {other:?}"),
+    }
+}
+
+#[test]
+fn an_empty_attribute_map_is_written_and_read_as_empty() {
+    // The `falsy_opaque` shape: no attributes, still nine slots. Written
+    // unconditionally rather than skipped, which is what keeps the slots
+    // aligned (#1541).
+    let e = Encoded {
+        attrs: attrs_of(&[]),
+        ..sample()
+    };
+    assert_eq!(parts_of(&e).len(), 9, "an empty map must not drop its slot");
+    assert_eq!(round_trip(&e), e);
+    assert!(round_trip(&e).attrs.is_empty());
+}
+
+#[test]
+fn a_malformed_attribute_slot_reads_as_absent_rather_than_guessed() {
+    // Same fail-to-absent the key slot takes: anything that is not a map is
+    // not a payload this crate wrote, so it restores NO attributes rather than
+    // a guess at some.
+    let e = sample();
+    for bad in [
+        Value::None,
+        Value::String("days=3".to_string()),
+        Value::Integer(3),
+        Value::List(vec![Value::String("days".to_string()), Value::Integer(3)]),
+        Value::Bool(true),
+    ] {
+        let mut parts = parts_of(&e);
+        parts[8] = bad.clone();
+        match decode_parts(parts) {
+            Value::Encoded(back) => assert!(
+                back.attrs.is_empty(),
+                "a malformed attribute slot must read as absent, not as a guess: {bad:?}",
+            ),
+            other => panic!("expected an Encoded: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn a_swap_of_the_key_and_attribute_slots_is_detectable() {
+    // Non-vacuity for slots 7 and 8. Neither is a string or a bool, so a swap
+    // survives every type check the reader makes and the width is unchanged —
+    // the VALUES are the only thing that can catch it. Both are therefore
+    // non-default in `sample()`, and both must come back wrong.
+    let e = sample();
+    assert!(
+        e.cmp_key.is_some() && !e.attrs.is_empty(),
+        "the sample stopped distinguishing the key and attribute slots",
+    );
+    let mut swapped = parts_of(&e);
+    swapped.swap(7, 8);
+    match decode_parts(swapped) {
+        Value::Encoded(back) => {
+            assert_ne!(
+                *back, e,
+                "a swap of the key and attribute slots was invisible"
+            );
+            assert_eq!(back.cmp_key, None, "a map must not read as a key");
+            assert!(back.attrs.is_empty(), "a key must not read as attributes");
+        }
+        other => panic!("expected an Encoded with both slots lost: {other:?}"),
+    }
+}
+
+#[test]
+fn every_variant_is_structurally_equal_to_its_own_clone() {
+    // `values_structurally_equal`'s wildcard arm is LAST, so a `Value` variant
+    // added without an arm compares UNEQUAL TO ITSELF — and every `assert_eq!`
+    // in this file is written against that comparison. One case per variant,
+    // so the omission fails HERE, once, rather than as a confusing round-trip
+    // failure somewhere else.
+    let every: Vec<(&str, Value)> = vec![
+        ("Missing", Value::Missing),
+        ("None", Value::None),
+        ("Bool", Value::Bool(false)),
+        ("Integer", Value::Integer(0)),
+        ("Float", Value::Float(0.0)),
+        ("String", Value::String(String::new())),
+        ("Decimal", Value::Decimal("0".to_string())),
+        ("BigInt", Value::BigInt("0".to_string())),
+        ("List", Value::List(vec![Value::Integer(1)])),
+        ("Tuple", Value::Tuple(vec![Value::Integer(1)])),
+        (
+            "Object",
+            Value::Object(attrs_of(&[("a", Value::Integer(1))])),
+        ),
+        (
+            "DictView",
+            Value::DictView {
+                kind: djust_core::DictViewKind::Items,
+                items: vec![Value::Integer(1)],
+            },
+        ),
+        ("Encoded", Value::Encoded(Box::new(sample()))),
+    ];
+    for (name, v) in &every {
+        assert!(
+            djust_core::values_structurally_equal(v, &v.clone()),
+            "{name} is not structurally equal to its own clone — it has no arm",
+        );
+    }
+
+    // And the pairs that must stay DISTINCT, each of which is a decision a
+    // careless arm would undo.
+    for (label, a, b) in [
+        ("Missing vs None (#2203)", Value::Missing, Value::None),
+        (
+            "List vs Tuple (#2276)",
+            Value::List(vec![Value::Integer(1)]),
+            Value::Tuple(vec![Value::Integer(1)]),
+        ),
+        (
+            "DictView vs its items (#2340)",
+            Value::DictView {
+                kind: djust_core::DictViewKind::Items,
+                items: vec![Value::Integer(1)],
+            },
+            Value::List(vec![Value::Integer(1)]),
+        ),
+        (
+            "Integer vs Float — NOT Django's == (values_equal says equal)",
+            Value::Integer(1),
+            Value::Float(1.0),
+        ),
+    ] {
+        assert!(
+            !djust_core::values_structurally_equal(&a, &b),
+            "{label}: these must not compare structurally equal",
+        );
     }
 }
 
@@ -232,13 +521,21 @@ fn a_one_slot_shift_is_detectable() {
         "the sample stopped distinguishing the three boolean slots",
     );
     let mut shifted = parts_of(&e);
-    shifted.remove(4); // now 7 elements: no width matches, so it is NOT an Encoded
+    // Now EIGHT elements — which since #2471/#2472 is a real width, so this
+    // case no longer refuses on width alone. It refuses on TYPES: with slot 4
+    // gone, `iterable` (a bool) sits where `sized_empty` belongs and `repr` (a
+    // string) sits where `iterable` belongs, and the eight-arm's pattern wants
+    // a bool there. That is a stronger statement than the width check it was,
+    // and it is why the assertion is spelled as "not an Encoded" rather than
+    // "wrong width".
+    shifted.remove(4);
+    assert_eq!(shifted.len(), 8, "the shifted payload must be a REAL width");
     match decode_parts(shifted) {
         Value::Object(_) => {}
-        other => panic!("a 7-element payload must not forge an Encoded: {other:?}"),
+        other => panic!("a type-misaligned 8-element payload must not forge an Encoded: {other:?}"),
     }
 
-    // And the sharper case: keep the width at 8 but SWAP two boolean slots.
+    // And the sharper case: keep the width at 9 but SWAP two boolean slots.
     // Every type still matches, so only the VALUES can catch it.
     let mut swapped = parts_of(&e);
     swapped.swap(4, 5);
@@ -256,6 +553,25 @@ fn the_older_widths_still_read_with_the_documented_fallbacks() {
     let e = sample();
     let full = parts_of(&e);
 
+    // EIGHT — the #2471/#2472 shape: everything but the attribute map, which
+    // restores EMPTY. `{{ dt.year }}` resolved to nothing before #2481, so an
+    // entry written by that build keeps answering exactly what it answered
+    // rather than half-way between.
+    match decode_parts(full[..8].to_vec()) {
+        Value::Encoded(back) => {
+            assert_eq!(back.repr, e.repr);
+            assert_eq!(
+                back.cmp_key, e.cmp_key,
+                "an 8-element read must keep the key"
+            );
+            assert!(
+                back.attrs.is_empty(),
+                "an 8-element read must not invent attributes"
+            );
+        }
+        other => panic!("8 elements must read: {other:?}"),
+    }
+
     // SIX — the #2466 shape: `repr` falls back to `display`, no key.
     match decode_parts(full[..6].to_vec()) {
         Value::Encoded(back) => {
@@ -267,6 +583,7 @@ fn the_older_widths_still_read_with_the_documented_fallbacks() {
                 "a 6-element read must not invent a repr"
             );
             assert_eq!(back.cmp_key, None, "a 6-element read must not invent a key");
+            assert!(back.attrs.is_empty());
         }
         other => panic!("6 elements must read: {other:?}"),
     }
@@ -278,6 +595,7 @@ fn the_older_widths_still_read_with_the_documented_fallbacks() {
             assert!(!back.sized_empty && !back.iterable);
             assert_eq!(back.repr, e.display);
             assert_eq!(back.cmp_key, None);
+            assert!(back.attrs.is_empty());
         }
         other => panic!("4 elements must read: {other:?}"),
     }
@@ -288,13 +606,16 @@ fn the_older_widths_still_read_with_the_documented_fallbacks() {
             assert_eq!(back.truthy, !e.display.is_empty());
             assert_eq!(back.repr, e.display);
             assert_eq!(back.cmp_key, None);
+            assert!(back.attrs.is_empty());
         }
         other => panic!("3 elements must read: {other:?}"),
     }
 
     // FIVE and SEVEN are NOT shapes this crate ever wrote, so they must fall
     // through to a plain dict rather than being read as a truncated Encoded —
-    // which is what keeps a user dict under this key from forging one.
+    // which is what keeps a user dict under this key from forging one. (One,
+    // two and zero are covered by the same rule and are not spelled out; the
+    // interesting widths are the ones ADJACENT to a real shape.)
     for n in [5usize, 7] {
         match decode_parts(full[..n].to_vec()) {
             Value::Object(_) => {}
@@ -349,9 +670,26 @@ fn test_no_field_is_conditionally_skipped() {
     );
     // And `Encoded`/`CmpKey` still do not derive their own encodings, which is
     // what makes the hand-written tuple above the single source of the shape.
-    assert!(
-        !src.contains("#[derive(Debug, Clone, PartialEq, Serialize"),
-        "`Encoded` gained a derived Serialize — the payload order is now in two \
-         places",
+    // `Encoded` derives NEITHER a Serialize nor (since #2481) a PartialEq:
+    // the encoding is the hand-written tuple, and the equality is the
+    // hand-written impl that compares the attribute map through
+    // `values_structurally_equal`. Pinned as the exact derive line, so a
+    // future `#[derive(..., Serialize)]` in ANY field order trips it.
+    let derive_line = src
+        .split("pub struct Encoded {")
+        .next()
+        .expect("the source has a `pub struct Encoded`")
+        .trim_end()
+        .lines()
+        .last()
+        .expect("a derive line above `pub struct Encoded`")
+        .trim()
+        .to_string();
+    assert_eq!(
+        derive_line, "#[derive(Debug, Clone)]",
+        "`Encoded`'s derives moved. A derived Serialize would put the payload \
+         order in two places; a derived PartialEq cannot compile against \
+         `attrs` (a `Value` has no `PartialEq`, deliberately — see \
+         `values_structurally_equal`).",
     );
 }

--- a/crates/djust_templates/src/filters.rs
+++ b/crates/djust_templates/src/filters.rs
@@ -6852,6 +6852,7 @@ mod tests {
                     hi: 737425,
                     lo: 11_045_000_000,
                 }),
+                attrs: Default::default(),
             })),
             Value::Encoded(Box::new(djust_core::Encoded {
                 type_name: "set".to_string(),
@@ -6862,6 +6863,7 @@ mod tests {
                 iterable: true,
                 repr: "set()".to_string(),
                 cmp_key: None,
+                attrs: Default::default(),
             })),
             // The THIRD shape, and the one that proves the two bits are two
             // questions: a class with a zero `__len__` and no `__iter__`.
@@ -6877,6 +6879,7 @@ mod tests {
                 iterable: false,
                 repr: "<LenZero object>".to_string(),
                 cmp_key: None,
+                attrs: Default::default(),
             })),
         ]
     }
@@ -7308,6 +7311,7 @@ mod tests {
                     hi: 737425,
                     lo: 11_045_000_000,
                 }),
+                attrs: Default::default(),
             })),
             // The SAME variant on the ITERATING side (#2466), which is why one
             // sample of it is no longer enough. Since `falsy_opaque` widened
@@ -7332,6 +7336,7 @@ mod tests {
                 // No key: `python_partial_cmp` must answer `None` for every
                 // pair either side of which came from `falsy_opaque` (#2471).
                 cmp_key: None,
+                attrs: Default::default(),
             })),
         ];
         // The hostile-display member, kept OUT of the array above so the
@@ -7347,6 +7352,7 @@ mod tests {
             iterable: false,
             repr: "<script>alert(1)</script>".to_string(),
             cmp_key: None,
+            attrs: Default::default(),
         }));
         assert!(
             iter_values(&hostile).is_none(),

--- a/crates/djust_templates/src/renderer.rs
+++ b/crates/djust_templates/src/renderer.rs
@@ -5906,6 +5906,7 @@ mod tests {
                     hi: 737425,
                     lo: 11_045_000_000,
                 }),
+                attrs: Default::default(),
             })),
             // A `set()`: `len` 0 and iterable, so both probes say
             // "iterates to nothing".
@@ -5918,6 +5919,7 @@ mod tests {
                 iterable: true,
                 repr: "set()".to_string(),
                 cmp_key: None,
+                attrs: Default::default(),
             })),
             // A zero-`__len__` class with no `__iter__`: `{% for %}` renders
             // the empty branch, `iter_values` refuses. The one sample that
@@ -5931,6 +5933,7 @@ mod tests {
                 iterable: false,
                 repr: "<LenZero object>".to_string(),
                 cmp_key: None,
+                attrs: Default::default(),
             })),
         ];
         // `Value::None` and `Value::Missing` are Django's `values is None`

--- a/python/tests/test_encoded_attributes_2481.py
+++ b/python/tests/test_encoded_attributes_2481.py
@@ -1,0 +1,575 @@
+"""`{{ dt.year }}` resolves — a `Value::Encoded` carries its attributes (#2481).
+
+The divergence
+--------------
+Django's ``Variable._resolve_lookup`` tries three things per dotted segment:
+mapping item access, then ``getattr``, then an integer index. djust's
+``context::lookup_segment`` implemented steps 1 and 3 and said so in as many
+words — *"attribute access — see the note above; a `Value` has none"*. So every
+dotted lookup on a ``datetime`` / ``date`` / ``time`` / ``timedelta`` resolved
+to NOTHING::
+
+    {{ p.year }}    datetime(2026, 3, 4)   django 2026   djust ''
+    {{ p.days }}    timedelta(days=3)      django 3      djust ''
+
+``{{ post.published.year }}`` is an ordinary Django idiom and it rendered the
+empty string.
+
+Which paths, measured rather than reasoned about
+-------------------------------------------------
+* The ``DjustTemplateBackend`` path is affected, and every case below is
+  measured through BOTH ``render_template`` and ``render_template_with_dirs``
+  — the entry points ``python/djust/template/backend.py`` binds. They are one
+  sink (``Context::get`` → ``lookup_segment``), and asserting both is what
+  keeps that a measurement.
+* The LiveView path had a partial escape: ``crates/djust_live/src/lib.rs``
+  attaches a ``raw_py_objects`` sidecar, so ``{{ dt.year }}`` could resolve
+  through ``getattr`` THERE. A fallback on one path is not the rule (#1646),
+  and the fix is at the carrier rather than at one caller — which is why
+  ``TestBothPathsAgree`` asserts the sidecar path answers the same.
+* It predates ``Value::Encoded``: before #2448 a ``datetime`` was
+  ``Value::String(str(o))``, which has no attributes either.
+
+What this closes, and what it deliberately does not
+-----------------------------------------------------
+The map carries the attributes Python answers WITHOUT being called and WITHOUT
+recursing. Two families stay divergent and are pinned below in the diverging
+direction rather than quietly widened:
+
+* **class attributes** ``min`` / ``max`` / ``resolution``. Their values are
+  themselves ``datetime``s, and ``datetime.min.min is datetime.min`` — so
+  collecting them would not terminate. Measured, in
+  ``test_the_class_attributes_would_not_terminate``.
+* **nullary methods** ``isoformat`` / ``weekday`` / ``ctime`` /
+  ``total_seconds`` / ``date`` / ``time`` / ``utcoffset`` / ``tzname`` /
+  ``dst`` / ``toordinal`` / ``timetuple`` / ``timestamp``. Django reaches these
+  through its auto-call (ADR-024), which turns a lookup into an EVALUATION.
+  Putting a call's result in the map makes the whole family eager at conversion
+  time, pays for it whether or not a template asks, and inherits whatever the
+  call raises. A different mechanism, so a different decision.
+
+``Decimal`` is a different CARRIER (``Value::Decimal``, not ``Encoded``), so
+``{{ d.real }}`` is untouched here and pinned as still-divergent.
+
+Every expectation is LIVE Django and LIVE Python, never a transcription.
+
+Refs #2481, #2478, #2466, #2458, #2448, #2371, #1541, #1646, #1079.
+"""
+
+from __future__ import annotations
+
+import datetime
+import decimal
+import pathlib
+import re
+import zoneinfo
+
+import pytest
+
+pytest.importorskip("django")
+
+from django.template import Context as DjangoContext  # noqa: E402
+from django.template import Template as DjangoTemplate  # noqa: E402
+
+from djust import _rust  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+CORE_RS = REPO / "crates" / "djust_core" / "src" / "lib.rs"
+CONTEXT_RS = REPO / "crates" / "djust_core" / "src" / "context.rs"
+
+
+def django_render(source: str, context: dict) -> str:
+    try:
+        return DjangoTemplate(source).render(DjangoContext(dict(context)))
+    except Exception:  # noqa: BLE001 — the refusal IS the answer
+        return "<<REFUSED>>"
+
+
+def djust_render(source: str, context: dict) -> str:
+    try:
+        return _rust.render_template(source, dict(context))
+    except Exception:  # noqa: BLE001
+        return "<<REFUSED>>"
+
+
+def self_round_trip(source: str, value: object) -> str:
+    """Render after a msgpack state round trip — what the default
+    `InMemoryStateBackend` does on every read."""
+    from djust._rust import RustLiveView
+
+    view = RustLiveView(source)
+    view.set_state("p", value)
+    return RustLiveView.deserialize_msgpack(view.serialize_msgpack()).render()
+
+
+def djust_render_with_dirs(source: str, context: dict) -> str:
+    """The OTHER entry point `DjustTemplateBackend` binds."""
+    try:
+        return _rust.render_template_with_dirs(source, dict(context), [])
+    except Exception:  # noqa: BLE001
+        return "<<REFUSED>>"
+
+
+DT = datetime.datetime(2026, 3, 4, 5, 6, 7, 8)
+DATE = datetime.date(2026, 3, 4)
+TIME = datetime.time(5, 6, 7, 8)
+TD = datetime.timedelta(days=3, seconds=90, microseconds=5)
+AWARE = datetime.datetime(2026, 3, 4, 5, 6, 7, tzinfo=datetime.timezone.utc)
+ZONED = datetime.datetime(2026, 3, 4, tzinfo=zoneinfo.ZoneInfo("America/New_York"))
+
+#: `(label, value, attribute)` for every attribute the map carries. Named per
+#: TYPE rather than swept off one value, because each type has a DIFFERENT list
+#: and a fix that served only `datetime` would look complete against a sweep
+#: that only fed it datetimes (#1104).
+CLOSED = [
+    *[
+        pytest.param(DT, a, id=f"datetime-{a}")
+        for a in (
+            "year",
+            "month",
+            "day",
+            "hour",
+            "minute",
+            "second",
+            "microsecond",
+            "fold",
+            "tzinfo",
+        )
+    ],
+    *[pytest.param(DATE, a, id=f"date-{a}") for a in ("year", "month", "day")],
+    *[
+        pytest.param(TIME, a, id=f"time-{a}")
+        for a in ("hour", "minute", "second", "microsecond", "fold", "tzinfo")
+    ],
+    *[pytest.param(TD, a, id=f"timedelta-{a}") for a in ("days", "seconds", "microseconds")],
+    *[pytest.param(AWARE, a, id=f"aware-{a}") for a in ("year", "hour", "tzinfo")],
+    *[pytest.param(ZONED, a, id=f"zoneinfo-{a}") for a in ("year", "tzinfo")],
+]
+
+#: Class attributes. Django renders them; the map cannot carry them because
+#: their values are the same type and the collection would not terminate.
+CLASS_ATTRS = (
+    [pytest.param(DT, a, id=f"datetime-{a}") for a in ("min", "max", "resolution")]
+    + [pytest.param(DATE, a, id=f"date-{a}") for a in ("min", "max", "resolution")]
+    + [pytest.param(TIME, a, id=f"time-{a}") for a in ("min", "max", "resolution")]
+    + [pytest.param(TD, a, id=f"timedelta-{a}") for a in ("min", "max", "resolution")]
+)
+
+#: Nullary methods. Django AUTO-CALLS them; the map holds lookups, not calls.
+METHODS = [
+    *[
+        pytest.param(DT, a, id=f"datetime-{a}")
+        for a in (
+            "date",
+            "time",
+            "weekday",
+            "isoformat",
+            "toordinal",
+            "ctime",
+            "timetuple",
+            "utcoffset",
+            "tzname",
+            "dst",
+            "timestamp",
+        )
+    ],
+    *[
+        pytest.param(DATE, a, id=f"date-{a}")
+        for a in ("weekday", "isoformat", "toordinal", "ctime", "timetuple")
+    ],
+    *[pytest.param(TIME, a, id=f"time-{a}") for a in ("isoformat", "utcoffset", "tzname", "dst")],
+    *[pytest.param(TD, a, id=f"timedelta-{a}") for a in ("total_seconds",)],
+]
+
+
+class TestTheCitedDivergenceIsClosed:
+    """The issue's table, per type, through both entry points."""
+
+    @pytest.mark.parametrize(("value", "attr"), CLOSED)
+    def test_the_attribute_renders_exactly_as_django_renders_it(
+        self, value: object, attr: str
+    ) -> None:
+        source = "{{ p.%s }}" % attr
+        expected = django_render(source, {"p": value})
+        # Non-vacuity for the row itself: an attribute Django ALSO renders
+        # empty would make the assertion below pass without the fix.
+        assert expected != "", f"Django renders nothing for .{attr} — bad row"
+        assert djust_render(source, {"p": value}) == expected
+        assert djust_render_with_dirs(source, {"p": value}) == expected
+
+    def test_the_issues_own_two_headline_cells(self) -> None:
+        """Spelled out verbatim so the issue's claim has a named assertion."""
+        assert django_render("{{ p.year }}", {"p": DT}) == "2026"
+        assert djust_render("{{ p.year }}", {"p": DT}) == "2026"
+        assert django_render("{{ p.days }}", {"p": datetime.timedelta(days=3)}) == "3"
+        assert djust_render("{{ p.days }}", {"p": datetime.timedelta(days=3)}) == "3"
+
+
+class TestTheValueIsAnINTNotItsSpelling:
+    """A carried attribute has to be the Python value, or every consumer that
+    is not `{{ }}` answers differently from Django.
+
+    The cheap wrong fix — carrying `str(getattr(o, name))` — renders the same
+    and fails all of these.
+    """
+
+    @pytest.mark.parametrize(
+        ("source", "value"),
+        [
+            ("{% if p.year > 2000 %}T{% else %}F{% endif %}", DT),
+            ("{% if p.year < 2000 %}T{% else %}F{% endif %}", DT),
+            ("{{ p.days|add:1 }}", TD),
+            ("{{ p.month|divisibleby:3 }}", DT),
+            ("{{ p.microsecond|stringformat:'05d' }}", DT),
+            ("{% if p.fold %}T{% else %}F{% endif %}", DT),
+            ("{% if p.tzinfo %}T{% else %}F{% endif %}", DT),
+            ("{% if p.tzinfo %}T{% else %}F{% endif %}", AWARE),
+        ],
+    )
+    def test_the_operand_channels_agree_with_django(self, source: str, value: object) -> None:
+        assert djust_render(source, {"p": value}) == django_render(source, {"p": value})
+
+    def test_a_string_spelling_would_have_failed_the_comparison(self) -> None:
+        """Why the assertions above are not decoration: the string spelling of
+        the same attribute answers a DIFFERENT `{% if %}`."""
+        source = "{% if p > 2000 %}T{% else %}F{% endif %}"
+        assert django_render(source, {"p": 2026}) == "T"
+        assert djust_render(source, {"p": 2026}) == "T"
+        assert djust_render(source, {"p": "2026"}) == "F"
+
+
+class TestWhereTheAttributeIsREACHED:
+    """The lookup is one segment of a walk, so it has to work at depth, in a
+    loop, and under the constructs that resolve through the other resolver
+    (`renderer::get_value_safe`, #1646)."""
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "{{ d.when.year }}",
+            "{% for x in rows %}{{ x.year }}|{% endfor %}",
+            "{% with y=d.when.year %}{{ y }}{% endwith %}",
+            "{% if d.when.year %}{{ d.when.year }}{% endif %}",
+            "{% firstof d.when.year %}",
+            "{{ rows.0.year }}",
+            "{{ d.when.year|add:1 }}",
+        ],
+    )
+    def test_every_operand_channel_reaches_it(self, source: str) -> None:
+        ctx = {"d": {"when": DT}, "rows": [DT, DATE]}
+        expected = django_render(source, ctx)
+        assert expected != "", source
+        assert djust_render(source, ctx) == expected
+        assert djust_render_with_dirs(source, ctx) == expected
+
+    def test_a_datetime_SUBCLASS_gets_the_datetime_list(self) -> None:
+        """The name list is keyed off the `tp_name` `django_json_encoded`
+        resolved, NOT off the `type_name` it carries — which for a Python-level
+        subclass is the SUBCLASS's `__name__` (right for a `TypeError` message,
+        wrong as a lookup key)."""
+
+        class MyDT(datetime.datetime):
+            pass
+
+        sub = MyDT(2026, 3, 4, 5, 6, 7)
+        for attr in ("year", "month", "hour"):
+            source = "{{ p.%s }}" % attr
+            assert djust_render(source, {"p": sub}) == django_render(source, {"p": sub})
+
+    def test_an_attribute_the_object_does_not_have_stays_empty(self) -> None:
+        """The map adds names; it must not add an ANSWER for a name that is
+        not one. Django renders empty for an unresolvable path."""
+        for source in ("{{ p.nope }}", "{{ p.year.nope }}", "{{ p.days }}"):
+            assert djust_render(source, {"p": DT}) == django_render(source, {"p": DT}) == ""
+
+
+class TestBothPathsAgree:
+    """The sidecar path (`raw_py_objects`, LiveView) and the plain value-stack
+    path must answer the same — the partial escape #2481 is about (#1646).
+
+    `RustLiveView.set_state` is the sidecar-attaching entry point.
+    """
+
+    @pytest.mark.parametrize(("value", "attr"), CLOSED)
+    def test_the_liveview_path_answers_the_same(self, value: object, attr: str) -> None:
+        from djust._rust import RustLiveView
+
+        source = "{{ p.%s }}" % attr
+        view = RustLiveView(source)
+        view.set_state("p", value)
+        assert view.render() == django_render(source, {"p": value})
+
+
+class TestTheStateRoundTripKeepsTheAttributes:
+    """`SerializableViewState.state` round-trips through msgpack on EVERY read
+    of the default `InMemoryStateBackend`, so an uncarried attribute map would
+    answer on the first render and go empty after one cache hit — the shape
+    #2458's `truthy` and #2471/#2472's `repr`/`cmp_key` each shipped to
+    prevent, now for the fourth time.
+    """
+
+    @staticmethod
+    def _round_trip(source: str, value: object) -> str:
+        from djust._rust import RustLiveView
+
+        view = RustLiveView(source)
+        view.set_state("p", value)
+        return RustLiveView.deserialize_msgpack(view.serialize_msgpack()).render()
+
+    @pytest.mark.parametrize(
+        ("value", "attr"),
+        [c for c in CLOSED if c.id not in ("datetime-tzinfo", "time-tzinfo")],
+    )
+    def test_a_round_trip_preserves_the_attribute(self, value: object, attr: str) -> None:
+        source = "{{ p.%s }}" % attr
+        assert self._round_trip(source, value) == django_render(source, {"p": value})
+
+    # The two rows excluded above are the NAIVE `tzinfo`s, whose value is
+    # Python `None`. They are excluded because of a codec gap that is not this
+    # slot's and is not fixed here — pinned in
+    # `TestWhatThisDeliberatelyDoesNOTClose::test_a_None_attribute_is_lost_by_the_state_round_trip`
+    # and filed as #2484. Excluding them by ID rather than by predicate is
+    # deliberate: a third row acquiring a `None` value fails loudly here rather
+    # than being silently swept into the exemption.
+
+    def test_the_payload_is_what_carries_it(self) -> None:
+        """Non-vacuity for the round trip: the blob names the tag AND the
+        NINTH element is the map. Without reading the payload the assertions
+        above would also pass on an implementation that kept the value alive
+        some other way, which is the #2135 shape exactly."""
+        msgpack = pytest.importorskip("msgpack")
+
+        from djust._rust import RustLiveView
+
+        view = RustLiveView("{{ p.days }}")
+        view.set_state("p", datetime.timedelta(days=3, seconds=90, microseconds=5))
+        blob = view.serialize_msgpack()
+        assert b"__djust_encoded__" in blob
+        payload = msgpack.unpackb(blob, raw=False, strict_map_key=False)[1]["p"][
+            "__djust_encoded__"
+        ]
+        assert len(payload) == 9, payload
+        assert payload[8] == {"days": 3, "seconds": 90, "microseconds": 5}
+
+    def test_an_EIGHT_element_payload_still_reads_with_no_attributes(self) -> None:
+        """A pre-#2481 process's state outlives it: a Redis backend hands back
+        an eight-element payload on the first request after a rolling deploy.
+
+        It restores to the answer that entry was WRITTEN with — no attributes,
+        so `{{ p.days }}` renders empty exactly as it did — rather than half-way
+        between. Built by TRUNCATING a real nine-element blob, so the test
+        cannot drift from the shape the serializer writes.
+        """
+        msgpack = pytest.importorskip("msgpack")
+
+        from djust._rust import RustLiveView
+
+        view = RustLiveView("{{ p.days }}|{{ p }}")
+        view.set_state("p", datetime.timedelta(days=3))
+        decoded = msgpack.unpackb(view.serialize_msgpack(), raw=False, strict_map_key=False)
+        payload = decoded[1]["p"]["__djust_encoded__"]
+        assert len(payload) == 9, payload
+        decoded[1]["p"]["__djust_encoded__"] = payload[:8]
+        legacy = msgpack.packb(decoded, use_bin_type=True)
+
+        assert RustLiveView.deserialize_msgpack(legacy).render() == "|3 days, 0:00:00"
+        # And the CURRENT payload for the same value answers the new way, which
+        # is what makes the arm above a compatibility read rather than a bug.
+        assert self._round_trip("{{ p.days }}|{{ p }}", datetime.timedelta(days=3)) == (
+            "3|3 days, 0:00:00"
+        )
+
+    def test_a_user_dict_under_the_tag_cannot_forge_an_encoded(self) -> None:
+        """The map is the ninth slot and reads as a `Value::Object`, so the
+        question "could a user dict be mistaken for a payload" is worth asking
+        again. It cannot: a nine-element LIST is required, and a dict is not
+        one."""
+        pytest.importorskip("msgpack")
+
+        from djust._rust import RustLiveView
+
+        view = RustLiveView("{{ p.days }}")
+        view.set_state("p", {"__djust_encoded__": {"days": 3}})
+        out = RustLiveView.deserialize_msgpack(view.serialize_msgpack()).render()
+        assert out == "", out
+
+
+class TestWhatThisDeliberatelyDoesNOTClose:
+    """Pinned as still-divergent so a stale exemption goes red (#1859)."""
+
+    @pytest.mark.parametrize(("value", "attr"), CLASS_ATTRS)
+    def test_a_class_attribute_still_renders_empty(self, value: object, attr: str) -> None:
+        source = "{{ p.%s }}" % attr
+        assert django_render(source, {"p": value}) != ""
+        assert djust_render(source, {"p": value}) == ""
+
+    def test_the_class_attributes_would_not_terminate(self) -> None:
+        """The REASON, measured rather than asserted. `min` / `max` /
+        `resolution` are values of the same family, so a collector that carried
+        them would convert a value whose own `min` is a value of the same
+        family, forever."""
+        assert datetime.datetime.min.min is datetime.datetime.min
+        assert datetime.date.max.max is datetime.date.max
+        assert datetime.timedelta.resolution.resolution is datetime.timedelta.resolution
+
+    @pytest.mark.parametrize(("value", "attr"), METHODS)
+    def test_a_nullary_method_still_renders_empty(self, value: object, attr: str) -> None:
+        """Django AUTO-CALLS these (ADR-024); the map holds lookups, not
+        calls."""
+        source = "{{ p.%s }}" % attr
+        assert django_render(source, {"p": value}) != ""
+        assert djust_render(source, {"p": value}) == ""
+
+    @pytest.mark.parametrize("attr", ["real", "imag", "as_tuple", "is_finite", "adjusted"])
+    def test_a_decimals_attributes_are_a_DIFFERENT_carrier(self, attr: str) -> None:
+        """`Decimal` is `Value::Decimal`, not `Value::Encoded` — a different
+        variant with no attribute slot. Filed rather than folded in (#1079)."""
+        source = "{{ p.%s }}" % attr
+        value = decimal.Decimal("1.5")
+        assert django_render(source, {"p": value}) != ""
+        assert djust_render(source, {"p": value}) == ""
+
+    def test_a_None_attribute_is_lost_by_the_state_round_trip(self) -> None:
+        """`Value::None` and `Value::Missing` are deliberately DISTINCT (#2203)
+        — `None` renders `"None"`, `Missing` renders `""` — and the msgpack
+        codec collapses them: both serialize as `nil` and `visit_unit` reads
+        every `nil` back as `Missing`.
+
+        So a naive datetime's `tzinfo` renders Django's `"None"` on the first
+        render and `""` after one cache hit. Filed as #2484, and pinned here in
+        the diverging direction so closing it reddens this test.
+
+        The gap is the CODEC's, not the attribute map's, and the second half of
+        this test is what makes that a measurement: a PLAIN dict loses it too,
+        with no `Encoded` involved at all — `{{ d.a }}` on `{"a": None}` has
+        answered `"None"` then `""` since #2203.
+        """
+        assert django_render("{{ p.tzinfo }}", {"p": DT}) == "None"
+        # Before the round trip, #2481's map answers Django's spelling.
+        assert djust_render("{{ p.tzinfo }}", {"p": DT}) == "None"
+        # After it, the codec gap.
+        assert self_round_trip("{{ p.tzinfo }}", DT) == ""
+
+        # The same loss with no `Encoded` in reach.
+        from djust._rust import RustLiveView
+
+        view = RustLiveView("{{ d.a }}")
+        view.set_state("d", {"a": None})
+        assert view.render() == django_render("{{ d.a }}", {"d": {"a": None}}) == "None"
+        assert RustLiveView.deserialize_msgpack(view.serialize_msgpack()).render() == ""
+
+    def test_a_custom_tzinfo_with_attributes_still_diverges(self) -> None:
+        """The one carried attribute whose VALUE can be an arbitrary object.
+
+        A `tzinfo` with a `__dict__` takes the `__dict__` bulk-dump arm of
+        `FromPyObject`, so it arrives as a mapping rather than as its `str()`.
+        That is the pre-existing behaviour of ANY such object placed in a
+        context — reached here through one more door, not created by it — and
+        it is the class #2478 is about.
+        """
+
+        class MyTz(datetime.tzinfo):
+            def __init__(self) -> None:
+                self.label = "custom"
+
+            def utcoffset(self, dt):  # noqa: ANN001, ANN201
+                return datetime.timedelta(0)
+
+            def tzname(self, dt):  # noqa: ANN001, ANN201
+                return "CUSTOM"
+
+            def dst(self, dt):  # noqa: ANN001, ANN201
+                return None
+
+        aware = datetime.datetime(2026, 3, 4, tzinfo=MyTz())
+        assert "MyTz object at" in django_render("{{ p.tzinfo }}", {"p": aware})
+        assert (
+            djust_render("{{ p.tzinfo }}", {"p": aware})
+            == "{&#x27;label&#x27;: &#x27;custom&#x27;}"
+        )
+        # The same object placed DIRECTLY in the context answers identically,
+        # which is what makes this pre-existing rather than introduced.
+        assert djust_render("{{ p }}", {"p": MyTz()}) == "{&#x27;label&#x27;: &#x27;custom&#x27;}"
+
+
+class TestTheSinkHasExactlyTheReadersItClaims:
+    """Grep the SINK, and pin the reader SET rather than a floor (#1125).
+
+    Both directions, with a canary that proves each can go red — a pin nobody
+    has watched fail is a pin whose failure mode is unknown (#2129/#2135).
+    """
+
+    @staticmethod
+    def _production(source: str) -> str:
+        """Source with `//` comments and any `#[cfg(test)]` module removed. A
+        pin that counts an occurrence in a COMMENT is the #2237 false alarm."""
+        head = source.split("#[cfg(test)]", 1)[0]
+        return "\n".join(line for line in head.splitlines() if not line.lstrip().startswith("//"))
+
+    def test_lookup_segment_is_the_only_reader_of_the_attribute_map(self) -> None:
+        """`Encoded::attrs` is read in exactly ONE place. Every other mention
+        in the crate is the field, the two producers, the codec and the
+        equality — none of which RESOLVE a name.
+
+        The count is an equality so a SECOND reader reddens it as loudly as a
+        deleted one: a second dotted-path walker that consults the map is the
+        parallel-path shape (#1646) this fix exists to end, and one that does
+        NOT consult it is the bug itself.
+        """
+        ctx = self._production(CONTEXT_RS.read_text(encoding="utf-8"))
+        assert ctx.count(".attrs.get(") == 1, (
+            "the attribute-map reader count moved in context.rs — a second "
+            "walker consulting the map is #1646 again"
+        )
+        assert "fn lookup_segment" in ctx
+        # And it is inside `lookup_segment`, not somewhere else in the file.
+        body = ctx.split("fn lookup_segment", 1)[1].split("\n}\n", 1)[0]
+        assert ".attrs.get(" in body, "the reader moved out of `lookup_segment`"
+
+    def test_lookup_segment_has_exactly_one_caller(self) -> None:
+        """The other half: `lookup_segment` serves `Context::get`, and
+        `Context::get` is what `resolve` / `get_value_safe` / every operand
+        channel funnel through. A second caller would be a second walk to keep
+        in step."""
+        ctx = self._production(CONTEXT_RS.read_text(encoding="utf-8"))
+        calls = re.findall(r"(?<!fn )lookup_segment\(", ctx)
+        assert len(calls) == 1, f"lookup_segment caller set moved: {len(calls)}"
+
+    def test_the_counters_go_red_in_BOTH_directions(self) -> None:
+        """The canary. Each mutation asserts it APPLIED before its count is
+        read, so a no-op edit cannot report a passing number."""
+        ctx = self._production(CONTEXT_RS.read_text(encoding="utf-8"))
+
+        baseline = ctx.count(".attrs.get(")
+        assert baseline == 1, baseline
+        added = ctx.replace(".attrs.get(", ".attrs.get(  /*dup*/ ", 1) + "\n.attrs.get(x)\n"
+        assert added != ctx, "the ADD mutation did not apply"
+        assert added.count(".attrs.get(") == baseline + 1
+        removed = ctx.replace(".attrs.get(", ".nothing.get(", 1)
+        assert removed != ctx, "the REMOVE mutation did not apply"
+        assert removed.count(".attrs.get(") == baseline - 1
+
+        base_calls = len(re.findall(r"(?<!fn )lookup_segment\(", ctx))
+        assert base_calls == 1, base_calls
+        more = ctx + "\nlet _ = lookup_segment(v, p);\n"
+        assert more != ctx, "the ADD mutation did not apply"
+        assert len(re.findall(r"(?<!fn )lookup_segment\(", more)) == base_calls + 1
+        fewer = ctx.replace("= lookup_segment(", "= other_segment(", 1)
+        assert fewer != ctx, "the REMOVE mutation did not apply"
+        assert len(re.findall(r"(?<!fn )lookup_segment\(", fewer)) == base_calls - 1
+
+    def test_the_name_list_is_the_whole_of_the_policy(self) -> None:
+        """One table, four types, and no `min` / `max` / `resolution` in it —
+        the non-termination guard is structural rather than a comment."""
+        src = self._production(CORE_RS.read_text(encoding="utf-8"))
+        assert src.count("pub const ENCODED_ATTR_NAMES") == 1
+        table = src.split("pub const ENCODED_ATTR_NAMES", 1)[1].split("];", 1)[0]
+        for tp in ("datetime.datetime", "datetime.date", "datetime.time", "datetime.timedelta"):
+            assert f'"{tp}"' in table, tp
+        for banned in ('"min"', '"max"', '"resolution"'):
+            assert banned not in table, (
+                f"{banned} entered the attribute table — its value is a value of "
+                "the same family, so the collection would not terminate"
+            )
+        # The collector is the only producer, and it is called once per type.
+        assert src.count("fn collect_named_attrs(") == 1

--- a/python/tests/test_encoded_truthiness_2458.py
+++ b/python/tests/test_encoded_truthiness_2458.py
@@ -254,10 +254,11 @@ class TestTheStateRoundTripKeepsTheAnswer:
         payload = msgpack.unpackb(blob, raw=False, strict_map_key=False)[1]["p"][
             "__djust_encoded__"
         ]
-        # EIGHT elements: #2466 appended `sized_empty` and `iterable`, then
-        # #2471/#2472 appended `repr(o)` and the comparison key — each for the
-        # reason this bit was appended, that a state entry dropping it restores
-        # a value answering with the pre-fix rule after one cache hit.
+        # NINE elements: #2466 appended `sized_empty` and `iterable`,
+        # #2471/#2472 appended `repr(o)` and the comparison key, and #2481
+        # appended the attribute map — each for the reason this bit was
+        # appended, that a state entry dropping it restores a value answering
+        # with the pre-fix rule after one cache hit.
         #
         # The fourth is still this issue's bit and its POSITION is what
         # matters: every optional is TRAILING, the safe slot in a positional
@@ -273,6 +274,10 @@ class TestTheStateRoundTripKeepsTheAnswer:
             False,
             "datetime.timedelta(0)",
             [1, 0, 0],
+            # #2481's attribute map, appended last for the reason every
+            # widening before it was: a positional payload only stays readable
+            # if nothing moves (#1541). `{{ p.days }}` resolves off this.
+            {"days": 0, "seconds": 0, "microseconds": 0},
         ]
         assert payload[3] is False, "the truthiness bit moved off element 3"
 
@@ -296,7 +301,7 @@ class TestTheStateRoundTripKeepsTheAnswer:
         view.set_state("p", datetime.timedelta(0))
         decoded = msgpack.unpackb(view.serialize_msgpack(), raw=False, strict_map_key=False)
         payload = decoded[1]["p"]["__djust_encoded__"]
-        assert len(payload) == 8, payload  # six until #2471/#2472 grew it
+        assert len(payload) == 9, payload  # eight until #2481 grew it
         decoded[1]["p"]["__djust_encoded__"] = payload[:3]
         legacy = msgpack.packb(decoded, use_bin_type=True)
 
@@ -325,7 +330,7 @@ class TestTheStateRoundTripKeepsTheAnswer:
         view.set_state("p", datetime.timedelta(0))
         decoded = msgpack.unpackb(view.serialize_msgpack(), raw=False, strict_map_key=False)
         payload = decoded[1]["p"]["__djust_encoded__"]
-        assert len(payload) == 8, payload
+        assert len(payload) == 9, payload
         decoded[1]["p"]["__djust_encoded__"] = payload[:4]
         legacy = msgpack.packb(decoded, use_bin_type=True)
         assert RustLiveView.deserialize_msgpack(legacy).render() == "F"
@@ -445,9 +450,9 @@ class TestTheSinkHasExactlyTheCallersItClaims:
         may fall back to `!display.is_empty()`, and it is the three-element
         one.
 
-        FOUR widths since #2471/#2472 appended `repr` and the comparison key
-        — eight (current), six (#2466-era), four (#2458-era) and three
-        (#2448-era) — so exactly THREE arms carry the bit verbatim from the
+        FIVE widths since #2481 appended the attribute map — nine (current),
+        eight (#2471/#2472-era), six (#2466-era), four (#2458-era) and three
+        (#2448-era) — so exactly FOUR arms carry the bit verbatim from the
         payload and exactly ONE derives it. The count is an equality rather
         than a floor so a DELETED compatibility arm reddens it as loudly as an
         added derivation: dropping the four-element read would silently turn
@@ -456,7 +461,7 @@ class TestTheSinkHasExactlyTheCallersItClaims:
         """
         src = self._production(CORE_RS.read_text(encoding="utf-8"))
         assert self._count(src, "truthy: !display.is_empty(),") == 1
-        assert self._count(src, "truthy: *truthy,") == 3
+        assert self._count(src, "truthy: *truthy,") == 4
 
     def test_the_counter_goes_red_in_BOTH_directions(self) -> None:
         """The canary. Each mutation asserts it APPLIED before its count is

--- a/python/tests/test_encoded_value_position_2471_2472_2473.py
+++ b/python/tests/test_encoded_value_position_2471_2472_2473.py
@@ -922,6 +922,10 @@ class TestTheStateRoundTripKeepsTheAnswers:
             False,
             "datetime.timedelta(0)",
             [1, 0, 0],
+            # #2481's attribute map, appended last for the reason every
+            # widening before it was: a positional payload only stays readable
+            # if nothing moves (#1541). `{{ p.days }}` resolves off this.
+            {"days": 0, "seconds": 0, "microseconds": 0},
         ]
 
     def test_a_shorter_payload_still_reads_without_fabricating_the_answers(self) -> None:
@@ -938,7 +942,7 @@ class TestTheStateRoundTripKeepsTheAnswers:
         recorded repr from a restored one, so the field carries the only
         spelling that entry has.
 
-        Built by TRUNCATING a real eight-element blob, so the test cannot
+        Built by TRUNCATING a real nine-element blob, so the test cannot
         drift from the shape the serializer actually writes."""
         msgpack = pytest.importorskip("msgpack")
 
@@ -949,7 +953,7 @@ class TestTheStateRoundTripKeepsTheAnswers:
             view.set_state("p", datetime.timedelta(0))
             view.set_state("q", datetime.timedelta(0))
             decoded = msgpack.unpackb(view.serialize_msgpack(), raw=False, strict_map_key=False)
-            assert len(decoded[1]["p"]["__djust_encoded__"]) == 8
+            assert len(decoded[1]["p"]["__djust_encoded__"]) == 9
             for key in ("p", "q"):
                 decoded[1][key]["__djust_encoded__"] = decoded[1][key]["__djust_encoded__"][:n]
             packed = msgpack.packb(decoded, use_bin_type=True)
@@ -958,7 +962,13 @@ class TestTheStateRoundTripKeepsTheAnswers:
         for n in (3, 4, 6):
             assert truncated(self.EQ, n) == "N", f"{n}-element payload gained a key"
             assert truncated(self.REPR, n) == "0:00:00", f"{n}-element payload gained a repr"
-        # And the EIGHT-element payload for the same value answers both the new
+        # EIGHT is the #2471/#2472 shape and carries both of these; it is the
+        # ATTRIBUTE MAP it lacks, which #2481's own suite pins.
+        assert truncated(self.EQ, 8) == "Y", "an 8-element payload lost its key"
+        assert truncated(self.REPR, 8) == "datetime.timedelta(0)", (
+            "an 8-element payload lost its repr"
+        )
+        # And the NINE-element payload for the same value answers both the new
         # way, which is what makes the arms above a compatibility read rather
         # than the bug.
         assert self._round_trip(self.EQ, datetime.timedelta(0)) == "Y"


### PR DESCRIPTION
Closes #2481.

## The divergence

Django's `Variable._resolve_lookup` tries three things at every dotted segment:
mapping item access, then `getattr`, then an integer index. `context::lookup_segment`
implemented steps 1 and 3, and said so in as many words:

```rust
// (2) attribute access — see the note above; a `Value` has none.
```

So every dotted lookup on a `datetime` / `date` / `time` / `timedelta` resolved
to **nothing**, on every path with no raw-Python sidecar — which is every
`DjustTemplateBackend` render:

```
case       attr           django                       djust (before)
datetime   {{ p.year }}   '2026'                       ''
datetime   {{ p.hour }}   '5'                          ''
date       {{ p.day }}    '4'                          ''
time       {{ p.minute }} '6'                          ''
timedelta  {{ p.days }}   '3'                          ''
```

`{{ post.published.year }}` is an ordinary Django idiom and rendered the empty
string. It predates the variant: before #2448 a `datetime` was
`Value::String(str(o))`, which has no attributes either.

## Reproducer, per type, before and after

Measured against **live Django 5.2.16** through BOTH entry points
`python/djust/template/backend.py:53` binds (`render_template` and
`render_template_with_dirs`), plus the LiveView path (`RustLiveView.render`).
Over the swept attribute surface — 68 `(type, attribute)` cells across
`datetime`, aware `datetime`, `date`, `time`, `timedelta` and `Decimal` —

| | before | after |
|---|---|---|
| mismatches | **64** | **41** |
| `djust REFUSES & django RENDERS` | 0 | **0** |

The 21 cells that moved are exactly the data attributes; the 41 that remain are
the two families declined below plus `Decimal`, every one pinned in the
diverging direction.

## The fix

`Value::Encoded` gains an `attrs: IndexMap<ObjectKey, Value>`, `lookup_segment`
gains step 2, and that arm is the **one** reader.

### Grep for the SINK, pin the caller SET

`lookup_segment` is reached only through `Context::get`, which is what
`Context::resolve` / `renderer::get_value_safe` / every operand channel funnel
through — verified by grepping for the sink rather than by enumerating callers.
Both counts are pinned as **equalities**, so a second dotted-path walker that
does not consult the map reddens as loudly as a deleted arm (#1125/#1646), and
`test_the_counters_go_red_in_BOTH_directions` proves each count can move in
either direction with an asserted-applied mutation.

### What the map carries is a rule, not a list

It holds what Python answers **without a call** and **without recursing**.

* `min` / `max` / `resolution` look like they belong and cannot: their values
  are values of the same family, and `datetime.min.min is datetime.min` —
  measured in `test_the_class_attributes_would_not_terminate` — so a collector
  carrying them would not terminate. `test_the_name_list_is_the_whole_of_the_policy`
  fails if they ever enter the table.
* The nullary methods (`isoformat`, `weekday`, `ctime`, `total_seconds`,
  `date`, `time`, `utcoffset`, …) are absent because Django reaches them
  through its auto-call (ADR-024), which turns a LOOKUP into an EVALUATION —
  eager at conversion time, paid whether or not a template asks, and
  inheriting whatever the call raises.

Both filed as **#2485**; `Decimal` is `Value::Decimal`, a different carrier with
no attribute slot, filed as **#2486**. All three families are pinned in the
DIVERGING direction so a fix reddens the exemption rather than passing.

### Wire — the ninth slot

```
  0 type_name    #2448      5 iterable     #2466
  1 display      #2448      6 repr         #2472
  2 json         #2448      7 cmp_key      #2471   nil, or [domain, hi, lo]
  3 truthy       #2458      8 attrs        #2481   a MAP of name -> Value
  4 sized_empty  #2466
```

Appended, written **unconditionally** as a map — an empty one costs a byte and
the slots stay aligned, the choice `cmp_key` makes one slot over and for the
same reason (#1541). The reader accepts **9 / 8 / 6 / 4 / 3**; an older width
restores NO attributes, the answer that entry was written with.

Carrying it is what makes the fix survive a cache hit:
`SerializableViewState.state` round-trips through msgpack on every read of the
default `InMemoryStateBackend`, so without the slot `{{ dt.year }}` would answer
once and go empty afterwards — the reopening `ENCODED_TAG` has now prevented
four times.

`crates/djust_core/tests/test_encoded_wire_positions_2471_2472.rs` grows the
slot-9 pins:

* a 13-shape sweep of everything the map can hold (int / float / bool / str /
  Missing / Decimal / BigInt / List / Tuple / Object / nested Encoded / empty
  list / empty object) plus an all-at-once case pinning **order**;
* the empty map, written and read as empty;
* a malformed slot reading as ABSENT rather than guessed;
* **`a_swap_of_the_key_and_attribute_slots_is_detectable`** — slots 7 and 8 are
  both "structured or nil", so a swap changes neither the width nor any type
  check. Only the values can catch it, so both are non-default in the fixture.

The pre-existing canary still reddens: `a_one_slot_shift_is_detectable` now
produces an **8-element** payload, which since #2471/#2472 is a REAL width — so
it refuses on TYPES rather than on width, which is a stronger statement than it
was, and the test says so.

### `Encoded`'s derived `PartialEq` becomes a hand-written one

The map holds `Value`s, and `Value` deliberately has no `PartialEq`: Django's
`==` for a template value is `renderer::values_equal`, which equates `1` with
`1.0` and asks `python_partial_cmp` for this family. Deriving a second `==`
onto `Value` would put a structural answer one keystroke from every site that
wants the Django one — two mechanisms for one question (#1646).

So the structural comparison is reachable **by name only**, as
`values_structurally_equal`, with every pair spelled explicitly and the
wildcard last, so `Missing` ≠ `None` (#2203), `List` ≠ `Tuple` (#2276) and
`DictView` ≠ its items (#2340) all survive.
`every_variant_is_structurally_equal_to_its_own_clone` turns a new variant
landing on the wildcard into a loud failure rather than a silent wrong answer.

## Surfaced rather than folded in (#1079)

`Value::None` and `Value::Missing` are deliberately distinct (#2203) and share
ONE msgpack `nil`, so every `None` in state comes back as `Missing` and renders
`''` after one cache hit. This is the CODEC's, not this slot's — pinned with a
plain `Value::Object` losing it too, which is what makes "pre-existing" a
measurement — and filed as **#2484**. The two naive-`tzinfo` rows are excluded
from the round-trip parametrize BY ID rather than by predicate, so a third row
acquiring a `None` value fails loudly instead of being swept in.

## Verification

* **Full suite, all three roots**: `pytest tests/ python/tests/ python/djust/tests/ -n auto`
  → **19217 passed, 420 skipped, 0 failed**.
* **Rust**: `make test-rust` → 65 test binaries, 0 failures.
* **Gate-off** (#1468, #2129/#2135) — four independent reverts, each asserting
  the mutation text matched **exactly once**, the source changed, the crate was
  **rebuilt** and the `.so` mtime advanced, `__pycache__` was cleared, and
  counting collection `errors` apart from `failed`:

  | gated off | result |
  |---|---|
  | baseline | 0 failed / 567 passed |
  | the reader (`lookup_segment` stops consulting the map) | **93 failed** |
  | the producer (no attribute is ever collected) | **96 failed** |
  | the wire WRITE (slot 9 not written) | **31 failed** |
  | the wire READ (slot 9 not read) | **25 failed** |
  | restored | **0 failed / 567 passed** |

  Four mechanisms, four independently-reachable failure sets — no two shadow
  each other (#2129).

## Files

| file | what |
|---|---|
| `crates/djust_core/src/lib.rs` | `Encoded::attrs`, `ENCODED_ATTR_NAMES`, `collect_named_attrs`, the 9th wire slot, `decode_cmp_key`, `values_structurally_equal`, hand-written `PartialEq` |
| `crates/djust_core/src/context.rs` | `lookup_segment` step 2 — the one reader |
| `crates/djust_core/tests/test_encoded_wire_positions_2471_2472.rs` | slot-9 pins + the swap canary |
| `python/tests/test_encoded_attributes_2481.py` | new — the reproducers, the declines, the structural pins |
| `python/tests/test_encoded_truthiness_2458.py` | payload width 8 → 9; the five-width read arm count |
| `python/tests/test_encoded_value_position_2471_2472_2473.py` | payload width 8 → 9; the 8-element compat read |
