### PR TITLE
fix(serialization): a class with no __module__ does not crash the branch that names it (#2488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A class with no `__module__` no longer crashes the branch that names it (#2488).** `normalize_django_value`'s final fallback built its warning message with an unguarded `type(value).__module__`. `__module__` is not guaranteed: `type(name, bases, ns)` fills it from the CALLING FRAME's `__name__`, so a class built in a namespace that has none — which is exactly what `eval(compile(...), {})` gives you — has no `__module__` at all and the attribute lookup RAISES.
+
+  ```python
+  cls = eval(compile(ast.Expression(...), "<x>", "eval"), {})   # globals with no __name__
+  cls.__name__      # 'C'
+  cls.__module__    # AttributeError: __module__
+  normalize_django_value({"p": cls()})   # AttributeError, not a warning
+  ```
+
+  The path is the LiveView render path — every WebSocket event normalizes the context — so the failure is a 500 on a page rather than a warning. And the value that reaches this branch is already the *"we don't know how to serialize this"* case: the guard that was supposed to produce a helpful warning was the thing that raised, in the branch least likely to be exercised.
+
+  **Grep the SINK, not the caller.** Three unguarded reads of `type(...).__module__` on an ARBITRARY value existed, all of them message-building or diagnostic paths, and all three are fixed: `serialization.py` (the cited one), `observability/tracebacks.py` (the exception RECORDER, where a second exception has nowhere to go) and `checks/configuration.py` (the ASGI middleware walk in `manage.py check`, where the pre-existing `or ""` covered a `__module__` that is `None` but not one that is ABSENT). `templatetags/live_tags.py` reads the same pair inside its own `except AttributeError` and is the one named exemption; a source pin asserts that SET rather than a floor (#1125), so a fourth unguarded read reddens it as loudly as a deleted guard.
+
+  **A fourth read the fix did not reach, found by the regression test rather than by inspection.** Guarding `tracebacks.py`'s own `__module__` left the recorder still raising one line later: CPython's `traceback.format_exception` makes the same unguarded read in `TracebackException.format_exception_only` (`smod = self.exc_type.__module__`), so a `__module__`-less exception class cannot be formatted at all — loudly enough to take pytest's own reporter down with it (an `INTERNALERROR`, which reports a SHORT pass count rather than a failure). The formatting call is now wrapped fail-soft, narrowly, so a genuine bug in that module is not swallowed with it.
+
+  How it was found: #2482 put a `type()`-built class instance in the differential corpus. The script builds it in a module that HAS `__name__`, so the script-built instance rendered fine; `test_sequence_op_chokepoint_2451.corpus()` rebuilds the same expression from the AST in a names-only namespace, so the reader-built instance crashed — the same corpus row behaving differently depending on which reader constructed it.
+
+  Regression coverage: new cases in `python/tests/test_module_guard_2488.py`, including the premise measured against live CPython in both directions and the four fixed sites exercised through their REAL paths (`normalize_django_value`, `record_traceback`, and `check_configuration` driven through a real `ASGI_APPLICATION` setting rather than by calling the expression directly). Gate-off verified against four independent reverts — the serialization guard (5 red), the tracebacks `getattr` (3 red), the tracebacks fail-soft wrapper (1 red), the checks guard (2 red) — each asserting the mutation matched exactly once, the source changed, and `__pycache__` was cleared, and counting collection errors and ABORTED runs apart from failures. The first counting pass reported two of those four as GREEN because pytest's reporter died on the mutated code and printed neither `failed` nor `error`, only a short pass count — a harness that reads the wrong instrument, rerun after teaching it to compare `passed + failed + errors` against `collected`.
+
 - **`{{ p }}` on a `None` renders `None` and keeps rendering it — a state round trip no longer turns every `Value::None` into a `Value::Missing` (#2484).** `Value::None` and `Value::Missing` are deliberately DISTINCT (#2203): `None` renders `"None"` as `str(None)` does, `Missing` renders `""` as Django's `string_if_invalid` does. The msgpack codec collapsed them — `impl Serialize for Value` wrote both as one `nil`, and `visit_unit` read every `nil` back as `Missing`:
 
   ```

--- a/python/djust/checks/configuration.py
+++ b/python/djust/checks/configuration.py
@@ -662,7 +662,12 @@ def check_configuration(app_configs: Any, **kwargs: Any) -> list[CheckMessage]:
                 current = ws_app
                 for _ in range(10):  # bounded walk
                     cls_name = type(current).__name__
-                    mod_name = type(current).__module__ or ""
+                    # `getattr` with a default (#2488). The `or ""` already
+                    # covered a `__module__` that is `None`; it does not cover
+                    # one that is ABSENT, which is what a `type()`-built ASGI
+                    # wrapper has — and this walk runs during `manage.py check`,
+                    # so the raise would be a startup crash.
+                    mod_name = getattr(type(current), "__module__", None) or ""
                     # #659 A001 — check for OriginValidator (any flavor)
                     if "originvalidator" in cls_name.lower():
                         has_origin_validator = True

--- a/python/djust/observability/tracebacks.py
+++ b/python/djust/observability/tracebacks.py
@@ -38,15 +38,42 @@ def record_traceback(
             {
                 "timestamp_ms": int(time.time() * 1000),
                 "exception_type": type(exception).__name__,
-                "exception_module": type(exception).__module__,
+                # `getattr` with a default (#2488): an exception class built by
+                # `type()` in a namespace with no `__name__` has no
+                # `__module__`, and an unguarded read would raise INSIDE the
+                # exception recorder — the one place a second exception has
+                # nowhere to go.
+                "exception_module": getattr(type(exception), "__module__", "<unknown>"),
                 "message": str(exception),
                 "error_type": error_type,
                 "event_name": event_name,
                 "view_class": view_class,
                 "session_id": session_id,
-                "traceback": "".join(traceback.format_exception(exception)),
+                "traceback": _format(exception),
             }
         )
+
+
+def _format(exception: BaseException) -> str:
+    """``traceback.format_exception``, fail-soft (#2488).
+
+    Guarding this module's OWN ``__module__`` read is not enough, and the
+    regression test is what proved it: CPython's ``traceback`` makes the same
+    unguarded read one frame further in —
+    ``TracebackException.format_exception_only`` does ``smod =
+    self.exc_type.__module__`` — so an exception class with no ``__module__``
+    raises from inside the formatter as well. (It is loud: it takes pytest's own
+    reporter down with it.)
+
+    A recorder that raises loses the exception it was called to record AND
+    replaces it with a less useful one, so this fails soft to the two spellings
+    that cannot raise. Deliberately narrow: only the formatting call is
+    wrapped, so a genuine bug in this module is not swallowed with it.
+    """
+    try:
+        return "".join(traceback.format_exception(exception))
+    except Exception:  # noqa: BLE001 — the recorder must not raise
+        return f"{type(exception).__name__}: {exception}\n"
 
 
 def get_recent_tracebacks(n: int = 1) -> List[Dict[str, Any]]:

--- a/python/djust/serialization.py
+++ b/python/djust/serialization.py
@@ -1493,7 +1493,16 @@ def normalize_django_value(value: Any, _depth: int = 0, *, state_roundtrip: bool
     from .config import config
 
     value_type = type(value).__name__
-    value_module = type(value).__module__
+    # `getattr` with a default, NOT a bare read (#2488). `__module__` is not
+    # guaranteed: `type(name, bases, ns)` fills it from the CALLING FRAME's
+    # `__name__`, so a class built in a namespace that has none — which is
+    # exactly what `eval(compile(...), {})` gives you — has no `__module__` at
+    # all and the attribute lookup RAISES. This is the render path (every
+    # WebSocket event normalizes the context), and the value that reaches this
+    # branch is already the "we cannot serialize this" case, so an unguarded
+    # read turns a helpful warning into a 500 — a crash inside the error
+    # handling, which is the branch least likely to be exercised.
+    value_module = getattr(type(value), "__module__", "<unknown>")
     msg = (
         f"LiveView state contains non-serializable value: {value_type} "
         f"(from {value_module}). This will be converted to a string, "

--- a/python/tests/test_module_guard_2488.py
+++ b/python/tests/test_module_guard_2488.py
@@ -1,0 +1,259 @@
+"""A class with no ``__module__`` does not crash the branch that names it (#2488).
+
+The crash
+---------
+``normalize_django_value``'s final fallback built its warning message with an
+UNGUARDED ``type(value).__module__``::
+
+    value_module = type(value).__module__     # AttributeError: __module__
+
+``__module__`` is not guaranteed. ``type(name, bases, ns)`` fills it from the
+**calling frame's** ``__name__``, so a class built in a namespace that has none
+— which is exactly what ``eval(compile(...), {})`` gives you — has no
+``__module__`` at all.
+
+Why that is worse than it looks: the path is the LiveView render path (every
+WebSocket event normalizes the context), and the value reaching that branch is
+already the *"we don't know how to serialize this"* case. The guard that was
+supposed to produce a helpful warning was the thing that raised — a crash
+inside the error handling, which is the branch least likely to be exercised.
+
+The sink, not the callers
+-------------------------
+Per the drain canon, the fix greps for the SINK — every ``type(...).__module__``
+read on an ARBITRARY value — rather than for the one caller the report cited.
+Three were unguarded and all three are message-building or diagnostic paths:
+
+============================================ =====================================
+``serialization.py``                          the cited one; the render path
+``observability/tracebacks.py``               the exception RECORDER
+``checks/configuration.py``                   the ASGI walk in ``manage.py check``
+============================================ =====================================
+
+``templatetags/live_tags.py`` reads the same pair inside its own
+``except AttributeError``, so it was already safe and is the one exemption the
+source pin below names.
+
+How it was found
+----------------
+#2482 put a ``type()``-built class instance in the differential corpus. The
+script builds it in a module that HAS ``__name__``, so the script-built instance
+rendered fine; the corpus reader rebuilds the same expression from the AST in a
+names-only namespace, so the reader-built instance crashed — the same corpus row
+behaving differently depending on which reader constructed it.
+
+Refs #2488, #2482.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+import sys
+import types
+
+import pytest
+
+pytest.importorskip("django")
+
+from djust.serialization import normalize_django_value  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+PKG = REPO / "python" / "djust"
+
+
+def _module_less(body: str = 'type("C", (), {})') -> type:
+    """A class with NO ``__module__``, built the way #2482's corpus reader does.
+
+    ``eval`` with a bare globals dict: the frame has no ``__name__``, so
+    ``type()`` has nothing to copy into ``__module__``.
+    """
+    node = ast.parse(body).body[0]
+    return eval(  # noqa: S307 — the expression is a literal in this file
+        compile(ast.Expression(node.value), "<x>", "eval"), {}
+    )
+
+
+class TestThePremiseIsMeasured:
+    """The bug's premise, asked of live CPython rather than transcribed."""
+
+    def test_a_type_built_class_really_has_no___module__(self) -> None:
+        cls = _module_less()
+        assert cls.__name__ == "C"
+        with pytest.raises(AttributeError):
+            cls.__module__
+
+    def test_an_ordinary_class_does_have_one(self) -> None:
+        """The other direction, so the fixture is not vacuously exotic."""
+        assert type(self).__module__ == __name__
+
+
+class TestTheWarningBranchNoLongerCrashes:
+    def test_normalize_django_value_answers_a_string(self) -> None:
+        """The issue's own reproducer. It raised ``AttributeError: __module__``
+        before the guard; it answers a string now."""
+        obj = _module_less('type("C", (), {"__bool__": lambda self: False})()')
+        out = normalize_django_value({"p": obj})
+        assert isinstance(out, dict)
+        assert isinstance(out["p"], str)
+
+    def test_the_warning_still_names_the_type_and_marks_the_module(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The guard must not silence the warning it exists to build — the
+        placeholder is what a reader sees where the module would have been."""
+        obj = _module_less('type("Widget", (), {})()')
+        with caplog.at_level("WARNING", logger="djust.serialization"):
+            normalize_django_value({"p": obj})
+        text = "\n".join(r.getMessage() for r in caplog.records)
+        assert "Widget" in text
+        assert "<unknown>" in text
+
+    def test_a_class_WITH_a_module_still_names_it(self) -> None:
+        """The placeholder is reached only by the absent case."""
+
+        class Ordinary:
+            pass
+
+        out = normalize_django_value({"p": Ordinary()})
+        assert isinstance(out["p"], str)
+
+    def test_strict_serialization_still_raises_TypeError_not_AttributeError(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The strict-mode branch builds the SAME message. Before the guard it
+        raised ``AttributeError`` from message construction rather than the
+        ``TypeError`` the mode promises."""
+        from djust import config as config_mod
+
+        monkeypatch.setattr(
+            config_mod.config, "get", lambda k, d=None: True if k == "strict_serialization" else d
+        )
+        with pytest.raises(TypeError, match="<unknown>"):
+            normalize_django_value({"p": _module_less('type("C", (), {})()')})
+
+
+class TestTheOtherTwoSinks:
+    def test_the_exception_recorder_survives_a_module_less_exception(self) -> None:
+        """A second exception raised INSIDE the recorder has nowhere to go."""
+        from djust.observability import tracebacks
+
+        exc_cls = _module_less('type("Boom", (Exception,), {})')
+        caught: BaseException | None = None
+        try:
+            raise exc_cls("bang")
+        except Exception as exc:  # noqa: BLE001
+            caught = exc
+        # Called OUTSIDE the `except` block on purpose: inside it, a raise from
+        # the recorder chains onto the module-less exception and pytest's own
+        # reporter dies formatting the chain (INTERNALERROR), which reports a
+        # SHORT pass count rather than a failure. A clean assertion is better
+        # evidence than an abort.
+        assert caught is not None
+        try:
+            tracebacks.record_traceback(caught)
+        except Exception as exc:  # noqa: BLE001
+            pytest.fail(f"the recorder raised {type(exc).__name__}: {exc}")
+        recorded = tracebacks.get_recent_tracebacks(1)[0]
+        assert recorded["exception_type"] == "Boom"
+        assert recorded["exception_module"] == "<unknown>"
+        # The traceback string is still recorded — through the fail-soft
+        # spelling, because CPython's own formatter cannot format it.
+        assert "Boom: bang" in recorded["traceback"]
+
+    def test_CPython_itself_cannot_format_such_an_exception(self) -> None:
+        """The measurement that made the first version of the fix insufficient.
+
+        Guarding this module's own ``__module__`` read left the recorder
+        crashing one line later, in ``traceback.format_exception`` —
+        ``TracebackException.format_exception_only`` reads
+        ``self.exc_type.__module__`` unguarded. So the fail-soft wrapper is
+        load-bearing rather than belt-and-braces: without it the recorder still
+        raises."""
+        import traceback as tb_mod
+
+        exc_cls = _module_less('type("Boom", (Exception,), {})')
+        try:
+            raise exc_cls("bang")
+        except Exception as exc:  # noqa: BLE001
+            with pytest.raises(AttributeError):
+                tb_mod.format_exception(exc)
+
+    def test_the_asgi_walk_survives_a_module_less_wrapper(self) -> None:
+        """``manage.py check`` walks arbitrary ASGI wrapper objects. This drives
+        the REAL check function through a real ``ASGI_APPLICATION`` setting
+        rather than calling the expression directly."""
+        from django.test import override_settings
+
+        from djust.checks.configuration import check_configuration
+
+        wrapper_cls = _module_less('type("Wrap", (), {})')
+        wrapper = wrapper_cls()
+
+        mod = types.ModuleType("djust_test_asgi_2488")
+        app = types.SimpleNamespace(application_mapping={"websocket": wrapper})
+        mod.application = app  # type: ignore[attr-defined]
+        sys.modules["djust_test_asgi_2488"] = mod
+        try:
+            with override_settings(ASGI_APPLICATION="djust_test_asgi_2488.application"):
+                # The assertion is that this RETURNS rather than raising
+                # `AttributeError: __module__` out of the check framework.
+                messages = check_configuration(None)
+            assert isinstance(messages, list)
+        finally:
+            del sys.modules["djust_test_asgi_2488"]
+
+
+class TestTheSinkIsPinnedAsASet:
+    """Grep the SINK and pin the SET, not a floor (#1125).
+
+    The rule: a ``type(...).__module__`` read is either wrapped in ``getattr``
+    with a default, or it lives inside its own ``except AttributeError``. The
+    second shape has exactly one inhabitant and it is named, so a FOURTH
+    unguarded read reddens this in the same breath as a deleted guard.
+    """
+
+    #: ``type(<anything>).__module__`` not written as `getattr(type(x), "__module__"`.
+    BARE = re.compile(r"(?<!getattr\()type\([^)]*\)\.__module__")
+
+    @staticmethod
+    def _sources() -> dict[pathlib.Path, str]:
+        return {
+            p: p.read_text(encoding="utf-8") for p in PKG.rglob("*.py") if "tests" not in p.parts
+        }
+
+    def test_the_only_bare_read_is_the_one_with_its_own_except(self) -> None:
+        hits = {
+            p.relative_to(REPO).as_posix(): self.BARE.findall(src)
+            for p, src in self._sources().items()
+            if self.BARE.search(src)
+        }
+        assert set(hits) == {"python/djust/templatetags/live_tags.py"}, (
+            "an unguarded `type(...).__module__` appeared: "
+            f"{sorted(hits)} — see #2488, the crash is in the branch that "
+            "builds the message"
+        )
+
+    def test_the_exemption_really_has_its_own_except(self) -> None:
+        src = (PKG / "templatetags" / "live_tags.py").read_text(encoding="utf-8")
+        block = src.split("type(view).__module__", 1)[1]
+        assert "except AttributeError" in block.split("\n\n", 1)[0]
+
+    def test_the_three_fixed_sites_are_written_with_getattr(self) -> None:
+        for rel in (
+            "serialization.py",
+            "observability/tracebacks.py",
+            "checks/configuration.py",
+        ):
+            src = (PKG / rel).read_text(encoding="utf-8")
+            assert "getattr(type(" in src and '"__module__"' in src, rel
+
+    def test_the_pin_goes_red_in_BOTH_directions(self) -> None:
+        """The canary. Each mutation asserts it APPLIED before its count is
+        read, so a no-op edit cannot report a passing number (#2129/#2135)."""
+        guarded = 'value_module = getattr(type(value), "__module__", "<unknown>")'
+        assert not self.BARE.search(guarded), "the guarded form must not match"
+        bare = "value_module = type(value).__module__"
+        assert bare != guarded, "the mutation did not apply"
+        assert self.BARE.search(bare), "the bare form must match"


### PR DESCRIPTION
Closes #2488.

## The crash, reproduced first

```python
node = ast.parse('type("C", (), {"__bool__": lambda self: False})()').body[0]
obj  = eval(compile(ast.Expression(node.value), "<x>", "eval"), {})   # globals with no __name__

type(obj).__name__     # 'C'
type(obj).__module__   # AttributeError: __module__
normalize_django_value({"p": obj})   # AttributeError, not a warning
```

`__module__` is not guaranteed. `type(name, bases, ns)` fills it from the
**calling frame's** `__name__`, so a class built in a namespace that has none
has no `__module__` at all. The path is the LiveView render path (every
WebSocket event normalizes the context), and the value that reaches this branch
is *already* the "we don't know how to serialize this" case — the guard meant to
produce a helpful warning was the thing that raised.

## Grep the SINK, not the caller

The issue asked for the sweep and it found two more, both the same class — a
`type(...).__module__` read on an ARBITRARY value in a message-building or
diagnostic path:

| file | path | why it matters |
|---|---|---|
| `python/djust/serialization.py:1505` | LiveView render | the cited one |
| `python/djust/observability/tracebacks.py:46` | the exception RECORDER | a second exception has nowhere to go |
| `python/djust/checks/configuration.py:670` | the ASGI walk in `manage.py check` | the pre-existing `or ""` covers `None`, not ABSENT |

`python/djust/templatetags/live_tags.py:870` reads the same pair inside its own
`except AttributeError`, so it was already safe. It is the one named exemption,
and `TestTheSinkIsPinnedAsASet` pins that **set** rather than a floor (#1125) —
a fourth unguarded read reddens it as loudly as a deleted guard.

## A fourth read the fix did not reach — found by the test, not by inspection

Guarding `tracebacks.py`'s own read left the recorder still raising one line
later. **CPython** makes the same unguarded read:

```
File ".../traceback.py", line 887, in format_exception_only
    smod = self.exc_type.__module__
AttributeError: __module__
```

so `traceback.format_exception` cannot format such an exception at all — loudly
enough to take pytest's own reporter down with it (`INTERNALERROR`). The
formatting call is now wrapped fail-soft, narrowly, around that call only.
`test_CPython_itself_cannot_format_such_an_exception` records the reason, so the
wrapper reads as load-bearing rather than as belt-and-braces (which the canon
says to delete rather than test around).

## Verification

- **Full suite, all three roots**: `pytest tests/ python/tests/ python/djust/tests/ -n auto`
  → **19653 passed, 432 skipped, 0 failed**.
- **13 new cases** in `python/tests/test_module_guard_2488.py`. Each fixed site
  is exercised through its REAL path: `normalize_django_value`,
  `record_traceback`, and `check_configuration` driven through a real
  `ASGI_APPLICATION` setting rather than by calling the guarded expression.
- **Gate-off, 4 mechanisms, 4 independent reds** (mutation asserted to match
  exactly once, source asserted changed, `__pycache__` cleared, `N error`
  counted apart from `N failed`, aborted runs detected):

  | mutation | result |
  |---|---|
  | M1 `serialization.py` → bare `type(value).__module__` | RED, 5 failed |
  | M2 `tracebacks.py` → bare `type(exception).__module__` | RED, 3 failed |
  | M3 `tracebacks.py` → unwrapped `format_exception` | RED, 1 failed |
  | M4 `checks/configuration.py` → bare `type(current).__module__` | RED, 2 failed |

  M2 and M3 redden disjoint counts, so they are two mechanisms rather than one
  shadowing the other.

  The first counting pass reported M2 and M3 as **GREEN**. They were not — the
  mutated code killed pytest's reporter, which prints neither `failed` nor
  `error`, only a short pass count (6 of 13). The harness now compares
  `passed + failed + errors` against `collected` and reports an aborted run as
  RED; the test was also restructured to call the recorder OUTSIDE the `except`
  block so a mutation produces a clean failure instead of an abort.

## Note for the reviewer

A first full-suite run on this branch reported 28 failures in
`test_encoded_attributes_2481.py`, `test_none_missing_state_round_trip_2484.py`
and `test_check_lockfile_registry.py`. Those were a **stale `.so`** — built
before `origin/main` moved to `81a5cedd` (#2492, a Rust change). After
`make build` at the branch base all 183 of them pass, and the full suite is the
green above. No Rust is touched by this PR.
