### PR TITLE
fix(templates): two opaque Encoded values compare by Python's contract (#2480)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two opaque `Value::Encoded` values compare by Python's CONTRACT, so `{% if p == q %}` on two `set()`s answers `Y` (#2480).** `opaque_value` set `cmp_key: None`, so `Encoded::python_partial_cmp` answered `None` for every pair either side of which came from that arm — never equal, never ordered:
+
+  ```
+                       p, q                          django    djust
+  {% if p == q %}      the SAME set()                Y         N
+  {% if p == q %}      two equal {'a'}s              Y         N
+  {% if p <= q %}      the SAME set()                Y         N
+  {% if p == q %}      the SAME complex(0)           Y         N
+  {% if p == q %}      complex(0) and 0              Y         N
+  ```
+
+  **Eight shapes, and "widened from four to eight" is the honest count.** Before #2476 a `set()` had no variant and landed on the terminal `Ok(Value::String(ob.str()?))`, where two of them compared **equal by TEXT** through the `(String, String)` arm — Django's answer, reached by the same accident that made `{{ p|length }}` count the characters of a repr, so the accident and the defect could not be separated. #2476 moved the FALSY half onto the carrier (`set()`, `frozenset()`, `{}.keys()`, `complex(0)`) and #2477/#2489 moved the TRUTHY half (`{'a'}`, `frozenset({'a'})`, `{'a': 1}.keys()`, `complex(1)`), pinning the cost in `TestTheComparisonAxisThisWIDENS` in the diverging direction. This closes all eight and FLIPS that class rather than deleting it, so the widening it recorded stays legible.
+
+  **No carried field decides it, in either direction — and that is a measurement, not an argument.** `set() == frozenset() == {}.keys() == {}.items()` is True **across** `type_name`s; `LenZero() == LenZero()` on two distinct instances is False **within** one; and `set() == {}.keys()` is True while `set() == {}.values()` is False, even though both views carry the same (empty) `items`. So neither the type name nor the items nor any carried spelling separates them. A NAME LIST — `{set, frozenset, dict_keys, dict_items}` — is wrong in **both** directions: it misses every `collections.abc.Set` registration a user writes, and it claims any user class merely *named* `set`, because `type(o).__name__` is unqualified. Both halves are run in `test_a_name_list_would_have_been_wrong_in_both_directions`.
+
+  So a fourth fact is MEASURED at the conversion — `Encoded::eq_class`, the PROTOCOL Python itself dispatches on, with four arms each justified by a contract:
+
+  | arm | measured | equality | ordering |
+  |---|---|---|---|
+  | `EqClass::Set` | `isinstance(o, collections.abc.Set)` | the carried `items`, both containments | a real SUBSET partial order |
+  | `EqClass::Number` | `isinstance(o, numbers.Number)`, as `complex(o)` | the two components | **none** |
+  | `EqClass::Identity` | default `__eq__` **and** default `__repr__` | the `repr` token | **none** |
+  | `None` | everything else | never equal | never ordered |
+
+  Arm 1 is the one that answers the hard direction: the ABC *defines* `__eq__` as `len(self) == len(other) and self <= other` and `__le__` as containment, so `set() == frozenset() == {}.keys() == {}.items()` falls out ACROSS type names and `set() != {}.values()` falls out for free — a `dict_values` is not a `Set`. Arm 3 is a **restoration** rather than a new hazard: before #2476 a `LenZero()` crossed as `Value::String("<LenZero object at 0x…>")` and compared by exactly that string, so the address-reuse caveat is the one it already had — and within a single render it cannot bite, because every context object is alive at once and their addresses are therefore distinct.
+
+  **The ordering trap, which is why this is not a one-line `cmp_key`.** Python's two operators come apart INSIDE this family: `set() <= set()` is `Y` (subset order) while `complex(0) <= complex(0)` is `N` (`<` RAISES, and Django's `smart_if` swallows it to False). An implementation that reaches equality by handing these values a comparison key gets the first right and **flips the second from `N` to `Y`** — eight cells bought, a new divergence sold. So `renderer::encoded_partial_cmp` is the ONE wrapper all three comparison sinks read (`values_equal` via `encoded_equal`, `try_compare`, `dictsort`'s `compare_sort_values`); it carries the Set order and answers `None` for the two equality-only classes, and `Encoded::python_partial_cmp` keeps the datetime family unchanged with **exactly one caller**. The Set order lives in an `Option<Ordering>` because Python's *is* partial — `{1}` and `{2}` are incomparable, and `None` is already rendered as "false for all four operators", which is Django's answer.
+
+  **Cross-carrier, closed too.** `complex(0) == 0` is True in Python and `Y` in Django, and no `(Encoded, Encoded)` arm reaches it. The new `(Encoded, Integer)` / `(Encoded, Float)` arms compare in the INTEGER domain because Python's comparison is exact: `complex(2**53) == 2**53 + 1` is **False** even though the float cast rounds, and `complex(1e300) == 2**63 - 1` is False even though `as i64` saturates onto that bound. Both guards are load-bearing and each has its own case.
+
+  **Four things are DECLINED, and each is pinned in the DIVERGING direction so widening one is a decision.** A class overriding `__eq__` — only Python can run it, and its answer is arbitrary. A class with default `__eq__` and a **custom `__repr__`**: a `dict_values` is the builtin case, and two DISTINCT empty ones share the spelling `dict_values([])`, so using the token would call them equal where Python says they are not — a NEW wrong answer rather than an unfixed cell. A `Decimal` or a big `int` against a complex, both exact types an `f64` cannot answer. And two sets past `SET_COMPARE_CAP` (1,000 items a side): containment without a hash is quadratic and a `set` states its own length, so `opaque_value` enumerates it in full — past the cap the answer is the pre-fix one rather than a render that does 10^10 comparisons.
+
+  **Wire.** Slot 11, appended for the sixth time and for the sixth identical reason: the class is measured from a live Python object that no longer exists when a state entry comes back, so an entry that dropped it would answer `{% if a == b %}` with the pre-fix rule after one cache hit — the reopening `ENCODED_TAG` exists to prevent. It is a **MAP, never `nil`** — an absent class is the EMPTY map — and that is the one structural decision here rather than a preference: eleven used to be a width no build wrote, so `an_interior_insert_is_refused_rather_than_silently_misread` could rely on WIDTH to refuse a ten-element payload with one element inserted; now that eleven is real, only a TYPE can, and every such insert pushes the ITEMS (a list or `nil`) or the intruder itself into this position, never a map. Writing `nil` for the absent case would have surrendered that — and the EXISTING canary could not say so, which is the sharper half of this. `an_interior_insert_is_refused_rather_than_silently_misread` inserts into the CURRENT payload, so it produces TWELVE elements, a width no arm matches however slot 10 is typed: it is answered by width and would stay green under the very mutation it looks like it guards. A gate-off found that (the mutation SURVIVED), so a second canary was added that inserts into a **ten**-element payload — the shape real state entries carry — and requires all ten refused, for both item shapes. Under a mutation that drops the `Value::Object` pattern, an insert at slot 6 decodes as an `Encoded` with `repr: "intruder"` and the last three slots silently emptied, and the new canary is the only test that reddens. Every narrower width (10 / 9 / 8 / 6 / 4 / 3) restores `eq_class: None`, which is the answer that entry was written with; each keeps its existing fail-to-absent read for every slot below 11. Growing the `attrs` map instead was rejected: that map is what `context::lookup_segment` resolves `{{ p.x }}` against, so a synthetic key there would be a template-visible attribute Django does not have.
+
+  **Corpus movement**, two builds of `scripts/filter-parity-differential.py` over **380,484 cells** — `origin/main` at `e5d499a0` against this branch, `--compare`d, and the build hashes confirm they are genuinely two builds:
+
+  ```
+  agree BEFORE : 277729   (refusal-collapsed: 324951)
+  agree AFTER  : 277777   (refusal-collapsed: 324999)
+  django REFUSES & djust RENDERS: 4722 -> 4722   (+0)
+  djust REFUSES & Django RENDERS: 39253 -> 39253   (+0)
+  cmp             48 moved  of  19663      (every other axis: 0 moved)
+  newly AGREEING: 48   no longer agreeing: 0   REGRESSIONS: 0
+  panics 0 -> 0     live-payload leaks 60 -> 60 (0 introduced)
+  ```
+
+  The raw headline is blind to refusal-class movement, so both refusal columns are reported: neither grew by a single cell. Of the 19,663 `@cmp` cells the corpus reaches, **48 disagreed with Django before and 0 disagree after** — `>=` 12, `<=` 12, `==` 8, `!=` 8, `>` 4, `<` 4 — which includes the 10 the #2477/#2489 compare counted as regressions.
+
+  And the full cross-product reproduction, every shape against every shape over all six operators on both djust paths, with Django CALLED as the oracle: same-object divergences **48 → 8**, two distinct instances **38 → 2**, cross-shape **196 → 60**, cross-carrier **9 → 6**. Every survivor involves one of the declined classes and nothing else — the 60 cross-shape cells are all the custom-`__eq__` class against something.
+
+  Regression coverage: 28 cases in `python/tests/test_opaque_equality_2480.py` (the cross-product sweep, the protocol facts asserted in both directions, the ordering trap on both halves, the cross-carrier boundaries, the state round trip and the chokepoint pins); new cases in `test_encoded_wire_positions_2471_2472.rs` (including `an_insert_into_the_ten_slot_payload_is_refused_by_the_last_slots_type`, the one a gate-off proved was missing); and `TestTheComparisonAxisThisWIDENS` (now `…WIDENED`), `TestAFalsyOpaqueEncodedIsNotComparable` and the `@cmp` corpus row in `test_lazy_corpus_rows_2482.py` are FLIPPED rather than deleted, so the same rows that measured the gap now measure its closure.
 - **A Python collection reaches the renderer as its ITEMS, not as its repr (#2477, #2489).** `impl FromPyObject for Value`'s fallback block ends in `Ok(Value::String(ob.str()?))`, so an object no variant models arrived as a plain string — and every consumer that iterates, sizes, subscripts or slices then read the **repr, one character at a time**, while Django read the object:
 
   ```

--- a/crates/djust_core/src/lib.rs
+++ b/crates/djust_core/src/lib.rs
@@ -569,6 +569,87 @@ pub struct Encoded {
     /// reaches [`filters::iter_values`] only from the empty-`len` claim, where
     /// `iterable` alone already answers it.
     pub items: Option<Vec<Value>>,
+    /// Which of Python's equality CONTRACTS this object obeys, measured at the
+    /// conversion (#2480). `None` is "no contract this crate can answer" —
+    /// never equal, which is the pre-fix answer for every value.
+    ///
+    /// # Why this is a fourth measured fact and not a rule over the others
+    ///
+    /// Nothing already carried decides it, in EITHER direction:
+    ///
+    /// * `set() == frozenset() == {}.keys() == {}.items()` is **True** in
+    ///   Python — ACROSS [`Encoded::type_name`]s;
+    /// * `LenZero() == LenZero()` on two DISTINCT instances is **False** —
+    ///   WITHIN one `type_name`, and True when it is the same object;
+    /// * `set() == {}.values()` is **False** while `set() == {}.keys()` is
+    ///   True, and both views carry the same (empty) [`Encoded::items`].
+    ///
+    /// So neither the type name nor the items nor any carried spelling decides
+    /// it. A NAME LIST would — `{set, frozenset, dict_keys, dict_items}` — and
+    /// is wrong in both directions: it misses every `collections.abc.Set`
+    /// registration a user writes, and it claims any user class that happens
+    /// to be called `set` (`type(o).__name__` is not qualified). The PROTOCOL
+    /// is the thing Python itself dispatches on, so it is the thing measured.
+    ///
+    /// # The four arms, each justified by a contract
+    ///
+    /// 1. [`EqClass::Set`] — `isinstance(o, collections.abc.Set)`. The ABC
+    ///    *defines* `__eq__` as `len(self) == len(other) and self <= other`
+    ///    and `__le__` as containment, so both the equality AND a real
+    ///    PARTIAL order fall out of [`Encoded::items`].
+    /// 2. [`EqClass::Number`] — `isinstance(o, numbers.Number)`, carrying
+    ///    `complex(o)`'s two components. Equality ONLY: `complex` refuses
+    ///    `<`, so this class must never grow an ordering.
+    /// 3. [`EqClass::Identity`] — `type(o).__eq__ is object.__eq__` AND
+    ///    `type(o).__repr__ is object.__repr__`. Identity semantics with an
+    ///    identity-bearing spelling, so the default repr
+    ///    (`<mod.X object at 0x…>`) IS a faithful token and
+    ///    [`Encoded::repr`] answers it with no new field. Equality only.
+    /// 4. `None` — every other object, including one that overrides `__eq__`
+    ///    (only Python can run it) and one with default `__eq__` but a CUSTOM
+    ///    `__repr__` (a `dict_values`: two distinct empty ones share the
+    ///    spelling `dict_values([])`, so the repr is not a token). Never
+    ///    equal, never ordered: exactly what a `cmp_key: None` already meant.
+    ///
+    /// **Arm 3 is a restoration, not a new hazard.** Before #2476 a
+    /// `LenZero()` crossed as `Value::String("<LenZero object at 0x…>")` and
+    /// compared by string through the `(String, String)` arm — this is the
+    /// same token, reached deliberately. Its one caveat is the same one:
+    /// CPython may reuse an address, so a value RESTORED from a state entry
+    /// could in principle match a fresh object allocated where the old one
+    /// died. Within a single render it cannot happen — every context object is
+    /// alive at once, so their addresses are distinct.
+    pub eq_class: Option<EqClass>,
+}
+
+/// Which of Python's equality contracts a [`Value::Encoded`] obeys (#2480).
+///
+/// Measured by [`equality_class`] at the conversion, because a render has no
+/// interpreter in reach and cannot call `__eq__`. See [`Encoded::eq_class`]
+/// for why each arm is a protocol rather than a type name, and
+/// `djust_templates::renderer::encoded_equal` for the one place it is read.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum EqClass {
+    /// `isinstance(o, collections.abc.Set)`. Equality AND a subset PARTIAL
+    /// order, both computed over [`Encoded::items`] — the ABC defines both in
+    /// terms of containment, so one derivation answers all five operators.
+    Set,
+    /// `isinstance(o, numbers.Number)`, as `complex(o)`'s two components.
+    ///
+    /// EQUALITY ONLY. `complex(0) < complex(0)` RAISES in Python — Django
+    /// swallows it to False — so this class must never reach an ordering.
+    /// Two components rather than one because `complex(0, 1) == 0` is False
+    /// and a real part alone cannot say so.
+    Number {
+        /// `o.real` — or `float(o)` for a real number, which is the same.
+        real: f64,
+        /// `o.imag`, `0.0` for every real number.
+        imag: f64,
+    },
+    /// `type(o).__eq__ is object.__eq__` AND `type(o).__repr__ is
+    /// object.__repr__`: identity semantics, spelled by a repr that carries
+    /// the address. Equality only — `object()` does not order either.
+    Identity,
 }
 
 /// The attribute names carried on a [`Value::Encoded`] for each of the four
@@ -797,6 +878,14 @@ impl PartialEq for Encoded {
                 }
                 _ => false,
             }
+            // The equality CLASS is part of the value (#2480): an entry that
+            // came back off the wire without it answers `{% if a == b %}`
+            // differently, which is exactly what a round-trip pin is for.
+            // `EqClass` derives `PartialEq`, and its `f64`s compare as `f64`s
+            // — a NaN component would make a value structurally unequal to
+            // itself, which is the same note `values_structurally_equal`
+            // already carries for `Value::Float`.
+            && self.eq_class == other.eq_class
     }
 }
 
@@ -866,11 +955,21 @@ pub fn values_structurally_equal(a: &Value, b: &Value) -> bool {
 impl Encoded {
     /// Python's answer for `a <op> b`, or `None` where Python refuses (#2471).
     ///
-    /// **THE** comparison for this family, and the only one: `values_equal`,
-    /// `try_compare` and `dictsort`'s ordering all read it, so `==` and `<` can
-    /// never drift apart the way they did for `Bool` (#2244), `Float` (#2243)
-    /// and `List` (#2335) before their arms were written as a pair (#1646).
-    /// Equality is `Some(Equal)` rather than a second rule.
+    /// **THE** comparison for the CMP-KEY family, and the only one. Since
+    /// #2480 its three readers — `values_equal`, `try_compare` and
+    /// `dictsort`'s ordering — reach it through ONE wrapper,
+    /// `djust_templates::renderer::encoded_partial_cmp`, which adds the
+    /// [`EqClass::Set`] subset order and otherwise delegates here. That
+    /// wrapper is this method's only caller outside this crate, which is what
+    /// keeps `==` and `<` from drifting apart the way they did for `Bool`
+    /// (#2244), `Float` (#2243) and `List` (#2335) before their arms were
+    /// written as a pair (#1646). Equality is `Some(Equal)` rather than a
+    /// second rule.
+    ///
+    /// It stays HERE, keyed on [`Encoded::cmp_key`] alone, because the Set
+    /// order compares [`Encoded::items`] with Django's `==` — which is
+    /// `renderer::values_equal`, a function this crate deliberately does not
+    /// have (`Value` has no `PartialEq`; see [`values_structurally_equal`]).
     ///
     /// `None` — which every caller renders as Django's own answer for a pair
     /// Python cannot compare: `False` for all four ordering operators, and NOT
@@ -1029,6 +1128,44 @@ impl Serialize for Value {
                         // statement as an empty list, and the deserializer
                         // keeps them apart.
                         &e.items,
+                        // Slot 11, appended for the SIXTH time and for the
+                        // sixth identical reason (#2480): the equality CLASS
+                        // is measured from a live Python object that no longer
+                        // exists when a state entry comes back, so an entry
+                        // that dropped it would restore a value whose
+                        // `{% if a == b %}` answer is the pre-fix one after
+                        // one cache hit — the exact reopening `ENCODED_TAG`
+                        // exists to prevent.
+                        //
+                        // A MAP, and NEVER `nil` — an absent class is the
+                        // EMPTY map. That is the one structural decision in
+                        // this slot, and it is what keeps the interior-insert
+                        // canary airtight now that eleven is a real width.
+                        //
+                        // Before this slot existed, a ten-element payload with
+                        // one element inserted was eleven long and refused on
+                        // WIDTH alone. It is now a real width, so only a TYPE
+                        // can refuse it — and an insert anywhere in a
+                        // ten-element payload shifts slot 9 (the ITEMS: a list
+                        // or `nil`) into this position, or the intruder
+                        // itself. No slot below carries a MAP except `attrs`
+                        // at 8, which an insert can only push to 9. So
+                        // "this slot is always a map" is exactly the predicate
+                        // that refuses every shift, and writing `nil` for the
+                        // absent case would have surrendered it.
+                        //
+                        // It also makes a swap with `cmp_key` (a list or
+                        // `nil`, four slots up) a REFUSAL rather than a
+                        // silent double loss.
+                        //
+                        // The class itself is fail-to-absent INSIDE the map,
+                        // like every other optional slot — see
+                        // `decode_eq_class`. The GROW-`attrs` alternative was
+                        // rejected: that map is what `context::lookup_segment`
+                        // resolves `{{ p.x }}` against, so a synthetic key
+                        // there would be a template-visible attribute Django
+                        // does not have.
+                        &encode_eq_class(e.eq_class),
                     ),
                 )?;
                 m.end()
@@ -1107,6 +1244,80 @@ fn decode_cmp_key(key: &Value) -> Option<CmpKey> {
                 lo: *lo,
             })
         }
+        _ => None,
+    }
+}
+
+/// The wire tag for [`EqClass::Set`].
+pub const EQ_CLASS_SET: u8 = 1;
+/// The wire tag for [`EqClass::Number`]. Its two limbs carry `complex(o)`.
+pub const EQ_CLASS_NUMBER: u8 = 2;
+/// The wire tag for [`EqClass::Identity`].
+pub const EQ_CLASS_IDENTITY: u8 = 3;
+
+/// The key the [`EqClass`] triple sits under inside slot 10's map (#2480).
+///
+/// Short, and deliberately NOT one of the four `_TAG` constants: this map is
+/// nested inside the `ENCODED_TAG` payload and reads back through the same
+/// `visit_map` as any other, so a name collision with a tag would make a
+/// one-key map decode as a `Decimal` or a `Tuple` instead.
+pub const EQ_CLASS_KEY: &str = "eq";
+
+/// Slot 10's payload for one [`EqClass`] (#2480) — the ONE writer.
+///
+/// A map, always: EMPTY for `None`, one `EQ_CLASS_KEY` entry holding
+/// `[tag, real, imag]` otherwise. See the serializer's comment on the slot for
+/// why "always a map" is the structural property and not a preference.
+fn encode_eq_class(class: Option<EqClass>) -> IndexMap<ObjectKey, Value> {
+    let mut map = IndexMap::new();
+    let (tag, real, imag) = match class {
+        None => return map,
+        Some(EqClass::Set) => (EQ_CLASS_SET, 0.0, 0.0),
+        Some(EqClass::Number { real, imag }) => (EQ_CLASS_NUMBER, real, imag),
+        Some(EqClass::Identity) => (EQ_CLASS_IDENTITY, 0.0, 0.0),
+    };
+    map.insert(
+        ObjectKey::Str(EQ_CLASS_KEY.to_string()),
+        Value::List(vec![
+            Value::Integer(i64::from(tag)),
+            Value::Float(real),
+            Value::Float(imag),
+        ]),
+    );
+    map
+}
+
+/// One [`EqClass`] slot, read back off the wire (#2480) — the ONE reader.
+///
+/// The map WRAPPER is required by the deserializer's pattern (it is what
+/// refuses a shifted payload); the class INSIDE it is fail-to-absent like
+/// every other optional slot. An empty map, a missing key, a wrong shape or an
+/// unknown tag all read as ABSENT rather than being guessed at — a value with
+/// no class keeps the pre-#2480 comparison answer, which is the direction to
+/// fail in, and a class a future build invents must not be answered by this
+/// one.
+fn decode_eq_class(map: &IndexMap<ObjectKey, Value>) -> Option<EqClass> {
+    let (Value::List(limbs) | Value::Tuple(limbs)) = map.get(EQ_CLASS_KEY)? else {
+        return None;
+    };
+    let [Value::Integer(tag), real, imag] = limbs.as_slice() else {
+        return None;
+    };
+    // A float limb is what this crate writes; an integer is accepted because a
+    // hand-built fixture (and a JSON round trip) can land a whole number on
+    // `Value::Integer`. Neither is a guess — both name the same number.
+    let as_f64 = |v: &Value| match v {
+        Value::Float(f) => Some(*f),
+        Value::Integer(i) => Some(*i as f64),
+        _ => None,
+    };
+    match u8::try_from(*tag) {
+        Ok(EQ_CLASS_SET) => Some(EqClass::Set),
+        Ok(EQ_CLASS_NUMBER) => Some(EqClass::Number {
+            real: as_f64(real)?,
+            imag: as_f64(imag)?,
+        }),
+        Ok(EQ_CLASS_IDENTITY) => Some(EqClass::Identity),
         _ => None,
     }
 }
@@ -1249,10 +1460,60 @@ impl<'de> Deserialize<'de> for Value {
                     // anything else is a real dict and falls through, so a
                     // user dict under this key cannot forge one.
                     if let Some(Value::List(parts)) = obj.get(ENCODED_TAG) {
+                        // ELEVEN elements: the #2480 shape — the equality
+                        // CLASS appended after the items.
+                        //
+                        // Every slot below 10 keeps the FREE binding and the
+                        // fail-to-absent read the ten-arm gives it — a
+                        // malformed `len` / key / `attrs` / `items` still
+                        // restores as "absent" rather than refusing the whole
+                        // payload.
+                        //
+                        // Slot 10 is the exception, and it is the one that
+                        // makes the width safe. Eleven used to be a width no
+                        // build wrote, so
+                        // `an_interior_insert_is_refused_rather_than_silently_misread`
+                        // could rely on WIDTH to refuse a ten-element payload
+                        // with one element inserted. Eleven is real now, so
+                        // only a TYPE can refuse it — and every such insert
+                        // pushes the ITEMS (a list or `nil`) or the intruder
+                        // itself into this position, never a MAP. Requiring a
+                        // map here is therefore exactly the predicate that
+                        // refuses all eleven shifts, and it is why the writer
+                        // spells an absent class as an EMPTY map rather than
+                        // as `nil`.
+                        if let [Value::String(type_name), Value::String(display), Value::String(json), Value::Bool(truthy), len, Value::Bool(iterable), Value::String(repr), key, attrs, items, Value::Object(eq_class)] =
+                            parts.as_slice()
+                        {
+                            return Ok(Value::Encoded(Box::new(Encoded {
+                                type_name: type_name.clone(),
+                                display: display.clone(),
+                                json: json.clone(),
+                                truthy: *truthy,
+                                len: match len {
+                                    Value::Integer(n) if *n >= 0 => usize::try_from(*n).ok(),
+                                    _ => None,
+                                },
+                                iterable: *iterable,
+                                repr: repr.clone(),
+                                cmp_key: decode_cmp_key(key),
+                                attrs: match attrs {
+                                    Value::Object(map) => map.clone(),
+                                    _ => IndexMap::new(),
+                                },
+                                items: match items {
+                                    Value::List(v) => Some(v.clone()),
+                                    _ => None,
+                                },
+                                eq_class: decode_eq_class(eq_class),
+                            })));
+                        }
                         // TEN elements: the #2477/#2489 shape — slot 5
                         // widened from the #2466 boolean to `len(o)` itself,
                         // and the enumerated items appended after the
-                        // attribute map.
+                        // attribute map. The equality CLASS restores ABSENT,
+                        // which is the answer the entry was WRITTEN with:
+                        // never equal, never ordered (#2480).
                         //
                         // `len` reads back as a `Value::Integer` (msgpack
                         // writes a `u64` as an unsigned int, which the visitor
@@ -1288,6 +1549,7 @@ impl<'de> Deserialize<'de> for Value {
                                     Value::List(v) => Some(v.clone()),
                                     _ => None,
                                 },
+                                eq_class: None,
                             })));
                         }
                         // NINE elements: the #2481 shape, the attribute map
@@ -1325,6 +1587,7 @@ impl<'de> Deserialize<'de> for Value {
                                 // See the four-line note in the shorter widths
                                 // below: this width predates the field.
                                 items: None,
+                                eq_class: None,
                             })));
                         }
                         // Eight elements: the #2471/#2472 shape, `repr` and
@@ -1364,6 +1627,7 @@ impl<'de> Deserialize<'de> for Value {
                                 // was WRITTEN with — and `iter_values` reads
                                 // `iterable` for it exactly as it did.
                                 items: None,
+                                eq_class: None,
                             })));
                         }
                         // Six elements: the #2466 shape, `sized_empty` and
@@ -1401,6 +1665,7 @@ impl<'de> Deserialize<'de> for Value {
                                 // was WRITTEN with — and `iter_values` reads
                                 // `iterable` for it exactly as it did.
                                 items: None,
+                                eq_class: None,
                             })));
                         }
                         // Four elements: the #2458 shape, `truthy` carried and
@@ -1429,6 +1694,7 @@ impl<'de> Deserialize<'de> for Value {
                                 // was WRITTEN with — and `iter_values` reads
                                 // `iterable` for it exactly as it did.
                                 items: None,
+                                eq_class: None,
                             })));
                         }
                         // Three elements: the #2448 shape, still readable
@@ -1455,6 +1721,7 @@ impl<'de> Deserialize<'de> for Value {
                                 // was WRITTEN with — and `iter_values` reads
                                 // `iterable` for it exactly as it did.
                                 items: None,
+                                eq_class: None,
                             })));
                         }
                     }
@@ -1663,6 +1930,7 @@ pub fn django_json_encoded(ob: &Bound<'_, PyAny>) -> Option<Encoded> {
         cmp_key,
         attrs,
         items: None,
+        eq_class: None,
     })
 }
 
@@ -3227,7 +3495,103 @@ pub fn opaque_value(ob: &Bound<'_, PyAny>) -> Option<Encoded> {
         // no values.
         attrs: public_dict_attrs(ob).unwrap_or_default(),
         items,
+        // The equality CONTRACT, measured from the live object (#2480). The
+        // one producer that sets this: `django_json_encoded` leaves it `None`
+        // because its four types already carry a real `cmp_key`, and this arm
+        // is where `set()`, `complex(0)` and arbitrary user classes land.
+        //
+        // Fails to `None` on any probe error, like every other measurement
+        // here — which restores the pre-#2480 answer (never equal) rather than
+        // guessing one.
+        eq_class: equality_class(ob),
     })
+}
+
+/// The Python types [`equality_class`] dispatches on, resolved once per
+/// interpreter (#2480).
+struct EqProtocols {
+    /// `collections.abc.Set` — the ABC that DEFINES `__eq__` as
+    /// `len(self) == len(other) and self <= other`.
+    set_abc: Py<PyAny>,
+    /// `numbers.Number`.
+    number_abc: Py<PyAny>,
+    /// The builtin `complex`, called to read a Number's two components.
+    complex_cls: Py<PyAny>,
+    /// `object.__eq__` and `object.__repr__`, for the `is`-identity probes
+    /// that decide the identity arm.
+    object_eq: Py<PyAny>,
+    object_repr: Py<PyAny>,
+}
+
+/// Which of Python's equality contracts does this object obey? (#2480)
+///
+/// Measured, not derived — see [`Encoded::eq_class`] for why a type-name list
+/// is wrong in BOTH directions and what each arm's contract is.
+///
+/// Fails CLOSED at every step, like [`django_json_encoded`] and [`is_decimal`]:
+/// an unimportable `collections.abc`, an `isinstance` that raises through a
+/// hostile `__class__`, a `complex(o)` that raises — every one answers `None`,
+/// which is the pre-#2480 behaviour (never equal, never ordered) rather than a
+/// guess.
+fn equality_class(ob: &Bound<'_, PyAny>) -> Option<EqClass> {
+    static PROTOCOLS: pyo3::sync::PyOnceLock<Option<EqProtocols>> = pyo3::sync::PyOnceLock::new();
+    let py = ob.py();
+    let protocols = PROTOCOLS
+        .get_or_init(py, || {
+            let object_type = py.get_type::<pyo3::types::PyAny>();
+            Some(EqProtocols {
+                set_abc: py
+                    .import("collections.abc")
+                    .ok()?
+                    .getattr("Set")
+                    .ok()?
+                    .unbind(),
+                number_abc: py.import("numbers").ok()?.getattr("Number").ok()?.unbind(),
+                complex_cls: py.get_type::<pyo3::types::PyComplex>().into_any().unbind(),
+                object_eq: object_type.getattr("__eq__").ok()?.unbind(),
+                object_repr: object_type.getattr("__repr__").ok()?.unbind(),
+            })
+        })
+        .as_ref()?;
+
+    // Arm 1. A `set`, a `frozenset`, a `dict_keys`, a `dict_items` and every
+    // user registration of the ABC. FIRST, because a Set's `__eq__` is the
+    // ABC's and so can never be `object`'s — the arms are disjoint, and
+    // ordering them this way says which contract is the specific one.
+    if ob.is_instance(protocols.set_abc.bind(py)).unwrap_or(false) {
+        return Some(EqClass::Set);
+    }
+    // Arm 2. `complex(o)` rather than `o.real` / `o.imag`, because a
+    // `numbers.Number` registration is only required to be convertible — a
+    // `Fraction` has no `.imag` until `complex()` gives it one. A raising
+    // conversion declines the whole arm.
+    if ob
+        .is_instance(protocols.number_abc.bind(py))
+        .unwrap_or(false)
+    {
+        let as_complex = protocols.complex_cls.bind(py).call1((ob,)).ok()?;
+        let real = as_complex.getattr("real").ok()?.extract::<f64>().ok()?;
+        let imag = as_complex.getattr("imag").ok()?.extract::<f64>().ok()?;
+        return Some(EqClass::Number { real, imag });
+    }
+    // Arm 3. Default `__eq__` AND default `__repr__`. BOTH are load-bearing:
+    // a `dict_values` has the first and not the second, and two DISTINCT empty
+    // ones share the spelling `dict_values([])` — so `repr` would call them
+    // equal where Python says they are not. Measured, not reasoned about.
+    let ty = ob.get_type();
+    let eq_is_default = ty
+        .getattr("__eq__")
+        .is_ok_and(|f| f.is(protocols.object_eq.bind(py)));
+    let repr_is_default = ty
+        .getattr("__repr__")
+        .is_ok_and(|f| f.is(protocols.object_repr.bind(py)));
+    if eq_is_default && repr_is_default {
+        return Some(EqClass::Identity);
+    }
+    // Arm 4. Everything else — a class that overrides `__eq__` (only Python
+    // can run it), and one with a custom `__repr__` whose spelling is not a
+    // token. Never equal: the answer this carrier already gave.
+    None
 }
 
 /// Convert Value to Python object using the new IntoPyObject trait.

--- a/crates/djust_core/tests/test_encoded_wire_positions_2471_2472.rs
+++ b/crates/djust_core/tests/test_encoded_wire_positions_2471_2472.rs
@@ -120,6 +120,12 @@ fn sample() -> Encoded {
         // fixture carrying one could not tell "slot 10 round-tripped" from
         // "slot 10 was dropped" (#2477/#2489).
         items: Some(vec![Value::String("a".to_string()), Value::Integer(2)]),
+        // NON-`None`, and a class whose wire tag DIFFERS from the
+        // sample's `cmp_key` domain, for the reason the attribute map
+        // is non-empty: slot 10 has the same three-element shape as
+        // slot 7, so only the VALUES can catch a swap of the two
+        // (#2480).
+        eq_class: Some(djust_core::EqClass::Identity),
     }
 }
 
@@ -183,18 +189,43 @@ fn parts_of(e: &Encoded) -> Vec<Value> {
         Some(items) => Value::List(items.clone()),
         None => Value::Missing,
     });
+    // Slot 10, the equality class (#2480). Always a MAP — EMPTY for an absent
+    // class, never `nil` — which is the property that refuses a shifted
+    // ten-element payload now that eleven is a real width.
+    let eq_limbs = |tag: u8, real: f64, imag: f64| {
+        Value::Object(
+            [(
+                djust_core::object_key::ObjectKey::Str(djust_core::EQ_CLASS_KEY.to_string()),
+                Value::List(vec![
+                    Value::Integer(i64::from(tag)),
+                    Value::Float(real),
+                    Value::Float(imag),
+                ]),
+            )]
+            .into_iter()
+            .collect(),
+        )
+    };
+    v.push(match e.eq_class {
+        Some(djust_core::EqClass::Set) => eq_limbs(djust_core::EQ_CLASS_SET, 0.0, 0.0),
+        Some(djust_core::EqClass::Number { real, imag }) => {
+            eq_limbs(djust_core::EQ_CLASS_NUMBER, real, imag)
+        }
+        Some(djust_core::EqClass::Identity) => eq_limbs(djust_core::EQ_CLASS_IDENTITY, 0.0, 0.0),
+        None => Value::Object(indexmap::IndexMap::new()),
+    });
     v
 }
 
 #[test]
-fn the_payload_is_ten_slots_in_the_documented_order() {
+fn the_payload_is_eleven_slots_in_the_documented_order() {
     let e = sample();
     // `Value` has no `PartialEq` (the renderer's own tests note it), so match
     // the variant and compare the `Encoded`, which does derive one.
-    assert_eq!(parts_of(&e).len(), 10, "the payload width moved");
+    assert_eq!(parts_of(&e).len(), 11, "the payload width moved");
     match decode_parts(parts_of(&e)) {
         Value::Encoded(back) => assert_eq!(*back, e),
-        other => panic!("the ten-slot payload did not read as an Encoded: {other:?}"),
+        other => panic!("the eleven-slot payload did not read as an Encoded: {other:?}"),
     }
 }
 
@@ -326,7 +357,7 @@ fn an_empty_attribute_map_is_written_and_read_as_empty() {
     };
     assert_eq!(
         parts_of(&e).len(),
-        10,
+        11,
         "an empty map must not drop its slot"
     );
     assert_eq!(round_trip(&e), e);
@@ -660,16 +691,21 @@ fn a_one_slot_shift_is_detectable() {
         "the sample stopped distinguishing the slots around `len`",
     );
     let mut shifted = parts_of(&e);
-    // Now NINE elements — a real width since #2481, so this case does not
+    // Now TEN elements — a real width since #2477/#2489, so this case does not
     // refuse on width alone. It refuses on TYPES: with slot 4 gone, `iterable`
-    // (a bool) sits where the nine-arm wants `sized_empty` — which it happens
-    // to accept — and `repr` (a string) sits where it wants a BOOL, which it
-    // does not.
+    // (a bool) sits where the ten-arm's free `len` binding accepts anything,
+    // and `repr` (a string) sits where it wants a BOOL, which it does not.
     shifted.remove(4);
-    assert_eq!(shifted.len(), 9, "the shifted payload must be a REAL width");
+    assert_eq!(
+        shifted.len(),
+        10,
+        "the shifted payload must be a REAL width"
+    );
     match decode_parts(shifted) {
         Value::Object(_) => {}
-        other => panic!("a type-misaligned 9-element payload must not forge an Encoded: {other:?}"),
+        other => {
+            panic!("a type-misaligned 10-element payload must not forge an Encoded: {other:?}")
+        }
     }
 
     // And the sharper case: keep the width at 10 but SWAP the two BOOLEAN
@@ -722,14 +758,14 @@ fn an_interior_insert_is_refused_rather_than_silently_misread() {
     // limitation.
     let e = sample();
     let full = parts_of(&e);
-    assert_eq!(full.len(), 10, "the payload width moved");
+    assert_eq!(full.len(), 11, "the payload width moved");
     let mut refused = 0;
     for at in 0..full.len() {
         let mut shifted = full.clone();
         // A STRING, which is a real type in this payload — so the refusal is
         // about the shape and not about an obviously-alien element.
         shifted.insert(at, Value::String("intruder".to_string()));
-        assert_eq!(shifted.len(), 11);
+        assert_eq!(shifted.len(), 12);
         match decode_parts(shifted) {
             Value::Object(_) => refused += 1,
             other => panic!(
@@ -738,7 +774,67 @@ fn an_interior_insert_is_refused_rather_than_silently_misread() {
             ),
         }
     }
-    assert_eq!(refused, 10, "every interior insert must be refused");
+    assert_eq!(refused, 11, "every interior insert must be refused");
+}
+
+#[test]
+fn an_insert_into_the_ten_slot_payload_is_refused_by_the_last_slots_type() {
+    // The case the test above does NOT cover, and the one #2480's slot exists
+    // to survive.
+    //
+    // Inserting into the CURRENT payload gives twelve, which is not a width
+    // any arm matches — so that canary is answered by WIDTH and would stay
+    // green however slot 10 were typed. The dangerous shape is one width down:
+    // a TEN-element payload (the #2477/#2489 shape, which real state entries
+    // carry) with one element inserted is ELEVEN, and eleven is now a REAL
+    // width. Only the TYPE of the last slot can refuse it.
+    //
+    // Every such insert pushes the ITEMS — a list, or `nil` — or the intruder
+    // itself into slot 10, and slot 10 is required to be a MAP. That is why
+    // the writer spells an absent class as an EMPTY map rather than as `nil`,
+    // and this test is the assertion that says so: drop the `Value::Object`
+    // pattern from the eleven-arm and several of these stop being refused.
+    //
+    // Run for BOTH item shapes, because they land different types in the slot.
+    for (label, e) in [
+        ("carried items", sample()),
+        (
+            "no items",
+            Encoded {
+                items: None,
+                ..sample()
+            },
+        ),
+    ] {
+        let eleven = parts_of(&e);
+        assert_eq!(eleven.len(), 11, "{label}: the payload width moved");
+        // The #2477/#2489 shape is this one without its last slot, and it must
+        // still read as an `Encoded` — otherwise the sweep below would be
+        // measuring a broken baseline rather than the insert.
+        let ten = eleven[..10].to_vec();
+        match decode_parts(ten.clone()) {
+            Value::Encoded(back) => assert!(
+                back.eq_class.is_none(),
+                "{label}: a ten-slot payload must restore with NO equality class",
+            ),
+            other => panic!("{label}: the ten-slot payload stopped reading: {other:?}"),
+        }
+
+        let mut refused = 0;
+        for at in 0..ten.len() {
+            let mut shifted = ten.clone();
+            shifted.insert(at, Value::String("intruder".to_string()));
+            assert_eq!(shifted.len(), 11, "{label}: the shifted width must be REAL");
+            match decode_parts(shifted) {
+                Value::Object(_) => refused += 1,
+                other => panic!(
+                    "{label}: an insert at slot {at} of a TEN-slot payload produced \
+                     an Encoded with shifted contents instead of being refused: {other:?}"
+                ),
+            }
+        }
+        assert_eq!(refused, 10, "{label}: every insert must be refused");
+    }
 }
 
 #[test]
@@ -760,7 +856,7 @@ fn the_slot_that_grew_inside_itself_did_not_take_a_position() {
         );
     }
     let parts = parts_of(&grown);
-    assert_eq!(parts.len(), 10, "growing the attribute map moved the width");
+    assert_eq!(parts.len(), 11, "growing the attribute map moved the width");
     // Slot 8 is still the map, and it carries every name.
     match &parts[8] {
         Value::Object(map) => {

--- a/crates/djust_templates/src/filters.rs
+++ b/crates/djust_templates/src/filters.rs
@@ -4203,9 +4203,10 @@ fn compare_sort_values(a_val: &Value, b_val: &Value) -> std::cmp::Ordering {
             // catches the `TypeError` and returns `""` where this returns the
             // list unsorted, a divergence that predates this variant and is
             // not this fix's (#1079).
-            (Value::Encoded(a_enc), Value::Encoded(b_enc)) => a_enc
-                .python_partial_cmp(b_enc)
-                .unwrap_or(std::cmp::Ordering::Equal),
+            (Value::Encoded(a_enc), Value::Encoded(b_enc)) => {
+                crate::renderer::encoded_partial_cmp(a_enc, b_enc)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            }
             // Any pair that is numeric on BOTH sides. Two deltas, not one:
             // a Decimal column used to sort as all-Equal, i.e. not at all
             // (#2214) — and so did a MIXED int/float column, since the arms
@@ -6866,6 +6867,7 @@ mod tests {
                 }),
                 attrs: Default::default(),
                 items: None,
+                eq_class: None,
             })),
             Value::Encoded(Box::new(djust_core::Encoded {
                 type_name: "set".to_string(),
@@ -6878,6 +6880,7 @@ mod tests {
                 cmp_key: None,
                 attrs: Default::default(),
                 items: Some(vec![]),
+                eq_class: None,
             })),
             // The FOURTH shape, and the one #2477/#2489 added: a NON-EMPTY
             // carried collection. It is what makes the `python_len` ==
@@ -6897,6 +6900,7 @@ mod tests {
                     Value::String("a".to_string()),
                     Value::String("b".to_string()),
                 ]),
+                eq_class: Some(djust_core::EqClass::Set),
             })),
             // The FIFTH: a falsy `__iter__` class with NO `__len__`. Django's
             // `|length` answers 0 (its `except TypeError`) while `{% for %}`
@@ -6913,6 +6917,7 @@ mod tests {
                 cmp_key: None,
                 attrs: Default::default(),
                 items: Some(vec![Value::String("x".to_string())]),
+                eq_class: None,
             })),
             // The THIRD shape, and the one that proves the two bits are two
             // questions: a class with a zero `__len__` and no `__iter__`.
@@ -6930,6 +6935,7 @@ mod tests {
                 cmp_key: None,
                 attrs: Default::default(),
                 items: None,
+                eq_class: None,
             })),
         ]
     }
@@ -6981,6 +6987,7 @@ mod tests {
             cmp_key: None,
             attrs: Default::default(),
             items: None,
+            eq_class: None,
         }));
         assert!(iter_values(&legacy).is_some_and(|items| items.is_empty()));
         assert_eq!(python_len(&legacy), Some(0));
@@ -7433,6 +7440,7 @@ mod tests {
                 }),
                 attrs: Default::default(),
                 items: None,
+                eq_class: None,
             })),
             // The SAME variant on the ITERATING side (#2466), which is why one
             // sample of it is no longer enough. Since `falsy_opaque` widened
@@ -7459,6 +7467,7 @@ mod tests {
                 cmp_key: None,
                 attrs: Default::default(),
                 items: Some(vec![]),
+                eq_class: None,
             })),
         ];
         // The hostile-display member, kept OUT of the array above so the
@@ -7476,6 +7485,7 @@ mod tests {
             cmp_key: None,
             attrs: Default::default(),
             items: None,
+            eq_class: None,
         }));
         assert!(
             iter_values(&hostile).is_none(),

--- a/crates/djust_templates/src/renderer.rs
+++ b/crates/djust_templates/src/renderer.rs
@@ -5,7 +5,7 @@ use crate::inheritance::TemplateLoader;
 use crate::parser::Node;
 use crate::registry::TagArg;
 use djust_components::Component;
-use djust_core::{Context, DjangoRustError, Result, Value};
+use djust_core::{Context, DjangoRustError, Encoded, EqClass, Result, Value};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashSet;
@@ -4212,14 +4212,28 @@ fn values_equal(a: &Value, b: &Value) -> bool {
         // shape #2335 fixed for lists, one variant later; `Value::Encoded`
         // arrived in #2448 and got neither this arm nor `try_compare`'s.
         //
-        // Through `python_partial_cmp`, so equality is `Some(Equal)` and not a
-        // second rule that could drift from the ordering one — the failure
-        // #2244/#2243/#2335 each had. A pair Python refuses (a `date` against a
-        // `datetime`, a naive against an aware) answers `None` there and so
-        // stays `false` here, which is what Django answers and what this
-        // wildcard already answered before the arm existed.
-        (Value::Encoded(a), Value::Encoded(b)) => {
-            a.python_partial_cmp(b) == Some(std::cmp::Ordering::Equal)
+        // Through `encoded_equal`, which reaches the ordering for every class
+        // that HAS one — so equality is `Some(Equal)` and not a second rule
+        // that could drift from the ordering one, the failure #2244/#2243/#2335
+        // each had. A pair Python refuses (a `date` against a `datetime`, a
+        // naive against an aware, a `set` against a `complex`) answers `None`
+        // there and so stays `false` here, which is what Django answers and
+        // what this wildcard already answered before the arm existed.
+        (Value::Encoded(a), Value::Encoded(b)) => encoded_equal(a, b),
+        // An opaque NUMBER against a real one (#2480). `complex(0) == 0` is
+        // True in Python and Django, and no `(Encoded, Encoded)` arm reaches
+        // it. A `Bool` has already become an `Integer` at the top of this
+        // function, so `{% if p == True %}` on a `complex(1)` lands here too.
+        //
+        // Deliberately NOT extended to `Decimal` or `BigInt`: both are exact
+        // types whose Python comparison against a `complex` is exact as well,
+        // and an `f64` cannot answer it. Those cells stay open and are pinned
+        // as declined rather than answered approximately.
+        (Value::Encoded(e), Value::Integer(i)) | (Value::Integer(i), Value::Encoded(e)) => {
+            encoded_equals_integer(e, *i)
+        }
+        (Value::Encoded(e), Value::Float(f)) | (Value::Float(f), Value::Encoded(e)) => {
+            matches!(e.eq_class, Some(EqClass::Number { real, imag }) if imag == 0.0 && real == *f)
         }
         // Pairs involving a DECIMAL, and only those. Without this
         // `{% if p == 19.99 %}` went false the moment a Decimal stopped being a
@@ -4244,6 +4258,149 @@ fn values_equal(a: &Value, b: &Value) -> bool {
         // `(Float, Integer)`, which has had its own exact arms since #2243.
         _ => false,
     }
+}
+
+/// Python's ordering for two [`Encoded`]s, or `None` where Python refuses
+/// (#2480).
+///
+/// **The ONE reader of `Encoded::python_partial_cmp`**, and the one place the
+/// `Encoded` half of `==` / `<` / `<=` / `>` / `>=` is decided. Its three
+/// callers — [`values_equal`] (through [`encoded_equal`]), [`try_compare`] and
+/// `filters::compare_sort_values` — reach every class through here, so an
+/// operator cannot drift from its neighbours (#1646). That is the same
+/// property `python_partial_cmp` had before this wrapper existed; the wrapper
+/// exists because the [`EqClass::Set`] order compares carried ITEMS with
+/// Django's `==`, which is [`values_equal`] — a function `djust_core` does not
+/// have and deliberately will not grow (`Value` has no `PartialEq`).
+///
+/// # The classes that order, and the ones that must not
+///
+/// | class | `==` | `<` `<=` `>` `>=` |
+/// |---|---|---|
+/// | `EqClass::Set` | items, both ways | SUBSET, a real partial order |
+/// | `EqClass::Number` | components | **never** — `complex(0) < complex(0)` RAISES |
+/// | `EqClass::Identity` | the repr token | **never** — `object() < object()` RAISES |
+/// | `None` (the datetime family) | `cmp_key` | `cmp_key` |
+///
+/// So the Number and Identity classes answer `None` HERE and are answered by
+/// [`encoded_equal`] instead. Giving them a key to reach equality — the
+/// obvious one-line version of this fix — would turn
+/// `{% if p <= q %}` on a `complex(0)` from Django's `N` into `Y`, trading
+/// eight closed cells for a new divergence.
+///
+/// A cross-class pair is `None`, which is right: `set() < complex(0)` raises
+/// in Python and `set() == complex(0)` is False.
+pub(crate) fn encoded_partial_cmp(a: &Encoded, b: &Encoded) -> Option<std::cmp::Ordering> {
+    match (a.eq_class, b.eq_class) {
+        (Some(EqClass::Set), Some(EqClass::Set)) => set_partial_cmp(a, b),
+        // Either side carrying a class that does not order — including a Set
+        // against a datetime — answers `None`, the pre-#2480 answer.
+        (Some(_), _) | (_, Some(_)) => None,
+        // The datetime family, unchanged: `Encoded::python_partial_cmp` is
+        // still the whole of it.
+        (None, None) => a.python_partial_cmp(b),
+    }
+}
+
+/// Python's `==` for two [`Encoded`]s (#2480).
+///
+/// Equality goes through [`encoded_partial_cmp`] for every class that HAS an
+/// ordering, so those two can never disagree; the two equality-only classes
+/// are the arms here, and they are the reason this is a separate function
+/// rather than a `== Some(Equal)` at the call site.
+fn encoded_equal(a: &Encoded, b: &Encoded) -> bool {
+    match (a.eq_class, b.eq_class) {
+        // Two numbers: the components, exactly. `f64`'s own `==` is Python's
+        // — `0.0 == -0.0` is true on both, and a NaN component is equal to
+        // nothing, which is also Python's answer.
+        (
+            Some(EqClass::Number { real: ra, imag: ia }),
+            Some(EqClass::Number { real: rb, imag: ib }),
+        ) => ra == rb && ia == ib,
+        // Two identity-semantics objects: the default `repr` carries the
+        // address, so the token IS the identity. See `Encoded::eq_class` for
+        // the address-reuse caveat and why it cannot bite within one render.
+        (Some(EqClass::Identity), Some(EqClass::Identity)) => a.repr == b.repr,
+        // Everything else — two Sets, two datetimes, and every CROSS-class
+        // pair (which answers `None` there, i.e. false, exactly as Python
+        // says `set() != complex(0)`).
+        _ => encoded_partial_cmp(a, b) == Some(std::cmp::Ordering::Equal),
+    }
+}
+
+/// The most items either side may carry before [`set_partial_cmp`] DECLINES.
+///
+/// Containment without a hash is quadratic, and a `set` states its own length
+/// so `opaque_value` enumerates it in full however large it is — a template
+/// comparing two 100k-element sets would otherwise do 10^10 [`values_equal`]
+/// calls inside a render. Past this the answer is `None`: the pre-#2480
+/// behaviour (never equal, never ordered), which is a cell left open rather
+/// than a wrong answer.
+///
+/// A hash-based version is not available here: the items are [`Value`]s, whose
+/// equality is [`values_equal`] — which equates `1` with `1.0` and so is not a
+/// hash-compatible relation without a canonicalisation this fix does not need.
+const SET_COMPARE_CAP: usize = 1_000;
+
+/// Python's `set` ordering — CONTAINMENT, which is partial (#2480).
+///
+/// `collections.abc.Set` defines `__le__` as "every element of self is in
+/// other" and `__eq__` as `len(self) == len(other) and self <= other`, so both
+/// directions of containment answer all five operators at once:
+///
+/// ```text
+/// a ⊆ b and b ⊆ a  ->  Equal      {'a'} == {'a'},  set() == frozenset()
+/// a ⊆ b only       ->  Less       set() < {'a'}
+/// b ⊆ a only       ->  Greater
+/// neither          ->  None       {1} vs {2}: all four operators False
+/// ```
+///
+/// `None` for the incomparable case is exactly Python's answer, and is why the
+/// partial order can live in an `Option<Ordering>` at all — every caller
+/// already renders `None` as "false for all four ordering operators", which is
+/// what `{% if {1} < {2} %}` must do.
+///
+/// Element equality is [`values_equal`] and not a structural compare, because
+/// Python's is: `{1} == {1.0}` is True.
+fn set_partial_cmp(a: &Encoded, b: &Encoded) -> Option<std::cmp::Ordering> {
+    // A Set is iterable by construction, so `items` is `Some` for every value
+    // this crate builds. It can be `None` for one restored from a wire width
+    // that predates the field — which also predates `eq_class`, so this is
+    // unreachable today and is a decline rather than a panic.
+    let (Some(a_items), Some(b_items)) = (&a.items, &b.items) else {
+        return None;
+    };
+    if a_items.len() > SET_COMPARE_CAP || b_items.len() > SET_COMPARE_CAP {
+        return None;
+    }
+    let contains = |hay: &[Value], needle: &Value| hay.iter().any(|x| values_equal(x, needle));
+    let a_in_b = a_items.iter().all(|x| contains(b_items, x));
+    let b_in_a = b_items.iter().all(|x| contains(a_items, x));
+    match (a_in_b, b_in_a) {
+        (true, true) => Some(std::cmp::Ordering::Equal),
+        (true, false) => Some(std::cmp::Ordering::Less),
+        (false, true) => Some(std::cmp::Ordering::Greater),
+        (false, false) => None,
+    }
+}
+
+/// Does this opaque NUMBER equal a Python `int`? (#2480)
+///
+/// EXACTLY, which is what Python does: `complex(2**53) == 2**53 + 1` is
+/// **False** even though `float(2**53 + 1)` rounds to the value the complex
+/// holds. So the comparison runs in the integer domain — the carried `f64` is
+/// converted back to an `i64` and must round-trip — rather than casting the
+/// `i64` to an `f64`, which would answer True for that pair.
+fn encoded_equals_integer(e: &Encoded, i: i64) -> bool {
+    let Some(EqClass::Number { real, imag }) = e.eq_class else {
+        return false;
+    };
+    // Through [`int_eq_float`] rather than a second spelling of it. That
+    // function already IS "Python's exact int-against-float", including the two
+    // traps a hand-rolled version gets wrong — the `2**53 + 1` rounding and the
+    // saturating `as i64` at `1e300` — and a belt-and-braces copy beside it is
+    // one fix plus one decoration that no test can separate (v1.1.1-2 rule 3).
+    imag == 0.0 && int_eq_float(i, real)
 }
 
 /// Django identity comparison for the `is` / `is not` template operators.
@@ -4451,7 +4608,7 @@ fn try_compare(a: &Value, b: &Value) -> Option<i32> {
         // `<` and `>` were both false and the template silently took the wrong
         // branch. A pair Python cannot order stays `None`, which is Django's
         // own answer (`smart_if` swallows the `TypeError` to False).
-        (Value::Encoded(a), Value::Encoded(b)) => a.python_partial_cmp(b).map(|ord| ord as i32),
+        (Value::Encoded(a), Value::Encoded(b)) => encoded_partial_cmp(a, b).map(|ord| ord as i32),
         // No `(Missing, Missing) => 0` arm, and its absence is deliberate
         // (#2338): Python's `None < None` RAISES, so Django answers False for
         // all four operators, and the 0 this used to return made `>=` and `<=`
@@ -5975,6 +6132,7 @@ mod tests {
                 }),
                 attrs: Default::default(),
                 items: None,
+                eq_class: None,
             })),
             // A `set()`: `len` 0 and iterable, so both probes say
             // "iterates to nothing".
@@ -5989,6 +6147,7 @@ mod tests {
                 cmp_key: None,
                 attrs: Default::default(),
                 items: Some(vec![]),
+                eq_class: None,
             })),
             // A `{'a'}`: truthy, `len` 1, and its item carried (#2477/#2489).
             // Without it every `Encoded` sample here is EMPTY, and the sweep
@@ -6005,6 +6164,7 @@ mod tests {
                 cmp_key: None,
                 attrs: Default::default(),
                 items: Some(vec![Value::String("a".to_string())]),
+                eq_class: None,
             })),
             // A falsy `__iter__` class with NO `__len__`: Django's `ForNode`
             // has no length to read, so it `list()`s the object and renders
@@ -6021,6 +6181,7 @@ mod tests {
                 cmp_key: None,
                 attrs: Default::default(),
                 items: Some(vec![Value::String("x".to_string())]),
+                eq_class: None,
             })),
             // A zero-`__len__` class with no `__iter__`: `{% for %}` renders
             // the empty branch, `iter_values` refuses. The one sample that
@@ -6036,6 +6197,7 @@ mod tests {
                 cmp_key: None,
                 attrs: Default::default(),
                 items: None,
+                eq_class: None,
             })),
         ];
         // `Value::None` and `Value::Missing` are Django's `values is None`

--- a/python/tests/test_encoded_attributes_2481.py
+++ b/python/tests/test_encoded_attributes_2481.py
@@ -360,7 +360,7 @@ class TestTheStateRoundTripKeepsTheAttributes:
         # items. Both assertions below are kept, so a change that moved the
         # map's contents into a POSITION of their own fails here rather than
         # arriving as a plausible width.
-        assert len(payload) == 10, payload  # nine until #2477/#2489 grew it
+        assert len(payload) == 11, payload  # ten until #2480 appended the class
         # The three DATA attributes, then the one AUTO-CALLED result (#2485) —
         # both producers write this ONE map, in table order, and the order is
         # what `values_structurally_equal`'s zipped compare reads.
@@ -391,7 +391,7 @@ class TestTheStateRoundTripKeepsTheAttributes:
         view.set_state("p", datetime.timedelta(days=3))
         decoded = msgpack.unpackb(view.serialize_msgpack(), raw=False, strict_map_key=False)
         payload = decoded[1]["p"]["__djust_encoded__"]
-        assert len(payload) == 10, payload
+        assert len(payload) == 11, payload
         # A LEGACY payload is not a truncation of the current one (#2477/#2489):
         # slot 4 widened from #2466's `sized_empty` boolean to `len(o)` itself,
         # so every width below 10 carries a `Bool` there while a 10-element one

--- a/python/tests/test_encoded_truthiness_2458.py
+++ b/python/tests/test_encoded_truthiness_2458.py
@@ -290,6 +290,11 @@ class TestTheStateRoundTripKeepsTheAnswer:
             # statement from an empty list, which is why the codec keeps them
             # apart.
             None,
+            # #2480's equality CLASS, appended last. A `timedelta` has none —
+            # it compares by its `cmp_key` — and the absent case is an EMPTY
+            # MAP rather than a nil, which is what refuses a shifted
+            # ten-element payload now that eleven is a real width.
+            {},
         ]
         assert payload[3] is False, "the truthiness bit moved off element 3"
 
@@ -313,7 +318,7 @@ class TestTheStateRoundTripKeepsTheAnswer:
         view.set_state("p", datetime.timedelta(0))
         decoded = msgpack.unpackb(view.serialize_msgpack(), raw=False, strict_map_key=False)
         payload = decoded[1]["p"]["__djust_encoded__"]
-        assert len(payload) == 10, payload  # nine until #2477/#2489 grew it
+        assert len(payload) == 11, payload  # ten until #2480 appended the class
         # A LEGACY payload is not a truncation of the current one (#2477/#2489):
         # slot 4 widened from #2466's `sized_empty` boolean to `len(o)` itself,
         # so every width below 10 carries a `Bool` there while a 10-element one
@@ -349,7 +354,7 @@ class TestTheStateRoundTripKeepsTheAnswer:
         view.set_state("p", datetime.timedelta(0))
         decoded = msgpack.unpackb(view.serialize_msgpack(), raw=False, strict_map_key=False)
         payload = decoded[1]["p"]["__djust_encoded__"]
-        assert len(payload) == 10, payload
+        assert len(payload) == 11, payload
         # A LEGACY payload is not a truncation of the current one (#2477/#2489):
         # slot 4 widened from #2466's `sized_empty` boolean to `len(o)` itself,
         # so every width below 10 carries a `Bool` there while a 10-element one
@@ -476,18 +481,19 @@ class TestTheSinkHasExactlyTheCallersItClaims:
         may fall back to `!display.is_empty()`, and it is the three-element
         one.
 
-        SIX widths since #2477/#2489 widened slot 4 and appended the items —
-        ten (current), nine (#2481-era), eight (#2471/#2472-era), six
-        (#2466-era), four (#2458-era) and three (#2448-era) — so exactly FIVE
-        arms carry the bit verbatim from the payload and exactly ONE derives
-        it. The count is an equality rather than a floor so a DELETED
-        compatibility arm reddens it as loudly as an added derivation:
-        dropping the four-element read would silently turn every state entry
-        written by a 1.1.x process into a plain dict after a rolling deploy.
+        SEVEN widths since #2480 appended the equality class — eleven
+        (current), ten (#2477/#2489-era), nine (#2481-era), eight
+        (#2471/#2472-era), six (#2466-era), four (#2458-era) and three
+        (#2448-era) — so exactly SIX arms carry the bit verbatim from the
+        payload and exactly ONE derives it. The count is an equality rather
+        than a floor so a DELETED compatibility arm reddens it as loudly as an
+        added derivation: dropping the four-element read would silently turn
+        every state entry written by a 1.1.x process into a plain dict after a
+        rolling deploy.
         """
         src = self._production(CORE_RS.read_text(encoding="utf-8"))
         assert self._count(src, "truthy: !display.is_empty(),") == 1
-        assert self._count(src, "truthy: *truthy,") == 5
+        assert self._count(src, "truthy: *truthy,") == 6
 
     def test_the_counter_goes_red_in_BOTH_directions(self) -> None:
         """The canary. Each mutation asserts it APPLIED before its count is

--- a/python/tests/test_encoded_value_position_2471_2472_2473.py
+++ b/python/tests/test_encoded_value_position_2471_2472_2473.py
@@ -819,8 +819,20 @@ class TestOneComparisonChokepoint:
     #: file -> number of CALLS (the definition is excluded). Deriving the
     #: expected set from the source would make the test compare the source to
     #: itself; these are written down.
+    #: ONE caller since #2480: `renderer::encoded_partial_cmp`, the wrapper
+    #: that adds the `EqClass::Set` subset order and delegates the datetime
+    #: family here. The three SINKS are unchanged and are pinned by
+    #: `EXPECTED_WRAPPER_CALLERS` below — the chokepoint moved out one level
+    #: rather than dissolving, which is what keeps `==` and `<` together.
     EXPECTED_CALLERS = {
-        "crates/djust_templates/src/renderer.rs": 2,  # values_equal, try_compare
+        "crates/djust_templates/src/renderer.rs": 1,  # encoded_partial_cmp
+    }
+
+    #: file -> CALLS of the wrapper, definition excluded. The three sinks:
+    #: `values_equal` (through `encoded_equal`), `try_compare`, and
+    #: `compare_sort_values`.
+    EXPECTED_WRAPPER_CALLERS = {
+        "crates/djust_templates/src/renderer.rs": 2,  # encoded_equal, try_compare
         "crates/djust_templates/src/filters.rs": 1,  # compare_sort_values
     }
 
@@ -835,11 +847,29 @@ class TestOneComparisonChokepoint:
                 found[str(path.relative_to(REPO))] = n
         return found
 
+    def _wrapper_calls(self) -> dict[str, int]:
+        found: dict[str, int] = {}
+        for path in sorted(REPO.glob("crates/*/src/**/*.rs")):
+            src = path.read_text(encoding="utf-8")
+            # Calls only: the definition is `pub(crate) fn encoded_partial_cmp(`.
+            # The lookbehind already excludes the definition
+            # (`pub(crate) fn encoded_partial_cmp(`), so nothing is subtracted.
+            n = len(re.findall(r"(?<!fn )encoded_partial_cmp\(", src))
+            if n:
+                found[str(path.relative_to(REPO))] = n
+        return found
+
     def test_the_caller_set_is_exactly_the_three_comparison_sinks(self) -> None:
         assert self._calls() == self.EXPECTED_CALLERS, (
-            "the set of `python_partial_cmp` callers changed. A NEW caller must be "
-            "added to EXPECTED_CALLERS with a test; a REMOVED one means a comparison "
-            "sink went back to answering an Encoded from a wildcard (#2471)."
+            "the set of `python_partial_cmp` callers changed. Since #2480 the ONLY "
+            "caller is `encoded_partial_cmp`; a second one would let the Set order "
+            "and the datetime order answer the same operator differently (#1646)."
+        )
+        assert self._wrapper_calls() == self.EXPECTED_WRAPPER_CALLERS, (
+            "the set of `encoded_partial_cmp` callers changed. A NEW caller must be "
+            "added to EXPECTED_WRAPPER_CALLERS with a test; a REMOVED one means a "
+            "comparison sink went back to answering an Encoded from a wildcard "
+            "(#2471/#2480)."
         )
 
     def test_the_definition_is_the_only_one(self) -> None:
@@ -978,6 +1008,11 @@ class TestTheStateRoundTripKeepsTheAnswers:
             # `timedelta`, which is not iterable — and `None` is a DIFFERENT
             # statement from an empty list.
             None,
+            # #2480's equality CLASS, appended last. A `timedelta` has none —
+            # it compares by its `cmp_key` two slots up — and the absent case
+            # is an EMPTY MAP rather than a nil, which is what refuses a
+            # shifted ten-element payload now that eleven is a real width.
+            {},
         ]
 
     def test_a_shorter_payload_still_reads_without_fabricating_the_answers(self) -> None:
@@ -1005,7 +1040,7 @@ class TestTheStateRoundTripKeepsTheAnswers:
             view.set_state("p", datetime.timedelta(0))
             view.set_state("q", datetime.timedelta(0))
             decoded = msgpack.unpackb(view.serialize_msgpack(), raw=False, strict_map_key=False)
-            assert len(decoded[1]["p"]["__djust_encoded__"]) == 10
+            assert len(decoded[1]["p"]["__djust_encoded__"]) == 11
             for key in ("p", "q"):
                 parts = decoded[1][key]["__djust_encoded__"]
                 # A LEGACY payload is not a truncation of the current one
@@ -1084,23 +1119,19 @@ class TestAFalsyOpaqueEncodedIsNotComparable:
     ``complex(0)`` and any falsy user object — so the comparison arm this PR
     adds is REACHED for values whose Python ordering it cannot know.
 
-    It answers ``None`` for every such pair, because ``opaque_value`` sets no
-    ``cmp_key``: never equal, never ordered. Pinned here for two reasons.
+    It answered ``None`` for every such pair — never equal, never ordered —
+    until **#2480 closed it** by measuring the object's equality CONTRACT at
+    the conversion (``Encoded::eq_class``: the ``collections.abc.Set`` ABC, a
+    ``numbers.Number``, or default ``__eq__`` + default ``__repr__``).
 
-    **It is not this PR's regression, and the pin says whose it is.** Before
-    #2476 a ``set()`` was a ``Value::String("set()")`` and two of them compared
-    EQUAL through the ``(String, String)`` arm, which is Django's answer.
-    #2476 made it an ``Encoded``, which fell to ``_ => false``. This PR's arm
-    answers the same ``false`` — measured, not argued: the gate-off mutation
-    that reverts ``values_equal``'s arm to ``false`` (M1) leaves every
-    assertion in this class green, which is the same-answer proof.
-
-    **No derivable rule exists, which is why it is filed rather than fixed
-    (#1079).** ``set() == frozenset()`` is True in Python ACROSS type names,
-    and ``LenZero() == LenZero()`` on two distinct instances is False WITHIN
-    one — so neither ``type_name`` nor any carried spelling separates them.
-    Answering it needs the object's ``__eq__``, i.e. a token the conversion
-    would have to invent. Filed as #2480.
+    This class is FLIPPED rather than deleted, so the same rows that measured
+    the gap now measure its closure — and the one member that is still
+    declined stays visible next to the four that are not.  ``BoolFalse`` has a
+    custom ``__repr__``, so its spelling is not an identity token and using it
+    would call two DISTINCT instances equal; that is a new wrong answer rather
+    than an unfixed cell, and it is the shape ``dict_values`` has too.  The
+    whole rule and its cross-product live in
+    ``test_opaque_equality_2480.py``.
     """
 
     class LenZero:
@@ -1119,6 +1150,10 @@ class TestAFalsyOpaqueEncodedIsNotComparable:
 
     FALSY_OPAQUE = ("set()", "frozenset()", "complex(0)", "LenZero()", "BoolFalse()")
 
+    #: The one member #2480 does not answer, and why.  Its ``__eq__`` is
+    #: ``object``'s but its ``__repr__`` is not, so there is no token.
+    STILL_DECLINED = ("BoolFalse()",)
+
     def _values(self) -> dict:
         return {
             "set()": set(),
@@ -1129,13 +1164,21 @@ class TestAFalsyOpaqueEncodedIsNotComparable:
         }
 
     @pytest.mark.parametrize("name", FALSY_OPAQUE)
-    def test_it_is_never_equal_even_to_itself_which_diverges_from_django(self, name: str) -> None:
-        """The divergence, stated as a measurement so it cannot be mistaken for
-        an intended answer. Django renders ``Y``; this renders ``N``."""
+    def test_it_is_equal_to_itself_as_django_says_since_2480(self, name: str) -> None:
+        """Closed by #2480 for four of the five, still open for the fifth —
+        and the split is asserted in BOTH directions, so neither half can
+        drift silently."""
         v = self._values()[name]
         dj, du = branch("==", v, v)
         assert dj == "Y", "Django stopped answering equal — the pin needs revisiting"
-        assert du == "N", f"{name} gained a comparison key — #2480 may be closed"
+        if name in self.STILL_DECLINED:
+            assert du == "N", (
+                f"{name} now compares EQUAL — the decline closed, so move it out of "
+                "STILL_DECLINED (its `__repr__` is custom, so the token is not an "
+                "identity)"
+            )
+        else:
+            assert du == "Y", f"{name} lost its equality class — #2480 regressed"
 
     @pytest.mark.parametrize("name", FALSY_OPAQUE)
     @pytest.mark.parametrize("op", ["<", ">"])

--- a/python/tests/test_lazy_corpus_rows_2482.py
+++ b/python/tests/test_lazy_corpus_rows_2482.py
@@ -115,12 +115,20 @@ class TestTheRowThePreviousHarnessCouldNotHold:
         du = diff._rust.render_template(source, ctx)
         assert dj in {"Y", "N"}, dj
         assert du in {"Y", "N"}, du
-        # And they DISAGREE, which is the divergence the row exists to expose:
-        # Python compares two empty views as equal sets; djust does not.
+        # They AGREE since #2480, and the row is what makes that measurable:
+        # Python compares two empty views as equal sets, and so does djust now
+        # that `Encoded::eq_class` carries `collections.abc.Set`.
+        #
+        # This assertion was `dj != du` — the divergence the row existed to
+        # EXPOSE — and it is flipped rather than deleted, so the same cell that
+        # measured the gap now measures its closure. It is still the sharpest
+        # thing this row does: the `@cmp` axis needs a `q` that is a second,
+        # independent object, which is exactly what `fresh()` provides and what
+        # `copy.deepcopy` refused.
         assert dj == "Y", "Python compares two empty dict views EQUAL"
-        assert dj != du, (
-            "the empty dict-view `==` divergence is closed — delete this "
-            "assertion and the issue it tracks"
+        assert du == "Y", (
+            "the empty dict-view `==` answer regressed — #2480 gave a "
+            "`dict_keys` the `EqClass::Set` contract"
         )
 
     def test_the_cmp_axis_goes_through_the_chokepoint(self) -> None:

--- a/python/tests/test_opaque_collections_2477_2489.py
+++ b/python/tests/test_opaque_collections_2477_2489.py
@@ -834,69 +834,73 @@ class TestThePredicateAgreesWithTheRealConversion:
         assert touched == [], touched
 
 
-class TestTheComparisonAxisThisWIDENS:
-    """The cost, measured — and it is a cost, not a spelling (#2480).
+class TestTheComparisonAxisThisWIDENED:
+    """The cost this fix paid, and the fix that PAID IT BACK (#2480).
 
-    An `Encoded` built by `opaque_value` carries NO comparison key, so
-    `python_partial_cmp` answers `None` for every pair either side of which
+    An `Encoded` built by `opaque_value` carried NO comparison key, so
+    `python_partial_cmp` answered `None` for every pair either side of which
     came from that arm: never equal, never ordered. As a `Value::String` these
     values compared by TEXT and got the right answer for the wrong reason —
     the same mechanism that made `{{ p|length }}` count the characters of a
-    repr, so the accident and the defect cannot be separated.
+    repr, so the accident and the defect could not be separated.
 
-    #2466 already did this to the falsy half (`set()`, `complex(0)`, an empty
-    `dict_keys`) and filed #2480. This widens it to the truthy members of the
-    same class. Sixteen consumers were swept in `TestBothPathsAnswerDjango` and
-    NONE of them is `{% if p == q %}` — a curated table samples one axis and
-    blinds you on the next (v1.1.1-2 rule 2), and this axis was found by a pin
-    in `test_encoded_value_position_2471_2472_2473.py` going red rather than by
-    the sweep. So it gets its own class, with the count, pinned in the
-    DIVERGING direction: closing #2480 reddens this rather than passing
-    silently.
+    #2466 did this to the falsy half (`set()`, `complex(0)`, an empty
+    `dict_keys`) and filed #2480; #2477/#2489 widened it to the truthy members
+    of the same class, which is why the honest count was **eight, four
+    already-wrong and four newly** rather than "introduced".
+
+    **#2480 closed all eight**, by measuring the object's equality CONTRACT at
+    the conversion instead of guessing from a carried spelling. The class is
+    FLIPPED rather than deleted — the same eight rows, the same two-half
+    accounting, now asserting `Y` — so the widening it recorded stays legible
+    and a regression on either half is one assertion away. The rule itself and
+    its cross-product live in `test_opaque_equality_2480.py`.
     """
 
-    #: The shapes whose `==` answer this fix moves from right to wrong, and the
-    #: ones it leaves alone. Exact in both directions.
+    #: The shapes #2477/#2489 moved from right-by-accident to wrong, and the
+    #: ones #2466 had already moved. Exact in both directions; both halves are
+    #: `Y` again.
     NEWLY_UNEQUAL = ("set-plain", "frozenset-plain", "dv-keys-plain", "complex-one")
     ALREADY_UNEQUAL = ("set-empty", "frozenset-empty", "dv-keys-empty", "complex-zero")
 
     EQ = "{% if p == q %}Y{% else %}N{% endif %}"
 
-    def test_every_carried_shape_compares_UNEQUAL_to_an_equal_twin(self) -> None:
-        """Django says `Y`; the carrier says `N`. Both halves, one rule."""
+    def test_every_carried_shape_compares_EQUAL_to_an_equal_twin(self) -> None:
+        """Django says `Y` and so does the carrier now. Both halves, one rule."""
         for key in self.NEWLY_UNEQUAL + self.ALREADY_UNEQUAL:
             a, b = _Members.build()[key], _Members.build()[key]
             assert a == b, f"{key}: the two fixtures are not Python-equal"
             ctx = {"p": a, "q": b}
             assert DjangoTemplate(self.EQ).render(DjangoContext(ctx)) == "Y", key
-            assert _rust.render_template(self.EQ, {"p": a, "q": b}) == "N", (
-                f"{key} now compares EQUAL — #2480 closed, so delete its row"
+            assert _rust.render_template(self.EQ, {"p": a, "q": b}) == "Y", (
+                f"{key} compares UNEQUAL again — #2480 regressed"
             )
 
     def test_the_two_halves_are_counted_and_disjoint(self) -> None:
-        """Which of them this fix moved, and which #2466 had already moved.
+        """Which of them #2477/#2489 moved, and which #2466 had already moved.
 
         The distinction is the whole of the accounting: four shapes were
-        already wrong here and four became wrong, so the honest statement is
-        "widened from four to eight" rather than "introduced".
+        already wrong and four became wrong, so the honest statement was
+        "widened from four to eight" rather than "introduced" — and #2480
+        closed the eight rather than the four.
         """
         assert not set(self.NEWLY_UNEQUAL) & set(self.ALREADY_UNEQUAL)
         assert len(self.NEWLY_UNEQUAL) == 4
         assert len(self.ALREADY_UNEQUAL) == 4
         # The already-wrong half is TRUTHY-independent: each is falsy, which is
-        # what `falsy_opaque` gated on before this fix widened it.
+        # what `falsy_opaque` gated on before #2477/#2489 widened it.
         for key in self.ALREADY_UNEQUAL:
             assert not _Members.build()[key], key
         for key in self.NEWLY_UNEQUAL:
             assert _Members.build()[key], key
 
     def test_a_value_python_calls_UNEQUAL_is_still_unequal(self) -> None:
-        """The direction that is right either way, so the rule is not "always N".
+        """The direction that is right either way, so the rule is not "always Y".
 
-        Two `LenZero()` instances are NOT equal in Python (no `__eq__`), and a
-        carrier with no comparison key cannot say they are. Without this the
-        class above would pass against an engine that answered `N` to
-        everything, which is a different bug wearing the same output.
+        Two `LenZero()` instances are NOT equal in Python (no `__eq__`), and
+        #2480's identity arm must not say they are. Without this the class
+        above would pass against an engine that answered `Y` to everything,
+        which is a different bug wearing the same output.
         """
         a = instance("LenZero", __len__=lambda self: 0)
         b = instance("LenZero", __len__=lambda self: 0)

--- a/python/tests/test_opaque_equality_2480.py
+++ b/python/tests/test_opaque_equality_2480.py
@@ -1,0 +1,679 @@
+"""Two opaque ``Value::Encoded``s compare by Python's CONTRACT (#2480).
+
+The divergence
+--------------
+``opaque_value`` set ``cmp_key: None``, so ``Encoded::python_partial_cmp``
+answered ``None`` for every pair either side of which came from that arm —
+never equal, never ordered::
+
+    {% if p == q %}   p = q = set()          django Y    djust N
+    {% if p == q %}   two equal {'a'}s       django Y    djust N
+    {% if p <= q %}   p = q = set()          django Y    djust N
+    {% if p == q %}   p = q = complex(0)     django Y    djust N
+
+#2476 moved the FALSY half off ``Value::String`` (where two ``set()``s had
+compared equal by TEXT, Django's answer reached by accident) and #2477/#2489
+moved the TRUTHY half, so the class this closes is **eight shapes**, four
+already wrong and four widened into it — the accounting
+``test_opaque_collections_2477_2489.py::TestTheComparisonAxisThisWIDENS``
+carried until this fix deleted its rows.
+
+The rule, and why no single carried field is it
+-----------------------------------------------
+Nothing already on the struct decides it, in EITHER direction — measured, in
+``test_no_single_carried_field_could_have_decided_this``:
+
+* ``set() == frozenset() == {}.keys() == {}.items()`` is True ACROSS
+  ``type_name``s;
+* ``LenZero() == LenZero()`` on two DISTINCT instances is False WITHIN one;
+* ``set() == {}.values()`` is **False** while ``set() == {}.keys()`` is True,
+  and both views carry the same (empty) ``items``.
+
+So a fourth fact is measured at the conversion — ``Encoded::eq_class``, the
+PROTOCOL Python itself dispatches on:
+
+===========================  ===============================================
+``EqClass::Set``             ``isinstance(o, collections.abc.Set)``.  The ABC
+                             defines ``__eq__`` and ``__le__`` by containment,
+                             so equality AND a real subset PARTIAL order both
+                             fall out of the carried ``items``.
+``EqClass::Number``          ``isinstance(o, numbers.Number)``, as
+                             ``complex(o)``.  **Equality only.**
+``EqClass::Identity``        default ``__eq__`` AND default ``__repr__`` — so
+                             ``repr`` carries the address and IS a token.
+                             **Equality only.**
+``None``                     everything else: never equal, never ordered —
+                             the answer this carrier already gave.
+===========================  ===============================================
+
+The trap this had to avoid
+--------------------------
+Equality must NOT be reached by giving these values a ``cmp_key``.  Python's
+answers for the two operators come apart inside this family::
+
+    same object          ==   <=   >=   <    >
+      set()      django   Y    Y    Y    N    N     (subset order)
+      complex(0) django   Y    N    N    N    N     (`<` RAISES)
+
+so the one-line version of this fix — a key, reached through
+``python_partial_cmp`` — buys eight cells and sells a new divergence at
+``{% if p <= q %}`` on a ``complex``.  ``TestTheOrderingTrap`` pins both halves.
+
+What is DECLINED, pinned in the diverging direction
+---------------------------------------------------
+Three shapes stay unequal and are ``TestWhatThisDeliberatelyDoesNOTClose``:
+
+* a class overriding ``__eq__`` — only Python can run it;
+* a class with default ``__eq__`` and a CUSTOM ``__repr__`` (a ``dict_values``
+  is the builtin case): two distinct empty ones share the spelling
+  ``dict_values([])``, so the repr is not a token and using it would be a NEW
+  wrong answer rather than an unfixed cell;
+* an ``Encoded`` against a ``Decimal`` or a big ``int`` — both exact types an
+  ``f64`` cannot answer.
+"""
+
+from __future__ import annotations
+
+import collections
+import collections.abc
+import numbers
+import re
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("django")
+
+from django.template import Context as DjangoContext  # noqa: E402
+from django.template import Template as DjangoTemplate  # noqa: E402
+
+from djust import _rust  # noqa: E402
+from djust.serialization import normalize_django_value  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[2]
+CORE_RS = REPO / "crates" / "djust_core" / "src" / "lib.rs"
+RENDERER_RS = REPO / "crates" / "djust_templates" / "src" / "renderer.rs"
+FILTERS_RS = REPO / "crates" / "djust_templates" / "src" / "filters.rs"
+
+#: Every operator ``{% if %}`` accepts for a pair, so a fix that moves one and
+#: not the others is visible rather than plausible.
+OPS = {
+    "==": "{% if p == q %}Y{% else %}N{% endif %}",
+    "!=": "{% if p != q %}Y{% else %}N{% endif %}",
+    "<=": "{% if p <= q %}Y{% else %}N{% endif %}",
+    ">=": "{% if p >= q %}Y{% else %}N{% endif %}",
+    "<": "{% if p < q %}Y{% else %}N{% endif %}",
+    ">": "{% if p > q %}Y{% else %}N{% endif %}",
+}
+
+
+def instance(name: str, **namespace: object) -> object:
+    """A fresh instance of a fresh class, with NOTHING defaulted.
+
+    Deliberately unlike ``test_opaque_collections_2477_2489.instance``, which
+    pins ``__repr__`` so its fixtures render deterministically.  The default
+    ``object.__repr__`` — the one carrying a MEMORY ADDRESS — is exactly the
+    thing under test here, so a fixture that overrode it would measure the
+    wrong arm.  ``__module__`` is still set, so the repr's prefix is stable.
+    """
+    namespace.setdefault("__module__", "djust_eq_fixtures")
+    return type(name, (), namespace)()
+
+
+def _shapes() -> dict[str, tuple[object, object]]:
+    """``name -> (a, b)``: two DISTINCT instances of the same shape.
+
+    Built fresh on each call.  The pair is what separates the two questions
+    Django answers differently — ``p is q`` and "two objects Python compares" —
+    and every sweep below runs both.
+    """
+    return {
+        # --- EqClass::Set: the ABC, across four type names ------------------
+        "set-empty": (set(), set()),
+        "set-plain": ({"a"}, {"a"}),
+        "set-two": ({"a", "b"}, {"b", "a"}),
+        "frozenset-empty": (frozenset(), frozenset()),
+        "frozenset-plain": (frozenset({"a"}), frozenset({"a"})),
+        "dictkeys-empty": ({}.keys(), {}.keys()),
+        "dictkeys-plain": ({"a": 1}.keys(), {"a": 1}.keys()),
+        "dictitems-empty": ({}.items(), {}.items()),
+        "dictitems-plain": ({"a": 1}.items(), {"a": 1}.items()),
+        "odict-keys": (
+            collections.OrderedDict({"a": 1}).keys(),
+            collections.OrderedDict({"a": 1}).keys(),
+        ),
+        # --- EqClass::Number ------------------------------------------------
+        "complex-zero": (complex(0), complex(0)),
+        "complex-one": (complex(1), complex(1)),
+        "complex-imag": (complex(0, 1), complex(0, 1)),
+        # --- EqClass::Identity: default __eq__ AND default __repr__ ---------
+        "lenzero": (
+            instance("LenZero", __len__=lambda s: 0),
+            instance("LenZero", __len__=lambda s: 0),
+        ),
+        "boolfalse": (
+            instance("BoolFalse", __bool__=lambda s: False),
+            instance("BoolFalse", __bool__=lambda s: False),
+        ),
+        # --- DECLINED: no class, three ways ---------------------------------
+        # Default `__eq__`, CUSTOM `__repr__` — the builtin case.
+        "dictvalues-empty": ({}.values(), {}.values()),
+        "dictvalues-plain": ({"a": 1}.values(), {"a": 1}.values()),
+        # ...and the user-class case, same protocol facts.
+        "lenzero-customrepr": (
+            instance("LenZeroR", __len__=lambda s: 0, __repr__=lambda s: "LenZeroR()"),
+            instance("LenZeroR", __len__=lambda s: 0, __repr__=lambda s: "LenZeroR()"),
+        ),
+        # A custom `__eq__`: only Python can run it.
+        "eq-always-true": (
+            instance("EqTrue", __len__=lambda s: 0, __eq__=lambda s, o: True, __hash__=lambda s: 1),
+            instance("EqTrue", __len__=lambda s: 0, __eq__=lambda s, o: True, __hash__=lambda s: 1),
+        ),
+    }
+
+
+#: Which arm each shape lands on, asserted in BOTH directions by
+#: ``test_the_protocol_facts_are_what_the_rule_reads``.  A name list would have
+#: been wrong here and the entries say why.
+EXPECTED_CLASS: dict[str, str] = {
+    "set-empty": "Set",
+    "set-plain": "Set",
+    "set-two": "Set",
+    "frozenset-empty": "Set",
+    "frozenset-plain": "Set",
+    "dictkeys-empty": "Set",
+    "dictkeys-plain": "Set",
+    "dictitems-empty": "Set",
+    "dictitems-plain": "Set",
+    "odict-keys": "Set",
+    "complex-zero": "Number",
+    "complex-one": "Number",
+    "complex-imag": "Number",
+    "lenzero": "Identity",
+    "boolfalse": "Identity",
+    # A `dict_values` is NOT a Set — Python says `set() != {}.values()` — and
+    # its `__repr__` is its own, so neither of the first three arms claims it.
+    "dictvalues-empty": "none",
+    "dictvalues-plain": "none",
+    "lenzero-customrepr": "none",
+    "eq-always-true": "none",
+}
+
+#: The shapes this fix DOES NOT answer, and the reason.  Every one is pinned in
+#: the DIVERGING direction below, so widening one is a decision rather than an
+#: accident.
+DECLINED: dict[str, str] = {
+    "dictvalues-empty": "default __eq__ but a custom __repr__: the spelling is not a token",
+    "dictvalues-plain": "default __eq__ but a custom __repr__: the spelling is not a token",
+    "lenzero-customrepr": "default __eq__ but a custom __repr__: the spelling is not a token",
+    "eq-always-true": "a custom __eq__: only Python can run it",
+}
+
+
+def render(source: str, a: object, b: object, engine: str) -> str:
+    """One cell, on one engine.  Django is CALLED, never transcribed."""
+    try:
+        if engine == "django":
+            return DjangoTemplate(source).render(DjangoContext({"p": a, "q": b}))
+        if engine == "raw":
+            return _rust.render_template(source, {"p": a, "q": b})
+        return _rust.render_template(source, normalize_django_value({"p": a, "q": b}))
+    except Exception as exc:  # noqa: BLE001 — a refusal IS the answer
+        found = re.search(r"raises (\w+Error)", str(exc))
+        return f"<<{found.group(1)}>>" if found else f"<<{type(exc).__name__}>>"
+
+
+def eq_class_of(value: object) -> str:
+    """The arm ``equality_class`` will pick, computed from Python.
+
+    A transcription of the Rust in Python, deliberately: it is what lets
+    ``EXPECTED_CLASS`` be checked against the PROTOCOL rather than against a
+    remembered table, so a fixture whose facts change is caught.
+    """
+    if isinstance(value, collections.abc.Set):
+        return "Set"
+    if isinstance(value, numbers.Number):
+        return "Number"
+    if type(value).__eq__ is object.__eq__ and type(value).__repr__ is object.__repr__:
+        return "Identity"
+    return "none"
+
+
+class TestTheCrossProduct:
+    """The reproducer, as a sweep: every shape against every shape, six
+    operators, both engines, with Django as the oracle.
+
+    A curated table samples one axis and blinds you on the next (v1.1.1-2
+    rule 2).  The axes here are: which shape, which shape it is compared TO
+    (including ACROSS classes), which operator, whether the two operands are
+    the SAME object, and which engine renders it.
+    """
+
+    #: A cell is EXPECTED to diverge exactly when Python calls the two operands
+    #: equal AND at least one of them carries no equality class — which is the
+    #: whole of what this fix declines, stated as a rule rather than as a list
+    #: of names.  Every OTHER cell must agree, and the counts below pin that
+    #: the exceptions are the size they are measured to be.
+    @staticmethod
+    def _expected_divergent(a: object, b: object, op: str) -> bool:
+        if op not in ("==", "!="):
+            # No ordering cell diverges: the Set class carries a real partial
+            # order and every other class answers `None`, which is Django's
+            # own answer for a pair Python refuses.
+            return False
+        try:
+            equal = bool(a == b)
+        except Exception:  # noqa: BLE001 — pragma: no cover
+            return False
+        return equal and "none" in {eq_class_of(a), eq_class_of(b)}
+
+    def _sweep(self, pairs) -> tuple[list, int]:
+        """Every operator over every pair; returns the offenders and the count
+        of cells that diverged AS EXPECTED."""
+        offenders: list[tuple[str, str, str, str]] = []
+        expected = 0
+        for label, a, b in pairs:
+            for op, source in OPS.items():
+                dj = render(source, a, b, "django")
+                raw = render(source, a, b, "raw")
+                if self._expected_divergent(a, b, op):
+                    expected += 1
+                    if dj == raw:
+                        offenders.append((f"{label} (CLOSED, delete its row)", op, dj, raw))
+                elif dj != raw:
+                    offenders.append((label, op, dj, raw))
+        return offenders, expected
+
+    def test_same_object_agrees_with_django_on_every_operator(self) -> None:
+        offenders, expected = self._sweep((name, a, a) for name, (a, _b) in _shapes().items())
+        assert not offenders, self._explain(offenders)
+        # Four shapes × `==` and `!=`: the two `dict_values`, the
+        # custom-`__repr__` class and the custom-`__eq__` one.
+        assert expected == 8, expected
+
+    def test_two_distinct_instances_agree_with_django_on_every_operator(self) -> None:
+        offenders, expected = self._sweep((name, a, b) for name, (a, b) in _shapes().items())
+        assert not offenders, self._explain(offenders)
+        # Only the custom-`__eq__` class: two distinct `dict_values` and two
+        # distinct custom-`__repr__` instances are Python-UNEQUAL, so `N` is
+        # the RIGHT answer for them here.
+        assert expected == 2, expected
+
+    def test_every_shape_against_every_other_shape(self) -> None:
+        """The CROSS-class half, which is where a per-type rule would break.
+
+        ``set() == frozenset()`` is True across type names and
+        ``set() == {}.values()`` is False across classes; both are here, and so
+        is every pair neither table names.
+        """
+        names = list(_shapes())
+        offenders, expected = self._sweep(
+            (f"{left} vs {right}", _shapes()[left][0], _shapes()[right][1])
+            for left in names
+            for right in names
+            if left != right
+        )
+        assert not offenders, self._explain(offenders)
+        # The custom-`__eq__` class against each OTHER shape, both directions,
+        # on `==` and `!=` — and nothing else, which is the statement: no
+        # cross-CLASS pair diverges, so `set() == {}.values()`,
+        # `set() == complex(0)` and `set() < complex(0)` are all right.
+        assert expected == (len(names) - 1) * 2 * 2, expected
+
+    def test_the_liveview_path_answers_the_same(self) -> None:
+        """Both djust paths, because the normalizer runs before the conversion
+        on one of them and used to flatten these values (#2477/#2489).
+        """
+        offenders = []
+        for name, (a, b) in _shapes().items():
+            for op, source in OPS.items():
+                raw = render(source, a, b, "raw")
+                live = render(source, a, b, "live")
+                if raw != live:
+                    offenders.append((name, op, raw, live))
+        assert not offenders, self._explain(offenders)
+
+    @staticmethod
+    def _explain(offenders: list[tuple[str, str, str, str]]) -> str:
+        return f"{len(offenders)} cells disagree with Django:\n" + "\n".join(
+            f"  {name:24s} {op:3s} django={dj!r} djust={du!r}"
+            for name, op, dj, du in offenders[:20]
+        )
+
+
+class TestTheRuleIsTheProtocol:
+    """Why the fix is a fourth measured fact rather than a rule over the three
+    already carried."""
+
+    def test_no_single_carried_field_could_have_decided_this(self) -> None:
+        """The issue's central claim, RUN rather than quoted."""
+        # ACROSS type names, and True.
+        assert set() == frozenset() == {}.keys() == {}.items()
+        assert len({type(v).__name__ for v in (set(), frozenset(), {}.keys(), {}.items())}) == 4
+        # WITHIN one type name, and False.
+        a, b = _shapes()["lenzero"]
+        assert type(a).__name__ == type(b).__name__
+        assert a != b
+        # Same carried ITEMS (both empty), opposite answers — so `items` alone
+        # cannot decide it either.
+        assert list({}.keys()) == list({}.values()) == []
+        assert set() == {}.keys()
+        assert set() != {}.values()
+
+    def test_the_protocol_facts_are_what_the_rule_reads(self) -> None:
+        """``EXPECTED_CLASS`` checked against the live protocol, both ways."""
+        for name, (a, _b) in _shapes().items():
+            assert eq_class_of(a) == EXPECTED_CLASS[name], name
+        assert set(EXPECTED_CLASS) == set(_shapes())
+        # Non-vacuity: all four arms are inhabited, so no arm is dead.
+        assert set(EXPECTED_CLASS.values()) == {"Set", "Number", "Identity", "none"}
+
+    def test_a_name_list_would_have_been_wrong_in_both_directions(self) -> None:
+        """Why ``type_name`` is not the discriminator (#2485's lesson).
+
+        A user class REGISTERED with the ABC is a Set that no builtin name list
+        holds, and a user class NAMED ``set`` is not one — ``type(o).__name__``
+        is unqualified, so a name list cannot tell them apart.
+        """
+        registered = instance("MySet", __len__=lambda s: 0, __iter__=lambda s: iter(()))
+        collections.abc.Set.register(type(registered))
+        assert isinstance(registered, collections.abc.Set)
+        assert type(registered).__name__ not in {"set", "frozenset", "dict_keys", "dict_items"}
+        assert eq_class_of(registered) == "Set"
+
+        impostor = instance("set", __len__=lambda s: 0)
+        assert type(impostor).__name__ == "set"
+        assert not isinstance(impostor, collections.abc.Set)
+        assert eq_class_of(impostor) == "Identity"
+        # ...and the engine follows the protocol, not the name: two DISTINCT
+        # impostors are Python-unequal and must stay unequal here.
+        other = instance("set", __len__=lambda s: 0)
+        assert impostor != other
+        assert render(OPS["=="], impostor, other, "raw") == "N"
+        assert render(OPS["=="], impostor, other, "django") == "N"
+
+
+class TestTheOrderingTrap:
+    """``==`` and ``<`` come apart INSIDE this family, so equality could not be
+    reached by handing every class a comparison key."""
+
+    def test_a_set_orders_and_a_complex_does_not(self) -> None:
+        """The two halves of the trap, side by side and both from Django."""
+        s1, s2 = _shapes()["set-empty"]
+        c1, c2 = _shapes()["complex-zero"]
+        for op in ("==", "<=", ">="):
+            assert render(OPS[op], s1, s2, "django") == "Y", op
+            assert render(OPS[op], s1, s2, "raw") == "Y", op
+        # The same three operators on a complex: equal, and NOT ordered.
+        assert render(OPS["=="], c1, c2, "django") == "Y"
+        assert render(OPS["=="], c1, c2, "raw") == "Y"
+        for op in ("<=", ">=", "<", ">"):
+            assert render(OPS[op], c1, c2, "django") == "N", op
+            assert render(OPS[op], c1, c2, "raw") == "N", op
+        # Python's own reason, so the pin is not a remembered fact.
+        with pytest.raises(TypeError):
+            _ = c1 <= c2
+
+    def test_an_identity_value_is_equal_to_itself_and_orders_against_nothing(self) -> None:
+        obj = _shapes()["lenzero"][0]
+        assert render(OPS["=="], obj, obj, "raw") == "Y"
+        for op in ("<=", ">=", "<", ">"):
+            assert render(OPS[op], obj, obj, "django") == "N", op
+            assert render(OPS[op], obj, obj, "raw") == "N", op
+
+    def test_the_set_order_is_PARTIAL_and_incomparable_answers_false_four_ways(
+        self,
+    ) -> None:
+        """``{1} vs {2}``: Python answers False for all four, which is what an
+        ``Option<Ordering>`` of ``None`` renders as.  A total-order key could
+        not say this."""
+        a, b = {"a"}, {"b"}
+        assert not (a <= b or a >= b or a < b or a > b)
+        for op in ("<=", ">=", "<", ">"):
+            assert render(OPS[op], a, b, "django") == "N", op
+            assert render(OPS[op], a, b, "raw") == "N", op
+        assert render(OPS["=="], a, b, "raw") == "N"
+
+    def test_a_proper_subset_orders_strictly(self) -> None:
+        """And the direction that proves the order is real rather than
+        all-Equal: ``set() < {'a'}`` is True, across type names too."""
+        for smaller, larger in (
+            (set(), {"a"}),
+            (frozenset(), {"a"}),
+            ({}.keys(), {"a"}),
+            (set(), {"a": 1}.keys()),
+        ):
+            assert render(OPS["<"], smaller, larger, "django") == "Y"
+            assert render(OPS["<"], smaller, larger, "raw") == "Y"
+            assert render(OPS[">"], larger, smaller, "raw") == "Y"
+            assert render(OPS["=="], smaller, larger, "raw") == "N"
+
+    def test_set_membership_is_djangos_equality_not_a_structural_one(self) -> None:
+        """``{1} == {1.0}`` is True in Python because ``1 == 1.0`` is, so the
+        item comparison has to be ``values_equal`` and not a structural one."""
+        assert {1} == {1.0}
+        assert render(OPS["=="], {1}, {1.0}, "django") == "Y"
+        assert render(OPS["=="], {1}, {1.0}, "raw") == "Y"
+
+
+class TestTheCrossCarrierArm:
+    """An opaque NUMBER against a real one — a pair no ``(Encoded, Encoded)``
+    arm reaches (the issue's §3a)."""
+
+    def test_a_complex_equals_the_int_and_float_it_names(self) -> None:
+        for value, other in (
+            (complex(0), 0),
+            (complex(0), 0.0),
+            (complex(1), 1),
+            (complex(1), 1.0),
+        ):
+            assert value == other
+            assert render(OPS["=="], value, other, "django") == "Y", (value, other)
+            assert render(OPS["=="], value, other, "raw") == "Y", (value, other)
+            # ...and the mirrored operand order, which is a separate match arm.
+            assert render(OPS["=="], other, value, "raw") == "Y", (other, value)
+
+    def test_a_bool_reaches_the_same_arm_through_the_integer_substitution(self) -> None:
+        """``bool_as_int`` runs first, so ``{% if p == True %}`` on a
+        ``complex(1)`` lands on the integer arm rather than falling through."""
+        assert complex(1) == True  # noqa: E712 — the point is Python's answer
+        assert render("{% if p == True %}Y{% else %}N{% endif %}", complex(1), 0, "raw") == "Y"
+        assert render("{% if p == False %}Y{% else %}N{% endif %}", complex(0), 0, "raw") == "Y"
+
+    def test_an_imaginary_part_is_not_equal_to_a_real_number(self) -> None:
+        assert complex(0, 1) != 0
+        assert render(OPS["=="], complex(0, 1), 0, "django") == "N"
+        assert render(OPS["=="], complex(0, 1), 0, "raw") == "N"
+
+    def test_the_integer_comparison_is_EXACT_at_the_float_boundary(self) -> None:
+        """Python compares an ``int`` to a ``complex`` exactly, so
+        ``complex(2**53) == 2**53 + 1`` is False even though the cast rounds.
+        A naive ``real == i as f64`` would answer True."""
+        big = 2**53
+        assert complex(big) == big
+        assert complex(big) != big + 1
+        assert render(OPS["=="], complex(big), big, "raw") == "Y"
+        assert render(OPS["=="], complex(big), big + 1, "django") == "N"
+        assert render(OPS["=="], complex(big), big + 1, "raw") == "N"
+
+    def test_a_huge_float_does_not_saturate_onto_an_integer_bound(self) -> None:
+        """``real as i64`` SATURATES, so ``complex(1e300)`` would land on
+        ``i64::MAX`` and compare equal to it without the second check."""
+        bound = 2**63 - 1
+        assert complex(1e300) != bound
+        assert render(OPS["=="], complex(1e300), bound, "raw") == "N"
+
+    def test_a_set_is_not_equal_to_a_list_or_a_scalar(self) -> None:
+        """The control: the cross-carrier arm is NUMERIC and claims nothing
+        else.  ``set() == []`` is False in Python."""
+        for other in ([], (), "", 0, 0.0):
+            assert set() != other
+            assert render(OPS["=="], set(), other, "raw") == "N", other
+
+
+class TestTheStateRoundTrip:
+    """The class is CARRIED, so one cache hit does not restore the pre-fix
+    answer — the reopening ``ENCODED_TAG`` exists to prevent, now for the
+    sixth time."""
+
+    @staticmethod
+    def _round_trip(source: str, a: object, b: object) -> str:
+        from djust._rust import RustLiveView
+
+        view = RustLiveView(source)
+        view.set_state("p", a)
+        view.set_state("q", b)
+        return RustLiveView.deserialize_msgpack(view.serialize_msgpack()).render()
+
+    def test_every_class_survives_a_msgpack_state_round_trip(self) -> None:
+        offenders = []
+        for name, (a, b) in _shapes().items():
+            for op, source in OPS.items():
+                direct = render(source, a, b, "raw")
+                after = self._round_trip(source, a, b)
+                if direct != after:
+                    offenders.append((name, op, direct, after))
+        assert not offenders, "state round trip changed the answer:\n" + "\n".join(
+            f"  {n} {o}: {d!r} -> {r!r}" for n, o, d, r in offenders[:20]
+        )
+
+    def test_the_payload_carries_an_eleventh_slot_and_it_is_a_map(self) -> None:
+        """The slot's shape, pinned from Python as well as from Rust: it is
+        always a MAP — empty when there is no class — because that is what
+        refuses a shifted ten-element payload now that eleven is a real width.
+        """
+        msgpack = pytest.importorskip("msgpack")
+
+        from djust._rust import RustLiveView
+
+        view = RustLiveView("{{ p }}")
+        view.set_state("p", set())
+        view.set_state("q", __import__("datetime").timedelta(0))
+        decoded = msgpack.unpackb(view.serialize_msgpack(), raw=False, strict_map_key=False)
+        opaque = decoded[1]["p"]["__djust_encoded__"]
+        datetime_payload = decoded[1]["q"]["__djust_encoded__"]
+        assert len(opaque) == 11, opaque
+        assert len(datetime_payload) == 11, datetime_payload
+        # A `set()` is the Set class...
+        assert opaque[10] == {"eq": [1, 0.0, 0.0]}, opaque[10]
+        # ...and a `timedelta` has NO class: it compares by its `cmp_key`, and
+        # the slot is an EMPTY MAP rather than a nil.
+        assert datetime_payload[10] == {}, datetime_payload[10]
+
+
+class TestWhatThisDeliberatelyDoesNOTClose:
+    """Pinned as still-divergent so a stale exemption goes red (#1859).
+
+    Each row is a shape whose equality this fix declines, with the reason.
+    Closing one reddens this class rather than passing silently.
+    """
+
+    def test_each_declined_shape_still_diverges_from_django(self) -> None:
+        for name, why in DECLINED.items():
+            a, b = _shapes()[name]
+            # The SAME object: Django says Y (Python's `is` shortcut or the
+            # custom `__eq__`), and this answers N.
+            assert render(OPS["=="], a, a, "django") == "Y", (name, why)
+            assert render(OPS["=="], a, a, "raw") == "N", (
+                f"{name} now compares EQUAL — the decline closed, so delete its row ({why})"
+            )
+
+    def test_a_dict_values_is_the_builtin_case_and_its_repr_is_why(self) -> None:
+        """Two DISTINCT empty ``dict_values`` share a repr, so the identity arm
+        must not claim them — using the token would be a NEW wrong answer."""
+        a, b = _shapes()["dictvalues-empty"]
+        assert type(a).__eq__ is object.__eq__
+        assert type(a).__repr__ is not object.__repr__
+        assert repr(a) == repr(b) == "dict_values([])"
+        assert a != b
+        assert render(OPS["=="], a, b, "django") == "N"
+        assert render(OPS["=="], a, b, "raw") == "N"
+
+    def test_a_decimal_and_a_big_int_are_not_reached_by_the_numeric_arm(self) -> None:
+        """Both are exact types an ``f64`` cannot answer, so they keep the
+        pre-fix ``N``."""
+        import decimal
+
+        assert complex(0) == decimal.Decimal(0)
+        assert render(OPS["=="], complex(0), decimal.Decimal(0), "django") == "Y"
+        assert render(OPS["=="], complex(0), decimal.Decimal(0), "raw") == "N"
+
+    def test_a_set_past_the_comparison_cap_declines_rather_than_answering(self) -> None:
+        """Containment without a hash is quadratic and a ``set`` states its own
+        length, so past ``SET_COMPARE_CAP`` the answer is the pre-fix one.
+
+        A cell left open, pinned so raising the cap is a decision.
+        """
+        cap = int(
+            re.search(r"const SET_COMPARE_CAP: usize = ([0-9_]+);", RENDERER_RS.read_text())
+            .group(1)
+            .replace("_", "")
+        )
+        assert cap == 1_000
+        under = set(range(cap))
+        assert render(OPS["=="], under, set(range(cap)), "raw") == "Y"
+        over = set(range(cap + 1))
+        assert render(OPS["=="], over, set(range(cap + 1)), "django") == "Y"
+        assert render(OPS["=="], over, set(range(cap + 1)), "raw") == "N"
+
+
+class TestTheChokepointIsStructural:
+    """One function decides the ``Encoded`` half of every comparison operator,
+    so ``==`` and ``<`` cannot drift (#1646).
+
+    ``Encoded::python_partial_cmp`` used to have three readers; #2480 wraps it
+    in ``encoded_partial_cmp``, which is now its only caller outside its own
+    crate.  Pinned by COUNT, in both directions, so a fourth reader that skips
+    the wrapper reddens this.
+    """
+
+    @staticmethod
+    def _production(src: str) -> str:
+        """Everything above the in-file ``#[cfg(test)]`` module."""
+        marker = "\n#[cfg(test)]\n"
+        return src.split(marker)[0] if marker in src else src
+
+    def test_python_partial_cmp_has_exactly_one_caller_outside_its_crate(self) -> None:
+        renderer = self._production(RENDERER_RS.read_text(encoding="utf-8"))
+        filters = self._production(FILTERS_RS.read_text(encoding="utf-8"))
+        assert renderer.count(".python_partial_cmp(") == 1, (
+            "a second reader would let `==` and `<` drift; call `encoded_partial_cmp` instead"
+        )
+        assert filters.count(".python_partial_cmp(") == 0
+
+    def test_every_comparison_reader_goes_through_the_wrapper(self) -> None:
+        renderer = self._production(RENDERER_RS.read_text(encoding="utf-8"))
+        filters = self._production(FILTERS_RS.read_text(encoding="utf-8"))
+        # `values_equal` (through `encoded_equal`), `try_compare`, and the
+        # definition itself.
+        assert renderer.count("encoded_partial_cmp(") == 3, renderer.count("encoded_partial_cmp(")
+        # `dictsort`'s ordering.
+        assert filters.count("encoded_partial_cmp(") == 1
+
+    def test_the_counter_goes_red_in_BOTH_directions(self) -> None:
+        """The canary: each mutation asserts it APPLIED before its count is
+        read, so a no-op edit cannot report a passing number (#2129/#2135)."""
+        src = self._production(RENDERER_RS.read_text(encoding="utf-8"))
+        baseline = src.count(".python_partial_cmp(")
+        assert baseline == 1
+
+        added = src.replace(
+            "a.python_partial_cmp(b)",
+            "a.python_partial_cmp(b).or(a.python_partial_cmp(b))",
+            1,
+        )
+        assert added != src, "the ADD mutation did not apply"
+        assert added.count(".python_partial_cmp(") == baseline + 1
+
+        removed = src.replace("a.python_partial_cmp(b)", "None", 1)
+        assert removed != src, "the REMOVE mutation did not apply"
+        assert removed.count(".python_partial_cmp(") == baseline - 1
+
+    def test_the_equality_class_is_measured_by_one_function(self) -> None:
+        """One producer, one consumer of each half — the drift shape this
+        repo keeps paying for (#1646)."""
+        core = self._production(CORE_RS.read_text(encoding="utf-8"))
+        assert core.count("fn equality_class(") == 1
+        assert core.count("equality_class(ob)") == 1
+        assert core.count("fn encode_eq_class(") == 1
+        assert core.count("fn decode_eq_class(") == 1


### PR DESCRIPTION
Closes #2480.

`opaque_value` set `cmp_key: None`, so `Encoded::python_partial_cmp` answered
`None` for every pair either side of which came from that arm — never equal,
never ordered.

## The reproduction, run against live Python/Django

Every shape against every shape, all six operators, both djust paths, Django
CALLED as the oracle (`scratchpad/repro2480.py`, and the same sweep is
`TestTheCrossProduct` in the new test file):

| axis | divergent cells before | after |
|---|---|---|
| the SAME object (`p is q`) | 48 | **8** |
| two distinct, Python-equal instances | 38 | **2** |
| every shape against every other shape | 196 | **60** |
| an `Encoded` against a plain scalar | 9 | **6** |

Every one of the 76 survivors involves a **declined** class and nothing else —
the 60 cross-shape cells are all the custom-`__eq__` class against something.

## The rule, and why no carried field is it

Measured, not argued:

* `set() == frozenset() == {}.keys() == {}.items()` is True **across**
  `type_name`s;
* `LenZero() == LenZero()` on two distinct instances is False **within** one;
* `set() == {}.keys()` is True while `set() == {}.values()` is **False**, and
  both views carry the same (empty) `items`.

A NAME LIST is wrong in *both* directions — it misses every
`collections.abc.Set` registration a user writes, and it claims any user class
merely *named* `set`, since `type(o).__name__` is unqualified. Both halves are
run in `test_a_name_list_would_have_been_wrong_in_both_directions`.

So a fourth fact is measured at the conversion — `Encoded::eq_class`, the
protocol Python itself dispatches on:

| arm | measured | equality | ordering |
|---|---|---|---|
| `EqClass::Set` | `isinstance(o, collections.abc.Set)` | the carried `items`, both containments | a real SUBSET partial order |
| `EqClass::Number` | `isinstance(o, numbers.Number)`, as `complex(o)` | the two components | **none** |
| `EqClass::Identity` | default `__eq__` **and** default `__repr__` | the `repr` token | **none** |
| `None` | everything else | never equal | never ordered |

Arm 1 answers the hard direction because the ABC *defines* `__eq__` as
`len(self) == len(other) and self <= other`. Arm 3 is a **restoration**: before
#2476 a `LenZero()` crossed as `Value::String("<LenZero object at 0x…>")` and
compared by exactly that string.

## The trap this had to avoid

`set() <= set()` is `Y`; `complex(0) <= complex(0)` is `N` (`<` RAISES).
Reaching equality by handing these values a `cmp_key` buys eight cells and
sells a new divergence. So `renderer::encoded_partial_cmp` is the one wrapper
all three comparison sinks read, it carries the Set order and answers `None`
for the two equality-only classes, and `Encoded::python_partial_cmp` keeps the
datetime family unchanged with **exactly one caller** (pinned by count, in both
directions).

## Did the wire change? Yes — slot 11, and it is a MAP

`eq_class` is measured from a live object that no longer exists when a state
entry comes back, so it is carried. It is a **map, never `nil`** — an absent
class is the EMPTY map — and that is the one structural decision: eleven used
to be a width no build wrote, so the interior-insert canary could rely on WIDTH
to refuse a shifted ten-element payload. Now that eleven is real, only a TYPE
can, and every such insert pushes the ITEMS (a list or `nil`) or the intruder
into slot 11, never a map. `nil` for the absent case would have surrendered
that; the canary now inserts at all **eleven** interior positions and requires
all eleven refused.

Growing the `attrs` map instead was rejected: that map is what
`context::lookup_segment` resolves `{{ p.x }}` against, so a synthetic key
there would be a template-visible attribute Django does not have.

**What each accepted narrower width restores**: `eq_class: None` — never equal,
never ordered, which is the answer that entry was written with. Widths 10 / 9 /
8 / 6 / 4 / 3 are otherwise untouched, and each keeps its existing
fail-to-absent read for every slot below 11 (the four `a_malformed_*_slot_reads_as_absent`
tests are unchanged and still pass).

## Also closed, and explicitly declined

**Closed**: `complex(0) == 0` / `== 0.0` / `complex(1) == 1` — an
`(Encoded, Integer)` / `(Encoded, Float)` pair no `(Encoded, Encoded)` arm
reaches. The integer half goes through the existing `int_eq_float`, which is
already Python's exact rule (`complex(2**53) == 2**53 + 1` is False;
`complex(1e300) == 2**63 - 1` is False), rather than a second spelling of it
beside it.

**Declined, each pinned in the DIVERGING direction**:

1. a class overriding `__eq__` — only Python can run it;
2. default `__eq__` with a **custom `__repr__`** — `dict_values` is the builtin
   case, and two distinct empty ones share the spelling `dict_values([])`, so
   the token would be a NEW wrong answer;
3. an `Encoded` against a `Decimal` or a big `int` — exact types an `f64`
   cannot answer;
4. two sets past `SET_COMPARE_CAP` (1,000 a side) — containment without a hash
   is quadratic and a `set` states its own length.

## Corpus movement

Two builds over **380,484 cells**, `origin/main` at `e5d499a0` against this
branch (build hashes confirm two genuinely different builds):

```
agree BEFORE : 277729   (refusal-collapsed: 324951)
agree AFTER  : 277777   (refusal-collapsed: 324999)
django REFUSES & djust RENDERS: 4722 -> 4722   (+0)
djust REFUSES & Django RENDERS: 39253 -> 39253  (+0)
cmp            48 moved  of  19663      (every other axis: 0 moved)
newly AGREEING: 48   no longer agreeing: 0   REGRESSIONS: 0
panics 0 -> 0    live-payload leaks 60 -> 60 (0 introduced)
```

The raw headline is blind to refusal-class movement, so both columns are
reported and **neither grew**. Of the 19,663 `@cmp` cells the corpus reaches,
**48 disagreed before and 0 disagree after** — `>=` 12, `<=` 12, `==` 8, `!=` 8,
`>` 4, `<` 4 — which is a superset of the 10 the #2477/#2489 compare counted as
regressions.

## Gate-off

Fifteen mutations. Each asserts the mutation text was found **exactly once**,
that the source changed, that the crate was **rebuilt** (the `.so` mtime is
asserted to move), with `__pycache__` cleared, `N error` counted apart from
`N failed`, and `cargo test --no-fail-fast`.

| # | mutation | result |
|---|---|---|
| M1 | the whole `(Encoded, Encoded)` equality arm reverts to the wildcard `false` | 38 failed |
| M2 | `equality_class`'s Set arm never fires | 11 failed |
| M3 | `equality_class`'s Number arm never fires | 8 failed |
| M4 | `equality_class`'s Identity arm never fires | 3 failed |
| M5 | `set_partial_cmp`'s containment collapses to always-`Equal` | 3 failed |
| M6 | `encoded_partial_cmp`'s Set branch answers `None` | 10 failed |
| M7 | the identity token becomes `type_name` instead of `repr` | 2 failed |
| M8 | the cross-carrier integer arm never matches | 3 failed |
| M9 | the exact `int_eq_float` becomes the rounding cast `real == i as f64` | 1 failed |
| M10 | the imaginary part stops being checked | 1 failed |
| M11 | the class is not written to the wire (slot 11 always empty) | 2 failed |
| M12 | the ordering trap: the equality-only classes get an ordering | 6 failed |
| M13 | slot 11 stops being type-constrained | **SURVIVED**, then 1 failed — see below |
| M14 | `SET_COMPARE_CAP` is lifted from 1,000 to 10,000 | 1 failed |
| M15 | the writer spells an absent class as `nil` instead of an empty map | 3 failed |
| — | clean source, restored and rebuilt | 0 failed (pytest), 0 failed (cargo) |

**M13 is the finding.** It survived, and the reason is the shape canon warns
about: `an_interior_insert_is_refused_rather_than_silently_misread` inserts
into the CURRENT payload, so it builds TWELVE elements — a width no arm matches
however slot 10 is typed. It is answered by WIDTH and would have stayed green
under the exact mutation it looks like it guards. The dangerous shape is one
width down, and nothing tested it.

`an_insert_into_the_ten_slot_payload_is_refused_by_the_last_slots_type` was
added for it: insert into a **ten**-element payload — the shape real state
entries carry — and require all ten refused, for both item shapes. M13 then
reddens exactly that test and nothing else, with the corruption spelled out:

```
an insert at slot 6 of a TEN-slot payload produced an Encoded with shifted
contents instead of being refused: Encoded { …, repr: "intruder",
cmp_key: None, attrs: {}, items: None, eq_class: None }
```

M13's first spelling did not COMPILE (a free binding is a `&Value` where
`decode_eq_class` wants a `&IndexMap`), and an INVALID is a question rather
than a pass — so it was rewritten to drop the constraint AND adapt the read to
the fail-to-absent shape every other optional slot uses, which changes exactly
the type constraint and nothing else.

**Three separately-reachable mechanisms, three distinct reds** — the
shadowing check: the Set *measurement* (M2, 11), the Set *routing* (M6, 10) and
the *containment logic itself* (M5, 3) each redden something on their own, so
none is covering for another.

Every mutation asserts its text was found **exactly once**, that the source
changed, that the `.so` mtime **moved** (a stale artifact reports a plausible
green), with `__pycache__` cleared, `N error` counted apart from `N failed`,
and `--no-fail-fast` on both suites.

No mutation survived.

## Tests

* **New**: 28 cases in `python/tests/test_opaque_equality_2480.py` — the
  cross-product sweep, the protocol facts asserted in both directions, the
  ordering trap on both halves, the cross-carrier boundaries, the state round
  trip, and the chokepoint pins with their own add/remove canary.
* **Flipped rather than deleted**, so the same rows that measured the gap now
  measure its closure: `TestTheComparisonAxisThisWIDENS` → `…WIDENED` (its
  eight rows and two-half accounting kept),
  `TestAFalsyOpaqueEncodedIsNotComparable` (four of five flipped; `BoolFalse`
  stays declined and says why), and the `@cmp` row in
  `test_lazy_corpus_rows_2482.py`.
* **Widened**: the wire pin file to eleven slots, including the interior-insert
  canary and the grew-inside-itself canary.

## Suites

* `pytest tests/ python/tests/ python/djust/tests/ -n auto` — 19867 passed, 438 skipped, 199 warnings in 282.69s (0:04:42)
* `cargo test --workspace --exclude djust_live` — 1357 passed, 0 failed
* `cargo test -p djust_live --no-default-features` — 40 passed, 0 failed
* `cargo clippy --all-targets` clean; `cargo fmt` clean; `ruff` clean.
