### PR TITLE
fix(quality): close six CodeQL code-quality alerts

### DIFF
--- a/python/djust/cli.py
+++ b/python/djust/cli.py
@@ -32,10 +32,13 @@ Examples:
 """
 
 import argparse
+import logging
 import os
 import re
 import sys
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 def setup_django() -> bool:
@@ -746,8 +749,19 @@ def cmd_replay(args: argparse.Namespace) -> int:
 
         if not settings.configured:
             django.setup()
-    except Exception:
-        pass
+    except Exception as exc:  # noqa: BLE001
+        # Deliberately broad and deliberately quiet. `django.setup()` runs every
+        # installed app's `ready()`, so it can raise essentially anything, and
+        # this CLI is documented to work OUTSIDE a project — `--inspect` on an
+        # inline blob needs no Django at all. Narrowing to ImportError /
+        # ImproperlyConfigured would let an unrelated app's `ready()` crash a
+        # command that never needed Django, which is worse than the swallow.
+        #
+        # Not silent, though: the specific failure surfaces from whichever
+        # operation actually required Django (the store read, or the URLconf
+        # lookup in `_replay_url`), and the cause is logged here for anyone
+        # who turns logging up to find out why.
+        logger.debug("django.setup() skipped for `djust replay`: %s", exc)
 
     from djust.bug_capture import BugCapture
 

--- a/python/djust/components/function_component.py
+++ b/python/djust/components/function_component.py
@@ -472,6 +472,10 @@ class RenderSlotTagHandler:
             if isinstance(parsed, (list, dict)):
                 return self._render_value(parsed)
         except (ValueError, TypeError):
+            # Not JSON. That is the ORDINARY case, not an error: every template
+            # spelling of this operand arrives as a dotted path, which the arm
+            # below resolves. Only the legacy caller noted above sends JSON, so
+            # a parse failure here means "try the path", never "something broke".
             pass
 
         # The operand as a dotted path, resolved HERE. A miss is the empty

--- a/scripts/filter-parity-differential.py
+++ b/scripts/filter-parity-differential.py
@@ -455,10 +455,10 @@ _rust.register_tag_handler("ct_ident", _RustTagProbe(_ct_ident, "tag"))
 _rust.register_tag_handler("ct_safe", _RustTagProbe(_ct_safe, "tag"))
 _rust.register_tag_handler("ct_cond", _RustTagProbe(_ct_cond, "tag"))
 _rust.register_block_tag_handler(
-    "cb_ident", "endcb_ident", _RustTagProbe(lambda content: _cb_ident(content), "block")
+    "cb_ident", "endcb_ident", _RustTagProbe(_cb_ident, "block")
 )
 _rust.register_block_tag_handler(
-    "cb_plain", "endcb_plain", _RustTagProbe(lambda content: _cb_plain(content), "block")
+    "cb_plain", "endcb_plain", _RustTagProbe(_cb_plain, "block")
 )
 _rust.register_assign_tag_handler("ca_ident", _RustTagProbe(_ca_ident, "assign"))
 
@@ -3982,7 +3982,8 @@ META_PREFIX = "@@"
 def load(path: str) -> dict[str, list[str]]:
     # Collapse the nondeterministic marker: `random` picks a different element
     # each run, so its LENGTH is not comparable between two runs either.
-    raw = json.load(open(path))
+    with open(path) as fh:
+        raw = json.load(fh)
     # The metadata filter has to come BEFORE the unpack, not after: a `for k,
     # (a, b) in ...` target destructures every row the comprehension iterates,
     # including the ones the `if` would have dropped, so a metadata value that
@@ -3996,7 +3997,8 @@ def load(path: str) -> dict[str, list[str]]:
 
 def load_meta(path: str) -> dict:
     """The metadata rows, or `{}` for a results file written before #2345."""
-    raw = json.load(open(path))
+    with open(path) as fh:
+        raw = json.load(fh)
     return {k[len(META_PREFIX) :]: v for k, v in raw.items() if k.startswith(META_PREFIX)}
 
 


### PR DESCRIPTION
Nine open code-scanning alerts. **Six are real and fixed here; three are not and were dismissed with reasons** rather than worked around.

## Fixed

| alert | rule | site |
|---|---|---|
| #2601, #2602 | `py/file-not-closed` | `json.load(open(path))` in the differential's two readers leaked the handle → `with open(...)` |
| #2604, #2605 | `py/unnecessary-lambda` | `lambda content: _cb_ident(content)` wrapping a callable already of the right shape → passed directly |
| #2606 | `py/empty-except` | `function_component.py`'s JSON probe |
| #2608 | `py/empty-except` | `cmd_replay`'s `django.setup()` guard |

**#2606** had its rationale in a comment *above* the `try`, so the `except` read as a silent swallow. The reason now sits in the block: a parse failure is the **ordinary** case, not an error — every template spelling arrives as a dotted path and is resolved by the arm below.

**#2608** is kept **deliberately broad**. `django.setup()` runs every installed app's `ready()` and can raise essentially anything, and this CLI is documented to work *outside* a project (`--inspect` on an inline blob needs no Django at all). Narrowing to `ImportError`/`ImproperlyConfigured` would let an unrelated app's `ready()` crash a command that never needed Django — worse than the swallow. It is now **logged at debug** with the reasoning in the block, satisfying CLAUDE.md's "always log or re-raise"; `cli.py` gained a module logger.

## Dismissed, each verified first

- **#2598** (`py/unsafe-cyclic-import`, the only *error*) — the import is inside `if TYPE_CHECKING:` and never executes. Verified by AST *and* empirically: after importing the module, `hasattr(m, "DjustTemplateBackend")` is `False`. The rule does not model TYPE_CHECKING guards.
- **#2607** (`py/unused-global-variable`) — `_STORE_CACHE` **is** used: read at `bug_capture_store.py:492` and `:497`, written at `:422`/`:501`/`:509`, verified by walking `Name` nodes by `Load`/`Store` context. It is double-checked locking; the rule misses the read on lock re-entry.
- **#2599** (`py/catch-base-exception`) — deliberate and load-bearing. `PanicException` derives from `BaseException`, so `except Exception` misses a Rust panic and the sweep aborts mid-run — which is how #2343 was found, by a traceback rather than a cell. `KeyboardInterrupt`/`SystemExit` are re-raised in the arm *above* (line 1315) to keep a 95,000-cell sweep interruptible.

## Verified, not just linted

- differential manifest still runs — 17 axes, **0 MISSING**
- `djust replay --inspect` still produces its proper error **from outside a Django project**, which is exactly what the #2608 swallow exists for
- 87 CLI + manifest tests, 86 component/slot tests, all passing