### PR TITLE
fix: per-include-site dj-if marker ids, Django-parity {% cache %} operand resolution, and a scoped inert-API marker (#2689, #2658, #2692)

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,8 +333,6 @@ pip install djust
 
 ```bash
 # Clone the repository
-
-> **Inert.** `@client_state` is INERT — it stamps metadata nothing in the shipped client reads (#2656), so a decorated handler behaves exactly like an undecorated one. The `StateBus` it named was deleted in #2680.
 git clone https://github.com/djust-org/djust.git
 cd djust
 
@@ -723,7 +721,7 @@ See the [State Management Quick Start](docs/STATE_MANAGEMENT_QUICKSTART.md).
 | `@throttle(interval)` | Rapid events | Scroll, resize |
 | `@optimistic` | Instant feedback | Counter, toggle |
 | `@cache(ttl, key_params)` | Repeated queries | Autocomplete |
-| `@client_state(keys)` | Multi-component | Dashboard filters |
+| `@client_state(keys)` | INERT (#2656) — stamps metadata nothing in the shipped client reads; the handler behaves as if undecorated | Dashboard filters |
 | `@background` | Long operations | AI generation, file processing |
 | `DraftModeMixin` | Auto-save forms | Contact form |
 
@@ -733,7 +731,7 @@ Quick decision guide:
 - Scrolling/resizing? → `@throttle(0.1)`
 - Need an instant UI update? → `@optimistic`
 - Same query multiple times? → `@cache(ttl)`
-- Multiple components? → `@client_state([keys])`
+- Multiple components? → update both in ONE handler; `@client_state([keys])` is INERT (#2656) and coordinates nothing
 - Long-running work? → `@background` or `self.start_async(callback)`
 - Auto-save forms? → `DraftModeMixin`
 

--- a/changelog.d/followups-2692-2689-2658.fixed.md
+++ b/changelog.d/followups-2692-2689-2658.fixed.md
@@ -1,0 +1,42 @@
+- **Two `{% include %}`s of one fragment no longer render identical `dj-if` marker ids** (#2689).
+  `if-<hash>-N` derives `<hash>` from the template SOURCE and `N` from a per-parse
+  ordinal, so any mechanism that renders one parsed template twice into one buffer
+  emitted duplicate ids — and the client resolves `RemoveSubtree` / `InsertSubtree` /
+  `MoveSubtree` by first match, so a toggle inside the second include landed on the
+  first. Third instance of the class after `{% for %}` iterations (#1832) and two
+  `template_name` component instances (#2686), and cured by the same shape: a new
+  render-time `Context::dj_if_include_path`, written only by the renderer's include
+  arm from a parse-time `Node::Include::site_id`. The path is lexical, so a
+  conditional sibling include cannot renumber it and the ids stay stable across
+  renders; its `-i<hex>_<n>` segments are disjoint from the loop path's pure-digit
+  ones, so the two suffixes compose unambiguously. Covers nested includes,
+  `{% include … only %}`, includes inside `{% for %}`, and an included template that
+  itself `{% extends %}`.
+
+- **`{% cache %}` resolves its operands the way Django does, so both engines compute
+  the same fragment key** (#2658). `CacheTagHandler` resolved every operand with
+  `ignore_failures=True` and applied a miss policy of its own — `None` for the vary
+  operands, an "unknown variable" error for the expiry. Django's `CacheNode` uses a
+  plain `FilterExpression.resolve(context)`, so an unresolvable vary operand is
+  `string_if_invalid` (`''`), not `None`; since `make_template_fragment_key` hashes
+  the vary list, djust and Django stored the same fragment under **different keys**.
+  Every operand now goes through Django's own call against a bound `Context`, which
+  also brings the three error messages to Django-verbatim text (#2581): `%r` on an
+  invalid cache alias, and `"cache" tag got a non-integer timeout value: ''` where
+  djust reported an unknown variable. The body still renders on a cache hit — that
+  needs a lazy-body block-handler protocol and is tracked on the issue.
+
+- **`scripts/check-inert-api-claims.py` scopes its `INERT` marker to the mention it
+  discharges** (#2692). The marker was file-level, so a caveat belonging to a
+  *different* decorator satisfied the one under test: deleting only the
+  `@client_state` caveat in `docs/BEST_PRACTICES_AI.md` left the checker green
+  because `@debounce`'s marker 28 lines earlier — inside the same code fence — stood
+  in for it, which is precisely the #2680 shape the checker exists to catch. A marker
+  now discharges either the whole file (when it is in the file's opening construct,
+  where a reader meets it before any example) or only its own block. The scan also
+  reaches `tests/`, `python/tests/`, `scripts/` and every repo-root `.md`, and the
+  canary runs the real `check()` against a temporary tree instead of asserting on the
+  regexes in isolation. Tightening and widening reported 29 previously-discharged
+  sites, all corrected here — including a `README.md` banner that had landed inside a
+  bash code fence while the decision-guide table routing readers to `@client_state`
+  carried no caveat at all.

--- a/crates/djust_core/src/context.rs
+++ b/crates/djust_core/src/context.rs
@@ -251,6 +251,26 @@ pub struct Context {
     /// and by `{% include … only %}`'s fresh context so a marker nested inside
     /// a component's include keeps the component's namespace.
     dj_if_id_namespace: String,
+    /// Per-include-SITE path for dj-if marker ids (#2689). The third known
+    /// instance of the same class as `dj_if_loop_path` (#1832) and
+    /// `dj_if_id_namespace` (#2686): `if-<hash>-N` is derived from the
+    /// template SOURCE, so two `{% include %}`s of one fragment in one page
+    /// emit the identical id and the client resolves subtree patches by FIRST
+    /// match — a toggle in the second include lands on the first.
+    ///
+    /// Written ONLY by the renderer's `{% include %}` arm, from the parse-time
+    /// `Node::Include::site_id`, and never by a context key — the #2529 lesson
+    /// that put the other two here applies verbatim. Each segment is
+    /// `-i<hex>_<digits>` (the including template's source hash and the tag's
+    /// document-order ordinal), so the path composes down a chain of nested
+    /// includes and stays stable across renders: it is LEXICAL, not an
+    /// execution counter, so a `{% if %}` that skips a sibling include cannot
+    /// renumber it.
+    ///
+    /// The grammar is disjoint from the loop path (segments of pure digits),
+    /// so the two compose without ambiguity. Copied by `Clone` and by
+    /// `{% include ... only %}`'s fresh context.
+    dj_if_include_path: String,
     /// Django's `Context.autoescape` (#2556). Default `true`; plain render APIs
     /// accept explicit policy, lexical autoescape bodies restore it on exit,
     /// and `{% include … only %}` copies it into its fresh context. Context
@@ -330,6 +350,7 @@ impl Clone for Context {
             emit_dj_if_markers: self.emit_dj_if_markers,
             dj_if_loop_path: self.dj_if_loop_path.clone(),
             dj_if_id_namespace: self.dj_if_id_namespace.clone(),
+            dj_if_include_path: self.dj_if_include_path.clone(),
             autoescape: self.autoescape,
             // SHARED, not copied: Django's `Context.__copy__` shallow-copies
             // `render_context`, so a `{% for %}` / `{% with %}` clone
@@ -391,6 +412,34 @@ pub enum Walked<'py> {
     Invalid,
 }
 
+/// `(-i<hex>_<digits>)*` — the grammar of `Context::dj_if_include_path`.
+///
+/// Segments are tagged `i` and always contain `_`, so they can never be
+/// mistaken for a `dj_if_loop_path` segment (pure digits, #1832), which is what
+/// lets the two suffixes be concatenated into one opaque marker id.
+fn is_dj_if_include_path(path: &str) -> bool {
+    if path.is_empty() {
+        return true;
+    }
+    let Some(rest) = path.strip_prefix('-') else {
+        return false;
+    };
+    rest.split('-').all(|segment| {
+        let Some(body) = segment.strip_prefix('i') else {
+            return false;
+        };
+        match body.split_once('_') {
+            Some((hash, ordinal)) => {
+                !hash.is_empty()
+                    && hash.chars().all(|c| c.is_ascii_hexdigit())
+                    && !ordinal.is_empty()
+                    && ordinal.chars().all(|c| c.is_ascii_digit())
+            }
+            None => false,
+        }
+    })
+}
+
 impl Context {
     pub fn new() -> Self {
         Self {
@@ -401,6 +450,7 @@ impl Context {
             emit_dj_if_markers: true,
             dj_if_loop_path: String::new(),
             dj_if_id_namespace: String::new(),
+            dj_if_include_path: String::new(),
             autoescape: true,
             cycle_state: std::sync::Arc::default(),
             ifchanged_state: std::sync::Arc::default(),
@@ -429,6 +479,7 @@ impl Context {
             emit_dj_if_markers: true,
             dj_if_loop_path: String::new(),
             dj_if_id_namespace: String::new(),
+            dj_if_include_path: String::new(),
             autoescape: true,
             cycle_state: std::sync::Arc::default(),
             ifchanged_state: std::sync::Arc::default(),
@@ -507,6 +558,31 @@ impl Context {
     /// embedding host set one.
     pub fn dj_if_id_namespace(&self) -> &str {
         &self.dj_if_id_namespace
+    }
+
+    /// Set the per-include-site dj-if id path for renders under this context
+    /// (#2689). Written ONLY by the renderer's `{% include %}` arm — once per
+    /// include, restored on exit — and never by a context key.
+    ///
+    /// The grammar is `(-i<hex>_<digits>)*`; anything else is refused and the
+    /// path left unchanged, for the same reason `set_dj_if_loop_path` refuses
+    /// non-`(-<digits>)*` input (#2529): the value is interpolated raw into a
+    /// marker comment, and `-->` in it would forge live markup.
+    pub fn set_dj_if_include_path(&mut self, path: impl Into<String>) {
+        let path = path.into();
+        if is_dj_if_include_path(&path) {
+            self.dj_if_include_path = path;
+        } else {
+            debug_assert!(
+                false,
+                "dj-if include path is not `(-i<hex>_<digits>)*`: {path:?}"
+            );
+        }
+    }
+
+    /// The dj-if include-site path (#2689) — empty outside any `{% include %}`.
+    pub fn dj_if_include_path(&self) -> &str {
+        &self.dj_if_include_path
     }
 
     /// Set Django's `Context.autoescape` for renders under this context
@@ -2379,6 +2455,55 @@ fn warn_once_on_orm_autocall(py: Python<'_>, obj: &pyo3::Bound<'_, pyo3::PyAny>,
 mod tests {
     use super::*;
     use indexmap::IndexMap;
+
+    /// #2689 / #2529 — the include path is interpolated RAW into a marker
+    /// comment, so its grammar is a refusal, not an escape.
+    #[test]
+    fn dj_if_include_path_grammar_accepts_only_tagged_segments() {
+        for good in ["", "-ia1b2c3d4_0", "-ia1b2c3d4_0-ideadbeef_12", "-i0_0"] {
+            assert!(is_dj_if_include_path(good), "rejected {good:?}");
+        }
+        for bad in [
+            "-i-->x_0",        // a comment terminator
+            "-ia1b2c3d4_0-->", // ...trailing
+            "ia1b2c3d4_0",     // no leading separator
+            "-a1b2c3d4_0",     // untagged
+            "-i_0",            // empty hash
+            "-ia1b2c3d4_",     // empty ordinal
+            "-ia1b2c3d4",      // no ordinal at all
+            "-ig1_0",          // non-hex hash
+            "-ia1_x",          // non-digit ordinal
+            "-i a1_0",         // a space
+            "-1",              // a LOOP-path segment must not validate here
+        ] {
+            assert!(!is_dj_if_include_path(bad), "accepted {bad:?}");
+        }
+    }
+
+    /// The two suffix axes concatenate into one opaque id, so their segment
+    /// alphabets must be disjoint or the composition is not injective (#2689).
+    #[test]
+    fn include_path_and_loop_path_segments_cannot_be_confused() {
+        // Every loop-path segment is pure digits; no include segment is.
+        for loop_path in ["-0", "-12", "-3-4"] {
+            assert!(
+                loop_path.chars().all(|c| c == '-' || c.is_ascii_digit()),
+                "not a loop path: {loop_path:?}"
+            );
+            assert!(
+                !is_dj_if_include_path(loop_path),
+                "a loop path validated as an include path: {loop_path:?}"
+            );
+        }
+        // ...and no include segment is a valid loop path.
+        for include_path in ["-ia1b2c3d4_0", "-i0_0-i1_2"] {
+            assert!(is_dj_if_include_path(include_path));
+            assert!(
+                !include_path.chars().all(|c| c == '-' || c.is_ascii_digit()),
+                "an include path validated as a loop path: {include_path:?}"
+            );
+        }
+    }
 
     #[test]
     fn test_context_simple_get() {

--- a/crates/djust_templates/src/parser.rs
+++ b/crates/djust_templates/src/parser.rs
@@ -58,6 +58,24 @@ pub enum Node {
         template: String,
         with_vars: Vec<(String, String)>, // key=value assignments
         only: bool,                       // if true, only pass with_vars, not parent context
+        /// Stable identity of THIS `{% include %}` tag, `<prefix>_<n>` where
+        /// `<prefix>` is the including template's source hash and `<n>` its
+        /// document-order ordinal among that template's includes. Assigned by
+        /// [`assign_if_marker_ids`], the one pass that already walks every
+        /// node with the prefix in hand.
+        ///
+        /// The renderer composes it into `Context::dj_if_include_path` so the
+        /// `<!--dj-if id=…-->` markers of an included fragment differ per
+        /// include SITE (#2689). The prefix is load-bearing, not decoration:
+        /// `{% extends %}` composes two SEPARATELY PARSED templates into one
+        /// buffer, so a bare ordinal would give the base's include #0 and the
+        /// child's include #0 the same suffix — the same reason the `{% if %}`
+        /// id carries it.
+        ///
+        /// `None` for `Include` nodes built by hand (tests) or reconstructed
+        /// outside `parse()`; the renderer then adds no suffix, which is the
+        /// pre-#2689 behaviour.
+        site_id: Option<String>,
     },
     Comment,
     /// {% load library_name %} — preserved so inheritance reconstruction can
@@ -618,9 +636,26 @@ pub fn template_hash_hex(source: &str) -> String {
 /// ReactComponent children. Variants that can't hold child Nodes
 /// (Text, Variable, Static, etc.) are leaves and don't recurse.
 pub(crate) fn assign_if_marker_ids(nodes: &mut [Node], prefix: &str, counter: &mut usize) {
+    let mut includes = 0usize;
+    assign_marker_ids_inner(nodes, prefix, counter, &mut includes);
+}
+
+fn assign_marker_ids_inner(
+    nodes: &mut [Node],
+    prefix: &str,
+    counter: &mut usize,
+    includes: &mut usize,
+) {
     for node in nodes.iter_mut() {
         match node {
-            Node::Located { nodes, .. } => assign_if_marker_ids(nodes, prefix, counter),
+            // Its own tag identity, for `Context::dj_if_include_path` (#2689).
+            Node::Include { site_id, .. } => {
+                *site_id = Some(format!("{prefix}_{includes}"));
+                *includes += 1;
+            }
+            Node::Located { nodes, .. } => {
+                assign_marker_ids_inner(nodes, prefix, counter, includes)
+            }
             Node::If {
                 marker_id,
                 true_nodes,
@@ -629,43 +664,43 @@ pub(crate) fn assign_if_marker_ids(nodes: &mut [Node], prefix: &str, counter: &m
             } => {
                 *marker_id = Some(format!("if-{}-{}", prefix, *counter));
                 *counter += 1;
-                assign_if_marker_ids(true_nodes, prefix, counter);
-                assign_if_marker_ids(false_nodes, prefix, counter);
+                assign_marker_ids_inner(true_nodes, prefix, counter, includes);
+                assign_marker_ids_inner(false_nodes, prefix, counter, includes);
             }
             Node::For {
                 nodes: body,
                 empty_nodes,
                 ..
             } => {
-                assign_if_marker_ids(body, prefix, counter);
-                assign_if_marker_ids(empty_nodes, prefix, counter);
+                assign_marker_ids_inner(body, prefix, counter, includes);
+                assign_marker_ids_inner(empty_nodes, prefix, counter, includes);
             }
             Node::Block { nodes: body, .. } => {
-                assign_if_marker_ids(body, prefix, counter);
+                assign_marker_ids_inner(body, prefix, counter, includes);
             }
             Node::With { nodes: body, .. } => {
-                assign_if_marker_ids(body, prefix, counter);
+                assign_marker_ids_inner(body, prefix, counter, includes);
             }
             Node::Spaceless { nodes: body, .. } | Node::AutoEscape { nodes: body, .. } => {
-                assign_if_marker_ids(body, prefix, counter);
+                assign_marker_ids_inner(body, prefix, counter, includes);
             }
             Node::Filter { nodes: body, .. } => {
-                assign_if_marker_ids(body, prefix, counter);
+                assign_marker_ids_inner(body, prefix, counter, includes);
             }
             Node::IfChanged {
                 nodes: body,
                 else_nodes,
                 ..
             } => {
-                assign_if_marker_ids(body, prefix, counter);
-                assign_if_marker_ids(else_nodes, prefix, counter);
+                assign_marker_ids_inner(body, prefix, counter, includes);
+                assign_marker_ids_inner(else_nodes, prefix, counter, includes);
             }
             Node::BlockSuperScope { super_nodes, nodes } => {
-                assign_if_marker_ids(super_nodes, prefix, counter);
-                assign_if_marker_ids(nodes, prefix, counter);
+                assign_marker_ids_inner(super_nodes, prefix, counter, includes);
+                assign_marker_ids_inner(nodes, prefix, counter, includes);
             }
             Node::BlockCustomTag { children, .. } => {
-                assign_if_marker_ids(children, prefix, counter);
+                assign_marker_ids_inner(children, prefix, counter, includes);
             }
             // Scope nodes (#2558) carry children; `RawBlockCustomTag` does
             // not (its body is a source string, never parsed here).
@@ -673,10 +708,10 @@ pub(crate) fn assign_if_marker_ids(nodes: &mut [Node], prefix: &str, counter: &m
             | Node::Timezone { children, .. }
             | Node::Localize { children, .. }
             | Node::LocalTime { children, .. } => {
-                assign_if_marker_ids(children, prefix, counter);
+                assign_marker_ids_inner(children, prefix, counter, includes);
             }
             Node::ReactComponent { children, .. } => {
-                assign_if_marker_ids(children, prefix, counter);
+                assign_marker_ids_inner(children, prefix, counter, includes);
             }
             // Leaf or non-AST-bearing variants — no recursion needed.
             _ => {}
@@ -1354,6 +1389,7 @@ fn parse_token_inner(
                         template,
                         with_vars,
                         only,
+                        site_id: None,
                     }))
                 }
 
@@ -5841,6 +5877,7 @@ mod dep_tests {
                 template: "\"x.html\"".into(),
                 with_vars: vec![],
                 only: false,
+                site_id: None,
             },
             Node::Comment,
             Node::Load(vec!["mytags".into()]),

--- a/crates/djust_templates/src/renderer.rs
+++ b/crates/djust_templates/src/renderer.rs
@@ -2535,9 +2535,16 @@ pub fn render_node_with_loader_mut<L: TemplateLoader>(
                     } else {
                         format!("-{namespace}")
                     };
+                    // The include-site path (#2689) is the same idea again,
+                    // on the third axis: two `{% include %}`s of one fragment
+                    // in one page render the same parsed template into one
+                    // buffer, so both emit `if-<hash>-0`. Segments are
+                    // `-i<hex>_<n>`, disjoint from the loop path's pure-digit
+                    // segments, so the two concatenate unambiguously.
+                    let include_path = context.dj_if_include_path();
                     let loop_path = context.dj_if_loop_path();
                     return Ok(format!(
-                        "<!--dj-if id=\"{id}{namespace}{loop_path}\"-->{body}<!--/dj-if-->"
+                        "<!--dj-if id=\"{id}{namespace}{include_path}{loop_path}\"-->{body}<!--/dj-if-->"
                     ));
                 }
             }
@@ -3256,6 +3263,7 @@ pub fn render_node_with_loader_mut<L: TemplateLoader>(
             template,
             with_vars,
             only,
+            site_id,
         } => {
             // Load and render the included template
             if let Some(loader) = loader {
@@ -3356,6 +3364,22 @@ pub fn render_node_with_loader_mut<L: TemplateLoader>(
                 // Resolved here rather than in the loader: the chain needs the
                 // render context (a variable parent name) and the loader is
                 // also the parse cache, which is shared across renders.
+                // This include site's contribution to the dj-if marker-id
+                // path (#2689), composed onto whatever chain reached here so
+                // nested includes nest. `site_id` is LEXICAL (the including
+                // template's source hash plus this tag's document-order
+                // ordinal), so a conditional sibling include cannot renumber
+                // it and the ids stay stable across renders — which is what
+                // the client needs, since it keys DOM subtrees on them.
+                let parent_include_path = context.dj_if_include_path().to_string();
+                let child_include_path = match site_id {
+                    Some(site) => format!("{parent_include_path}-i{site}"),
+                    // Hand-built or reconstructed `Include` nodes never went
+                    // through the parser's assignment pass; add no suffix,
+                    // which is exactly the pre-#2689 behaviour.
+                    None => parent_include_path.clone(),
+                };
+
                 // Create context for included template
                 let mut fresh_context = if *only {
                     Some({
@@ -3376,6 +3400,11 @@ pub fn render_node_with_loader_mut<L: TemplateLoader>(
                         // inside a component's `{% include … only %}` still
                         // belongs to that component's namespace (#2686).
                         fresh.set_dj_if_id_namespace(context.dj_if_id_namespace());
+                        // ...and the include-site path of the chain that
+                        // reached here, extended by THIS site (#2689). Set on
+                        // the fresh context for the same reason the two above
+                        // are: `only` drops context, not render-time switches.
+                        fresh.set_dj_if_include_path(child_include_path.clone());
                         // Django's `context.new()` is `copy(self)`, so the
                         // `{% autoescape %}` policy crosses an `only` include
                         // (#2556, `include14`).
@@ -3452,7 +3481,13 @@ pub fn render_node_with_loader_mut<L: TemplateLoader>(
                 if let Some(fresh) = fresh_context.as_mut() {
                     render_include(fresh)
                 } else {
-                    context.with_scope(render_include)
+                    // `with_scope` pushes a context FRAME; the marker-id path
+                    // is a context FIELD, so restore it by hand on the way out
+                    // exactly as the `{% for %}` arm does for the loop path.
+                    context.set_dj_if_include_path(child_include_path);
+                    let rendered = context.with_scope(render_include);
+                    context.set_dj_if_include_path(parent_include_path);
+                    rendered
                 }
             } else {
                 // No loader available — silently omit ({% include %} without a loader
@@ -6348,6 +6383,7 @@ mod tests {
             template: "\"boom.html\"".to_string(),
             with_vars: Vec::new(),
             only: false,
+            site_id: None,
         }
     }
 

--- a/crates/djust_templates/tests/test_dj_if_markers_off_2519.rs
+++ b/crates/djust_templates/tests/test_dj_if_markers_off_2519.rs
@@ -423,12 +423,20 @@ mod feature_on_default_context {
             render_with_loader("{% include 'inc_false_if_text.html' only %}", &ctx),
             "<!--dj-if-->"
         );
-        assert_eq!(
-            strip_prefix(&render_with_loader(
-                "{% include 'inc_false_if.html' only %}",
-                &ctx
-            )),
-            "<!--dj-if id=\"if-0\"--><!--/dj-if-->"
+        // The `-i<hex>_<n>` suffix is this include SITE's identity (#2689):
+        // two `{% include %}`s of one fragment would otherwise emit the same
+        // id into one buffer, and the client resolves subtree patches by first
+        // match. What this test pins is that the marker survives `only` at
+        // all; the id shape is pinned in
+        // `python/djust/tests/test_include_marker_id_namespace_2689.py`.
+        let rendered = strip_prefix(&render_with_loader(
+            "{% include 'inc_false_if.html' only %}",
+            &ctx,
+        ));
+        assert!(
+            rendered.starts_with("<!--dj-if id=\"if-0-i")
+                && rendered.ends_with("\"--><!--/dj-if-->"),
+            "got {rendered:?}"
         );
     }
 

--- a/crates/djust_templates/tests/test_if_markers.rs
+++ b/crates/djust_templates/tests/test_if_markers.rs
@@ -60,10 +60,16 @@ fn strip_prefix(rendered: &str) -> String {
     re.replace_all(rendered, r#"id="if-$1""#).to_string()
 }
 
-/// Return all `if-<prefix>-N` IDs present in the rendered output,
+/// Return all `if-<prefix>-N…` IDs present in the rendered output,
 /// preserving order of first occurrence.
+///
+/// The trailing group is the render-time suffix chain — `dj_if_loop_path`
+/// (#1832), `dj_if_id_namespace` (#2686) and `dj_if_include_path` (#2689).
+/// The id is opaque; matching only the parse-time head silently dropped every
+/// suffixed marker from the sample, which is how this helper started failing
+/// when #2689 gave every `{% include %}` site its own suffix.
 fn extract_marker_ids(rendered: &str) -> Vec<String> {
-    let re = regex::Regex::new(r#"id="(if-[0-9a-f]{8}-\d+)""#).expect("regex");
+    let re = regex::Regex::new(r#"id="(if-[0-9a-f]{8}-\d+[0-9A-Za-z_-]*)""#).expect("regex");
     let mut seen = Vec::new();
     let mut set = HashSet::new();
     for cap in re.captures_iter(rendered) {

--- a/docs/state-management/STATE_MANAGEMENT_API.md
+++ b/docs/state-management/STATE_MANAGEMENT_API.md
@@ -4,6 +4,10 @@
 > server-side MARKERS: the decorator stamps metadata and nothing in the shipped
 > client reads it, so the handler runs on every event. Harmless and
 > forward-compatible, but not rate control today. `@cache` IS wired end-to-end.
+>
+> **`@client_state` is INERT too (#2656)** — every example below that uses it
+> works because the server re-renders, not because anything is published. The
+> `StateBus` these examples credit was deleted in #2680.
 
 
 **Status:** ✅ Implemented (Phase 5 Complete: @cache, @client_state, DraftModeMixin, @loading)

--- a/docs/state-management/STATE_MANAGEMENT_COMPARISON.md
+++ b/docs/state-management/STATE_MANAGEMENT_COMPARISON.md
@@ -1,5 +1,7 @@
 # State Management Framework Comparison
 
+> **Inert.** `@client_state` is INERT — it stamps metadata nothing in the shipped client reads (#2656), so a decorated handler behaves exactly like an undecorated one. The `StateBus` it named was deleted in #2680.
+
 **Date**: January 2025
 **Version**: djust 0.4.0 vs Phoenix LiveView 0.20 vs Laravel Livewire 3.0
 

--- a/python/djust/decorators.py
+++ b/python/djust/decorators.py
@@ -966,18 +966,18 @@ def client_state(keys: List[str]) -> Callable[[F], F]:
 
     Usage (the shape the metadata records — not working behaviour):
         class DashboardView(LiveView):
-            @client_state(keys=["filter"])
+            @client_state(keys=["filter"])  # INERT (#2656)
             def update_filter(self, filter: str = "", **kwargs):
                 # WOULD publish "filter" — today this comment is the
                 # only thing that happens.
                 self.filter = filter
 
-            @client_state(keys=["filter"])
+            @client_state(keys=["filter"])  # INERT (#2656)
             def on_filter_change(self, filter: str = "", **kwargs):
                 # WOULD be called when "filter" changes; it is not.
                 self.apply_filter()
 
-            @client_state(keys=["filter", "sort"])
+            @client_state(keys=["filter", "sort"])  # INERT (#2656)
             def apply_filters(self, filter: str = "", sort: str = "", **kwargs):
                 # WOULD publish both "filter" and "sort".
                 self.filter = filter

--- a/python/djust/schema.py
+++ b/python/djust/schema.py
@@ -901,7 +901,10 @@ DECORATORS: List[Dict[str, Any]] = [
             "keys": "List[str] — state keys to publish/subscribe",
         },
         "usage": [
-            "@client_state(keys=['filter'])\ndef update_filter(self, filter: str = '', **kwargs):",
+            # INERT (#2656) — repeated here because this snippet is what an
+            # agent copies; the entry's `description` is a separate block.
+            "@client_state(keys=['filter'])  # INERT (#2656): publishes nothing\n"
+            "def update_filter(self, filter: str = '', **kwargs):",
         ],
     },
     {

--- a/python/djust/template_libraries.py
+++ b/python/djust/template_libraries.py
@@ -1170,7 +1170,7 @@ class CacheTagHandler:
     handler is the store/lookup half only. The observable difference is that a
     cache HIT still paid to render the body — the OUTPUT is the cached one
     either way, which is what the tag's semantics are about, but the
-    performance win is not there yet (tracked with the row).
+    performance win is not there yet (#2658).
 
     Argument handling is Django's, token for token (``defaulttags`` has no say
     here; this is ``django/templatetags/cache.py``):
@@ -1183,6 +1183,19 @@ class CacheTagHandler:
     * the rest vary the key, and each IS resolved.
     * ``using="alias"`` selects the cache; an unknown alias is a
       ``TemplateSyntaxError``, not a fallback.
+
+    EVERY resolved operand goes through :func:`_resolve_cache_operand`, which
+    is `FilterExpression.resolve(context)` against a ``Context`` bound to the
+    active backend's engine — the same call ``CacheNode.render`` makes, with
+    no ``ignore_failures``. An earlier version had its own miss policy (a
+    sentinel mapped to ``None`` for the vary operands and to an
+    "unknown variable" error for the expiry), and its comment said Django
+    resolves the vary operands with ``ignore_failures``. Django's source says
+    otherwise — `vary_on = [var.resolve(context) for var in self.vary_on]` —
+    and the divergence was not cosmetic: an unresolvable vary operand became
+    ``None`` here and ``string_if_invalid`` (``''``) in Django, so the two
+    engines hashed DIFFERENT `make_template_fragment_key` keys for the same
+    fragment (#2658).
     """
 
     #: Raw tokens: this handler resolves what Django resolves and leaves the
@@ -1215,7 +1228,7 @@ class CacheTagHandler:
         # not a cache selector. Popping it there left one operand and raised
         # `IndexError` — an unhandled crash on input Django renders.
         if len(tokens) > 2 and tokens[-1].startswith("using="):
-            cache_name = _literal_or_resolve(tokens.pop()[len("using=") :], context)
+            cache_name = _resolve_cache_operand(tokens.pop()[len("using=") :], context)
 
         expire_token, fragment_name, vary_tokens = tokens[0], tokens[1], tokens[2:]
 
@@ -1223,8 +1236,10 @@ class CacheTagHandler:
             try:
                 cache_backend = caches[cache_name]
             except InvalidCacheBackendError as exc:
+                # `%r`, as Django writes it — the bare name read as though a
+                # cache called `nosuch` might exist under another spelling.
                 raise TemplateSyntaxError(
-                    f"Invalid cache name specified for cache tag: {cache_name}"
+                    f"Invalid cache name specified for cache tag: {cache_name!r}"
                 ) from exc
         else:
             # Django's `CacheNode.render`: a cache named `template_fragments`
@@ -1234,26 +1249,28 @@ class CacheTagHandler:
             except InvalidCacheBackendError:
                 cache_backend = caches["default"]
 
-        expire_time = _literal_or_resolve(expire_token, context)
-        if expire_time is _MISSING:
-            # Django resolves the expiry WITHOUT `ignore_failures`, so an
-            # unresolvable operand is an error rather than "cache forever" —
-            # `{% cache foo bar %}` with no `foo` raises. The literal `None`
-            # is a different thing and does mean forever.
-            raise TemplateSyntaxError(f"'cache' tag got an unknown variable: {expire_token!r}")
+        # Unresolvable is NOT its own error case. `FilterExpression.resolve`
+        # substitutes `string_if_invalid` (`''` by default) and the `int()`
+        # below then refuses it, which is how Django reports
+        # `{% cache nope "f" %}` — as a non-integer timeout of `''`, never as
+        # an unknown variable. (`CacheNode.render` does carry an
+        # unknown-variable branch, but `FilterExpression` never propagates
+        # `VariableDoesNotExist` to it, so it is unreachable there too.) The
+        # literal `None` is a different thing and does mean forever.
+        expire_time = _resolve_cache_operand(expire_token, context)
         if expire_time is not None:
             try:
                 expire_time = int(expire_time)
             except (ValueError, TypeError) as exc:
+                # Django double-quotes the tag name in BOTH timeout messages
+                # while single-quoting it in the arity ones. Verbatim (#2581).
                 raise TemplateSyntaxError(
-                    f"'cache' tag got a non-integer timeout value: {expire_time!r}"
+                    f'"cache" tag got a non-integer timeout value: {expire_time!r}'
                 ) from exc
 
-        # The vary operands ARE `ignore_failures`, so a miss is `None` there.
-        vary_on = [
-            None if (v := _literal_or_resolve(token, context)) is _MISSING else v
-            for token in vary_tokens
-        ]
+        # Django: `vary_on = [var.resolve(context) for var in self.vary_on]` —
+        # the same resolution as everything else, NOT `ignore_failures`.
+        vary_on = [_resolve_cache_operand(token, context) for token in vary_tokens]
         key = make_template_fragment_key(fragment_name, vary_on)
 
         cached = cache_backend.get(key)
@@ -1263,56 +1280,30 @@ class CacheTagHandler:
         return content
 
 
-#: "no such variable" — distinct from the literal ``None`` a `{% cache %}`
-#: expiry may legitimately carry.
-_MISSING = object()
+def _resolve_cache_operand(token: str, context: Dict[str, Any]) -> Any:
+    """One ``{% cache %}`` operand, resolved exactly as ``CacheNode`` resolves it.
 
+    Django's own ``FilterExpression`` — through the same synthetic parser the
+    rest of this module uses, so a literal, a dotted lookup and a FILTER chain
+    (``{% cache 2|noop:"x y" k %}``) all behave as Django behaves, with its
+    libraries in scope — resolved against a ``Context`` BOUND to the active
+    backend's engine.
 
-def _literal_or_resolve(token: str, context: Dict[str, Any]) -> Any:
-    """A ``{% cache %}`` operand: a literal if it looks like one, else a lookup.
-
-    Deliberately small — it covers what the tag's operands actually are
-    (a number, a quoted string, ``None``, or a dotted context path) rather
-    than re-implementing ``FilterExpression``. A miss returns
-    :data:`_MISSING`, which the caller maps: `None` for the vary operands
-    (Django's ``ignore_failures``) and an error for the expiry (Django
-    resolves that one without it). The literal ``None`` is distinct from a
-    miss and means "cache forever".
+    The binding is what makes this Django's semantics rather than an
+    approximation: `FilterExpression.resolve` reads `string_if_invalid` off
+    `context.template.engine` when a lookup fails, and reaching for it on an
+    unbound `Context` is an `AttributeError` — which is why the version this
+    replaces passed `ignore_failures=True` and then had to invent a miss policy
+    of its own. That policy disagreed with Django twice (#2658): it turned an
+    unresolvable vary operand into `None` rather than `''`, changing the
+    `make_template_fragment_key` HASH, and it reported an unresolvable expiry
+    as an unknown variable rather than as a non-integer timeout.
     """
     from django.template import Context as DjangoContext
-    from django.template.base import VariableDoesNotExist
 
-    token = token.strip()
-    # Django's OWN `FilterExpression`, through the same synthetic parser the
-    # rest of this module uses — so a literal, a dotted lookup, and a FILTER
-    # chain (`{% cache 2|noop:"x y" k %}`) all resolve the way Django resolves
-    # them, with its libraries in scope. Re-implementing this was wrong twice
-    # over: it missed filters, and it had its own opinion about literals.
-    try:
-        expression = _parser([]).compile_filter(token)
-    except Exception:
-        return _MISSING
-    try:
-        resolved = expression.resolve(DjangoContext(dict(context)), ignore_failures=True)
-    except VariableDoesNotExist:
-        return _MISSING
-    # `ignore_failures=True` answers `None` for BOTH "no such variable" and "the
-    # variable is None". Collapsing them made `{% cache t "f" %}` with `t=None`
-    # raise where Django caches forever, so the two are separated structurally:
-    # a name that does not resolve is a miss, a name that resolves to None is
-    # the value None.
-    if resolved is not None:
-        return resolved
-    if token == "None":
-        return None
-    try:
-        # Django's own miss signal, without the ignore_failures collapse.
-        expression.resolve(DjangoContext(dict(context)))
-    except VariableDoesNotExist:
-        return _MISSING
-    except Exception:
-        return _MISSING
-    return None
+    ctx = DjangoContext(dict(context))
+    ctx.template = _stub_template_with(*_render_engine_options())
+    return _parser([]).compile_filter(token.strip()).resolve(ctx)
 
 
 def _bridge_bespoke_block_tag(label: str, name: str) -> None:

--- a/python/djust/tests/test_decorators.py
+++ b/python/djust/tests/test_decorators.py
@@ -311,7 +311,7 @@ class TestDecoratorMetadata:
         undecorated one. This pins the stamp, not any behaviour.
         """
 
-        @client_state(keys=["filter", "sort"])
+        @client_state(keys=["filter", "sort"])  # INERT (#2656)
         def handler(self, **kwargs):
             pass
 

--- a/python/djust/tests/test_include_marker_id_namespace_2689.py
+++ b/python/djust/tests/test_include_marker_id_namespace_2689.py
@@ -1,0 +1,340 @@
+"""#2689 — two ``{% include %}``s of one fragment must not render identical
+``<!--dj-if id=...-->`` marker ids (link N+2 of #2530/#2686).
+
+``if-<hash>-<N>`` takes ``<hash>`` from the template SOURCE and ``<N>`` from a
+per-parse ordinal, so ANY mechanism that renders one parsed template more than
+once into a single output buffer emits duplicate ids. Three instances of that
+class are now known:
+
+===========================================  ============================
+axis                                         cure
+===========================================  ============================
+``{% for %}`` iterations                     ``Context::dj_if_loop_path`` (#1832)
+two ``template_name`` component instances    ``Context::dj_if_id_namespace`` (#2686)
+two ``{% include %}``s of one fragment       this issue
+===========================================  ============================
+
+The client resolves ``RemoveSubtree`` / ``InsertSubtree`` / ``MoveSubtree`` by
+FIRST matching id (``static/djust/src/12-vdom-patch.js``), so a toggle inside
+the second include lands on the first.
+
+Every assertion here is POSITIONAL. Under the bug the two ids are EQUAL, and a
+dict keyed on the id silently collapses them to one entry — the exact tautology
+that stayed green under the live bug in #2686 (#2135, "green while destroying
+what it guards").
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+from django.test import override_settings
+
+from djust import LiveView
+from djust.decorators import event_handler
+from djust.testing import LiveViewTestClient
+from djust.utils import clear_template_dirs_cache
+
+pytestmark = [pytest.mark.django_db]
+
+MOD = __name__
+
+_MARKER = re.compile(r'<!--dj-if id="(if-[0-9A-Za-z_-]+)"-->(.*?)<!--/dj-if-->', re.S)
+
+
+class TwoIncludes2689(LiveView):
+    template_name = "inc_2689/page.html"
+
+    def mount(self, request: Any, **kwargs: Any) -> None:
+        self.a = False
+        self.b = False
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        return {"a": self.a, "b": self.b}
+
+    @event_handler()
+    def toggle_b(self, **kwargs: Any) -> None:
+        self.b = not self.b
+
+
+class NestedIncludes2689(LiveView):
+    """An include whose own body includes the fragment twice, plus a sibling.
+
+    Three renders of one parsed fragment, reached down two different include
+    chains — so a per-site ordinal that resets inside a nested include would
+    still collide.
+    """
+
+    template_name = "inc_2689/outer.html"
+
+    def mount(self, request: Any, **kwargs: Any) -> None:
+        self.a = False
+        self.b = False
+        self.c = False
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        return {"a": self.a, "b": self.b, "c": self.c}
+
+
+class OnlyIncludes2689(LiveView):
+    """``{% include … only %}`` builds a FRESH ``Context`` mid-render.
+
+    That fresh context is the one place the include-site path can be dropped
+    on the floor — it already had to be taught to carry the marker flag
+    (#2519), the loop path (#1832) and the component namespace (#2686).
+    """
+
+    template_name = "inc_2689/only.html"
+
+    def mount(self, request: Any, **kwargs: Any) -> None:
+        self.a = False
+        self.b = False
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        return {"a": self.a, "b": self.b}
+
+
+class ExtendsIncludes2689(LiveView):
+    """A base and its child each include the fragment.
+
+    Page-level ``{% extends %}`` resolves through ONE parse of the merged
+    source, so the two include sites share a counter and are already distinct
+    without the source hash in ``site_id`` — gate-off proved that, contradicting
+    the guess this test was first written on. The case that does need the hash
+    is :class:`IncludedExtender2689`; this one pins that composing an
+    ``{% extends %}`` page does not lose the suffix altogether.
+    """
+
+    template_name = "inc_2689/child.html"
+
+    def mount(self, request: Any, **kwargs: Any) -> None:
+        self.a = False
+        self.b = False
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        return {"a": self.a, "b": self.b}
+
+
+class IncludedExtender2689(LiveView):
+    """``{% include %}`` of a template that itself ``{% extends %}``.
+
+    The page-level ``{% extends %}`` resolves through one parse of the merged
+    source, so its include ordinals share a counter. This path does NOT: the
+    renderer's include arm calls ``build_inheritance_chain_from`` on nodes the
+    loader parsed SEPARATELY, so the base's include #0 and the extender's
+    include #0 both start at 0. Only the including template's source hash in
+    ``site_id`` keeps them apart.
+    """
+
+    template_name = "inc_2689/host.html"
+
+    def mount(self, request: Any, **kwargs: Any) -> None:
+        self.a = False
+        self.b = False
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        return {"a": self.a, "b": self.b}
+
+
+class IncludeInLoop2689(LiveView):
+    """``{% include %}`` inside ``{% for %}`` — the two suffix axes composed."""
+
+    template_name = "inc_2689/loop.html"
+
+    def mount(self, request: Any, **kwargs: Any) -> None:
+        self.rows = [False, False, False]
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        return {"rows": self.rows}
+
+
+@pytest.fixture
+def templates(tmp_path: Any) -> Any:
+    d = tmp_path / "templates" / "inc_2689"
+    d.mkdir(parents=True)
+    (d / "frag.html").write_text("<p>{% if flag %}<b>on</b>{% endif %}</p>")
+    (d / "page.html").write_text(
+        f'<div dj-root dj-view="{MOD}.TwoIncludes2689" dj-id="0">'
+        '<div id="a">{% include "inc_2689/frag.html" with flag=a %}</div>'
+        '<div id="b">{% include "inc_2689/frag.html" with flag=b %}</div>'
+        "</div>"
+    )
+    (d / "pair.html").write_text(
+        '<span>{% include "inc_2689/frag.html" with flag=a %}'
+        '{% include "inc_2689/frag.html" with flag=b %}</span>'
+    )
+    (d / "outer.html").write_text(
+        f'<div dj-root dj-view="{MOD}.NestedIncludes2689" dj-id="0">'
+        '{% include "inc_2689/pair.html" %}'
+        '<div id="c">{% include "inc_2689/frag.html" with flag=c %}</div>'
+        "</div>"
+    )
+    (d / "only_pair.html").write_text(
+        '<span>{% include "inc_2689/frag.html" with flag=a only %}'
+        '{% include "inc_2689/frag.html" with flag=b only %}</span>'
+    )
+    (d / "only.html").write_text(
+        f'<div dj-root dj-view="{MOD}.OnlyIncludes2689" dj-id="0">'
+        '{% include "inc_2689/only_pair.html" with a=a b=b only %}'
+        '<div id="c">{% include "inc_2689/frag.html" with flag=a only %}</div>'
+        "</div>"
+    )
+    (d / "base.html").write_text(
+        f'<div dj-root dj-view="{MOD}.ExtendsIncludes2689" dj-id="0">'
+        '<div id="base">{% include "inc_2689/frag.html" with flag=a %}</div>'
+        "{% block extra %}{% endblock %}"
+        "</div>"
+    )
+    (d / "child.html").write_text(
+        '{% extends "inc_2689/base.html" %}'
+        '{% block extra %}<div id="child">{% include "inc_2689/frag.html" with flag=b %}</div>'
+        "{% endblock %}"
+    )
+    (d / "inner_base.html").write_text(
+        '<u>{% include "inc_2689/frag.html" with flag=a %}{% block slot %}{% endblock %}</u>'
+    )
+    (d / "inner_child.html").write_text(
+        '{% extends "inc_2689/inner_base.html" %}'
+        '{% block slot %}{% include "inc_2689/frag.html" with flag=b %}{% endblock %}'
+    )
+    (d / "host.html").write_text(
+        f'<div dj-root dj-view="{MOD}.IncludedExtender2689" dj-id="0">'
+        '{% include "inc_2689/inner_child.html" %}'
+        "</div>"
+    )
+    (d / "loop.html").write_text(
+        f'<div dj-root dj-view="{MOD}.IncludeInLoop2689" dj-id="0">'
+        '{% for row in rows %}{% include "inc_2689/frag.html" with flag=row %}{% endfor %}'
+        "</div>"
+    )
+    with override_settings(
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "DIRS": [str(tmp_path / "templates")],
+                "APP_DIRS": False,
+                "OPTIONS": {},
+            }
+        ],
+        LIVEVIEW_ALLOWED_MODULES=[MOD],
+    ):
+        # `get_template_dirs()` is lru-cached (#1801).
+        clear_template_dirs_cache()
+        try:
+            yield
+        finally:
+            clear_template_dirs_cache()
+
+
+def _ids(html: str) -> list[str]:
+    return [mid for mid, _ in _MARKER.findall(html)]
+
+
+class TestTwoIncludesGetDistinctMarkerIds:
+    def test_the_two_include_sites_do_not_share_a_marker_id(self, templates: Any) -> None:
+        client = LiveViewTestClient(TwoIncludes2689)
+        client.mount()
+        html = client.render()
+        ids = _ids(html)
+        assert len(ids) == 2, f"expected one marker per include site, got {ids} in {html}"
+        assert len(set(ids)) == 2, (
+            f"both {{% include %}}s of one fragment rendered the SAME dj-if id {ids[0]!r} — "
+            "the client resolves subtree patches by first match, so a toggle in the "
+            "second include would land on the first (#2689)."
+        )
+
+    def test_the_toggled_body_belongs_to_the_second_include(self, templates: Any) -> None:
+        """Positional, never keyed on the id — see the module docstring."""
+        client = LiveViewTestClient(TwoIncludes2689)
+        client.mount()
+        before = _MARKER.findall(client.render())
+        client.send_event("toggle_b")
+        after = _MARKER.findall(client.render())
+
+        assert len(before) == len(after) == 2, (before, after)
+        assert [mid for mid, _ in before] == [mid for mid, _ in after], (before, after)
+        assert before[0][1] == after[0][1] == "", (
+            f"the FIRST include's subtree changed on a toggle of the SECOND: {before} -> {after}"
+        )
+        assert before[1][1] == "" and after[1][1] == "<b>on</b>", (before, after)
+        assert after[1][0] != after[0][0], (
+            "the two include sites still share a marker id, so the client would "
+            f"resolve the second's patch onto the first (#2689): {after}"
+        )
+
+    def test_ids_are_stable_across_renders(self, templates: Any) -> None:
+        """The client keys DOM subtrees on these ids, so they must not churn."""
+        client = LiveViewTestClient(TwoIncludes2689)
+        client.mount()
+        first = _ids(client.render())
+        client.send_event("toggle_b")
+        second = _ids(client.render())
+        assert first == second, (first, second)
+
+
+class TestNestedAndComposedAxes:
+    def test_three_renders_down_two_include_chains_stay_distinct(self, templates: Any) -> None:
+        client = LiveViewTestClient(NestedIncludes2689)
+        client.mount()
+        html = client.render()
+        ids = _ids(html)
+        assert len(ids) == 3, f"expected three markers, got {ids} in {html}"
+        assert len(set(ids)) == 3, (
+            f"a nested include collided with a sibling include: {ids} (#2689)"
+        )
+
+    def test_only_includes_carry_the_site_path_into_their_fresh_context(
+        self, templates: Any
+    ) -> None:
+        """Three ``only`` includes down two chains — the fresh-`Context` arm."""
+        client = LiveViewTestClient(OnlyIncludes2689)
+        client.mount()
+        html = client.render()
+        ids = _ids(html)
+        assert len(ids) == 3, f"expected three markers, got {ids} in {html}"
+        assert len(set(ids)) == 3, (
+            f"`{{% include … only %}}` dropped the include-site path: {ids} (#2689)"
+        )
+
+    def test_base_and_child_include_sites_stay_distinct(self, templates: Any) -> None:
+        """Two SEPARATELY PARSED templates composed by ``{% extends %}``.
+
+        A bare per-parse ordinal gives base-site-0 and child-site-0 the same
+        suffix, so the ordinal must carry the including template's identity.
+        """
+        client = LiveViewTestClient(ExtendsIncludes2689)
+        client.mount()
+        html = client.render()
+        ids = _ids(html)
+        assert len(ids) == 2, f"expected one marker per include site, got {ids} in {html}"
+        assert len(set(ids)) == 2, (
+            f"the base's include and the child's include collided: {ids} (#2689)"
+        )
+
+    def test_an_included_extender_does_not_collide_with_its_own_base(self, templates: Any) -> None:
+        """The one case that needs the source hash inside ``site_id``.
+
+        Both templates are parsed by the LOADER, independently, and their nodes
+        are merged at render time — so both include ordinals start at 0 at the
+        same depth of the path. Gating the hash off (``site_id`` = a bare
+        ordinal) makes exactly this case go red and nothing else.
+        """
+        client = LiveViewTestClient(IncludedExtender2689)
+        client.mount()
+        html = client.render()
+        ids = _ids(html)
+        assert len(ids) == 2, f"expected one marker per include site, got {ids} in {html}"
+        assert len(set(ids)) == 2, (
+            f"an included extender's include collided with its base's: {ids} (#2689)"
+        )
+
+    def test_include_inside_a_for_loop_stays_distinct(self, templates: Any) -> None:
+        """The include suffix must compose with ``dj_if_loop_path`` (#1832)."""
+        client = LiveViewTestClient(IncludeInLoop2689)
+        client.mount()
+        html = client.render()
+        ids = _ids(html)
+        assert len(ids) == 3, f"expected one marker per iteration, got {ids} in {html}"
+        assert len(set(ids)) == 3, f"loop iterations of an included fragment collided: {ids}"

--- a/python/djust/tests/test_inert_api_claims.py
+++ b/python/djust/tests/test_inert_api_claims.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = ROOT / "scripts" / "check-inert-api-claims.py"
@@ -31,32 +32,135 @@ def test_no_docs_or_code_prescribe_a_deleted_or_inert_api() -> None:
     )
 
 
+def _load_checker() -> Any:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_inert_check", SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _tree(root: Path, files: dict[str, str]) -> Path:
+    for rel, body in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+    return root
+
+
 def test_the_checker_actually_catches_a_reintroduction(tmp_path: Path) -> None:
-    """The guard is load-bearing, not decorative (#1859).
+    """The guard is load-bearing, not decorative (#1859, #1459).
 
-    A green run above means nothing unless the checker fails on the shape it
-    claims to catch, so re-introduce one and confirm it is reported.
+    The first version of this test asserted on the regexes in ISOLATION, so a
+    broken ``SCAN_DIRS`` / ``_files()`` — a directory silently dropped from the
+    walk — would not have failed it (#2692). Run the real ``check()`` against a
+    tmp tree instead, so the finding has to survive discovery, decoding, the
+    exemption list and the scoping rules.
     """
-    sys.path.insert(0, str(ROOT / "scripts"))
-    try:
-        import importlib.util
+    mod = _load_checker()
+    root = _tree(
+        tmp_path,
+        {
+            # The exact pre-fix shape from .semgrep/djust-security.yaml.
+            ".semgrep/rules.yaml": "message: Use djustSecurity.safeSetInnerHTML() instead\n",
+            # The exact pre-fix shape from STATE_MANAGEMENT_API.md.
+            "docs/state.md": "```js\nwindow.StateBus.subscribe('temperature', cb)\n```\n",
+            # A doc teaching the inert decorator with no marker at all.
+            "docs/guide.md": '# Guide\n\n## Use it\n\n@client_state(keys=["filter"])\n',
+            # An import of it, in a directory the original SCAN_DIRS omitted.
+            "tests/e2e/test_x.py": "from djust.decorators import client_state\n",
+            # A repo-root `.md` other than README/llms.txt — the original walk
+            # named those two by hand, so this one was invisible (#2692).
+            "QUICKSTART.md": "# Quickstart\n\nCall djustSecurity.safeSetInnerHTML(el, s).\n",
+        },
+    )
+    found = mod.check(root)
+    blob = "\n".join(found)
 
-        spec = importlib.util.spec_from_file_location("_inert_check", SCRIPT)
-        assert spec and spec.loader
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-    finally:
-        sys.path.pop(0)
+    assert any("rules.yaml" in f and "djustSecurity" in f for f in found), blob
+    assert any("state.md" in f and "StateBus" in f for f in found), blob
+    assert any("guide.md" in f and "client_state" in f for f in found), blob
+    # Ceiling 2 of #2692: `tests/` was not scanned at all before...
+    assert any("tests/e2e/test_x.py" in f for f in found), blob
+    # ...and neither was any repo-root `.md` beyond the two named by hand.
+    assert any("QUICKSTART.md" in f for f in found), blob
 
-    # The exact pre-fix shape from .semgrep/djust-security.yaml.
-    assert mod.DELETED_GLOBAL_CALL.search("Use djustSecurity.safeSetInnerHTML() instead")
-    # The exact pre-fix shape from STATE_MANAGEMENT_API.md.
-    assert mod.DELETED_STATEBUS_USE.search("window.StateBus.subscribe('temperature', cb)")
-    # A doc teaching the inert decorator.
-    assert mod.INERT_DECORATOR_USE.search('@client_state(keys=["filter"])')
-    assert mod.INERT_DECORATOR_USE.search("from djust.decorators import client_state")
 
-    # And it must NOT fire on the corrections themselves, or every fix is a
-    # violation and the guard is unusable.
-    assert not mod.DELETED_GLOBAL_CALL.search("There is no `djustSecurity` global.")
-    assert mod.INERT_MARKER.search("(inert — no client impl, #2656)")
+def test_a_marker_elsewhere_in_the_file_does_not_discharge_the_mention(tmp_path: Path) -> None:
+    """#2692 ceiling 1 — the reported hole, as an executable case.
+
+    Deleting only the ``@client_state`` caveat in ``docs/BEST_PRACTICES_AI.md``
+    left the checker green, because ``@debounce``'s marker 28 lines earlier —
+    inside the SAME code fence — satisfied the file-level rule. That shape is
+    the one #2680 was about: siblings labelled inert, this one not.
+    """
+    mod = _load_checker()
+    same_fence = (
+        "# Decorators\n\n"
+        "## Usage\n\n"
+        "```python\n"
+        "@debounce(wait=0.5)  # INERT — no client impl (#2656)\n"
+        "def search(self, **kwargs): ...\n"
+        "\n"
+        '@client_state(keys=["active_tab"])\n'
+        "def switch_tab(self, **kwargs): ...\n"
+        "```\n"
+    )
+    found = mod.check(_tree(tmp_path / "a", {"docs/d.md": same_fence}))
+    assert any("d.md" in f and "client_state" in f for f in found), found
+
+    # ...and a marker in the mention's OWN block does discharge it.
+    marked = same_fence.replace(
+        '@client_state(keys=["active_tab"])',
+        '@client_state(keys=["active_tab"])  # INERT (#2656)',
+    )
+    assert marked != same_fence
+    assert mod.check(_tree(tmp_path / "b", {"docs/d.md": marked})) == []
+
+
+def test_a_header_banner_discharges_every_mention_in_the_file(tmp_path: Path) -> None:
+    """The banner escape hatch, which the doc corpus relies on.
+
+    A marker in the file's opening construct — the markdown preamble, a module
+    docstring, a leading template comment — covers the whole file, because a
+    reader meets it before any example. Below that opening it covers only its
+    own block.
+    """
+    mod = _load_checker()
+    body = '## Examples\n\n@client_state(keys=["a"])\n\n@client_state(keys=["b"])\n'
+
+    banner = "# Doc\n\n> **Inert.** `@client_state` does nothing (#2656).\n\n" + body
+    assert mod.check(_tree(tmp_path / "banner", {"docs/d.md": banner})) == []
+
+    # The same sentence one line BELOW the preamble covers neither mention.
+    late = "# Doc\n\n" + body + "\n> **Inert.** `@client_state` does nothing (#2656).\n"
+    assert len(mod.check(_tree(tmp_path / "late", {"docs/d.md": late}))) == 2
+
+    # Module docstring, for the .py arm of the banner rule.
+    py_banner = '"""Helper.\n\n@client_state is INERT (#2656).\n"""\n\n@client_state(keys=["a"])\n'
+    assert mod.check(_tree(tmp_path / "py", {"docs/x.py": py_banner})) == []
+
+    # Leading `{# ... #}` template comment, for the .html arm.
+    html_banner = '{# @client_state is INERT (#2656) #}\n<div>@client_state(keys=["a"])</div>\n'
+    assert mod.check(_tree(tmp_path / "html", {"docs/t.html": html_banner})) == []
+
+
+def test_the_checker_does_not_fire_on_the_corrections_themselves(tmp_path: Path) -> None:
+    """If a fix is itself a violation, the guard is unusable."""
+    mod = _load_checker()
+    assert (
+        mod.check(
+            _tree(
+                tmp_path,
+                {
+                    "docs/fix.md": (
+                        "# Fix\n\n> There is no `djustSecurity` global; use textContent.\n"
+                        "> `StateBus` was deleted in #2680.\n"
+                    )
+                },
+            )
+        )
+        == []
+    )

--- a/python/djust/tests/test_inert_api_claims.py
+++ b/python/djust/tests/test_inert_api_claims.py
@@ -120,6 +120,79 @@ def test_a_marker_elsewhere_in_the_file_does_not_discharge_the_mention(tmp_path:
     assert mod.check(_tree(tmp_path / "b", {"docs/d.md": marked})) == []
 
 
+def test_a_marked_sibling_entry_does_not_discharge_an_unmarked_one(tmp_path: Path) -> None:
+    """The `python/djust/schema.py` shape — an UNBROKEN literal (#2692 review).
+
+    The case above separates its two snippets with a BLANK LINE, so it only
+    ever exercised the blank-line half of the rule (v1.0.0rc4 finding #1). A
+    dict literal has no blank lines in it: `schema.py`'s decorator schema is
+    one ~135-line expression, so under a purely blank-line-delimited block
+    `@debounce`'s marker discharged `@client_state` 46 and 56 lines away —
+    further than the 28 lines of the `BEST_PRACTICES_AI.md` hole this checker
+    was written for, and the same sibling-list shape: siblings labelled inert,
+    this one not.
+
+    What bounds it is dedent: the `{` opening each entry is shallower than the
+    entry's keys, so a neighbour's marker cannot reach across it.
+    """
+    mod = _load_checker()
+    entries = (
+        "SCHEMA = [\n"
+        "    {\n"
+        '        "name": "@debounce",\n'
+        '        "description": "INERT — no client implementation (#2656).",\n'
+        '        "usage": ["@debounce(wait=0.5)"],\n'
+        "    },\n"
+        "    {\n"
+        '        "name": "@client_state",\n'
+        '        "import": "from djust.decorators import client_state",\n'
+        '        "description": "Coordinate state across components.",\n'
+        "    },\n"
+        "]\n"
+    )
+    assert "\n\n" not in entries, "the whole point is that there is no blank line"
+    found = mod.check(_tree(tmp_path / "unmarked", {"docs/schema.py": entries}))
+    assert any("schema.py" in f and "client_state" in f for f in found), (
+        f"a marked SIBLING entry discharged an unmarked one: {found}"
+    )
+
+    # The MIRROR: the unmarked entry FIRST, the marked sibling below it. The
+    # backward and forward walks are independent halves, so each needs its own
+    # red case — gating off only the forward bound left the suite green until
+    # this one existed.
+    reversed_order = (
+        "SCHEMA = [\n"
+        "    {\n"
+        '        "name": "@client_state",\n'
+        '        "import": "from djust.decorators import client_state",\n'
+        '        "description": "Coordinate state across components.",\n'
+        "    },\n"
+        "    {\n"
+        '        "name": "@debounce",\n'
+        '        "description": "INERT — no client implementation (#2656).",\n'
+        "    },\n"
+        "]\n"
+    )
+    assert "\n\n" not in reversed_order
+    found_below = mod.check(_tree(tmp_path / "below", {"docs/schema.py": reversed_order}))
+    assert any("schema.py" in f and "client_state" in f for f in found_below), (
+        f"a marked sibling entry BELOW discharged an unmarked one: {found_below}"
+    )
+
+    # A marker inside the entry's OWN block does discharge it...
+    marked = entries.replace(
+        '        "description": "Coordinate state across components.",\n',
+        '        "description": "MARKER ONLY — inert, publishes nothing (#2656).",\n',
+    )
+    assert marked != entries
+    assert mod.check(_tree(tmp_path / "marked", {"docs/schema.py": marked})) == []
+
+    # ...and so does a caveat introducing a MORE-indented snippet, which is
+    # why the bounding line is included rather than excluded.
+    dedented_caveat = 'USAGE = [\n    # INERT (#2656)\n        "@client_state(keys=[])",\n]\n'
+    assert mod.check(_tree(tmp_path / "dedent", {"docs/u.py": dedented_caveat})) == []
+
+
 def test_a_header_banner_discharges_every_mention_in_the_file(tmp_path: Path) -> None:
     """The banner escape hatch, which the doc corpus relies on.
 
@@ -145,6 +218,29 @@ def test_a_header_banner_discharges_every_mention_in_the_file(tmp_path: Path) ->
     # Leading `{# ... #}` template comment, for the .html arm.
     html_banner = '{# @client_state is INERT (#2656) #}\n<div>@client_state(keys=["a"])</div>\n'
     assert mod.check(_tree(tmp_path / "html", {"docs/t.html": html_banner})) == []
+
+
+def test_a_banner_below_the_mention_does_not_discharge_it(tmp_path: Path) -> None:
+    """The banner arm's justification is order, so the rule must check order.
+
+    A `.md` with no `##` heading and no fence has NO end to its preamble, so
+    the header zone is the whole file — and without an ordering condition a
+    marker at the BOTTOM would discharge a mention at the top, which is the
+    opposite of "a reader meets it before any example" (#2692 review).
+    """
+    mod = _load_checker()
+    body = '# Notes\n\n@client_state(keys=["a"])\n'
+    assert "##" not in body and "```" not in body, "the whole file must be header zone"
+
+    above = (
+        '# Notes\n\n> Inert: `@client_state` does nothing (#2656).\n\n@client_state(keys=["a"])\n'
+    )
+    assert mod.check(_tree(tmp_path / "above", {"docs/n.md": above})) == []
+
+    below = body + "\n> Inert: `@client_state` does nothing (#2656).\n"
+    assert mod.check(_tree(tmp_path / "below", {"docs/n.md": below})), (
+        "a marker BELOW the mention discharged it via the banner arm"
+    )
 
 
 def test_the_checker_does_not_fire_on_the_corrections_themselves(tmp_path: Path) -> None:

--- a/python/tests/test_cache_tag_django_parity_2658.py
+++ b/python/tests/test_cache_tag_django_parity_2658.py
@@ -1,0 +1,305 @@
+"""``{% cache %}`` operand resolution must be Django's, byte for byte (#2658).
+
+#2658 asked for message-text parity and called it minor. Running the two
+engines side by side showed the message was the visible end of a real
+divergence: ``CacheTagHandler`` resolved every operand with
+``ignore_failures=True`` and then applied a miss policy of its own — ``None``
+for the vary operands, an "unknown variable" error for the expiry. Its comment
+said Django resolves the vary operands with ``ignore_failures``.
+``django/templatetags/cache.py`` says otherwise::
+
+    vary_on = [var.resolve(context) for var in self.vary_on]
+
+so an unresolvable vary operand is ``string_if_invalid`` (``''``) in Django and
+was ``None`` here — and ``make_template_fragment_key`` hashes the vary list, so
+the two engines stored the SAME fragment under DIFFERENT keys. A message nit
+and a cache-key bug, one root.
+
+Two of the issue's four items were already true when this was written, which is
+why every claim below is measured against a live Django ``Engine`` rather than
+asserted from the issue text:
+
+* the arity errors (``test_cache11`` / ``test_cache12``) already raise at PARSE
+  time, with Django's exact text — ``CacheTagHandler.validate_at_parse`` calls
+  Django's own ``do_cache``;
+* the body still renders on a cache HIT, which needs a lazy-body block-handler
+  protocol and is deliberately NOT attempted here (see the issue).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+pytest.importorskip("django")
+
+from django.core.cache import caches  # noqa: E402
+from django.template import Context as DjangoContext  # noqa: E402
+from django.template import Engine  # noqa: E402
+
+from djust.template.backend import DjustTemplateBackend  # noqa: E402
+
+_LIB = {"cache": "django.templatetags.cache"}
+
+
+@pytest.fixture(autouse=True)
+def _clear() -> Any:
+    caches["default"].clear()
+    yield
+    caches["default"].clear()
+
+
+@pytest.fixture
+def backend() -> Any:
+    return DjustTemplateBackend(
+        {
+            "NAME": "cache2658",
+            "DIRS": [],
+            "APP_DIRS": False,
+            "OPTIONS": {"libraries": _LIB},
+        }
+    )
+
+
+@pytest.fixture
+def django_engine() -> Any:
+    return Engine(libraries=_LIB)
+
+
+def _django(engine: Any, src: str, ctx: Dict[str, Any]) -> Tuple[str, str]:
+    try:
+        template = engine.from_string(src)
+    except Exception as exc:  # noqa: BLE001
+        return "parse", f"{type(exc).__name__}: {exc}"
+    try:
+        return "ok", template.render(DjangoContext(ctx))
+    except Exception as exc:  # noqa: BLE001
+        return "render", f"{type(exc).__name__}: {exc}"
+
+
+def _djust(backend: Any, src: str, ctx: Dict[str, Any]) -> Tuple[str, str]:
+    try:
+        template = backend.from_string(src)
+    except Exception as exc:  # noqa: BLE001
+        return "parse", f"{type(exc).__name__}: {exc}"
+    try:
+        return "ok", str(template.render(ctx))
+    except Exception as exc:  # noqa: BLE001
+        return "render", f"{type(exc).__name__}: {exc}"
+
+
+def _keys() -> List[str]:
+    """The fragment keys currently in the cache, cleared before each engine."""
+    return sorted(caches["default"]._cache.keys())
+
+
+#: Every shape the issue names, plus the neighbours a curated table misses.
+#: ``(label, template body after ``{% load cache %}``, context)``.
+CASES: List[Tuple[str, str, Dict[str, Any]]] = [
+    # --- the two scoreboard cells (arity, parse-time) ----------------------
+    ("cache11 no operands", "{% cache %}{% endcache %}", {}),
+    ("cache12 one operand", "{% cache 1 %}{% endcache %}", {}),
+    # --- the expiry --------------------------------------------------------
+    ("literal expiry", '{% cache 60 "f" %}b{% endcache %}', {}),
+    ("literal None is forever", '{% cache None "f" %}b{% endcache %}', {}),
+    ("variable expiry", '{% cache t "f" %}b{% endcache %}', {"t": 60}),
+    ("variable expiry is None", '{% cache t "f" %}b{% endcache %}', {"t": None}),
+    ("filter expiry", '{% cache 2|add:1 "f" %}b{% endcache %}', {}),
+    ("unresolvable expiry", '{% cache nope "f" %}b{% endcache %}', {}),
+    ("non-integer expiry", '{% cache t "f" %}b{% endcache %}', {"t": "x"}),
+    ("expiry resolves to a list", '{% cache t "f" %}b{% endcache %}', {"t": [1]}),
+    ("dotted expiry", '{% cache d.t "f" %}b{% endcache %}', {"d": {"t": 5}}),
+    ("dotted expiry missing leaf", '{% cache d.t "f" %}b{% endcache %}', {"d": {}}),
+    # --- the vary operands (the cache-key axis) ----------------------------
+    ("one vary", '{% cache 60 "f" v %}b{% endcache %}', {"v": "a"}),
+    ("vary is None", '{% cache 60 "f" v %}b{% endcache %}', {"v": None}),
+    ("vary unresolvable", '{% cache 60 "f" nope %}b{% endcache %}', {}),
+    ("vary int", '{% cache 60 "f" v %}b{% endcache %}', {"v": 7}),
+    ("two varies one missing", '{% cache 60 "f" v nope %}b{% endcache %}', {"v": 1}),
+    ("two varies both missing", '{% cache 60 "f" a b %}b{% endcache %}', {}),
+    ("vary with a filter", '{% cache 60 "f" v|upper %}b{% endcache %}', {"v": "a"}),
+    ("vary dotted missing", '{% cache 60 "f" d.x %}b{% endcache %}', {"d": {}}),
+    ("vary literal string", '{% cache 60 "f" "lit" %}b{% endcache %}', {}),
+    # --- `using=` ----------------------------------------------------------
+    ("using default", '{% cache 60 "f" using="default" %}b{% endcache %}', {}),
+    ("using unknown alias", '{% cache 60 "f" using="nosuch" %}b{% endcache %}', {}),
+    ("using with two operands only", '{% cache 10 using="default" %}b{% endcache %}', {}),
+    ("using with a vary", '{% cache 60 "f" v using="default" %}b{% endcache %}', {"v": 1}),
+]
+
+
+class TestOutcomeMatchesDjango:
+    @pytest.mark.parametrize("label,body,ctx", CASES, ids=[c[0] for c in CASES])
+    def test_stage_and_message_match(
+        self, backend: Any, django_engine: Any, label: str, body: str, ctx: Dict[str, Any]
+    ) -> None:
+        src = "{% load cache %}" + body
+        caches["default"].clear()
+        expected = _django(django_engine, src, ctx)
+        caches["default"].clear()
+        actual = _djust(backend, src, ctx)
+        assert actual == expected, (
+            f"{label}: djust {actual!r} != django {expected!r}\n"
+            "Django's message text is the standard (#2581); the resolution that "
+            "produces it is Django's own FilterExpression (#2658)."
+        )
+
+
+class TestCacheKeyMatchesDjango:
+    """The key, not just the output — a divergent key is a silent cache miss.
+
+    Each engine renders into a CLEARED cache and the resulting key is compared,
+    so this measures ``make_template_fragment_key(fragment, vary_on)`` and thus
+    the resolution of every vary operand. The same-name-into-one-cache shape
+    would instead make the second render a HIT on the first engine's value and
+    compare a string to itself.
+    """
+
+    @pytest.mark.parametrize(
+        "label,body,ctx",
+        [c for c in CASES if "nosuch" not in c[1] and "cache11" not in c[0]],
+        ids=[c[0] for c in CASES if "nosuch" not in c[1] and "cache11" not in c[0]],
+    )
+    def test_key_matches(
+        self, backend: Any, django_engine: Any, label: str, body: str, ctx: Dict[str, Any]
+    ) -> None:
+        src = "{% load cache %}" + body
+        caches["default"].clear()
+        if _django(django_engine, src, ctx)[0] != "ok":
+            pytest.skip("Django does not reach the store for this case")
+        expected = _keys()
+        caches["default"].clear()
+        assert _djust(backend, src, ctx)[0] == "ok"
+        actual = _keys()
+        assert actual == expected, (
+            f"{label}: djust stored under {actual} where Django stores under "
+            f"{expected} — the two engines cache the same fragment under "
+            "different names (#2658)."
+        )
+
+    def test_an_unresolvable_vary_operand_is_the_case_that_diverged(
+        self, backend: Any, django_engine: Any
+    ) -> None:
+        """The specific pre-fix divergence, spelled out.
+
+        ``None`` and ``''`` are different vary values, so they hash to
+        different keys. Pre-fix djust produced the ``None`` key; Django
+        produces the ``''`` one. Asserted here against Django's key AND
+        against the key the bug produced, so a revert cannot look green.
+        """
+        from django.core.cache.utils import make_template_fragment_key
+
+        src = '{% load cache %}{% cache 60 "f" nope %}b{% endcache %}'
+        # The fragment name is the RAW token, quote characters and all —
+        # Django's own comment is "fragment_name can't be a variable", so
+        # neither engine strips them.
+        django_key = make_template_fragment_key('"f"', [""])
+        buggy_key = make_template_fragment_key('"f"', [None])
+        assert django_key != buggy_key, "the two policies must be distinguishable"
+
+        caches["default"].clear()
+        assert _django(django_engine, src, {})[0] == "ok"
+        assert any(django_key in k for k in _keys()), _keys()
+
+        caches["default"].clear()
+        assert _djust(backend, src, {})[0] == "ok"
+        assert any(django_key in k for k in _keys()), (
+            f"djust did not use Django's key; stored {_keys()} (#2658)"
+        )
+        assert not any(buggy_key in k for k in _keys()), (
+            "djust still resolves a missing vary operand to None (#2658)"
+        )
+
+
+class TestArityIsAlreadyRefusedAtParseTime:
+    """#2658 item 2 was fixed before this PR; pinned so it cannot regress.
+
+    ``CacheTagHandler.validate_at_parse`` hands the tokens to Django's own
+    ``do_cache``, so the message is Django's by construction — including its
+    doubled quotes, which are Django's and not a djust artefact.
+    """
+
+    @pytest.mark.parametrize("body", ["{% cache %}{% endcache %}", "{% cache 1 %}{% endcache %}"])
+    def test_refused_by_from_string_not_by_render(self, backend: Any, body: str) -> None:
+        from django.template import TemplateSyntaxError
+
+        with pytest.raises((TemplateSyntaxError, Exception)) as caught:
+            backend.from_string("{% load cache %}" + body)
+        assert "requires at least 2 arguments" in str(caught.value)
+
+
+class TestTheBodyStillRendersOnAHit:
+    """#2658 item 1 is NOT fixed here — pinned as a known gap, not as correct.
+
+    The block-handler protocol hands ``render()`` a body that is already a
+    string, so the handler cannot decide *whether* to render. Making the tag
+    actually save the work needs a lazy-body protocol; this test exists so that
+    when one lands, it fails and is updated deliberately rather than the gap
+    being rediscovered.
+    """
+
+    def test_a_hit_returns_the_cached_output_but_still_paid_for_the_body(
+        self, backend: Any
+    ) -> None:
+        renders: List[int] = []
+
+        class Probe:
+            def __str__(self) -> str:
+                renders.append(1)
+                return "body"
+
+        src = '{% load cache %}{% cache 300 "hitprobe" %}{{ probe }}{% endcache %}'
+        template = backend.from_string(src)
+
+        assert str(template.render({"probe": Probe()})) == "body"
+        after_miss = len(renders)
+        assert after_miss > 0, "the body must render on a MISS"
+
+        assert str(template.render({"probe": Probe()})) == "body"
+        assert len(renders) > after_miss, (
+            "the body no longer renders on a cache hit — #2658 item 1 is fixed; "
+            "delete this test and assert the new behaviour instead."
+        )
+
+    def test_item_4_is_now_only_a_consequence_of_item_1(
+        self, backend: Any, django_engine: Any
+    ) -> None:
+        """#2658 item 4 no longer has the symptom the issue reported.
+
+        The issue showed ``{{ k }}`` rendering EMPTY after a
+        ``{% cycle … as k %}`` inside a ``{% cache %}`` body — an ``as``-binding
+        that never escaped the body's sub-scope::
+
+            django -> '<1>1|<1>1|<1>1|'
+            djust  -> '<1>|<1>|<1>|'
+
+        Measured now, the binding escapes fine; what differs is only that
+        Django's iterations 2 and 3 are cache HITS, so its body — and its
+        ``{% cycle %}`` — never runs again and ``k`` keeps the value bound on
+        iteration 1. djust re-renders the body (item 1), so the cycle advances.
+
+        So item 4 is not a separate scope bug to fix; it resolves exactly when
+        item 1 does. Pinned rather than described, because the issue's
+        description is now wrong and a reader would otherwise go looking for a
+        scope bug that is not there.
+        """
+        src = (
+            "{% load cache %}{% for i in v %}"
+            '{% cache 300 f4 %}<{% cycle "1" "2" "3" as k %}>{% endcache %}'
+            "{{ k }}|{% endfor %}"
+        )
+        ctx = {"v": [1, 2, 3]}
+
+        caches["default"].clear()
+        assert django_engine.from_string(src).render(DjangoContext(ctx)) == "<1>1|<1>1|<1>1|"
+
+        caches["default"].clear()
+        out = str(backend.from_string(src).render(ctx))
+        assert "|" in out and out.split("|")[0].endswith("1"), out
+        assert out == "<1>1|<1>2|<1>3|", (
+            f"got {out!r}. Empty `{{{{ k }}}}` segments would be the ORIGINAL item-4 "
+            "report (the binding not escaping the body); '<1>1|<1>1|<1>1|' would "
+            "mean item 1 is fixed and this test should be replaced by an equality "
+            "assertion against Django."
+        )

--- a/scripts/check-inert-api-claims.py
+++ b/scripts/check-inert-api-claims.py
@@ -61,16 +61,20 @@ SCAN_SUFFIXES = {".md", ".py", ".yaml", ".yml", ".html", ".txt", ".js"}
 # `djustSecurity.` call with nothing to catch it (#2692).
 ROOT_EXTRA_FILES = ("llms.txt",)
 
-# This file explains the rules, and the changelog / CONTRIBUTING / retro
-# records the deletions in prose. Their mentions are the audit trail, not
-# prescriptions.
+# This file explains the rules, and the changelog records the deletions in
+# prose. Their mentions are the audit trail, not prescriptions — `CHANGELOG.md`
+# is exempt because an already-shipped section is immutable (#2028), so a
+# historical entry naming `client_state` can never be corrected in place.
+#
+# `RETRO.md` and `ROADMAP.md` were exempt in the first version of this list and
+# are NOT any more (#2692 review): neither matches anything today, so the
+# exemptions bought nothing — and the ROADMAP is precisely where a future
+# "use `@client_state` to…" plan would land uncaveated.
 EXEMPT = {
     "scripts/check-inert-api-claims.py",
     "python/djust/tests/test_inert_api_claims.py",
     "CONTRIBUTING.md",
     "CHANGELOG.md",
-    "RETRO.md",
-    "ROADMAP.md",
 }
 
 # A CALL on the deleted global. `djustSecurity` bare is fine — that is how the
@@ -184,13 +188,42 @@ def _header_zone(text: str, suffix: str) -> int:
     return zone
 
 
+def _indent(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
 def _block_bounds(lines: list[str], lineno: int) -> tuple[int, int]:
-    """The maximal run of consecutive non-blank lines containing `lineno` (1-based)."""
+    """The mention's own block: consecutive non-blank lines, bounded by dedent.
+
+    A blank line ends the block, and so does the first line — in either
+    direction — indented LESS than the mention itself. That second bound is
+    what makes this a block rather than a region: without it, a long unbroken
+    literal is one block however far apart its entries are.
+
+    `python/djust/schema.py`'s decorator schema is the case that proves it
+    (#2692 review). It is a single dict literal spanning ~135 lines with no
+    blank line in it, so the blank-line rule alone made `@debounce`'s
+    `INERT … #2656` discharge `@client_state` **46 and 56 lines away** — the
+    same sibling-list shape as the `docs/BEST_PRACTICES_AI.md` hole this
+    checker exists to catch, and further apart than the 28 lines that one
+    spanned. Dedent stops the walk at the `{` opening `@client_state`'s own
+    entry, so its neighbours no longer speak for it.
+
+    The bounding line itself is INCLUDED, so a caveat introducing an indented
+    block (`# INERT (#2656)` above an indented snippet) still discharges it.
+    At indent 0 — prose, and the top level of a fenced snippet — nothing can
+    be shallower, so the rule degrades to the blank-line one.
+    """
+    depth = _indent(lines[lineno - 1])
     start = end = lineno - 1
     while start > 0 and lines[start - 1].strip():
         start -= 1
+        if _indent(lines[start]) < depth:
+            break  # the bounding line is included, but the walk stops here
     while end + 1 < len(lines) and lines[end + 1].strip():
         end += 1
+        if _indent(lines[end]) < depth:
+            break
     return start + 1, end + 1
 
 
@@ -223,11 +256,20 @@ def check(root: Path = ROOT) -> list[str]:
             continue
         lines = text.splitlines()
         banner = _header_zone(text, path.suffix)
-        if any(INERT_MARKER.search(ln) for ln in lines[:banner]):
-            continue  # the file opens by saying it is inert — every mention is covered
+        # The FIRST marker in the header zone, or None. A line number rather
+        # than a boolean because the banner arm's whole justification is that
+        # a reader meets the marker BEFORE any example — for a `.md` with no
+        # `##` and no fence the zone is the whole file, and without this the
+        # arm would let a marker BELOW a mention discharge it, which is the
+        # opposite of what it claims (#2692 review).
+        banner_at = next(
+            (i for i, ln in enumerate(lines[:banner], 1) if INERT_MARKER.search(ln)), None
+        )
         for lineno, line in enumerate(lines, 1):
             if not INERT_DECORATOR_USE.search(line):
                 continue
+            if banner_at is not None and banner_at < lineno:
+                continue  # the file opened by saying it is inert
             start, end = _block_bounds(lines, lineno)
             if any(INERT_MARKER.search(lines[k - 1]) for k in range(start, end + 1)):
                 continue

--- a/scripts/check-inert-api-claims.py
+++ b/scripts/check-inert-api-claims.py
@@ -19,10 +19,27 @@ by hand-counting — to have fixed "four places":
    `window.StateBus.subscribe(...)` snippet against a class that no longer
    exists.
 
-The bar is deliberately FILE-level and mechanical, because the thing that
-failed was a human claim of completeness (#1859: a pin nobody can drift past
-beats a promise). A file may teach `@client_state` all it likes — it must just
-also say, somewhere, that it is inert.
+The bar is mechanical, because the thing that failed was a human claim of
+completeness (#1859: a pin nobody can drift past beats a promise). A file may
+teach `@client_state` all it likes — it must just also say that it is inert,
+somewhere a reader of THAT mention will see.
+
+"Somewhere a reader will see" was originally the whole FILE, and #2692 showed
+that is too loose: deleting only the `@client_state` caveat in
+`docs/BEST_PRACTICES_AI.md` left the checker green, because `@debounce`'s
+marker 28 lines earlier — inside the same code fence — satisfied the file.
+That is exactly the #2680 shape the checker exists to catch: siblings labelled
+inert, this one not, and the contrast actively inviting the inference that
+this one works. So the marker is now scoped to the mention:
+
+  * a **header banner** — a marker in the file's opening construct (the
+    markdown preamble before the first `##` or fence, a module docstring, a
+    leading template/HTML/JS/YAML comment) discharges the whole file, because
+    a reader meets it before any example; or
+  * a **block-local** marker — one inside the mention's own block, i.e. the
+    maximal run of consecutive non-blank lines containing it.
+
+A marker that is neither discharges nothing.
 """
 
 from __future__ import annotations
@@ -34,15 +51,26 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 
 # Directories worth scanning: what a human or an AI agent reads as instruction.
-SCAN_DIRS = ["docs", "python/djust", ".semgrep", "examples"]
+# `tests` and `scripts` are in the list because a test or a helper script is
+# read as a worked example just as readily as a doc is (#2692).
+SCAN_DIRS = ["docs", "python/djust", "python/tests", ".semgrep", "examples", "scripts", "tests"]
 SCAN_SUFFIXES = {".md", ".py", ".yaml", ".yml", ".html", ".txt", ".js"}
 
-# This file explains the rules, and the changelog/CONTRIBUTING record the
-# deletions in prose. Their mentions are the audit trail, not prescriptions.
+# Every repo-root `.md` is scanned too — the original list named only
+# `README.md`/`llms.txt`, so `QUICKSTART.md` could have reintroduced a
+# `djustSecurity.` call with nothing to catch it (#2692).
+ROOT_EXTRA_FILES = ("llms.txt",)
+
+# This file explains the rules, and the changelog / CONTRIBUTING / retro
+# records the deletions in prose. Their mentions are the audit trail, not
+# prescriptions.
 EXEMPT = {
     "scripts/check-inert-api-claims.py",
     "python/djust/tests/test_inert_api_claims.py",
     "CONTRIBUTING.md",
+    "CHANGELOG.md",
+    "RETRO.md",
+    "ROADMAP.md",
 }
 
 # A CALL on the deleted global. `djustSecurity` bare is fine — that is how the
@@ -63,26 +91,113 @@ INERT_DECORATOR_USE = re.compile(
 INERT_MARKER = re.compile(r"#2656|\bINERT\b|\binert\b")
 
 
-def _files() -> list[Path]:
+def _files(root: Path = ROOT) -> list[Path]:
     out: list[Path] = []
     for d in SCAN_DIRS:
-        base = ROOT / d
+        base = root / d
         if not base.is_dir():
             continue
         for p in base.rglob("*"):
             if p.is_file() and p.suffix in SCAN_SUFFIXES and "__pycache__" not in p.parts:
                 out.append(p)
-    for name in ("llms.txt", "README.md"):
-        p = ROOT / name
+    for p in root.glob("*.md"):
         if p.is_file():
             out.append(p)
-    return out
+    for name in ROOT_EXTRA_FILES:
+        p = root / name
+        if p.is_file():
+            out.append(p)
+    return sorted(set(out))
 
 
-def check() -> list[str]:
+# A markdown heading of depth >= 2, i.e. the end of the document preamble.
+_MD_SUBHEADING = re.compile(r"^\s{0,3}#{2,6}\s")
+# A leading `"""`/`'''` module docstring opener, prefixes and all.
+_PY_DOCSTRING_OPEN = re.compile(r"""^\s*(?:[rubRUBfF]{0,2})("{3}|'{3})""")
+# The opening delimiter of a leading comment, per family.
+_COMMENT_OPEN = {
+    ".html": ("{#", "<!--"),
+    ".js": ("/*", "//"),
+    ".yaml": ("#",),
+    ".yml": ("#",),
+}
+_COMMENT_CLOSE = {"{#": "#}", "<!--": "-->", "/*": "*/"}
+
+
+def _header_zone(text: str, suffix: str) -> int:
+    """How many leading lines count as the file's header banner.
+
+    A marker there discharges the whole file: it is the title block, the module
+    docstring, or the leading comment — a reader meets it before any example.
+    Anything below it only speaks for its own block (#2692).
+    """
+    lines = text.splitlines()
+    if suffix == ".py":
+        for i, ln in enumerate(lines):
+            if not ln.strip():
+                continue
+            m = _PY_DOCSTRING_OPEN.match(ln)
+            if not m:
+                return 0  # no module docstring — no banner zone
+            quote = m.group(1)
+            if quote in ln[m.end() :]:
+                return i + 1
+            for j in range(i + 1, len(lines)):
+                if quote in lines[j]:
+                    return j + 1
+            return 0
+        return 0
+    if suffix in {".md", ".txt"}:
+        for i, ln in enumerate(lines):
+            if _MD_SUBHEADING.match(ln) or ln.lstrip().startswith("```"):
+                return i
+        return len(lines)
+    openers = _COMMENT_OPEN.get(suffix)
+    if not openers:
+        return 0
+    zone = 0
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if not stripped:
+            i += 1
+            continue
+        opener = next((o for o in openers if stripped.startswith(o)), None)
+        if opener is None:
+            break
+        closer = _COMMENT_CLOSE.get(opener)
+        if closer is None:  # a `//` or `#` line comment
+            zone = i + 1
+            i += 1
+            continue
+        if closer in stripped[len(opener) :]:
+            zone = i + 1
+            i += 1
+            continue
+        for j in range(i + 1, len(lines)):
+            if closer in lines[j]:
+                zone = j + 1
+                i = j + 1
+                break
+        else:
+            return zone
+    return zone
+
+
+def _block_bounds(lines: list[str], lineno: int) -> tuple[int, int]:
+    """The maximal run of consecutive non-blank lines containing `lineno` (1-based)."""
+    start = end = lineno - 1
+    while start > 0 and lines[start - 1].strip():
+        start -= 1
+    while end + 1 < len(lines) and lines[end + 1].strip():
+        end += 1
+    return start + 1, end + 1
+
+
+def check(root: Path = ROOT) -> list[str]:
     failures: list[str] = []
-    for path in sorted(_files()):
-        rel = path.relative_to(ROOT).as_posix()
+    for path in _files(root):
+        rel = path.relative_to(root).as_posix()
         if rel in EXEMPT:
             continue
         try:
@@ -104,16 +219,25 @@ def check() -> list[str]:
                     f"deleted in #2680 (it had zero consumers).\n    {line.strip()}"
                 )
 
-        if INERT_DECORATOR_USE.search(text) and not INERT_MARKER.search(text):
-            first = next(
-                (i for i, ln in enumerate(text.splitlines(), 1) if INERT_DECORATOR_USE.search(ln)),
-                1,
-            )
+        if not INERT_DECORATOR_USE.search(text):
+            continue
+        lines = text.splitlines()
+        banner = _header_zone(text, path.suffix)
+        if any(INERT_MARKER.search(ln) for ln in lines[:banner]):
+            continue  # the file opens by saying it is inert — every mention is covered
+        for lineno, line in enumerate(lines, 1):
+            if not INERT_DECORATOR_USE.search(line):
+                continue
+            start, end = _block_bounds(lines, lineno)
+            if any(INERT_MARKER.search(lines[k - 1]) for k in range(start, end + 1)):
+                continue
             failures.append(
-                f"{rel}:{first}: teaches `@client_state` without saying anywhere in the file "
-                f"that it is inert. It stamps metadata nothing in the shipped client reads "
-                f"(#2656) — a handler decorated with it behaves exactly like an undecorated "
-                f"one. Add a marker mentioning #2656 (or the word INERT)."
+                f"{rel}:{lineno}: teaches `@client_state` with no marker on this line or "
+                f"anywhere in its block (lines {start}-{end}), and no header banner. It "
+                f"stamps metadata nothing in the shipped client reads (#2656) — a handler "
+                f"decorated with it behaves exactly like an undecorated one. A marker "
+                f"elsewhere in the file does NOT cover this mention (#2692): add one "
+                f"mentioning #2656 (or the word INERT) here.\n    {line.strip()}"
             )
     return failures
 

--- a/tests/e2e/test_phase5_decorators.py
+++ b/tests/e2e/test_phase5_decorators.py
@@ -3,7 +3,9 @@ End-to-End tests for Phase 5 State Management decorators.
 
 Tests the complete integration of:
 - @cache decorator (client-side response caching)
-- @client_state decorator (StateBus coordination)
+- @client_state decorator (INERT, #2656: it stamps metadata nothing in the
+  shipped client reads, and the `StateBus` it coordinated was deleted in
+  #2680 — these tests pin the metadata stamp, not any client behaviour)
 - dj-loading HTML attributes (loading indicators)
 
 These tests verify the full Python → Rust → WebSocket → JavaScript flow.


### PR DESCRIPTION
Drains three follow-ups. Each was reproduced first and traced symptom-up; in two of the three the issue's own premise turned out to be partly wrong, and the corrections are recorded in the commits and on the issues rather than quietly worked around.

## Issue × file × test

| issue | change | files | covering tests |
|---|---|---|---|
| **#2692** marker scoping | `INERT_MARKER` scoped to the mention (header banner, else the mention's own block); `SCAN_DIRS` gains `tests/`, `python/tests/`, `scripts/` and every repo-root `.md`; `check()` takes a root so the canary can run it | `scripts/check-inert-api-claims.py` | `python/djust/tests/test_inert_api_claims.py` — `test_the_checker_actually_catches_a_reintroduction` (now against a tmp tree), `test_a_marker_elsewhere_in_the_file_does_not_discharge_the_mention`, `test_a_header_banner_discharges_every_mention_in_the_file`, `test_the_checker_does_not_fire_on_the_corrections_themselves` |
| **#2692** the 30 sites the tightening reported | local caveats / completed header banners; a `README.md` banner removed from inside a bash code fence | `README.md`, `docs/state-management/STATE_MANAGEMENT_API.md`, `docs/state-management/STATE_MANAGEMENT_COMPARISON.md`, `python/djust/decorators.py`, `python/djust/schema.py`, `python/djust/tests/test_decorators.py`, `tests/e2e/test_phase5_decorators.py` | `test_no_docs_or_code_prescribe_a_deleted_or_inert_api` (the repo-wide run) |
| **#2689** duplicate `dj-if` ids across include sites | new `Context::dj_if_include_path` + parse-time `Node::Include::site_id`, composed by the renderer's include arm and appended at marker emission | `crates/djust_core/src/context.rs`, `crates/djust_templates/src/parser.rs`, `crates/djust_templates/src/renderer.rs` | `python/djust/tests/test_include_marker_id_namespace_2689.py` (8 cases); Rust grammar unit tests in `crates/djust_core/src/context.rs`; two existing Rust tests corrected in `crates/djust_templates/tests/{test_if_markers.rs,test_dj_if_markers_off_2519.rs}` |
| **#2658** `{% cache %}` operand resolution | bespoke miss policy replaced by Django's own `FilterExpression.resolve` against a bound `Context`; Django-verbatim messages | `python/djust/template_libraries.py` | `python/tests/test_cache_tag_django_parity_2658.py` (25 shapes × outcome parity, the same set × cache-key parity, plus the explicit divergence case and two known-gap pins); `python/tests/test_block_super_and_cache_2517.py` stays green |

## What each issue actually turned out to be

**#2692 — as reported.** Reproduced the cited hole exactly: deleting the `@client_state` caveat at `docs/BEST_PRACTICES_AI.md:338` left the checker at exit 0, because `@debounce`'s marker at `:313` — inside the *same code fence* — satisfied the file-level rule. After the tightening that same deletion exits 1.

Scoping and widening reported **30** previously-discharged sites (29 before the review's dedent bound, plus `schema.py:904`). Two were real defects rather than bookkeeping: the #2690 banner in `README.md` had landed **inside a bash code fence**, splitting the clone instructions, while the decision-guide table and bullet that actually route a reader to `@client_state` carried no caveat at all; and `tests/e2e/test_phase5_decorators.py` — never scanned, ceiling 2 — taught "`@client_state` decorator (StateBus coordination)" as the mechanism.

A marker now discharges either the whole file (when it sits in the file's opening construct — markdown preamble, module docstring, leading template comment — **and precedes the mention**) or only its own block, where a block is bounded by blank lines **and by dedent**.

The dedent bound came from the review, and it is the round worth writing down (#2142): the first version defined a block as the maximal run of non-blank lines, which is correct for prose and for a fenced snippet but not for a literal. `python/djust/schema.py`'s decorator schema is a single dict spanning ~135 lines with no blank line in it, so `@debounce`'s marker discharged `@client_state` **46 and 56 lines away** — the same sibling-list shape as the hole being fixed, one file over, in the AI-facing schema where it matters more. Both existing fence fixtures separated their snippets with a blank line, so they sampled only the blank-line-delimited variant of the surface (v1.0.0rc4 finding #1). The `{` opening each entry is shallower than the entry's keys, so dedent bounds it: the blocks are now 11 and 3 lines, and the tightened rule reported one further real site — `schema.py:904`, the `usage` snippet an agent copies, whose block excludes the entry's `description`. The banner arm is what keeps the diff proportionate: without it the same rule reports 92 sites across 22 files, including the `client_state` implementation's own docstring.

**#2689 — as reported, plus one variant the issue did not name.** Reproduced at the issue's exact numbers (`if-7f2bb6ab-0` twice). Cured as the third instance of a known class rather than by a new mechanism (#1646), mirroring `dj_if_loop_path` (#1832) and `dj_if_id_namespace` (#2686).

The variant: an **included template that itself `{% extends %}`** merges nodes the loader parsed *separately*, so both include sites start at ordinal 0 at the same depth. That is the one case needing the including template's source hash inside `site_id` — and it was found by gate-off, not by inspection. The first extends fixture I wrote passed with the hash mutated off, i.e. it did not test what its docstring claimed; a second fixture covers the case that does, and the first docstring now says so.

The parse-time prefix is deliberately **not** salted, per the constraint #2690 established: `template_hash_hex(source)` must keep equalling what `parse_with_source` derives, and the parse cache is source-keyed.

Every assertion in the new test file is **positional**. Under the bug the two ids are equal, and a dict keyed on the id collapses them to one entry — the exact tautology that stayed green under the live bug in #2686.

**#2658 — two of four items were already true, and the "minor" one was a cache-key bug.**

- *Item 2 (arity errors are render-time)* was **already fixed**: both scoreboard cells raise at `from_string()`. The doubled quotes in `''cache'' tag requires at least 2 arguments.` are **Django's own** output — the Django engine in the same process emits the identical string. Pinned so it cannot silently regress.
- *Item 3 (message parity, filed as minor)* was the visible end of a real divergence. The handler resolved every operand with `ignore_failures=True` and applied a miss policy of its own; its comment claimed Django resolves the vary operands with `ignore_failures`, but `django/templatetags/cache.py` reads `vary_on = [var.resolve(context) for var in self.vary_on]`. So an unresolvable vary operand is `string_if_invalid` (`''`) in Django and was `None` here — and since `make_template_fragment_key` hashes that list, **the two engines stored the same fragment under different keys**. Fixed by removing the bespoke policy rather than patching three strings.
- *Item 4 (`as`-bindings do not escape)* no longer has the reported symptom; the binding escapes fine, and the residual difference is purely that Django's later iterations are cache hits so its body never re-runs. Pinned, because a reader following the issue text would go hunting a scope bug that is not there.
- *Item 1 (the body renders on a hit)* is **deliberately not attempted** — see below.

## Left out, and why

**The lazy-body block-handler protocol (#2658 item 1).** `crates/djust_templates/src/renderer.rs:1134` `call_block_custom_tag` is the one dispatch site for block handlers, and its first statement (`:1142`) renders the children; the handler receives a body that already exists and cannot decline. The tractable shape is a two-phase handler capability — `before_body(args, context) -> str | None` and `after_body(args, content, context) -> str` — not a re-entrant callback, which would mean Python calling back into the renderer while Rust holds `&mut Context`.

I left it out because it is a design decision this evidence does not settle, not because it is hard: it adds a capability to the block-handler registry alongside `RETURNS_BINDINGS` / `WANTS_AUTOESCAPE` / the raw-body kind (Rust registry, PyO3 bridge, and a contract every handler class must be re-checked against), the only consumer today is `cache` — the sole member of `_BESPOKE_BLOCK_TAGS` — so the shape ought to be chosen with the next callers in mind, and it changes *when user template code runs* (a body with side effects stops executing on a hit, which is correct and is exactly what item 4's numbers show, but is a behaviour change). The full reasoning and sketch are on the issue; `TestTheBodyStillRendersOnAHit` pins the gap as a gap, and fails with an instruction to update it the moment a lazy body lands.

**#2658 stays open**, scoped to item 1 alone.

## Gate-off

Every mutation asserts it was found and that the source changed; errors are counted separately from failures, and a mutation that broke the module reports `INVALID` rather than a number.

**#2692** (`test_inert_api_claims.py`) — baseline `0 failed, 0 error`

| mutation | result |
|---|---|
| file-level marker restored | 2 failed |
| `tests` dropped from `SCAN_DIRS` | 1 failed |
| header-banner arm neutered | 3 failed |
| repo-root `*.md` dropped from `_files()` | 1 failed |
| backward dedent bound removed | 1 failed |
| forward dedent bound removed | 1 failed |
| banner ordering condition removed | 1 failed |

**Two of these survived their first round** and each was treated as a question rather than a pass. The repo-root `*.md` arm had no test at all; a case was added. The forward-dedent bound had no test because the schema fixture placed the marked sibling only *above*, so the two walks were one mechanism with one test between them (the #2129/#2135 shadowing shape) — the mirrored fixture exists because of that.

Plus the issue's own reproduction against the real repo: deleting the `docs/BEST_PRACTICES_AI.md` caveat now exits 1 where it exited 0; and, from the review, stripping the `schema.py` `@client_state` entry's own markers now exits 1 with 2 findings where the pre-fix checker exited 0.

**#2689** (`test_include_marker_id_namespace_2689.py`, 8 cases) — baseline `0 failed, 0 error`

| mutation | result |
|---|---|
| parser stamps no `site_id` | 6 failed |
| renderer does not compose this site | 6 failed |
| marker emission drops the include path | 6 failed |
| ordinal loses the including template's hash | 1 failed |
| `{% include … only %}` fresh `Context` drops it | 1 failed |

Row 4 also survived its first round, against a fixture whose docstring claimed to exercise it — the finding described above.

**#2658** (`test_cache_tag_django_parity_2658.py` + `test_block_super_and_cache_2517.py`) — baseline `0 failed, 0 error`

| mutation | result |
|---|---|
| `ignore_failures` restored (the pre-fix policy) | 8 failed |
| invalid cache name loses its `%r` | 1 failed |
| timeout message single-quotes the tag name | 4 failed |
| `validate_at_parse` removed | 4 failed |

## Verification

- `pytest tests/ python/tests/ python/djust/tests/` — **26539 passed, 489 skipped, 0 failed**
- `cargo test -p djust_core -p djust_templates` — green; `cargo clippy --all-targets` clean
- `ruff` / `mypy` / pre-commit green on every commit
- Django parity measured against a live `django.template.Engine` in the same process, not read off the source

Closes #2692
Closes #2689

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116FTX9dXEq8E5cFN7wh1u8
