### PR TITLE
fix(templates): a sized sequence is no longer materialised at conversion, and dictsort consumes a one-shot iterator (#2695, #2693)

### DIFF
--- a/changelog.d/2695-2693.fixed.md
+++ b/changelog.d/2695-2693.fixed.md
@@ -1,0 +1,31 @@
+- **Templates:** a sized sequence is no longer materialised when it enters a
+  context, so `range(10**9)` renders instead of hanging (#2695), and
+  `dictsort` / `dictsortreversed` consume a one-shot iterator through the same
+  sink `{% for %}` and `|join` use (#2693).
+
+  #2678 stopped the conversion enumerating an object whose stated `__len__`
+  its `__getitem__` could never reach, but scoped the decline to that one
+  shape — so `range(10**9)`, which terminates, was still read a billion times
+  the moment it entered a context and `{{ v.0 }}`, `{{ v|length }}`,
+  `{{ v }}` and `{% for %}` all failed to return. Django never enumerates at
+  binding time, so the bound now sits on the stated length for EVERY sized
+  sequence, and each sink reads what it needs off ADR-027's live handle:
+  `|length` is `len(v)`, `{{ v.0 }}` / `|first` / `|last` are `v[i]`,
+  `|slice` is `v[slice(*bits)]`, `in` is Python's own `__contains__` and
+  `{{ v }}` is `str(v)` — all in constant time, all Django's own answers.
+
+  The cap moved to where it belongs rather than being removed: the conversion
+  asks "is the stated length too large to spend here" and the SINKS ask "can
+  this walk end at all", so `list(range(100_001))` still renders every item at
+  `{% for %}` while #2678's liar still raises. `{% for %}` / `|join` /
+  `dictsort` over a stated billion still does not return — measured with a
+  60 s deadline and a 4 GiB ceiling, neither does Django's.
+
+  `dictsort` had iteration of its own instead of going through
+  `filters::iter_values`, so it answered `''` for a generator, a `map`, a
+  `zip` and a one-shot `iter([...])` where Django sorts them. A structural
+  test now pins the SET of functions allowed to match a sequence by hand, so
+  the next filter written that way is loud.
+
+  Verified by a Django 5.2 differential over 12 sinks x 19 shapes x both
+  `template_resolve_lazy` settings, in `TestTheDjangoDifferential`.

--- a/changelog.d/2695-2693.fixed.md
+++ b/changelog.d/2695-2693.fixed.md
@@ -16,14 +16,21 @@
   Django's own answers.
 
   A `list` and an evaluated `QuerySet` are exempt from the decline at any
-  length, because for those two the items are already built by the time the
-  length is known (`QuerySet.__len__` calls `_fetch_all()`), so declining can
-  only change the SPELLING — and it did: a 100 001-row queryset rendered
-  `{{ rows }}` as 66 MB of djust's own serialization dicts where the same
-  queryset one row shorter renders `[qs0, qs1, qs2]`, and `{{ rows.0 }}`
-  answered `''`. Not a floor breach — the rows are denylist-filtered on both
-  sides — but a content and payload change, now pinned on both paths a
-  queryset reaches the engine by.
+  length, because declining them produced a WRONG SPELLING: a 100 001-row
+  queryset rendered `{{ rows }}` as 66 MB of djust's own serialization dicts
+  where the same queryset one row shorter renders `[qs0, qs1, qs2]`, and
+  `{{ rows.0 }}` answered `''`. Not a floor breach — the rows are
+  denylist-filtered on both sides — but a content and payload change, now
+  pinned on both paths a queryset reaches the engine by.
+
+  That exemption is a TRADE and the price is not zero: asking a `QuerySet`'s
+  length sinks `_fetch_all()` (~140 MB of rows) but NOT the conversion of
+  those rows into values, so on an unevaluated 150 000-row queryset
+  `{{ v|length }}` peaks at 4 650 MB with the exemption against 593 MB
+  without it. It is taken because the declined spelling is wrong and because
+  the cost is not new — neither shape was ever declined before #2695 either.
+  Getting both — decline the carrier AND spell it correctly at the sink — is
+  #2717.
 
   The cap moved to where it belongs rather than being removed: the conversion
   asks "is the stated length too large to spend here" and the SINKS ask "can

--- a/changelog.d/2695-2693.fixed.md
+++ b/changelog.d/2695-2693.fixed.md
@@ -8,24 +8,40 @@
   shape — so `range(10**9)`, which terminates, was still read a billion times
   the moment it entered a context and `{{ v.0 }}`, `{{ v|length }}`,
   `{{ v }}` and `{% for %}` all failed to return. Django never enumerates at
-  binding time, so the bound now sits on the stated length for EVERY sized
-  sequence, and each sink reads what it needs off ADR-027's live handle:
-  `|length` is `len(v)`, `{{ v.0 }}` / `|first` / `|last` are `v[i]`,
-  `|slice` is `v[slice(*bits)]`, `in` is Python's own `__contains__` and
-  `{{ v }}` is `str(v)` — all in constant time, all Django's own answers.
+  binding time, so the bound now sits on the stated length for every sized
+  sequence whose items do not already exist, and each sink reads what it needs
+  off ADR-027's live handle: `|length` is `len(v)`, `{{ v.0 }}` / `|first` /
+  `|last` are `v[i]`, `|slice` is `v[slice(*bits)]`, `in` is Python's own
+  `__contains__` and `{{ v }}` is `str(v)` — all in constant time, all
+  Django's own answers.
+
+  A `list` and an evaluated `QuerySet` are exempt from the decline at any
+  length, because for those two the items are already built by the time the
+  length is known (`QuerySet.__len__` calls `_fetch_all()`), so declining can
+  only change the SPELLING — and it did: a 100 001-row queryset rendered
+  `{{ rows }}` as 66 MB of djust's own serialization dicts where the same
+  queryset one row shorter renders `[qs0, qs1, qs2]`, and `{{ rows.0 }}`
+  answered `''`. Not a floor breach — the rows are denylist-filtered on both
+  sides — but a content and payload change, now pinned on both paths a
+  queryset reaches the engine by.
 
   The cap moved to where it belongs rather than being removed: the conversion
   asks "is the stated length too large to spend here" and the SINKS ask "can
-  this walk end at all", so `list(range(100_001))` still renders every item at
-  `{% for %}` while #2678's liar still raises. `{% for %}` / `|join` /
-  `dictsort` over a stated billion still does not return — measured with a
-  60 s deadline and a 4 GiB ceiling, neither does Django's.
+  this walk end at all", so `collections.deque(range(100_001))` still renders
+  every item at `{% for %}` while #2678's liar still raises. `{% for %}` /
+  `|join` / `dictsort` over a stated billion still does not return — measured
+  with a 60 s deadline and a 4 GiB ceiling, neither does Django's.
 
   `dictsort` had iteration of its own instead of going through
   `filters::iter_values`, so it answered `''` for a generator, a `map`, a
   `zip` and a one-shot `iter([...])` where Django sorts them. A structural
-  test now pins the SET of functions allowed to match a sequence by hand, so
-  the next filter written that way is loud.
+  test now pins the SET of functions allowed to match a sequence by hand, and
+  requires every such `match` to name `Value::Encoded` IN THAT MATCH — the
+  per-function version of that check was satisfied by an unrelated line and
+  could not fail.
 
   Verified by a Django 5.2 differential over 12 sinks x 19 shapes x both
-  `template_resolve_lazy` settings, in `TestTheDjangoDifferential`.
+  `template_resolve_lazy` settings, in `TestTheDjangoDifferential`: on the
+  shipped lazy default 192 of 218 comparable cells render Django's string
+  byte for byte and the remaining 26 are pinned as a set, with 148 of 204 on
+  the eager escape hatch and 56 pinned there.

--- a/crates/djust_core/src/lib.rs
+++ b/crates/djust_core/src/lib.rs
@@ -656,22 +656,28 @@ pub struct Encoded {
     /// **What can never acquire one.** `crosses_as_encoded` / the
     /// `FromPyObject` impl claim a `dict`, a tuple, anything with
     /// `__djust_serialize__` and any `Model` in arms ABOVE [`opaque_value`],
-    /// so no dict, model or manager reaches this field. That is enforced by
-    /// the existing ordering rather than by a new rule.
+    /// so no dict, model or manager reaches this field. A `list` and an
+    /// evaluated `QuerySet` are also excluded, but by a RULE rather than by
+    /// the ordering: [`len_call_already_materialised_the_items`] exempts them
+    /// from the conversion's decline at any length, because for those two the
+    /// items exist by the time the length is known and declining could only
+    /// change the spelling (#2695 review — it changed it to 66 MB of djust's
+    /// own serialization dicts).
     ///
-    /// A `list` or an evaluated `QuerySet` used to be on that list too, and
-    /// since #2695 it is not: past [`OPAQUE_ITEM_CAP`] the sequence arm
-    /// declines to enumerate and the object arrives HERE, so
-    /// `{{ rows.0.password }}` over a 100,001-row list is answered by
-    /// [`Context::walk_live`] rather than by a `Value::List` whose elements
-    /// were already denylist-filtered at the conversion. The floor is the
-    /// same either way — `protect_sidecar_strict` re-wraps after every
+    /// An ordinary sized sequence — a `deque`, an `array`, a `range`, a duck
+    /// type with a stated `__len__` — DOES arrive here past
+    /// [`OPAQUE_ITEM_CAP`], and that is what #2695 changed: over a
+    /// 100 001-element `deque` of models `{{ rows.0.password }}` is answered
+    /// by [`Context::walk_live`] rather than by a `Value::List` whose
+    /// elements were already denylist-filtered at the conversion. The floor
+    /// is the same either way — `protect_sidecar_strict` re-wraps after every
     /// segment — and that is a MEASUREMENT rather than an inference:
     /// `TestTheSerializationFloorHoldsOnTheNewHandle` in
-    /// `python/tests/test_sized_sequence_conversion_2695_2693.py` renders
-    /// the denylisted field on both sides of the cap and asserts both are
-    /// empty, with a non-vacuity case proving the padded list really is a
-    /// carrier.
+    /// `python/tests/test_sized_sequence_conversion_2695_2693.py` renders the
+    /// denylisted field on both sides of the cap and asserts both are empty,
+    /// with a non-vacuity case proving the padded collection really is a
+    /// carrier — the case that caught the `list` exemption making the class
+    /// vacuous.
     ///
     /// [`Context::walk_live`]: crate::Context::walk_live
     ///
@@ -3533,8 +3539,9 @@ fn surrogatepass_bytes_to_string(bytes: &[u8]) -> String {
 ///   belongs on BOTH halves of the same rule and this is only the first:
 ///   the conversion declines, and the SINKS then walk the live object under
 ///   [`Encoded::live_walk_terminates`], which is where "can the walk end"
-///   is asked. `list(range(100_001))` crosses as a carrier here and still
-///   renders every item at `{% for %}`, because its walk terminates.
+///   is asked. `collections.deque(range(100_001))` crosses as a carrier here
+///   and still renders every item at `{% for %}`, because its walk
+///   terminates.
 ///
 /// * **`resolve_lazy()` is on** — the shipped default. The decline only
 ///   improves on the hang because ADR-027's carrier holds a LIVE HANDLE, so
@@ -3546,8 +3553,60 @@ fn surrogatepass_bytes_to_string(bytes: &[u8]) -> String {
 ///   had a slow-but-correct one, so the hatch keeps enumerating in full and
 ///   both #2678's and #2695's hangs stay unfixed there. An unfixed cell
 ///   beats a wrong one.
-fn stated_len_is_too_large_to_enumerate(len: usize) -> bool {
-    len > OPAQUE_ITEM_CAP && resolve_lazy()
+///
+/// * **Asking the length did not ALREADY materialise the items**
+///   ([`len_call_already_materialised_the_items`], #2695 review). The decline
+///   exists to avoid PAYING to build items the object only DESCRIBES —
+///   `range(10**9)` states a billion and holds none of them. When the items
+///   already exist the decline saves nothing, and it is not free: the
+///   carrier it falls back to spells `str(o)` AND `repr(o)`, each of which
+///   enumerates the whole collection anyway.
+fn stated_len_is_too_large_to_enumerate(ob: &Bound<'_, PyAny>, len: usize) -> bool {
+    len > OPAQUE_ITEM_CAP && resolve_lazy() && !len_call_already_materialised_the_items(ob)
+}
+
+/// Are this object's items ALREADY built by the time its length is known?
+/// (#2695 review.)
+///
+/// The question [`stated_len_is_too_large_to_enumerate`] has to ask before
+/// declining, because the decline's whole justification is the cost of
+/// materialising — and for these two shapes that cost is already sunk, so
+/// declining only changes the SPELLING:
+///
+/// * A **`list`** holds its elements: `len()` is O(1) and creates nothing.
+/// * A Django **`QuerySet`**: `__len__` calls `_fetch_all()`, so the row
+///   objects are in `_result_cache` the moment the length is known.
+///
+/// The shape that found it is one object wearing both hats. A 100 001-row
+/// `QuerySet` in a template context is auto-serialised by
+/// `DjustTemplate.render` into a `list` of djust's own identity dicts;
+/// declining that list spelled `{{ rows }}` as
+/// `[{'id': 1, 'pk': 1, '__str__': 'qs0', '__model__': 'User', …}]` — 66 MB —
+/// where the same queryset one row shorter renders `[qs0, qs1, qs2]`, and
+/// declining the QuerySet itself answered `{{ rows.0 }}` with `''` because
+/// `_SidecarQuerySetProxy` has no `__getitem__` for the live walk to use.
+/// Neither is a floor breach — the rows are denylist-filtered on both sides,
+/// pinned by `TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap` — but
+/// both are a content and payload change on the exact shape
+/// [`Encoded::live`]'s doc names.
+///
+/// Nothing else is exempt, and that is the point of asking about
+/// materialisation rather than listing types: a `tuple` never reaches here
+/// (the tuple arm above [`bounded_sequence_items`] claims it), and `range` /
+/// `bytes` / `array` / `deque` / a numpy array / a duck type with a stated
+/// `__len__` all DESCRIBE or PACK their items, so the decline is a real
+/// saving for them and they keep it.
+fn len_call_already_materialised_the_items(ob: &Bound<'_, PyAny>) -> bool {
+    if ob.is_instance_of::<PyList>() {
+        return true;
+    }
+    // A cached `sys.modules` lookup, and only ever reached once the stated
+    // length is already past the cap — never on the hot path.
+    ob.py()
+        .import("django.db.models")
+        .and_then(|m| m.getattr("QuerySet"))
+        .and_then(|cls| ob.is_instance(&cls))
+        .unwrap_or(false)
 }
 
 fn bounded_sequence_items<'py>(ob: &Bound<'py, PyAny>) -> Option<Vec<Bound<'py, PyAny>>> {
@@ -3560,7 +3619,7 @@ fn bounded_sequence_items<'py>(ob: &Bound<'py, PyAny>) -> Option<Vec<Bound<'py, 
         return None;
     }
     let len = ob.len().ok()?;
-    if stated_len_is_too_large_to_enumerate(len) {
+    if stated_len_is_too_large_to_enumerate(ob, len) {
         return None;
     }
     let mut items = Vec::with_capacity(len.min(OPAQUE_ITEM_CAP));
@@ -3783,6 +3842,15 @@ impl<'py> FromPyObject<'_, 'py> for Value {
                     // or list-of-dicts (queryset) — recurse via Value so both
                     // shapes convert (Object / List). The result carries no
                     // proxies, so this does not re-enter this branch.
+                    //
+                    // The list-of-dicts converts IN FULL at any length, and
+                    // that is not a second rule: it is a `list`, and
+                    // `stated_len_is_too_large_to_enumerate` exempts a `list`
+                    // because its items are already materialised (#2695
+                    // review — see that function). Before the exemption a
+                    // 100 001-row queryset's rows were declined HERE and
+                    // spelled `{{ rows }}` as `str()` of djust's own identity
+                    // dicts.
                     if let Ok(v) = result.extract::<Value>() {
                         return Ok(v);
                     }
@@ -3957,11 +4025,13 @@ fn opaque_gate(ob: &Bound<'_, PyAny>) -> Option<OpaqueFacts> {
         // marked unbounded so `opaque_value` leaves `items` at `None` rather
         // than paying the billion reads that are the reported hang — for a
         // `range(10**9)` as much as for the liar whose `__getitem__` never
-        // raises. Every sized collection UNDER the cap — `list`, `set`,
-        // `range(3)`, an evaluated `QuerySet` — is enumerated in full exactly
-        // as before. Over it, the ITEMS are read at the sink instead, from
-        // the live handle, under the sink's own termination rule
-        // ([`Encoded::live_walk_terminates`]).
+        // raises. Every sized collection UNDER the cap — `set`, `range(3)`,
+        // a `deque` — is enumerated in full exactly as before, and so is a
+        // `list` / an evaluated `QuerySet` at ANY length (their items are
+        // already built, so the decline could only change the spelling —
+        // `len_call_already_materialised_the_items`). Over the cap the ITEMS
+        // are read at the sink instead, from the live handle, under the
+        // sink's own termination rule ([`Encoded::live_walk_terminates`]).
         //
         // Without a `__len__` there is no bound at all, so walk to the cap: a
         // class whose `__iter__` returns `itertools.count()` is RE-iterable,
@@ -3978,7 +4048,7 @@ fn opaque_gate(ob: &Bound<'_, PyAny>) -> Option<OpaqueFacts> {
         //
         // Counted, not collected: the items are not converted here.
         match len {
-            Some(n) if stated_len_is_too_large_to_enumerate(n) => {
+            Some(n) if stated_len_is_too_large_to_enumerate(ob, n) => {
                 unbounded = true;
             }
             Some(_) => {}
@@ -4055,8 +4125,8 @@ impl Encoded {
     ///   the walk and must not.
     ///
     /// When both hold the walk is Django's own: `{% for %}` over
-    /// `list(range(100_001))` renders all 100 001 items, and `{% for %}`
-    /// over `range(10**9)` does not come back — which is measured Django
+    /// `collections.deque(range(100_001))` renders all 100 001 items, and
+    /// `{% for %}` over `range(10**9)` does not come back — which is measured Django
     /// behaviour for that same input, not a djust limitation (see the
     /// differential table in `python/tests/test_sized_sequence_conversion_2695_2693.py`).
     ///
@@ -4245,8 +4315,9 @@ impl Encoded {
     ///
     /// Load-bearing because the conversion now declines to enumerate a sized
     /// sequence past [`OPAQUE_ITEM_CAP`]: without this arm
-    /// `{{ v|slice:":3" }}` over `list(range(100_001))` returned the WHOLE
-    /// carrier unchanged — 100 001 items where Django renders three.
+    /// `{{ v|slice:":3" }}` over `collections.deque(range(100_001))` — or over
+    /// `range(10**9)` — returned the WHOLE carrier unchanged, where Django
+    /// renders three items.
     pub fn live_get_slice(
         &self,
         start: Option<isize>,

--- a/crates/djust_core/src/lib.rs
+++ b/crates/djust_core/src/lib.rs
@@ -654,10 +654,26 @@ pub struct Encoded {
     /// GIL — the same shape `Context::raw_py_objects` already uses.
     ///
     /// **What can never acquire one.** `crosses_as_encoded` / the
-    /// `FromPyObject` impl claim a `list`, a `dict`, a tuple, anything with
+    /// `FromPyObject` impl claim a `dict`, a tuple, anything with
     /// `__djust_serialize__` and any `Model` in arms ABOVE [`opaque_value`],
-    /// so no list, dict, model, manager or queryset reaches this field. That
-    /// is enforced by the existing ordering rather than by a new rule.
+    /// so no dict, model or manager reaches this field. That is enforced by
+    /// the existing ordering rather than by a new rule.
+    ///
+    /// A `list` or an evaluated `QuerySet` used to be on that list too, and
+    /// since #2695 it is not: past [`OPAQUE_ITEM_CAP`] the sequence arm
+    /// declines to enumerate and the object arrives HERE, so
+    /// `{{ rows.0.password }}` over a 100,001-row list is answered by
+    /// [`Context::walk_live`] rather than by a `Value::List` whose elements
+    /// were already denylist-filtered at the conversion. The floor is the
+    /// same either way — `protect_sidecar_strict` re-wraps after every
+    /// segment — and that is a MEASUREMENT rather than an inference:
+    /// `TestTheSerializationFloorHoldsOnTheNewHandle` in
+    /// `python/tests/test_sized_sequence_conversion_2695_2693.py` renders
+    /// the denylisted field on both sides of the cap and asserts both are
+    /// empty, with a non-vacuity case proving the padded list really is a
+    /// carrier.
+    ///
+    /// [`Context::walk_live`]: crate::Context::walk_live
     ///
     /// **When it is `Some`, [`Encoded::attrs`] is EMPTY** — see
     /// [`opaque_value`]. The handle is the authority for attribute lookups,
@@ -3477,9 +3493,10 @@ fn surrogatepass_bytes_to_string(bytes: &[u8]) -> String {
 /// can never produce a short list (#2129: a rule about the operation, not a
 /// list of shapes). A `list`, `tuple`, `range`, `bytes`, `deque`, `array`,
 /// numpy array and evaluated `QuerySet` all state a length and cross exactly
-/// as they did — including past [`OPAQUE_ITEM_CAP`]. See
-/// [`stated_bound_is_unverifiable`] for the one shape whose stated bound is
-/// NOT trusted, and for why the cap is scoped that narrowly (#2678).
+/// as they did — up to [`OPAQUE_ITEM_CAP`]. See
+/// [`stated_len_is_too_large_to_enumerate`] for what happens past it and why
+/// enumerating a stated billion at BINDING time is the wrong half of the
+/// rule (#2678, #2695).
 ///
 /// A `str` is refused, as PyO3's `Vec` extraction refuses it: the `str` arm
 /// sits above the sequence arm and claims every string first.
@@ -3490,8 +3507,8 @@ fn surrogatepass_bytes_to_string(bytes: &[u8]) -> String {
 /// stricter test would silently move every unregistered user class with
 /// `__getitem__` and `__len__` out of the list arm, which is a second
 /// behaviour change this fix has no reason to make.
-/// Is this object's stated `__len__` one we cannot afford to take on trust?
-/// (#2678, corrected by the PR #2691 review.)
+/// Is this object's stated `__len__` too large to spend at the CONVERSION?
+/// (#2678, widened to every sized sequence by #2695.)
 ///
 /// The ONE statement of that question, read by both sites that would
 /// otherwise pay `len` calls up front — [`bounded_sequence_items`] and
@@ -3500,21 +3517,24 @@ fn surrogatepass_bytes_to_string(bytes: &[u8]) -> String {
 ///
 /// TWO conditions, and both are load-bearing:
 ///
-/// * **The object has no `__iter__` of its own.** Then PyO3's iteration is
-///   CPython's legacy sequence protocol — `o[0]`, `o[1]`, … until
-///   `IndexError` — and nothing connects that walk to the stated `__len__`:
-///   a class returning `10**9` from `__len__` with a never-raising
-///   `__getitem__` is read a billion times, which is the hang #2678 reports.
-///   An object WITH `__iter__` has a real iterator whose own exhaustion ends
-///   the walk, and its length is as honest as any `list`'s.
+/// * **The stated length is past [`OPAQUE_ITEM_CAP`].** Then materialising
+///   the object costs one `Value` per item before the template has said what
+///   it wants, and `range(10**9)` is thirty gigabytes for a `{{ v.0 }}` that
+///   Django answers with a single `__getitem__` (#2695). Django never
+///   enumerates at binding time — `{{ v.0 }}`, `{{ v|length }}` and
+///   `{{ v }}` are `current[0]`, `len(v)` and `str(v)` — so declining here
+///   is what Django parity looks like, not a safeguard against it.
 ///
-///   The first version of this fix capped on `len` ALONE, and that claimed
-///   every `list`, `set`, `deque`, `range`, `bytes` and `QuerySet` past the
-///   cap — collections that terminate, that Django renders in ~0.1s, and
-///   that had crossed as real items since forever. Measured on that version:
-///   `{% for %}` over `list(range(100_001))` RAISED, `|first` raised,
-///   `|join` raised. A bound on the wrong axis is a regression, not a
-///   safeguard: the axis is "can the walk end", not "is the number big".
+///   #2678's first version capped on `len` alone and REGRESSED
+///   `list(range(100_001))`: `{% for %}` raised, `|first` raised, `|join`
+///   raised. Its second version therefore also required the object to have
+///   no `__iter__` — which fixed the regression by never claiming `range`
+///   at all, and so left #2695's hang exactly as it found it. The bound
+///   belongs on BOTH halves of the same rule and this is only the first:
+///   the conversion declines, and the SINKS then walk the live object under
+///   [`Encoded::live_walk_terminates`], which is where "can the walk end"
+///   is asked. `list(range(100_001))` crosses as a carrier here and still
+///   renders every item at `{% for %}`, because its walk terminates.
 ///
 /// * **`resolve_lazy()` is on** — the shipped default. The decline only
 ///   improves on the hang because ADR-027's carrier holds a LIVE HANDLE, so
@@ -3524,14 +3544,10 @@ fn surrogatepass_bytes_to_string(bytes: &[u8]) -> String {
 ///   from the REPR — `{{ v.0 }}` renders `[`, `|length` counts repr
 ///   characters. That is a silently wrong answer where the hatch previously
 ///   had a slow-but-correct one, so the hatch keeps enumerating in full and
-///   #2678's hang stays unfixed there. An unfixed cell beats a wrong one.
-fn stated_bound_is_unverifiable(ob: &Bound<'_, PyAny>, len: usize) -> bool {
-    len > OPAQUE_ITEM_CAP
-        && resolve_lazy()
-        && !ob
-            .get_type()
-            .hasattr(pyo3::intern!(ob.py(), "__iter__"))
-            .unwrap_or(false)
+///   both #2678's and #2695's hangs stay unfixed there. An unfixed cell
+///   beats a wrong one.
+fn stated_len_is_too_large_to_enumerate(len: usize) -> bool {
+    len > OPAQUE_ITEM_CAP && resolve_lazy()
 }
 
 fn bounded_sequence_items<'py>(ob: &Bound<'py, PyAny>) -> Option<Vec<Bound<'py, PyAny>>> {
@@ -3544,7 +3560,7 @@ fn bounded_sequence_items<'py>(ob: &Bound<'py, PyAny>) -> Option<Vec<Bound<'py, 
         return None;
     }
     let len = ob.len().ok()?;
-    if stated_bound_is_unverifiable(ob, len) {
+    if stated_len_is_too_large_to_enumerate(len) {
         return None;
     }
     let mut items = Vec::with_capacity(len.min(OPAQUE_ITEM_CAP));
@@ -3936,13 +3952,16 @@ fn opaque_gate(ob: &Bound<'_, PyAny>) -> Option<OpaqueFacts> {
         }
         // An object that states a `__len__` has stated its own bound, and the
         // walk is skipped — which is what keeps this gate O(1) for a `set`
-        // and a `dict_keys`. The ONE exception is the shape whose stated
-        // bound cannot end the walk ([`stated_bound_is_unverifiable`], #2678):
-        // it is marked unbounded so `opaque_value` leaves `items` at `None`
-        // rather than paying the billion `__getitem__` calls that are the
-        // reported hang. Every honest sized collection — `list`, `set`,
-        // `range`, `QuerySet` — is enumerated in full exactly as before, at
-        // any length.
+        // and a `dict_keys`. The exception is a bound too large to SPEND here
+        // ([`stated_len_is_too_large_to_enumerate`], #2678 + #2695): it is
+        // marked unbounded so `opaque_value` leaves `items` at `None` rather
+        // than paying the billion reads that are the reported hang — for a
+        // `range(10**9)` as much as for the liar whose `__getitem__` never
+        // raises. Every sized collection UNDER the cap — `list`, `set`,
+        // `range(3)`, an evaluated `QuerySet` — is enumerated in full exactly
+        // as before. Over it, the ITEMS are read at the sink instead, from
+        // the live handle, under the sink's own termination rule
+        // ([`Encoded::live_walk_terminates`]).
         //
         // Without a `__len__` there is no bound at all, so walk to the cap: a
         // class whose `__iter__` returns `itertools.count()` is RE-iterable,
@@ -3959,7 +3978,7 @@ fn opaque_gate(ob: &Bound<'_, PyAny>) -> Option<OpaqueFacts> {
         //
         // Counted, not collected: the items are not converted here.
         match len {
-            Some(n) if stated_bound_is_unverifiable(ob, n) => {
+            Some(n) if stated_len_is_too_large_to_enumerate(n) => {
                 unbounded = true;
             }
             Some(_) => {}
@@ -4009,6 +4028,57 @@ fn opaque_gate(ob: &Bound<'_, PyAny>) -> Option<OpaqueFacts> {
 }
 
 impl Encoded {
+    /// Does a full walk of the live object END BY ITSELF? (#2695)
+    ///
+    /// The SINK half of the conversion's [`stated_len_is_too_large_to_enumerate`]
+    /// — the two questions that #2678's second version tried to answer with
+    /// one predicate, which is why it could only fix one of the two hangs.
+    ///
+    /// * The conversion asks "is the stated length too large to spend HERE",
+    ///   and declines every sized sequence past [`OPAQUE_ITEM_CAP`].
+    /// * This asks "can the walk end at all", and is what decides whether a
+    ///   sink that genuinely needs every item may exceed the cap.
+    ///
+    /// TWO conditions, and both are load-bearing:
+    ///
+    /// * **`len(o)` succeeded at the conversion.** An object that never
+    ///   stated a length has stated no bound: `itertools.count()`, a
+    ///   generator, a class whose `__iter__` is endless. Those keep the cap
+    ///   and RAISE past it — Django hangs on them, and an error is the
+    ///   strictly better answer.
+    /// * **The type has a real `__iter__`.** Without one, PyO3's iteration
+    ///   is CPython's legacy sequence protocol — `o[0]`, `o[1]`, … until
+    ///   `IndexError` — and nothing connects that walk to the stated
+    ///   `__len__`. #2678's liar (a `__len__` of `10**9` over a
+    ///   never-raising `__getitem__`) is exactly this shape and must keep
+    ///   the cap; a `range` has a real iterator whose own exhaustion ends
+    ///   the walk and must not.
+    ///
+    /// When both hold the walk is Django's own: `{% for %}` over
+    /// `list(range(100_001))` renders all 100 001 items, and `{% for %}`
+    /// over `range(10**9)` does not come back — which is measured Django
+    /// behaviour for that same input, not a djust limitation (see the
+    /// differential table in `python/tests/test_sized_sequence_conversion_2695_2693.py`).
+    ///
+    /// **The limit of the claim, stated rather than assumed.** Two conditions
+    /// are what CPython lets us ask; they are not a proof. A class that
+    /// states a `__len__` and whose `__iter__` never ends — a lying length —
+    /// passes both and is walked without a bound. That shape does not come
+    /// back today either: [`opaque_value`]'s enumeration has no cap of its
+    /// own, so before #2695 it failed to return at the CONVERSION, for
+    /// `{{ v|length }}` as much as for `{% for %}`. Moving the walk to the
+    /// sink makes it strictly rarer (only a template that asks for every
+    /// item pays it) and changes nothing else, so it is unfixed rather than
+    /// newly broken — pinned as a measurement by
+    /// `TestALyingLengthIsUnfixedRatherThanNewlyBroken`.
+    fn live_walk_terminates(&self, ob: &Bound<'_, PyAny>) -> bool {
+        self.len.is_some()
+            && ob
+                .get_type()
+                .hasattr(pyo3::intern!(ob.py(), "__iter__"))
+                .unwrap_or(false)
+    }
+
     /// Consume a ONE-SHOT iterator carried by the live handle into its items
     /// (#2613) — Django's `list(values)` in `ForNode.render`, run at the
     /// `{% for %}` sink rather than at conversion so that a generator the
@@ -4016,11 +4086,11 @@ impl Encoded {
     ///
     /// `None` when there is nothing to consume: no handle (eager path, or a
     /// wire round-trip), not iterable, or the items were already enumerated
-    /// at conversion (a re-iterable object). Bounded by [`OPAQUE_ITEM_CAP`]:
-    /// past it the render RAISES rather than truncating — Django would hang
-    /// on the same `itertools.count()`, so an error is the strictly better
-    /// answer and a short list would be a silently wrong one. A raising
-    /// `__next__` propagates as Django propagates it.
+    /// at conversion (a re-iterable object). Bounded by [`OPAQUE_ITEM_CAP`]
+    /// UNLESS [`Encoded::live_walk_terminates`] — past it the render RAISES
+    /// rather than truncating, because Django would hang on the same
+    /// `itertools.count()` and a short list would be a silently wrong
+    /// answer. A raising `__next__` propagates as Django propagates it.
     ///
     /// A second call after exhaustion yields an empty list, exactly as a
     /// second `{% for %}` over the same generator is empty in Django.
@@ -4031,15 +4101,12 @@ impl Encoded {
         let handle = self.live.as_ref()?;
         Some(Python::attach(|py| {
             let ob = handle.bind(py);
+            let capped = !self.live_walk_terminates(ob);
             let mut collected = Vec::new();
             for item in ob.try_iter()? {
                 collected.push(item?.extract::<Value>()?);
-                if collected.len() > OPAQUE_ITEM_CAP {
-                    return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
-                        "'{}' object yielded more than {} items — \
-                         an unbounded iterable cannot be rendered",
-                        self.type_name, OPAQUE_ITEM_CAP
-                    )));
+                if capped && collected.len() > OPAQUE_ITEM_CAP {
+                    return Err(self.unbounded_error());
                 }
             }
             Ok(collected)
@@ -4057,6 +4124,12 @@ impl Encoded {
     /// the stopping rule differs, which is why it is a sibling of that
     /// method rather than a caller-side `take_while`.
     ///
+    /// This is the walk Python falls back to when the type has no
+    /// `__contains__`; [`Encoded::live_contains`] is the other half and must
+    /// be tried FIRST, or `{% if 987654321 in range(10**9) %}` walks nine
+    /// hundred million items to reach an answer `range.__contains__` has in
+    /// constant time (#2695).
+    ///
     /// `None` when there is nothing to consume, exactly as its sibling.
     pub fn consume_live_match(
         &self,
@@ -4068,22 +4141,143 @@ impl Encoded {
         let handle = self.live.as_ref()?;
         Some(Python::attach(|py| {
             let ob = handle.bind(py);
+            let capped = !self.live_walk_terminates(ob);
             let mut seen = 0usize;
             for item in ob.try_iter()? {
                 if matches(&item?.extract::<Value>()?) {
                     return Ok(true);
                 }
                 seen += 1;
-                if seen > OPAQUE_ITEM_CAP {
-                    return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
-                        "'{}' object yielded more than {} items — \
-                         an unbounded iterable cannot be rendered",
-                        self.type_name, OPAQUE_ITEM_CAP
-                    )));
+                if capped && seen > OPAQUE_ITEM_CAP {
+                    return Err(self.unbounded_error());
                 }
             }
             Ok(false)
         }))
+    }
+
+    /// Python's own `needle in o`, for a type that answers it WITHOUT
+    /// iterating (#2695).
+    ///
+    /// `range(10**9).__contains__(987654321)` is arithmetic; `set` and
+    /// `dict_keys` hash. Django evaluates `x in value` in Python and gets
+    /// those answers for free, so walking the object here is not merely slow
+    /// — for a stated billion it is the reported hang, on a cell Django
+    /// renders instantly.
+    ///
+    /// Gated on the type actually defining `__contains__`, and that gate is
+    /// what keeps this safe for a one-shot iterator: without the slot,
+    /// CPython's `in` falls back to iterating and CONSUMES the caller's
+    /// generator up to the match, which is precisely the behaviour
+    /// [`Encoded::consume_live_match`] already reproduces with djust's own
+    /// element comparison. So the two are exclusive rather than layered —
+    /// this arm handles the objects Python answers without a walk, its
+    /// sibling handles the ones it answers with one.
+    ///
+    /// `None` when there is nothing to ask: no handle, not iterable, items
+    /// already enumerated, no `__contains__`, or a needle that has no
+    /// faithful Python spelling.
+    pub fn live_contains(&self, needle: &Value) -> Option<PyResult<bool>> {
+        if !self.iterable || self.items.is_some() {
+            return None;
+        }
+        let handle = self.live.as_ref()?;
+        Python::attach(|py| {
+            let ob = handle.bind(py);
+            if !ob
+                .get_type()
+                .hasattr(pyo3::intern!(py, "__contains__"))
+                .unwrap_or(false)
+            {
+                return None;
+            }
+            // A needle that cannot cross back exactly is left to the walking
+            // sibling: `Value`'s `IntoPyObject` spells a carried object as a
+            // string, and `"<map object …>" in o` is a different question.
+            let py_needle = match needle {
+                Value::None
+                | Value::Bool(_)
+                | Value::Integer(_)
+                | Value::Float(_)
+                | Value::String(_)
+                | Value::SafeString(_) => needle.into_pyobject(py).ok()?,
+                _ => return None,
+            };
+            Some(ob.contains(py_needle))
+        })
+    }
+
+    /// Python's `o[index]` over the live handle — Django's `first` / `last`
+    /// filters and its `Variable._resolve_lookup` integer step (#2695).
+    ///
+    /// `Ok(None)` is an `IndexError`, which is the ONE exception Django's
+    /// `first` and `last` catch (`except IndexError: return ""`). Every
+    /// other Python failure is the caller's to spell, and the caller has
+    /// only [`crate::Value`]-level error variants — so a `TypeError` (`o` is
+    /// not subscriptable) and a `KeyError` are told apart here and anything
+    /// else is reported as the not-subscriptable case.
+    ///
+    /// Only ever reached for a carrier whose items were NOT enumerated: a
+    /// `set` or a `dict_keys` keeps the inert `items` path and its existing
+    /// refusal. For `range(10**9)` this is `{{ v|first }}` -> `0` and
+    /// `{{ v|last }}` -> `999999999`, both in constant time, both Django's
+    /// own answers.
+    pub fn live_get_item(&self, index: i64) -> Option<PyResult<Option<Value>>> {
+        if self.items.is_some() {
+            return None;
+        }
+        let handle = self.live.as_ref()?;
+        Some(Python::attach(|py| match handle.bind(py).get_item(index) {
+            Ok(found) => Ok(Some(found.extract::<Value>()?)),
+            Err(e) if e.is_instance_of::<pyo3::exceptions::PyIndexError>(py) => Ok(None),
+            Err(e) => Err(e),
+        }))
+    }
+
+    /// Python's `o[start:stop:step]` over the live handle — Django's `slice`
+    /// filter, which is a bare `value[slice(*bits)]` passthrough (#2695).
+    ///
+    /// `None` when there is nothing to slice (no handle, items already
+    /// enumerated) and `Some(Err(..))` when Python raises — both of which the
+    /// caller answers with Django's `except (ValueError, TypeError,
+    /// KeyError): return value`, i.e. the input unchanged. That is what a
+    /// `generator` gets, on both engines.
+    ///
+    /// Load-bearing because the conversion now declines to enumerate a sized
+    /// sequence past [`OPAQUE_ITEM_CAP`]: without this arm
+    /// `{{ v|slice:":3" }}` over `list(range(100_001))` returned the WHOLE
+    /// carrier unchanged — 100 001 items where Django renders three.
+    pub fn live_get_slice(
+        &self,
+        start: Option<isize>,
+        stop: Option<isize>,
+        step: Option<isize>,
+    ) -> Option<PyResult<Value>> {
+        if self.items.is_some() {
+            return None;
+        }
+        let handle = self.live.as_ref()?;
+        Some(Python::attach(|py| {
+            // Built through Python's own `slice(...)` rather than
+            // `PySlice::new`, which cannot spell `None`. The difference is
+            // observable for a negative step: `o[::-1]` starts at the END
+            // while `o[0::-1]` is a single element, so substituting `0` for
+            // an absent start would answer a different question.
+            let slice = py
+                .get_type::<pyo3::types::PySlice>()
+                .call1((start, stop, step))?;
+            handle.bind(py).get_item(slice)?.extract::<Value>()
+        }))
+    }
+
+    /// The ONE spelling of "this object yielded more than the cap", shared by
+    /// the two walking sinks so their messages cannot drift (#1646).
+    fn unbounded_error(&self) -> PyErr {
+        pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "'{}' object yielded more than {} items — \
+             an unbounded iterable cannot be rendered",
+            self.type_name, OPAQUE_ITEM_CAP
+        ))
     }
 }
 

--- a/crates/djust_core/src/lib.rs
+++ b/crates/djust_core/src/lib.rs
@@ -3554,13 +3554,11 @@ fn surrogatepass_bytes_to_string(bytes: &[u8]) -> String {
 ///   both #2678's and #2695's hangs stay unfixed there. An unfixed cell
 ///   beats a wrong one.
 ///
-/// * **Asking the length did not ALREADY materialise the items**
-///   ([`len_call_already_materialised_the_items`], #2695 review). The decline
-///   exists to avoid PAYING to build items the object only DESCRIBES —
-///   `range(10**9)` states a billion and holds none of them. When the items
-///   already exist the decline saves nothing, and it is not free: the
-///   carrier it falls back to spells `str(o)` AND `repr(o)`, each of which
-///   enumerates the whole collection anyway.
+/// * **The object is not one whose declined SPELLING would be wrong**
+///   ([`len_call_already_materialised_the_items`], #2695 review). A `list`
+///   and a Django `QuerySet` are exempt at any length. That exemption is a
+///   TRADE and not a free one — read that function before assuming the
+///   decline costs those two shapes nothing.
 fn stated_len_is_too_large_to_enumerate(ob: &Bound<'_, PyAny>, len: usize) -> bool {
     len > OPAQUE_ITEM_CAP && resolve_lazy() && !len_call_already_materialised_the_items(ob)
 }
@@ -3568,16 +3566,39 @@ fn stated_len_is_too_large_to_enumerate(ob: &Bound<'_, PyAny>, len: usize) -> bo
 /// Are this object's items ALREADY built by the time its length is known?
 /// (#2695 review.)
 ///
-/// The question [`stated_len_is_too_large_to_enumerate`] has to ask before
-/// declining, because the decline's whole justification is the cost of
-/// materialising — and for these two shapes that cost is already sunk, so
-/// declining only changes the SPELLING:
+/// True for a **`list`** (it holds its elements; `len()` is O(1) and creates
+/// nothing) and for a Django **`QuerySet`** (`__len__` calls `_fetch_all()`,
+/// so the row objects are in `_result_cache` the moment the length is
+/// known). [`stated_len_is_too_large_to_enumerate`] asks it and exempts both
+/// from the decline at any length.
 ///
-/// * A **`list`** holds its elements: `len()` is O(1) and creates nothing.
-/// * A Django **`QuerySet`**: `__len__` calls `_fetch_all()`, so the row
-///   objects are in `_result_cache` the moment the length is known.
+/// **The exemption is a TRADE, and the price is NOT zero.** An earlier
+/// version of this comment said the cost was "already sunk, so declining only
+/// changes the SPELLING". That is false, by about 4 GB, and the measurement
+/// is the re-review's (#2706): an UNEVALUATED `User.objects.all()` over a
+/// real 150 000-row table, rendering `{{ v|length }}` —
 ///
-/// The shape that found it is one object wearing both hats. A 100 001-row
+/// ```text
+/// exemption ON  (as shipped)      4 650 MB peak, 13.45 s
+/// exemption OFF (decline applies)   593 MB peak,  9.74 s
+/// ```
+///
+/// `len()` sinks the cost of `_fetch_all()` — about 140 MB of row objects —
+/// and NOT the conversion of those rows into [`Value`]s, which is the other
+/// ~4 GB. So what the exemption buys is a correct spelling, and what it pays
+/// is a real per-row conversion the decline would have avoided.
+///
+/// It is taken anyway, for two reasons that are about correctness rather than
+/// cost: the declined spelling is WRONG (below), and the exempted cost is not
+/// new — `main` never declined a `list` or a `QuerySet` either
+/// (`stated_bound_is_unverifiable` required the object to have NO `__iter__`),
+/// so this restores exactly the cost those two shapes already had rather than
+/// adding one. Getting both — decline the carrier AND spell it correctly at
+/// the sink — is filed as its own change (#2717); doing it here would have
+/// meant designing a lazy QuerySet carrier inside a review fix-pass.
+///
+/// The shape that found the spelling defect is one object wearing both hats.
+/// A 100 001-row
 /// `QuerySet` in a template context is auto-serialised by
 /// `DjustTemplate.render` into a `list` of djust's own identity dicts;
 /// declining that list spelled `{{ rows }}` as

--- a/crates/djust_templates/src/filters.rs
+++ b/crates/djust_templates/src/filters.rs
@@ -1907,6 +1907,29 @@ fn apply_builtin_filter(
                     Some(n) => dictsort_by_index(items, n),
                     None => dictsort_by_key(items, sort_key),
                 },
+                // A CARRIED collection, through the same `iter_values` sink
+                // `{% for %}` / `|join` / `in` use (#2693, link N+1 of
+                // #2674). `sorted()` takes ANY iterable, so Django sorts a
+                // generator, a `map`, a `zip` and a one-shot `iter([...])`
+                // — and this arm answered `''` for every one of them,
+                // because it fell to the `_ => None` below. Routing it here
+                // consumes a one-shot handle exactly once, at whichever sink
+                // reaches it first, with the same cap semantics.
+                Value::Encoded(_) => match iter_values(value) {
+                    Ok(Some(items)) => match index {
+                        Some(n) => dictsort_by_index(&items, n),
+                        None => dictsort_by_key(&items, sort_key),
+                    },
+                    // Not iterable — `sorted()` raises `TypeError`, which
+                    // Django's own `except TypeError: return ""` catches.
+                    Ok(None) => None,
+                    // A raising `__next__`, or an unbounded walk past the
+                    // cap: propagated, as `|join` propagates it. `Some(..)`
+                    // because this function's return type is
+                    // `Option<Result<Value>>` and a bare `Err` would target
+                    // the Option.
+                    Err(err) => return Some(Err(err)),
+                },
                 // Not a sequence at all: `sorted()` raises `TypeError`.
                 _ => None,
             };

--- a/crates/djust_templates/src/filters.rs
+++ b/crates/djust_templates/src/filters.rs
@@ -3010,6 +3010,22 @@ fn apply_slice(value: &Value, slice_str: &str) -> Result<Value> {
             // the populated one (#2321).
             Ok(rebuild_like(value, picked))
         }
+        // A carrier whose items were NOT enumerated is sliced on the LIVE
+        // object, which is Django's `value[slice(*bits)]` verbatim (#2695).
+        // Without this arm the fallback below returns the WHOLE value, so
+        // `{{ v|slice:":3" }}` over a `list(range(100_001))` — which the
+        // conversion now declines to enumerate — rendered a hundred thousand
+        // items where Django renders three.
+        //
+        // Python raising is Django's own `except (ValueError, TypeError,
+        // KeyError): return value`, so a `generator` comes back unchanged on
+        // both engines.
+        Value::Encoded(e) if e.items.is_none() && e.live.is_some() => {
+            match e.live_get_slice(start, stop, step) {
+                Some(Ok(sliced)) => Ok(sliced),
+                Some(Err(_)) | None => Ok(value.clone()),
+            }
+        }
         // Django slices whatever it is handed; an int, a float, `None`, a dict
         // and a bool all raise `TypeError` and come back unchanged.
         _ => Ok(value.clone()),
@@ -6696,6 +6712,36 @@ pub(crate) fn python_getitem(
         }
         // Iterable, not subscriptable (#2340).
         Value::DictView { .. } => Err(ValueOpError::NotSubscriptable),
+        // A carrier whose items were NOT enumerated is subscripted on the
+        // LIVE object, which is Django's own `value[0]` / `value[-1]`
+        // (#2695). Before this arm every `Encoded` fell to the refusal
+        // below, so `{{ v|first }}` over a `range(10**9)` raised where
+        // Django answers `0` in constant time — and the only way to answer
+        // it from carried data would have been to enumerate a billion items
+        // at the conversion, which is the hang the conversion now declines.
+        //
+        // A `set`, a `frozenset` and a `dict_keys` carry `items` and keep
+        // the refusal: they are iterable and genuinely not subscriptable, so
+        // this arm must not claim them.
+        Value::Encoded(e) if e.items.is_none() && e.live.is_some() => {
+            match e.live_get_item(index) {
+                // `IndexError` — Django's `except IndexError: return ""`.
+                Some(Ok(found)) => Ok(found),
+                Some(Err(err)) => Err(pyo3::Python::attach(|py| {
+                    if err.is_instance_of::<pyo3::exceptions::PyKeyError>(py) {
+                        ValueOpError::MissingKey(index)
+                    } else {
+                        // `TypeError: 'generator' object is not
+                        // subscriptable` is the shape that reaches here, and
+                        // it is the one this variant already spells. Anything
+                        // rarer is reported the same way rather than given a
+                        // variant no other caller can produce.
+                        ValueOpError::NotSubscriptable
+                    }
+                })),
+                None => Err(ValueOpError::NotSubscriptable),
+            }
+        }
         _ => Err(ValueOpError::NotSubscriptable),
     }
 }

--- a/crates/djust_templates/src/renderer.rs
+++ b/crates/djust_templates/src/renderer.rs
@@ -4691,8 +4691,18 @@ fn evaluate_condition(condition: &str, context: &Context) -> Result<bool> {
                 // propagated, which contradicted the comment six lines above
                 // it — the operand that used to reach `_ => false` now had a
                 // path that raised (PR #2691 review).
+                //
+                // Asked of PYTHON first when the type defines `__contains__`
+                // (#2695): `987654321 in range(10**9)` is arithmetic there
+                // and nine hundred million element comparisons here, so the
+                // walk below is the fallback for objects Python itself would
+                // walk — which is also what keeps the one-shot behaviour
+                // above exactly as described.
                 Value::Encoded(ref e) if e.items.is_none() && e.live.is_some() => {
-                    match e.consume_live_match(|item| values_equal(&needle, item)) {
+                    match e
+                        .live_contains(&needle)
+                        .or_else(|| e.consume_live_match(|item| values_equal(&needle, item)))
+                    {
                         Some(Ok(found)) => Ok(found),
                         Some(Err(_)) | None => Ok(false),
                     }

--- a/python/tests/test_engine_followups_2674_2670_2678_2657.py
+++ b/python/tests/test_engine_followups_2674_2670_2678_2657.py
@@ -290,8 +290,9 @@ class TestAStatedBoundIsTrustedOnlyToTheCap2678:
             # passing: it terminates, so it was not the shape THIS fix bounds
             # and putting it in a context still materialised it. That was
             # closed separately by #2695, which moved the conversion's bound
-            # onto the stated length for every sized sequence and gave the
-            # SINKS their own termination rule — see
+            # onto the stated length for every sized sequence whose items do
+            # not already exist, and gave the SINKS their own termination
+            # rule — see
             # `test_sized_sequence_conversion_2695_2693.py`. Its cells live
             # there rather than here, so this table stays the liar's.
             #

--- a/python/tests/test_engine_followups_2674_2670_2678_2657.py
+++ b/python/tests/test_engine_followups_2674_2670_2678_2657.py
@@ -26,6 +26,7 @@ so a future divergence in either direction reddens.
 
 from __future__ import annotations
 
+import collections
 import itertools
 import re
 import shutil
@@ -324,14 +325,27 @@ class TestAStatedBoundIsTrustedOnlyToTheCap2678:
         `TestATerminatingCollectionPastTheCapIsUntouched` below).
 
         So the carried set is now "anything whose stated length exceeds the
-        cap", the liar included, and nothing under it moved.
+        cap AND has not already materialised its items" — the liar and a
+        `range` included, a `list` and a `QuerySet` excluded, because for
+        those two the decline saves nothing (a `list` holds its elements
+        already; `QuerySet.__len__` calls `_fetch_all()`). See
+        `len_call_already_materialised_the_items` and, for the content change
+        that exemption prevents,
+        `TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap` in
+        `test_sized_sequence_conversion_2695_2693.py`.
         """
         assert _rust.crosses_as_encoded(Liar()) is True
-        assert _rust.crosses_as_encoded(list(range(100_001))) is True
         assert _rust.crosses_as_encoded(range(10**9)) is True
+        # A `deque` past the cap DESCRIBES nothing it has not built, but
+        # nothing about `len(deque)` builds it either — it is the ordinary
+        # sized-sequence case, and it is carried.
+        assert _rust.crosses_as_encoded(collections.deque(range(100_001))) is True
+        # Already materialised: exempt at any length (#2695 review).
+        assert _rust.crosses_as_encoded(list(range(100_001))) is False
         # Under the cap: unchanged, on both the sized and the ordinary shape.
         assert _rust.crosses_as_encoded(list(range(10))) is False
         assert _rust.crosses_as_encoded(range(10)) is False
+        assert _rust.crosses_as_encoded(collections.deque(range(100_000))) is False
         assert _rust.crosses_as_encoded(list(range(100_000))) is False
 
 

--- a/python/tests/test_engine_followups_2674_2670_2678_2657.py
+++ b/python/tests/test_engine_followups_2674_2670_2678_2657.py
@@ -286,16 +286,13 @@ class TestAStatedBoundIsTrustedOnlyToTheCap2678:
         "src,ctx",
         [
             # NOT `range(10**9)`, the "honest builtin twin" #2678 mentions in
-            # passing. That one terminates, so it is not the shape this fix
-            # bounds (see `stated_bound_is_unverifiable`), and putting it in a
-            # context still materialises it exactly as on main — a
-            # pre-existing cost, unchanged here and NOT fixed by this PR.
-            # It was in this table once and passed only because the first
-            # version of the fix capped on LENGTH, which is the same
-            # over-reach that broke `{% for %}` over a 100,001-item list.
-            # Fixing it means not materialising ANY sized sequence at
-            # conversion, which changes `|first`, `|slice` and `in` for every
-            # collection in the codebase: its own change, tracked separately.
+            # passing: it terminates, so it was not the shape THIS fix bounds
+            # and putting it in a context still materialised it. That was
+            # closed separately by #2695, which moved the conversion's bound
+            # onto the stated length for every sized sequence and gave the
+            # SINKS their own termination rule — see
+            # `test_sized_sequence_conversion_2695_2693.py`. Its cells live
+            # there rather than here, so this table stays the liar's.
             #
             # Still a plain list under the cap — the fix is a shape rule, not
             # a change of carrier for ordinary sequences.
@@ -313,19 +310,29 @@ class TestAStatedBoundIsTrustedOnlyToTheCap2678:
         out = _render_in_child("{{ v }}", "liar", timeout=25)
         assert "Liar object at" in out, out
 
-    def test_only_the_unverifiable_shape_is_bounded(self):
-        """The scope of the cap, stated as the two shapes it separates.
+    def test_the_conversion_bound_is_the_stated_length(self):
+        """The scope of the cap, as #2695 left it.
 
-        `Liar` states `10**9` and has no `__iter__`, so nothing can end its
-        walk short of paying it — it is carried. A `list` of the same length
-        class states a length its own iterator honours, so it is enumerated
-        exactly as before, at any size. The first version of this fix keyed on
-        the NUMBER and claimed both, which turned `{% for %}` over a
-        100,001-item list into a `RuntimeError` (PR #2691 review)."""
+        This fix keyed on TWO conditions — past the cap AND no `__iter__` —
+        because its first version keyed on the number alone and turned
+        `{% for %}` over a 100,001-item list into a `RuntimeError` (PR #2691
+        review). #2695 showed the number really is the conversion's axis, and
+        that the earlier version's mistake was applying it at the SINK too:
+        a `list` past the cap is carried here and still renders every item,
+        because `Encoded::live_walk_terminates` asks the other question
+        (`{% for %}` over 100 001 items is pinned by
+        `TestATerminatingCollectionPastTheCapIsUntouched` below).
+
+        So the carried set is now "anything whose stated length exceeds the
+        cap", the liar included, and nothing under it moved.
+        """
         assert _rust.crosses_as_encoded(Liar()) is True
-        assert _rust.crosses_as_encoded(list(range(100_001))) is False
-        assert _rust.crosses_as_encoded(range(10**9)) is False
+        assert _rust.crosses_as_encoded(list(range(100_001))) is True
+        assert _rust.crosses_as_encoded(range(10**9)) is True
+        # Under the cap: unchanged, on both the sized and the ordinary shape.
         assert _rust.crosses_as_encoded(list(range(10))) is False
+        assert _rust.crosses_as_encoded(range(10)) is False
+        assert _rust.crosses_as_encoded(list(range(100_000))) is False
 
 
 #: A collection ONE past `OPAQUE_ITEM_CAP` that genuinely terminates. This is

--- a/python/tests/test_escape_chain_and_sequence_filters_2281_2283.py
+++ b/python/tests/test_escape_chain_and_sequence_filters_2281_2283.py
@@ -522,7 +522,16 @@ def test_the_iteration_sink_has_exactly_the_callers_it_claims() -> None:
     # the pin reported that a filter had stopped routing through the sink when
     # it had not. A delimiter cannot drift that way, and it is strictly TIGHTER
     # than a window: it can never reach into a NEIGHBOURING arm's call either.
-    arm_starts = [(m.start(), m.group(1)) for m in re.finditer(r'\n        "(\w+)" =>', body)]
+    # A MULTI-NAME arm (`"dictsort" | "dictsortreversed" =>`) is an arm start
+    # too. It was not matched until #2693 routed `dictsort` through the sink,
+    # and the effect was the drift this pin's own comments warn about one more
+    # time: the call landed inside the window of the previous single-name arm,
+    # so the pin reported `time` as a caller of `iter_values`. The arm is
+    # keyed on its FIRST name, which is the one the assertions below spell.
+    arm_starts = [
+        (m.start(), m.group(1))
+        for m in re.finditer(r'\n        "(\w+)"(?:\s*\|\s*"\w+")* =>', body)
+    ]
     raw: set[str] = set()
     wrapped: set[str] = set()
     subscripted: set[str] = set()
@@ -535,9 +544,14 @@ def test_the_iteration_sink_has_exactly_the_callers_it_claims() -> None:
             wrapped.add(name)
         if "python_getitem(value" in arm_body:
             subscripted.add(name)
-    # The RAW sink, for the one filter that must FAIL SOFT: Django's `join` has
-    # `except TypeError: return value`, so it needs the `None` rather than a raise.
-    assert raw == {"join"}, raw
+    # The RAW sink, for the filters that must FAIL SOFT: Django's `join` has
+    # `except TypeError: return value` and its `dictsort` /
+    # `dictsortreversed` have `except (TypeError, VariableDoesNotExist):
+    # return ""`, so both need the `None` rather than a raise. `dictsort`
+    # joined them in #2693 — it had iteration of its OWN and so answered
+    # `''` for every carried collection, which is the omission the sink
+    # exists to prevent.
+    assert raw == {"join", "dictsort"}, raw
     # The WRAPPED sink, for the three whose Django bodies have no `except` at
     # all — `python_iter` is `iter_values` plus the name of the exception Python
     # raises where it answers `None` (#2451).

--- a/python/tests/test_falsy_with_attributes_2478.py
+++ b/python/tests/test_falsy_with_attributes_2478.py
@@ -1233,10 +1233,15 @@ class TestThePreFixTableIsNOTVacuous:
                 "answers — either the fix regressed or PRE_FIX is recording "
                 "the CURRENT build"
             )
-        # 131 for the four shapes #2478 claimed, plus 32 for the fifth that
+        # 132 for the four shapes #2478 claimed, plus 32 for the fifth that
         # #2477/#2489 added — `LenTwoBoolFalseWithAttrs`, which moved off the
         # `Value::Object` of its attributes and onto the carrier.
-        assert sum(len(v) for v in moved.values()) == 163, (
+        #
+        # 131 until #2693 routed `dictsort` through `iter_values`: that moved
+        # one more cell, `{{ p|dictsort:'a' }}` on `LenZeroWithAttrsAndIter`,
+        # from `''` to `[]` — which is Django's own answer for it, verified
+        # rather than assumed.
+        assert sum(len(v) for v in moved.values()) == 164, (
             "the total cell movement changed; re-measure with "
             "`scratch/sweep_2478.py` before editing this number"
         )

--- a/python/tests/test_sized_sequence_conversion_2695_2693.py
+++ b/python/tests/test_sized_sequence_conversion_2695_2693.py
@@ -1,0 +1,858 @@
+"""A sized sequence is no longer materialised at conversion (#2695), and
+``dictsort`` consumes a live handle (#2693).
+
+#2678 stopped the conversion from enumerating an object whose stated
+``__len__`` its ``__getitem__`` could never reach. It scoped the decline to
+that ONE shape — an object with no ``__iter__`` — because its first version
+had capped on the stated length alone and regressed every honest collection
+past the cap. So ``range(10**9)``, which terminates, kept being materialised
+into a billion ``Value``s the moment it entered a context, and
+``{{ v.0 }}`` / ``{{ v|length }}`` / ``{{ v }}`` / ``{% for %}`` all failed to
+return — measured identical on ``main`` and on #2691's head.
+
+Django never enumerates at binding time. ``{{ v.0 }}`` is one
+``__getitem__``, ``{{ v|length }}`` is ``len(v)``, ``{{ v }}`` is ``str(v)``,
+``|first`` is ``value[0]``, ``|last`` is ``value[-1]``, ``|slice`` is
+``value[slice(*bits)]`` and ``in`` is Python's own ``in``. So the fix is not a
+cap, it is the same lazy carrier ADR-027 already has: the conversion declines
+to enumerate past ``OPAQUE_ITEM_CAP`` on EITHER axis, and each sink reads what
+it needs off the live handle.
+
+The bound then moves to where it belongs. The conversion asks "is the stated
+length too large to spend HERE"; the SINKS ask "can this walk end at all"
+(``Encoded::live_walk_terminates``) — which is why ``list(range(100_001))``
+still renders every item at ``{% for %}`` while #2678's liar still raises.
+
+Every claim above is checked against REAL Django 5.2, in a subprocess, on both
+settings of ``template_resolve_lazy``: #2691 was reverted once for verifying
+only the four sinks that never need the items.
+
+Any cell where djust does not answer Django's string is either in
+``LAZY_PARITY`` / ``EAGER_PARITY`` (it agrees) or it is not — and the two sets
+are pinned, so adding a divergence and removing one are equally loud.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+
+import pytest
+
+# --------------------------------------------------------------------------
+# The differential child.
+#
+# One process per (engine, template_resolve_lazy); it renders the cells named
+# on argv and writes one JSON line per cell, FLUSHED — so a parent that has to
+# kill it still knows every answer it did produce, and which cell it died on.
+# --------------------------------------------------------------------------
+_CHILD = textwrap.dedent(
+    '''
+    import array, collections, json, re, sys
+    import django
+    from django.conf import settings
+
+    ENGINE, LAZY, CELLS = sys.argv[1], sys.argv[2] == "lazy", json.loads(sys.argv[3])
+
+    settings.configure(
+        SECRET_KEY="x", DEBUG=False, USE_TZ=False,
+        TEMPLATES=[{
+            "BACKEND": (
+                "django.template.backends.django.DjangoTemplates"
+                if ENGINE == "django"
+                else "djust.template_backend.DjustTemplateBackend"
+            ),
+            "NAME": "e", "DIRS": [], "APP_DIRS": False, "OPTIONS": {},
+        }],
+        LIVEVIEW_CONFIG={"template_resolve_lazy": LAZY},
+    )
+    django.setup()
+    from django.template import engines
+    ENG = engines["e"]
+
+    BIG = 10**9
+
+
+    class Liar:
+        """#2678: no ``__iter__``, and a stated ``__len__`` its
+        ``__getitem__`` can never reach."""
+
+        def __len__(self):
+            return BIG
+
+        def __getitem__(self, k):
+            return "x"
+
+        def __str__(self):
+            return "liar"
+
+
+    class QuerySetShape:
+        """Sized, re-iterable, subscriptable, with a result cache."""
+
+        def __init__(self, rows):
+            self._result_cache = list(rows)
+
+        def __iter__(self):
+            return iter(self._result_cache)
+
+        def __len__(self):
+            return len(self._result_cache)
+
+        def __getitem__(self, k):
+            return self._result_cache[k]
+
+
+    class LyingLength:
+        """A stated `__len__` its own `__iter__` never honours — the shape
+        `Encoded::live_walk_terminates` cannot see through. NOT in the matrix;
+        used only by `TestALyingLengthIsUnfixedRatherThanNewlyBroken`."""
+
+        def __init__(self, stated):
+            self._stated = stated
+
+        def __len__(self):
+            return self._stated
+
+        def __iter__(self):
+            import itertools
+
+            return itertools.count()
+
+        def __str__(self):
+            return "lying"
+
+
+    D = [{"k": 2}, {"k": 1}]
+
+    SHAPES = {
+        "lying_len_small": lambda: LyingLength(3),
+        "lying_len_big": lambda: LyingLength(BIG),
+        "range_big": lambda: range(BIG),
+        "range_small": lambda: range(3),
+        "list": lambda: [3, 1, 2],
+        "list_big": lambda: list(range(100_001)),
+        "set": lambda: {3, 1, 2},
+        "frozenset": lambda: frozenset({3, 1, 2}),
+        "dict_keys": lambda: {3: "a", 1: "b", 2: "c"}.keys(),
+        "deque": lambda: collections.deque([3, 1, 2]),
+        "array": lambda: array.array("i", [3, 1, 2]),
+        "bytes": lambda: b"\\x03\\x01\\x02",
+        "tuple": lambda: (3, 1, 2),
+        "generator": lambda: (x for x in [3, 1, 2]),
+        "map": lambda: map(int, ["3", "1", "2"]),
+        "zip": lambda: zip([3, 1], [2, 0]),
+        "queryset": lambda: QuerySetShape([3, 1, 2]),
+        "liar": lambda: Liar(),
+        "dict_list": lambda: list(D),
+        "dict_gen": lambda: (d for d in D),
+        "dict_iter": lambda: iter(list(D)),
+    }
+
+    SINKS = {
+        "for": "{% for x in v %}{{ x }},{% endfor %}",
+        "join": '{{ v|join:"," }}',
+        "length": "{{ v|length }}",
+        "index0": "{{ v.0 }}",
+        "first": "{{ v|first }}",
+        "last": "{{ v|last }}",
+        "slice": '{{ v|slice:":3" }}',
+        "in_hit": "{% if 1 in v %}Y{% else %}N{% endif %}",
+        "in_miss": "{% if 987654321 in v %}Y{% else %}N{% endif %}",
+        "dictsort": '{{ v|dictsort:"k" }}',
+        "dictsortreversed": '{{ v|dictsortreversed:"k" }}',
+        "str": "{{ v }}",
+        # NOT part of the matrix — the grid hands every cell a FRESH object
+        # by design, and this one asks what happens when it does not.
+        "consume_once": '{{ v|dictsort:"k" }}|{% for x in v %}{{ x }}{% endfor %}',
+    }
+
+
+    def scrub(text):
+        # A repr carrying a heap address differs between two processes for
+        # reasons that have nothing to do with the engines.
+        return re.sub(r"0x[0-9a-f]+", "0xADDR", text)
+
+
+    for shape, sink in CELLS:
+        try:
+            # A FRESH object per cell: a one-shot iterator consumed by one
+            # sink would otherwise decide the next one's answer.
+            out = ENG.from_string(SINKS[sink]).render({"v": SHAPES[shape]()})
+            if len(out) > 400:
+                out = "<%d chars>%s" % (len(out), out[:80])
+            rec = {"cell": [shape, sink], "ok": True, "out": scrub(out)}
+        except Exception as exc:  # noqa: BLE001 - the differential records it
+            rec = {
+                "cell": [shape, sink],
+                "ok": False,
+                "out": scrub("%s: %s" % (type(exc).__name__, exc))[:300],
+            }
+        sys.stdout.write(json.dumps(rec) + "\\n")
+        sys.stdout.flush()
+    '''
+)
+
+SHAPES = (
+    "range_big",
+    "range_small",
+    "list",
+    "list_big",
+    "set",
+    "frozenset",
+    "dict_keys",
+    "deque",
+    "array",
+    "bytes",
+    "tuple",
+    "generator",
+    "map",
+    "zip",
+    "queryset",
+    "liar",
+    "dict_list",
+    "dict_gen",
+    "dict_iter",
+)
+
+SINKS = (
+    "for",
+    "join",
+    "length",
+    "index0",
+    "first",
+    "last",
+    "slice",
+    "in_hit",
+    "in_miss",
+    "dictsort",
+    "dictsortreversed",
+    "str",
+)
+
+#: The sinks that need EVERY item. Over a stated billion neither engine comes
+#: back from these — Django because ``sorted()`` / ``list()`` / the joined
+#: output is a billion long, djust because ``consume_live_items`` walks the
+#: same billion. Measured with a 60 s deadline and a 4 GiB ceiling on both:
+#:
+#: ===============  ======================  ======================
+#: cell             Django 5.2              djust (lazy)
+#: ===============  ======================  ======================
+#: ``for``          60 s, no output         >4 GiB after 33 s
+#: ``join``         >4 GiB after 32 s       >4 GiB after 12 s
+#: ``dictsort``     >4 GiB after 1 s        >4 GiB after 12 s
+#: ``dictsortrev``  >4 GiB after 1 s        >4 GiB after 12 s
+#: ===============  ======================  ======================
+#:
+#: So they are excluded from the batch grid (a child that never exits answers
+#: nothing) and asserted separately by
+#: :class:`TestNeitherEngineReturnsFromAWalkOfAStatedBillion`.
+WALKING_SINKS = ("for", "join", "dictsort", "dictsortreversed")
+
+#: Django walks the liar's legacy sequence protocol forever; djust raises at
+#: the cap (#2678) for the four walking sinks, and its ``{% if %}`` fails soft
+#: for the two ``in`` cells. Excluded from Django's batch for the same reason.
+LIAR_NON_TERMINATING_FOR_DJANGO = WALKING_SINKS + ("in_hit", "in_miss")
+
+_DEADLINE = float(os.environ.get("DJUST_2695_DEADLINE", "45"))
+_RSS_CEILING_KB = 1_500_000
+
+
+def _rss_kb(pid: int) -> int:
+    try:
+        out = subprocess.run(
+            ["ps", "-o", "rss=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+        return int(out) if out else 0
+    except Exception:  # noqa: BLE001 - a dead pid is just "no memory"
+        return 0
+
+
+def _drain(stream, sink: list[str]) -> None:
+    for line in stream:
+        sink.append(line)
+
+
+def _render_in_child(
+    engine: str,
+    lazy: bool,
+    cells: list[tuple[str, str]],
+    deadline: float = _DEADLINE,
+) -> tuple[dict[tuple[str, str], str], str | None]:
+    """Render ``cells`` in a subprocess; answer what it produced and why it
+    stopped.
+
+    The repo's ``_render_in_child`` pattern
+    (``test_value_conversion_crashes_2555_2624_2572.py``) with a second axis:
+    a cell that fails to return here does so by ALLOCATING — a billion
+    ``Value``s, or a billion-element joined string — so the child is watched
+    on memory as well as on the clock. macOS refuses
+    ``setrlimit(RLIMIT_AS)``, hence the poll.
+
+    Returns ``(answers, stop_reason)``; ``stop_reason`` is ``None`` on a clean
+    exit, else ``"HANG"`` / ``"RUNAWAY-MEMORY"`` / a crash description, and
+    the cell it died on is the first of ``cells`` missing from ``answers``.
+    """
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            _CHILD,
+            engine,
+            "lazy" if lazy else "eager",
+            json.dumps([list(c) for c in cells]),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    lines: list[str] = []
+    errs: list[str] = []
+    threads = [
+        threading.Thread(target=_drain, args=(proc.stdout, lines), daemon=True),
+        threading.Thread(target=_drain, args=(proc.stderr, errs), daemon=True),
+    ]
+    for t in threads:
+        t.start()
+    began = time.monotonic()
+    reason: str | None = None
+    while proc.poll() is None:
+        if time.monotonic() - began > deadline:
+            reason = "HANG"
+            break
+        if _rss_kb(proc.pid) > _RSS_CEILING_KB:
+            reason = "RUNAWAY-MEMORY"
+            break
+        time.sleep(0.1)
+    if reason is not None:
+        proc.kill()
+    proc.wait()
+    for t in threads:
+        t.join(timeout=5)
+    answers: dict[tuple[str, str], str] = {}
+    for line in lines:
+        if line.strip():
+            rec = json.loads(line)
+            answers[tuple(rec["cell"])] = rec["out"]
+    if reason is None and proc.returncode != 0:
+        reason = f"CRASH rc={proc.returncode} {''.join(errs).strip()[-200:]}"
+    return answers, reason
+
+
+def _batch_cells(engine: str, lazy: bool) -> list[tuple[str, str]]:
+    """Every cell that TERMINATES on this column, so one child can answer all
+    of them."""
+    cells = []
+    for shape in SHAPES:
+        for sink in SINKS:
+            if shape == "range_big" and sink in WALKING_SINKS:
+                continue
+            if engine == "django" and shape == "liar":
+                if sink in LIAR_NON_TERMINATING_FOR_DJANGO:
+                    continue
+            if engine == "djust" and not lazy and shape in ("range_big", "liar"):
+                # The eager escape hatch has no live handle to read an object
+                # through, so it keeps enumerating in full and both #2678's
+                # and #2695's hangs stay unfixed there — deliberately, since
+                # a decline would land on ``str(o)`` and answer ``{{ v.0 }}``
+                # with a bracket. Asserted by
+                # ``TestTheEagerHatchStillEnumerates``.
+                continue
+            cells.append((shape, sink))
+    return cells
+
+
+@pytest.fixture(scope="module")
+def grids() -> dict[str, dict[tuple[str, str], str]]:
+    out = {}
+    for key, engine, lazy in (
+        ("django", "django", True),
+        ("lazy", "djust", True),
+        ("eager", "djust", False),
+    ):
+        answers, reason = _render_in_child(engine, lazy, _batch_cells(engine, lazy))
+        assert reason is None, (
+            f"the {key} grid did not finish: {reason}. It stopped at "
+            f"{[c for c in _batch_cells(engine, lazy) if c not in answers][:1]}"
+        )
+        out[key] = answers
+    return out
+
+
+# --------------------------------------------------------------------------
+# The parity pins.
+#
+# A cell is in the set when djust's rendered string EQUALS live Django's for
+# the same input. Pinned as a set rather than as expected strings so a Django
+# patch release that changes a repr does not churn the file, while a djust
+# change that gains or loses parity anywhere is loud in both directions.
+# --------------------------------------------------------------------------
+
+
+def _cells(shape: str, *sinks: str) -> set[str]:
+    return {f"{shape}|{sink}" for sink in sinks}
+
+
+_ALL_SINKS_AGREE = (
+    "list",
+    "list_big",
+    "tuple",
+    "dict_list",
+)
+
+#: Cells where djust (``template_resolve_lazy`` ON, the shipped default)
+#: renders exactly what Django 5.2 renders.
+LAZY_PARITY: frozenset[str] = frozenset(
+    {f"{shape}|{sink}" for shape in _ALL_SINKS_AGREE for sink in SINKS}
+    # #2695: every sink a stated billion can answer without a walk.
+    | _cells(
+        "range_big",
+        "length",
+        "index0",
+        "first",
+        "last",
+        "in_hit",
+        "in_miss",
+        "str",
+    )
+    | _cells("liar", "length", "index0", "first", "last", "slice", "str")
+    | _cells(
+        "range_small",
+        *(s for s in SINKS if s not in ("slice", "str")),
+    )
+    | _cells("set", *(s for s in SINKS if s not in ("first", "last")))
+    | _cells("frozenset", *(s for s in SINKS if s not in ("first", "last")))
+    | _cells("dict_keys", *(s for s in SINKS if s not in ("first", "last")))
+    | _cells("deque", *(s for s in SINKS if s not in ("slice", "str")))
+    | _cells("array", *(s for s in SINKS if s not in ("slice", "str")))
+    | _cells("bytes", *(s for s in SINKS if s not in ("slice", "str")))
+    | _cells("queryset", *(s for s in SINKS if s != "str"))
+    # #2693: a one-shot iterator now answers ``dictsort`` too.
+    | _cells("generator", *(s for s in SINKS if s not in ("first", "last")))
+    | _cells("map", *(s for s in SINKS if s not in ("first", "last")))
+    | _cells("zip", *(s for s in SINKS if s not in ("first", "last")))
+    | _cells("dict_gen", *(s for s in SINKS if s not in ("first", "last")))
+    | _cells("dict_iter", *(s for s in SINKS if s not in ("first", "last")))
+)
+
+#: The divergences that remain, each with the reason it is out of #2695's and
+#: #2693's scope. Pinned as prose next to the set above rather than as a
+#: second data structure, but grouped here so a reader does not have to
+#: subtract two frozensets by hand:
+#:
+#: * ``{first,last}`` over a ``set`` / ``frozenset`` / ``dict_keys`` /
+#:   generator / ``map`` / ``zip`` / one-shot iterator — BOTH engines raise,
+#:   and djust's message quotes Django's sentence verbatim
+#:   (``TypeError: 'set' object is not subscriptable``); only the exception
+#:   CLASS wrapping it differs. Pre-existing.
+#: * ``{slice,str}`` over ``range``/``deque``/``array``/``bytes``, and ``str``
+#:   over the QuerySet shape — those cross as a ``Value::List``, so
+#:   ``{{ v }}`` is ``[3, 1, 2]`` where Django renders ``deque([3, 1, 2])``.
+#:   A container-spelling divergence that predates both issues and is
+#:   independent of the cap: ``range(3)`` has it too.
+#: * ``range_big|slice`` is that same cell: the live slice answers Python's
+#:   ``range(0, 3)``, which then crosses as a list exactly as ``range(3)``
+#:   does. It is the class above, not a new one.
+
+
+#: Cells where djust on the EAGER escape hatch renders exactly Django's
+#: string. The hatch has no live handle, so every carrier-answered cell above
+#: is missing here: a one-shot iterator falls to ``str(o)`` and ``{% for %}``
+#: walks the repr CHARACTER by character. That is #2613/#2674's documented
+#: non-fix, restated by measurement rather than assumed.
+EAGER_PARITY: frozenset[str] = frozenset(
+    {f"{shape}|{sink}" for shape in _ALL_SINKS_AGREE for sink in SINKS}
+    | _cells("range_small", *(s for s in SINKS if s not in ("slice", "str")))
+    | _cells("set", *(s for s in SINKS if s not in ("first", "last")))
+    | _cells("frozenset", *(s for s in SINKS if s not in ("first", "last")))
+    | _cells("dict_keys", *(s for s in SINKS if s not in ("first", "last")))
+    | _cells("deque", *(s for s in SINKS if s not in ("slice", "str")))
+    | _cells("array", *(s for s in SINKS if s not in ("slice", "str")))
+    | _cells("bytes", *(s for s in SINKS if s not in ("slice", "str")))
+    | _cells("queryset", *(s for s in SINKS if s != "str"))
+    # A one-shot iterator has no handle here, so it keeps the terminal
+    # ``str(o)`` and `{% for %}` walks the REPR character by character. The
+    # cells that still agree do so because BOTH engines answer nothing:
+    # ``dictsort`` over ints is a `TypeError` on Django too, and ``in`` fails
+    # soft. `dict_gen` / `dict_iter` lose even those two, because Django
+    # genuinely sorts them and the hatch cannot.
+    | _cells("generator", "in_miss", "dictsort", "dictsortreversed", "str")
+    | _cells("map", "in_miss", "dictsort", "dictsortreversed", "str")
+    | _cells("zip", "in_hit", "in_miss", "dictsort", "dictsortreversed", "str")
+    | _cells("dict_gen", "in_hit", "in_miss", "str")
+    | _cells("dict_iter", "in_hit", "in_miss", "str")
+)
+
+
+class TestTheDjangoDifferential:
+    """Every sink x every shape, against real Django 5.2, on both settings."""
+
+    def test_lazy_parity_set_is_exactly_what_is_pinned(self, grids) -> None:
+        django, lazy = grids["django"], grids["lazy"]
+        agree = {
+            f"{shape}|{sink}"
+            for (shape, sink), answer in lazy.items()
+            if (shape, sink) in django and django[(shape, sink)] == answer
+        }
+        gained = agree - LAZY_PARITY
+        lost = LAZY_PARITY - agree
+        assert not lost, (
+            "these cells USED to answer Django's string and no longer do: "
+            + json.dumps(
+                {
+                    c: {
+                        "django": django[tuple(c.split("|"))],
+                        "djust": lazy.get(tuple(c.split("|")), "<not rendered>"),
+                    }
+                    for c in sorted(lost)
+                },
+                indent=1,
+            )
+        )
+        assert not gained, (
+            "these cells now agree with Django and are not in LAZY_PARITY — "
+            "add them, so the next regression is loud: " + ", ".join(sorted(gained))
+        )
+
+    def test_eager_parity_set_is_exactly_what_is_pinned(self, grids) -> None:
+        django, eager = grids["django"], grids["eager"]
+        agree = {
+            f"{shape}|{sink}"
+            for (shape, sink), answer in eager.items()
+            if (shape, sink) in django and django[(shape, sink)] == answer
+        }
+        assert agree == EAGER_PARITY, {
+            "lost": sorted(EAGER_PARITY - agree),
+            "gained": sorted(agree - EAGER_PARITY),
+        }
+
+    def test_the_grid_really_covered_every_sink_and_shape(self, grids) -> None:
+        """The differential is only evidence if it ran. #2691 was reverted for
+        verifying four sinks; a silently shrunken matrix would repeat that."""
+        seen_shapes = {shape for shape, _ in grids["lazy"]}
+        seen_sinks = {sink for _, sink in grids["lazy"]}
+        assert seen_shapes == set(SHAPES)
+        assert seen_sinks == set(SINKS)
+        assert len(grids["lazy"]) == len(SHAPES) * len(SINKS) - len(WALKING_SINKS)
+
+
+class TestASizedSequenceIsNotMaterialisedAtConversion:
+    """#2695 — the reproducer, cell by cell, with Django's answer inline."""
+
+    @pytest.mark.parametrize(
+        ("sink", "expected"),
+        [
+            ("length", "1000000000"),
+            ("index0", "0"),
+            ("first", "0"),
+            ("last", "999999999"),
+            ("in_hit", "Y"),
+            ("in_miss", "Y"),
+            ("str", "range(0, 1000000000)"),
+        ],
+    )
+    def test_range_of_a_billion_answers_django_s_value(self, sink: str, expected: str) -> None:
+        """Each of these ran away in memory on ``main`` and on #2691's head.
+
+        In a child with a deadline because the failure mode is a non-return:
+        an in-process assertion cannot report "did not hang".
+        """
+        answers, reason = _render_in_child("djust", True, [("range_big", sink)], deadline=20)
+        assert reason is None, f"{sink} over range(10**9) did not return: {reason}"
+        assert answers[("range_big", sink)] == expected
+
+    def test_a_list_past_the_cap_still_renders_every_item(self) -> None:
+        """The regression #2678's second version was written to avoid, and the
+        reason the sink keeps its own termination rule rather than inheriting
+        the conversion's cap."""
+        answers, reason = _render_in_child(
+            "djust",
+            True,
+            [("list_big", "for"), ("list_big", "join"), ("list_big", "length")],
+            deadline=30,
+        )
+        assert reason is None, reason
+        assert answers[("list_big", "length")] == "100001"
+        # Every one of the 100 001 items, in order, with the separator each
+        # sink uses — `{% for %}` appends a comma per item, `|join` puts one
+        # BETWEEN them, hence the 100 001-character difference.
+        # 488 896 digits for 0..100000, plus one comma per item for
+        # `{% for %}` and one BETWEEN items for `|join`.
+        assert answers[("list_big", "for")].startswith("<588897 chars>0,1,2,3,")
+        assert answers[("list_big", "join")].startswith("<588896 chars>0,1,2,3,")
+
+    def test_a_list_past_the_cap_slices_to_three_items(self) -> None:
+        """``|slice`` had to grow a live arm with the conversion change: the
+        fallback returns the value UNCHANGED, so a carried 100 001-item list
+        rendered all of them where Django renders three."""
+        answers, reason = _render_in_child("djust", True, [("list_big", "slice")], deadline=20)
+        assert reason is None, reason
+        assert answers[("list_big", "slice")] == "[0, 1, 2]"
+
+    def test_the_liar_still_raises_rather_than_walking_forever(self) -> None:
+        """#2678 must survive #2695. The liar states a billion and has no
+        ``__iter__``, so its walk cannot end and the sink keeps the cap."""
+        answers, reason = _render_in_child("djust", True, [("liar", "for")], deadline=20)
+        assert reason is None, f"the liar walked instead of raising: {reason}"
+        assert "yielded more than 100000 items" in answers[("liar", "for")]
+
+
+class TestNeitherEngineReturnsFromAWalkOfAStatedBillion:
+    """The cells this fix does NOT close, with the proof they are Django's
+    behaviour rather than djust's limitation."""
+
+    @pytest.mark.parametrize("sink", WALKING_SINKS)
+    def test_django_does_not_return_either(self, sink: str) -> None:
+        for engine in ("django", "djust"):
+            answers, reason = _render_in_child(engine, True, [("range_big", sink)], deadline=8)
+            assert reason in ("HANG", "RUNAWAY-MEMORY"), (
+                f"{engine} ANSWERED {sink} over range(10**9) with "
+                f"{answers.get(('range_big', sink))!r} — if it now terminates, "
+                f"djust's non-return is no longer parity and this is a real gap"
+            )
+
+
+class TestALyingLengthIsUnfixedRatherThanNewlyBroken:
+    """`Encoded::live_walk_terminates` asks the two questions CPython lets it
+    ask — "did `len(o)` answer" and "does the type have `__iter__`" — and a
+    class that states a length its own iterator never honours passes both.
+
+    That is a limit of the claim, so it is measured rather than asserted. It
+    is not a regression: `opaque_value`'s enumeration has no cap either, so
+    the same object failed to return at the CONVERSION before #2695 — which
+    is why the SMALL variant, whose length is under the cap and which
+    therefore still takes the conversion path, is unchanged here. Moving the
+    walk to the sink makes the big variant strictly better: only a template
+    that asks for every item pays it.
+    """
+
+    def test_a_small_lying_length_still_does_not_return(self) -> None:
+        """Under the cap, so the conversion still enumerates — the pre-#2695
+        behaviour, unchanged."""
+        _, reason = _render_in_child("djust", True, [("lying_len_small", "length")], deadline=8)
+        assert reason in ("HANG", "RUNAWAY-MEMORY"), reason
+
+    def test_a_big_lying_length_now_answers_the_cheap_sinks(self) -> None:
+        """Past the cap the conversion declines, so `{{ v|length }}` is
+        answered from the object instead of being paid for."""
+        answers, reason = _render_in_child(
+            "djust", True, [("lying_len_big", "length")], deadline=20
+        )
+        assert reason is None, reason
+        assert answers[("lying_len_big", "length")] == "1000000000"
+
+    def test_a_big_lying_length_still_does_not_return_from_a_full_walk(self) -> None:
+        """And the walk it cannot bound is still unbounded — said out loud so
+        the next reader does not take `live_walk_terminates` for a proof."""
+        _, reason = _render_in_child("djust", True, [("lying_len_big", "for")], deadline=8)
+        assert reason in ("HANG", "RUNAWAY-MEMORY"), reason
+
+
+class TestTheEagerHatchStillEnumerates:
+    """``template_resolve_lazy=False`` has no live handle to read an object
+    through, so a decline would land on ``str(o)`` and answer ``{{ v.0 }}``
+    with a bracket. #2678 chose the unfixed cell over the wrong one and #2695
+    keeps that choice; this pins it as a decision rather than an oversight."""
+
+    @pytest.mark.parametrize("shape", ["range_big", "liar"])
+    def test_the_hatch_does_not_return_for_a_stated_billion(self, shape: str) -> None:
+        answers, reason = _render_in_child("djust", False, [(shape, "length")], deadline=8)
+        assert reason in ("HANG", "RUNAWAY-MEMORY"), (
+            f"the eager hatch answered {shape}|length with "
+            f"{answers.get((shape, 'length'))!r} — if it is fixed, say so here"
+        )
+
+
+class TestTheSerializationFloorHoldsOnTheNewHandle:
+    """A `list` past the cap now reaches `Encoded::live`, which it never did
+    before — so the floor has to be re-checked rather than assumed.
+
+    Under the cap a list is a `Value::List` whose `Model` elements went
+    through `normalize_django_value`, and the denylist was applied at the
+    CONVERSION. Past it the list crosses as a carrier and `{{ v.0.password }}`
+    is answered by `Context::walk_live` over the RAW list instead — a
+    different mechanism, so "unchanged in kind" would be a guess.
+
+    It is protected by `Context::protect_sidecar_strict`, which re-wraps after
+    EVERY segment; this is the measurement that says so. `Encoded::live`'s own
+    doc claimed no list could reach the field, and #2695 made that claim
+    false — the claim is corrected there and pinned here.
+    """
+
+    @staticmethod
+    def _rows(padding: int):
+        from django.contrib.auth.models import User
+
+        rows = []
+        for i in range(3):
+            user = User(username="alice", password="pbkdf2_sha256$SECRET", email="a@b.c")
+            user.pk = i
+            rows.append(user)
+        # `None` padding puts the list past the cap without building 100 000
+        # models; only element 0 is ever read.
+        return rows + [None] * padding
+
+    @pytest.mark.parametrize(
+        ("label", "padding"), [("under the cap", 0), ("past the cap", 100_001 - 3)]
+    )
+    @pytest.mark.parametrize(
+        ("src", "expected"),
+        [
+            ("{{ v.0.password }}", ""),
+            ("{{ v.0.username }}", "alice"),
+            ("{{ v.0 }}", "alice"),
+        ],
+    )
+    def test_a_denylisted_field_is_empty_on_both_sides_of_the_cap(
+        self, label: str, padding: int, src: str, expected: str
+    ) -> None:
+        from djust import _rust
+
+        out = _rust.render_template(src, {"v": self._rows(padding)})
+        assert out == expected, f"{label}: {src} rendered {out!r}"
+        assert "SECRET" not in out
+
+    def test_the_carrier_really_is_the_path_being_tested(self) -> None:
+        """Non-vacuity: if the padded list did NOT cross as a carrier, the
+        three cells above would be testing the old `Value::List` path twice
+        and the class would prove nothing (#1200)."""
+        from djust import _rust
+
+        assert _rust.crosses_as_encoded(self._rows(100_001 - 3)) is True
+        assert _rust.crosses_as_encoded(self._rows(0)) is False
+
+
+class TestEverySequenceArmDecidesTheCarrier:
+    """The omission #2693 is, pinned as a SET rather than as a floor (#1125).
+
+    ``dictsort`` answered ``''`` for a carried collection because it had
+    iteration of ITS OWN — a hand-written ``Value::List(items) |
+    Value::Tuple(items) | …`` arm — instead of going through
+    ``filters::iter_values``, the sink #2674 fixed. That is the "grep for the
+    sink, not for the callers you expect" shape: the next filter written the
+    same way inherits the same bug silently.
+
+    So the rule is mechanical: any function in ``filters.rs`` that matches a
+    sequence by hand must also NAME ``Value::Encoded``, i.e. must have made a
+    decision about the carrier — routing it to ``iter_values``, reading it off
+    the live handle, or refusing it deliberately. Four functions do today.
+    """
+
+    #: Every function allowed to hand-match a sequence, and what it decided.
+    SEQUENCE_ARM_OWNERS = {
+        # The sink itself.
+        "iter_values": "consumes the live handle once (#2613/#2674)",
+        # `dictsort` / `dictsortreversed` live here.
+        "apply_builtin_filter": "routes a carrier through `iter_values` (#2693)",
+        "apply_slice": "slices the live object, Django's `value[slice]` (#2695)",
+        "python_getitem": "subscripts the live object (#2695)",
+        "value_to_json": "has its own `Value::Encoded` arm above (#2448)",
+    }
+
+    def test_the_owner_set_is_exactly_what_is_pinned(self) -> None:
+        source = (
+            __import__("pathlib")
+            .Path(__file__)
+            .resolve()
+            .parents[2]
+            .joinpath("crates/djust_templates/src/filters.rs")
+            .read_text()
+        )
+        # `filters.rs` interleaves SIX `#[cfg(test)] mod` blocks with its
+        # production code, so splitting at the first one would hide two
+        # thirds of the file — including `python_getitem`. Drop each block
+        # from its attribute to the `}` that closes the module at column 0.
+        production_lines: list[str] = []
+        in_tests = False
+        for line in source.splitlines():
+            if not in_tests and line == "#[cfg(test)]":
+                in_tests = True
+                continue
+            if in_tests:
+                if line == "}":
+                    in_tests = False
+                continue
+            production_lines.append(line)
+        assert len(production_lines) > 4000, (
+            "the test-module stripper dropped the file — the scan below would "
+            f"then be vacuous (kept {len(production_lines)} lines)"
+        )
+        owners: dict[str, list[str]] = {}
+        current = None
+        for line in production_lines:
+            # Top-level `fn` only: a nested helper (`python_getitem`'s `nth`)
+            # is part of its parent, not an owner of its own.
+            if line.startswith(("fn ", "pub fn ", "pub(crate) fn ")):
+                current = line.split("fn ", 1)[1].split("(")[0].split("<")[0]
+                owners.setdefault(current, [])
+            if current is not None:
+                owners[current].append(line)
+        # The signature of a hand-written sequence arm is destructuring the
+        # ITEMS out of all three sequence variants. `rebuild_like` matches
+        # `Value::NamedTuple { .. }` without them — it BUILDS a sequence
+        # rather than reading one — so it is correctly not an owner.
+        hand_matchers = {
+            name
+            for name, body in owners.items()
+            if any("Value::NamedTuple { items, .. }" in line for line in body)
+        }
+        assert hand_matchers == set(self.SEQUENCE_ARM_OWNERS), {
+            "new hand-matching functions — route the carrier through "
+            "`iter_values` (or decide it explicitly) and add them here": sorted(
+                hand_matchers - set(self.SEQUENCE_ARM_OWNERS)
+            ),
+            "gone": sorted(set(self.SEQUENCE_ARM_OWNERS) - hand_matchers),
+        }
+        for name in hand_matchers:
+            assert any("Value::Encoded" in line for line in owners[name]), (
+                f"{name} matches a sequence by hand and never names "
+                f"Value::Encoded — a carried collection falls to its "
+                f"catch-all, which is exactly #2693"
+            )
+
+
+class TestDictsortConsumesTheLiveHandle:
+    """#2693 — link N+1 of #2674."""
+
+    @pytest.mark.parametrize("shape", ["dict_gen", "dict_iter"])
+    @pytest.mark.parametrize(
+        ("sink", "expected"),
+        [
+            ("dictsort", "[{&#x27;k&#x27;: 1}, {&#x27;k&#x27;: 2}]"),
+            ("dictsortreversed", "[{&#x27;k&#x27;: 2}, {&#x27;k&#x27;: 1}]"),
+        ],
+    )
+    def test_a_one_shot_iterator_sorts_where_it_used_to_answer_empty(
+        self, shape: str, sink: str, expected: str
+    ) -> None:
+        answers, reason = _render_in_child("djust", True, [(shape, sink)], deadline=20)
+        assert reason is None, reason
+        assert answers[(shape, sink)] == expected
+
+    def test_a_one_shot_iterator_is_spent_by_the_sort_exactly_once(self) -> None:
+        """Django's ``sorted()`` consumes the generator, so the ``{% for %}``
+        AFTER it is empty. The whole point of routing through the one sink is
+        that the handle is read once, wherever it is first read — a second arm
+        with iteration of its own would read it twice, or not at all.
+
+        Asserted against live Django rather than a transcribed expectation,
+        because "how much of the generator is left" is exactly the claim a
+        transcription would get wrong.
+        """
+        cell = [("dict_gen", "consume_once")]
+        mine, reason = _render_in_child("djust", True, cell, deadline=20)
+        assert reason is None, reason
+        theirs, reason = _render_in_child("django", True, cell, deadline=20)
+        assert reason is None, reason
+        assert mine[("dict_gen", "consume_once")] == theirs[("dict_gen", "consume_once")]
+        # And it really is spent: the loop after the sort renders nothing.
+        assert mine[("dict_gen", "consume_once")].endswith("|")

--- a/python/tests/test_sized_sequence_conversion_2695_2693.py
+++ b/python/tests/test_sized_sequence_conversion_2695_2693.py
@@ -20,8 +20,16 @@ it needs off the live handle.
 
 The bound then moves to where it belongs. The conversion asks "is the stated
 length too large to spend HERE"; the SINKS ask "can this walk end at all"
-(``Encoded::live_walk_terminates``) — which is why ``list(range(100_001))``
-still renders every item at ``{% for %}`` while #2678's liar still raises.
+(``Encoded::live_walk_terminates``) — which is why
+``collections.deque(range(100_001))`` still renders every item at
+``{% for %}`` while #2678's liar still raises.
+
+The conversion's question has a second half, added by the #2695 review: an
+object whose items ALREADY EXIST has nothing to decline, because the decline
+only avoids the cost of BUILDING them. A ``list`` holds its elements and
+``QuerySet.__len__`` calls ``_fetch_all()``, so both are exempt at any length
+— see ``TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap`` for the 66 MB
+of serialization dicts that exemption prevents.
 
 Every claim above is checked against REAL Django 5.2, in a subprocess, on both
 settings of ``template_resolve_lazy``: #2691 was reverted once for verifying

--- a/python/tests/test_sized_sequence_conversion_2695_2693.py
+++ b/python/tests/test_sized_sequence_conversion_2695_2693.py
@@ -34,6 +34,7 @@ are pinned, so adding a divergence and removing one are equally loud.
 
 from __future__ import annotations
 
+import collections
 import json
 import os
 import subprocess
@@ -149,6 +150,11 @@ _CHILD = textwrap.dedent(
         "zip": lambda: zip([3, 1], [2, 0]),
         "queryset": lambda: QuerySetShape([3, 1, 2]),
         "liar": lambda: Liar(),
+        # NOT in the matrix (Django never returns from any sink over it) —
+        # the shape that covers `live_walk_terminates`'s OTHER half, the one
+        # a gate-off of `self.len.is_some()` leaves green everywhere else.
+        # A one-shot iterator with an endless `__next__` and NO `__len__`.
+        "count": lambda: __import__("itertools").count(),
         "dict_list": lambda: list(D),
         "dict_gen": lambda: (d for d in D),
         "dict_iter": lambda: iter(list(D)),
@@ -590,13 +596,20 @@ class TestASizedSequenceIsNotMaterialisedAtConversion:
         assert answers[("list_big", "for")].startswith("<588897 chars>0,1,2,3,")
         assert answers[("list_big", "join")].startswith("<588896 chars>0,1,2,3,")
 
-    def test_a_list_past_the_cap_slices_to_three_items(self) -> None:
+    @pytest.mark.parametrize("shape", ["list_big", "range_big"])
+    def test_a_collection_past_the_cap_slices_to_three_items(self, shape: str) -> None:
         """``|slice`` had to grow a live arm with the conversion change: the
-        fallback returns the value UNCHANGED, so a carried 100 001-item list
-        rendered all of them where Django renders three."""
-        answers, reason = _render_in_child("djust", True, [("list_big", "slice")], deadline=20)
+        fallback returns the value UNCHANGED, so a CARRIED 100 001-item
+        sequence rendered all of them where Django renders three.
+
+        Both shapes, because they take different arms since the #2695 review:
+        a `list` is exempt from the decline and reaches `apply_slice`'s
+        `Value::List` arm, while `range(10**9)` is carried and reaches the
+        live one. Only the second exercises `Encoded::live_get_slice`.
+        """
+        answers, reason = _render_in_child("djust", True, [(shape, "slice")], deadline=20)
         assert reason is None, reason
-        assert answers[("list_big", "slice")] == "[0, 1, 2]"
+        assert answers[(shape, "slice")] == "[0, 1, 2]"
 
     def test_the_liar_still_raises_rather_than_walking_forever(self) -> None:
         """#2678 must survive #2695. The liar states a billion and has no
@@ -604,6 +617,48 @@ class TestASizedSequenceIsNotMaterialisedAtConversion:
         answers, reason = _render_in_child("djust", True, [("liar", "for")], deadline=20)
         assert reason is None, f"the liar walked instead of raising: {reason}"
         assert "yielded more than 100000 items" in answers[("liar", "for")]
+
+
+class TestBothHalvesOfTheSinkTerminationRuleAreCovered:
+    """``Encoded::live_walk_terminates`` is a conjunction, and each half needs
+    a test that goes RED when only that half is removed (#2129).
+
+    The PR shipped one: the liar covers the ``__iter__`` half. Gating off the
+    OTHER half — ``self.len.is_some()`` — left the whole file green, and the
+    only signal was a *hang in a different file* (the #2695 review, finding
+    3). ``itertools.count()`` is the shape that half exists for: an endless
+    iterator that never stated a length, so nothing bounds its walk but the
+    cap.
+
+    Both cells run in a child with a deadline AND an RSS ceiling, because the
+    failure they guard against is a NON-RETURN — an in-process assertion
+    cannot report "did not hang", it just never reports.
+    """
+
+    @pytest.mark.parametrize(
+        ("shape", "half"),
+        [
+            ("count", "self.len.is_some()"),
+            ("liar", "the `__iter__` half"),
+        ],
+    )
+    def test_an_unbounded_walk_raises_at_the_cap(self, shape: str, half: str) -> None:
+        answers, reason = _render_in_child("djust", True, [(shape, "for")], deadline=20)
+        assert reason is None, (
+            f"{shape} did not return from `{{% for %}}` ({reason}) — with "
+            f"{half} gone the sink walks it forever instead of raising"
+        )
+        assert "yielded more than 100000 items" in answers[(shape, "for")], answers[(shape, "for")]
+
+    def test_django_does_not_return_from_the_same_count(self) -> None:
+        """The reason an error is the right answer rather than a limitation:
+        Django's own ``{% for %}`` over ``itertools.count()`` never comes
+        back."""
+        _, reason = _render_in_child("django", True, [("count", "for")], deadline=8)
+        assert reason in ("HANG", "RUNAWAY-MEMORY"), (
+            "Django ANSWERED `{% for %}` over itertools.count() — if it now "
+            "terminates, djust's RuntimeError is no longer the better answer"
+        )
 
 
 class TestNeitherEngineReturnsFromAWalkOfAStatedBillion:
@@ -672,34 +727,49 @@ class TestTheEagerHatchStillEnumerates:
         )
 
 
-class TestTheSerializationFloorHoldsOnTheNewHandle:
-    """A `list` past the cap now reaches `Encoded::live`, which it never did
-    before — so the floor has to be re-checked rather than assumed.
+def _model_rows(padding: int) -> list:
+    """Three real `User`s carrying a denylisted field, plus `None` padding.
 
-    Under the cap a list is a `Value::List` whose `Model` elements went
-    through `normalize_django_value`, and the denylist was applied at the
-    CONVERSION. Past it the list crosses as a carrier and `{{ v.0.password }}`
-    is answered by `Context::walk_live` over the RAW list instead — a
-    different mechanism, so "unchanged in kind" would be a guess.
+    The padding puts a collection past the cap without building 100 000
+    models; only element 0 is ever read.
+    """
+    from django.contrib.auth.models import User
+
+    rows = []
+    for i in range(3):
+        user = User(username="alice", password="pbkdf2_sha256$SECRET", email="a@b.c")
+        user.pk = i
+        rows.append(user)
+    return rows + [None] * padding
+
+
+class TestTheSerializationFloorHoldsOnTheNewHandle:
+    """A sized sequence of `Model`s past the cap now reaches `Encoded::live`,
+    which it never did before — so the floor has to be re-checked rather than
+    assumed.
+
+    Under the cap the collection is a `Value::List` whose `Model` elements
+    went through `normalize_django_value`, and the denylist was applied at the
+    CONVERSION. Past it it crosses as a carrier and `{{ v.0.password }}` is
+    answered by `Context::walk_live` over the RAW object instead — a different
+    mechanism, so "unchanged in kind" would be a guess.
 
     It is protected by `Context::protect_sidecar_strict`, which re-wraps after
-    EVERY segment; this is the measurement that says so. `Encoded::live`'s own
-    doc claimed no list could reach the field, and #2695 made that claim
-    false — the claim is corrected there and pinned here.
+    EVERY segment; this is the measurement that says so.
+
+    A `deque` and not a `list`: the #2695 review found that declining a
+    `list` spends more than it saves (its items are already built, and the
+    carrier then has to spell `str()` and `repr()` of all of them), so
+    `len_call_already_materialised_the_items` exempts `list` and `QuerySet`
+    and this class would be vacuous on either — see
+    `test_the_carrier_really_is_the_path_being_tested`, which is what would
+    have caught the substitution. A `deque` is the ordinary sized-sequence
+    case and is carried.
     """
 
     @staticmethod
     def _rows(padding: int):
-        from django.contrib.auth.models import User
-
-        rows = []
-        for i in range(3):
-            user = User(username="alice", password="pbkdf2_sha256$SECRET", email="a@b.c")
-            user.pk = i
-            rows.append(user)
-        # `None` padding puts the list past the cap without building 100 000
-        # models; only element 0 is ever read.
-        return rows + [None] * padding
+        return collections.deque(_model_rows(padding))
 
     @pytest.mark.parametrize(
         ("label", "padding"), [("under the cap", 0), ("past the cap", 100_001 - 3)]
@@ -722,13 +792,133 @@ class TestTheSerializationFloorHoldsOnTheNewHandle:
         assert "SECRET" not in out
 
     def test_the_carrier_really_is_the_path_being_tested(self) -> None:
-        """Non-vacuity: if the padded list did NOT cross as a carrier, the
-        three cells above would be testing the old `Value::List` path twice
-        and the class would prove nothing (#1200)."""
+        """Non-vacuity: if the padded collection did NOT cross as a carrier,
+        the three cells above would be testing the old `Value::List` path
+        twice and the class would prove nothing (#1200)."""
         from djust import _rust
 
         assert _rust.crosses_as_encoded(self._rows(100_001 - 3)) is True
         assert _rust.crosses_as_encoded(self._rows(0)) is False
+
+
+class TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap:
+    """#2695 review, finding 2 — a REAL `django.db.models.QuerySet`, not the
+    3-element duck type the differential grid carries.
+
+    The security section names *"a `list` or an evaluated `QuerySet`"*, and
+    neither the grid (`QuerySetShape`, always 3 elements) nor the floor class
+    above (a collection of `Model`s) ever rendered one past the cap. Doing it
+    found a content and payload change on both of the two paths a queryset
+    reaches the engine by, and they are separate mechanisms (#1646):
+
+    * ``render_template`` protects the queryset into a
+      ``_SidecarQuerySetProxy``, whose ``__djust_serialize__`` hands back a
+      `list` of identity dicts — declined past the cap, so ``{{ rows }}``
+      became ``str()`` of djust's OWN dicts (66 MB) instead of the rows.
+      And the RAW queryset was declined too, so ``{{ rows.0 }}`` answered
+      ``''``: the live walk subscripts the proxy, which has no
+      ``__getitem__``.
+    * ``DjustTemplate.render`` auto-serialises the queryset to that same list
+      BEFORE Rust sees it, so it hit the identical decline one layer up.
+
+    Both are closed by `len_call_already_materialised_the_items`: a `list`
+    holds its elements and `QuerySet.__len__` calls `_fetch_all()`, so past
+    the cap the decline can only change the spelling. Not a floor breach on
+    either side — asserted here as well, since the whole point is that the
+    fix moves the rows back onto the `Value::List` path.
+    """
+
+    @staticmethod
+    def _queryset(padding: int):
+        """A real ``QuerySet`` with its result cache stuffed.
+
+        ``_result_cache`` is what ``_fetch_all`` fills, so this is the exact
+        state an evaluated queryset is in — no database, and `None` padding
+        for the same reason the floor class uses it.
+        """
+        from django.contrib.auth.models import User
+
+        qs = User.objects.all()
+        qs._result_cache = _model_rows(padding)
+        return qs
+
+    #: How many rows each container sink spells the identity map of. ``{{ v }}``
+    #: renders a model row as its ``__str__``, so the map never shows; the two
+    #: dump filters do show it, once per REAL row (the padding is ``None``).
+    #: The bug spelled `{{ v }}` with the map too — that is what made it 66 MB.
+    _IDENTITY_MAPS_PER_SINK = {
+        "{{ v }}": 0,
+        "{{ v|pprint }}": 3,
+        '{{ v|json_script:"x" }}': 3,
+    }
+
+    @pytest.mark.parametrize("src", sorted(_IDENTITY_MAPS_PER_SINK))
+    def test_the_container_sinks_use_the_same_spelling_on_both_sides(self, src: str) -> None:
+        """The 66 MB cell, and the one the duck type could never reach.
+
+        Asserted as "the same spelling either side of the cap" rather than as
+        two expected strings: the point is not what a queryset renders as —
+        djust has never matched Django's ``<QuerySet [...]>`` here — but that
+        crossing 100 000 rows does not CHANGE it.
+        """
+        from djust import _rust
+
+        under = _rust.render_template(src, {"v": self._queryset(0)})
+        past = _rust.render_template(src, {"v": self._queryset(100_001 - 3)})
+        assert "SECRET" not in under and "SECRET" not in past
+        expected = self._IDENTITY_MAPS_PER_SINK[src]
+        assert under.count("__model__") == expected, f"under the cap: {under[:200]!r}"
+        assert past.count("__model__") == expected, (
+            f"past the cap {src} spells {past.count('__model__')} identity maps where "
+            f"under the cap it spells {expected} — the decline put djust's own "
+            f"serialization dicts on screen: {past[:200]!r}"
+        )
+        # And the payload is the padding, not a re-spelling of every row: the
+        # measured regression was 66 MB for `{{ v }}` / 75 MB for `|pprint` /
+        # 43 MB for `|json_script` against ~0.6-0.7 MB here.
+        assert len(past) < 5_000_000, f"{src} rendered {len(past)} bytes past the cap"
+
+    @pytest.mark.parametrize(
+        ("label", "padding"), [("under the cap", 0), ("past the cap", 100_001 - 3)]
+    )
+    @pytest.mark.parametrize(
+        ("src", "expected"),
+        [
+            ("{{ v.0.password }}", ""),
+            ("{{ v.0.username }}", "alice"),
+            ("{{ v.0 }}", "alice"),
+            ("{{ v|first }}", "alice"),
+        ],
+    )
+    def test_the_item_sinks_answer_the_same_on_both_sides(
+        self, label: str, padding: int, src: str, expected: str
+    ) -> None:
+        from djust import _rust
+
+        out = _rust.render_template(src, {"v": self._queryset(padding)})
+        assert out == expected, f"{label}: {src} rendered {out!r}"
+        assert "SECRET" not in out
+
+    def test_the_padded_queryset_really_is_past_the_cap(self) -> None:
+        """Non-vacuity for the two classes above: the padded queryset has to
+        be the shape that WOULD have been declined, or both are measuring the
+        under-cap path twice (#1200)."""
+        assert len(self._queryset(100_001 - 3)) == 100_001
+        assert len(self._queryset(0)) == 3
+
+    def test_a_queryset_is_exempt_from_the_conversion_decline_at_any_length(
+        self,
+    ) -> None:
+        """The mechanism, named: `QuerySet.__len__` calls `_fetch_all()`, so
+        by the time the length is known every row exists and the decline can
+        only change the spelling."""
+        from djust import _rust
+
+        assert _rust.crosses_as_encoded(self._queryset(100_001 - 3)) is False
+        assert _rust.crosses_as_encoded(self._queryset(0)) is False
+        # And the duck type that merely LOOKS like one is not exempt — the
+        # exemption is about the `__len__` contract, not the shape.
+        assert _rust.crosses_as_encoded(collections.deque(range(100_001))) is True
 
 
 class TestEverySequenceArmDecidesTheCarrier:
@@ -741,10 +931,26 @@ class TestEverySequenceArmDecidesTheCarrier:
     sink, not for the callers you expect" shape: the next filter written the
     same way inherits the same bug silently.
 
-    So the rule is mechanical: any function in ``filters.rs`` that matches a
-    sequence by hand must also NAME ``Value::Encoded``, i.e. must have made a
-    decision about the carrier — routing it to ``iter_values``, reading it off
-    the live handle, or refusing it deliberately. Four functions do today.
+    So the rule is mechanical: every ``match`` in ``filters.rs`` that matches
+    a sequence by hand must also NAME ``Value::Encoded`` IN THAT SAME MATCH,
+    i.e. must have made a decision about the carrier — routing it to
+    ``iter_values``, reading it off the live handle, or refusing it
+    deliberately.
+
+    **Per MATCH, not per function**, and that correction is the whole of the
+    #2695 review's finding 4. The first version scanned per top-level
+    function, and every one of the ~56 builtin filters lives inside
+    ``apply_builtin_filter`` — which already contained an unrelated
+    ``Value::Encoded`` line (the ``datetime.date`` guard). So the assertion
+    was satisfied for that function no matter what any individual filter arm
+    did: the reviewer's canary showed that DELETING #2693's arm outright, and
+    ADDING a new filter in #2693's exact shape, both left the pin green. A pin
+    that cannot fail is worse than none, because it makes the class look
+    handled (#1859).
+
+    The enclosing match is found by INDENTATION, which `cargo fmt` makes
+    reliable: the nearest preceding ``match`` line indented less than the
+    hand-matching arm, ending where the indentation returns to that level.
     """
 
     #: Every function allowed to hand-match a sequence, and what it decided.
@@ -758,7 +964,21 @@ class TestEverySequenceArmDecidesTheCarrier:
         "value_to_json": "has its own `Value::Encoded` arm above (#2448)",
     }
 
-    def test_the_owner_set_is_exactly_what_is_pinned(self) -> None:
+    #: The signature of a hand-written sequence arm: destructuring the ITEMS
+    #: out of all three sequence variants. ``rebuild_like`` matches
+    #: ``Value::NamedTuple { .. }`` WITHOUT them — it builds a sequence rather
+    #: than reading one — so it is correctly not a hand-matcher.
+    HAND_MATCH = "Value::NamedTuple { items, .. }"
+
+    @staticmethod
+    def _production_lines() -> list[str]:
+        """``filters.rs`` with its ``#[cfg(test)]`` modules removed.
+
+        The file interleaves SIX of them with production code, so splitting at
+        the first would hide two thirds of it — including ``python_getitem``.
+        Each block is dropped from its attribute to the ``}`` that closes the
+        module at column 0.
+        """
         source = (
             __import__("pathlib")
             .Path(__file__)
@@ -767,11 +987,7 @@ class TestEverySequenceArmDecidesTheCarrier:
             .joinpath("crates/djust_templates/src/filters.rs")
             .read_text()
         )
-        # `filters.rs` interleaves SIX `#[cfg(test)] mod` blocks with its
-        # production code, so splitting at the first one would hide two
-        # thirds of the file — including `python_getitem`. Drop each block
-        # from its attribute to the `}` that closes the module at column 0.
-        production_lines: list[str] = []
+        kept: list[str] = []
         in_tests = False
         for line in source.splitlines():
             if not in_tests and line == "#[cfg(test)]":
@@ -781,11 +997,39 @@ class TestEverySequenceArmDecidesTheCarrier:
                 if line == "}":
                     in_tests = False
                 continue
-            production_lines.append(line)
-        assert len(production_lines) > 4000, (
-            "the test-module stripper dropped the file — the scan below would "
-            f"then be vacuous (kept {len(production_lines)} lines)"
+            kept.append(line)
+        assert len(kept) > 4000, (
+            "the test-module stripper dropped the file — every scan below "
+            f"would then be vacuous (kept {len(kept)} lines)"
         )
+        return kept
+
+    @staticmethod
+    def _indent(line: str) -> int:
+        return len(line) - len(line.lstrip(" "))
+
+    @classmethod
+    def _enclosing_match(cls, lines: list[str], i: int) -> tuple[int, int]:
+        """``(start, end)`` of the ``match`` block containing line ``i``."""
+        arm_indent = cls._indent(lines[i])
+        start = None
+        for j in range(i - 1, -1, -1):
+            if lines[j].strip() and "match " in lines[j] and cls._indent(lines[j]) < arm_indent:
+                start = j
+                break
+        assert start is not None, f"no enclosing `match` for line {i}: {lines[i]!r}"
+        base = cls._indent(lines[start])
+        end = len(lines)
+        for j in range(start + 1, len(lines)):
+            if lines[j].strip() and cls._indent(lines[j]) <= base:
+                end = j
+                break
+        return start, end
+
+    def test_the_owner_set_is_exactly_what_is_pinned(self) -> None:
+        """Half one, unchanged and load-bearing: a NEW top-level function that
+        hand-matches a sequence has to be declared here."""
+        production_lines = self._production_lines()
         owners: dict[str, list[str]] = {}
         current = None
         for line in production_lines:
@@ -796,14 +1040,8 @@ class TestEverySequenceArmDecidesTheCarrier:
                 owners.setdefault(current, [])
             if current is not None:
                 owners[current].append(line)
-        # The signature of a hand-written sequence arm is destructuring the
-        # ITEMS out of all three sequence variants. `rebuild_like` matches
-        # `Value::NamedTuple { .. }` without them — it BUILDS a sequence
-        # rather than reading one — so it is correctly not an owner.
         hand_matchers = {
-            name
-            for name, body in owners.items()
-            if any("Value::NamedTuple { items, .. }" in line for line in body)
+            name for name, body in owners.items() if any(self.HAND_MATCH in line for line in body)
         }
         assert hand_matchers == set(self.SEQUENCE_ARM_OWNERS), {
             "new hand-matching functions — route the carrier through "
@@ -812,11 +1050,27 @@ class TestEverySequenceArmDecidesTheCarrier:
             ),
             "gone": sorted(set(self.SEQUENCE_ARM_OWNERS) - hand_matchers),
         }
-        for name in hand_matchers:
-            assert any("Value::Encoded" in line for line in owners[name]), (
-                f"{name} matches a sequence by hand and never names "
-                f"Value::Encoded — a carried collection falls to its "
-                f"catch-all, which is exactly #2693"
+
+    def test_every_hand_matching_MATCH_names_the_carrier(self) -> None:
+        """Half two, the one the #2695 review proved decorative when it was
+        scoped per FUNCTION: the decision has to live in the SAME ``match`` as
+        the sequence arm, so a new filter inside ``apply_builtin_filter``
+        cannot ride on a neighbour's ``Value::Encoded`` line."""
+        production_lines = self._production_lines()
+        sites = [i for i, line in enumerate(production_lines) if self.HAND_MATCH in line]
+        assert len(sites) >= 5, (
+            f"only {len(sites)} hand-matching arms found — the scan is looking "
+            f"for {self.HAND_MATCH!r} and something renamed it"
+        )
+        for i in sites:
+            start, end = self._enclosing_match(production_lines, i)
+            block = production_lines[start:end]
+            assert any("Value::Encoded" in line for line in block), (
+                f"the match at line {start + 1} of filters.rs "
+                f"({production_lines[start].strip()!r}) matches a sequence by "
+                f"hand and never names Value::Encoded in the same match — a "
+                f"carried collection falls to its catch-all, which is exactly "
+                f"#2693"
             )
 
 


### PR DESCRIPTION
Two halves of one rule: the conversion must not enumerate a sequence just
because it entered a context, and every sink that needs the items must read
them through the ONE live-handle path.

> **Review round 2.** The adversarial review confirmed the security claim
> (198 cells + 22 sinks x 9 grids + 16 QuerySet cells, zero leaks, non-vacuity
> real) and raised four things. All four are addressed below and every number
> in this body has been re-measured on the current head:
>
> | finding | what changed |
> |---|---|
> | 🔴 a real `QuerySet`'s `{{ v }}` past the cap was 66 MB of djust's own serialization dicts, and `{{ v.0 }}` was `''` | the conversion no longer declines an object whose items ALREADY EXIST (`list`, `QuerySet`); new `TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap` renders a real `QuerySet` on both sides for `{{ v }}` / `\|pprint` / `\|json_script` and the item sinks |
> | 🟡 `live_walk_terminates`'s `len` half had no covering test | new `TestBothHalvesOfTheSinkTerminationRuleAreCovered` — a `count` cell that reports RED rather than stalling |
> | 🟡 the structural pin was decorative | it scans per **match** now, not per function; the reviewer's two canaries both go RED (proof below) |
> | 🟡 the differential figures did not reproduce | re-measured with the PR's own unmodified harness; the before/after framing is withdrawn |
>
> **Re-review: APPROVE.** One claim corrected since — the exemption's
> justification was measurably wrong (below), reworded in `2c601d6e`, and the
> 4 GB it accepts is filed as #2717.

## #2695 — `range(10**9)` was still materialised at conversion

Root cause, symptom-up: **not** the shape #2678 fixed, and not `Encoded`.
`bounded_sequence_items` (`crates/djust_core/src/lib.rs`) claims anything
`PySequence_Check` accepts and then reads `len(o)` items out of it. #2678 had
added a decline for the liar shape only — past the cap **and** with no
`__iter__` — because its own first version capped on the length alone and made
`{% for %}` over `list(range(100_001))` raise. `range(10**9)` has an
`__iter__`, so it was enumerated in full: a billion `Value`s before the
template had said what it wanted.

The fix moves the bound onto the axis each half actually has:

| | question | answer |
|---|---|---|
| conversion (`stated_len_is_too_large_to_enumerate`) | is the stated length too large to spend **here**? | decline past `OPAQUE_ITEM_CAP` — unless the items already exist |
| conversion (`len_call_already_materialised_the_items`) | did asking the length already BUILD the items? | a `list` holds them; `QuerySet.__len__` calls `_fetch_all()` — both exempt, at any length |
| sink (`Encoded::live_walk_terminates`) | can this walk **end** at all? | uncapped when the object states a length AND has a real `__iter__` |

That is why `collections.deque(range(100_001))` still renders all 100 001
items at `{% for %}` (it terminates) while #2678's liar still raises (it
cannot). The sinks then answer from the live object exactly as Django does —
`len(v)`, `v[0]`, `v[-1]`, `v[slice(*bits)]`, Python's own `in`, `str(v)` — so
every cell Django answers in constant time, djust now answers in constant
time.

### The already-materialised exemption (review finding 1)

The decline exists to avoid **paying to build** items an object only
DESCRIBES. Applied to a `list` and a `QuerySet` — whose items exist by the
time the length is known — what it changed was the *spelling*, and it changed
it badly, on both of the two paths a queryset reaches the engine by:

| cell, 100 001-row `User` queryset | under the cap | past the cap, before | past the cap, after |
|---|---|---|---|
| `{{ v }}` | `[qs0, qs1, qs2]` | **66 MB** of `[{'id': 1, 'pk': 1, '__str__': 'qs0', '__model__': 'User', …}]` | `[qs0, qs1, …]`, 0.9 MB |
| `{{ v\|pprint }}` | the identity dicts, 3 of them | 75 MB, one per row | 0.7 MB |
| `{{ v\|json_script:"x" }}` | a JSON array of 3 | 43 MB, and a quoted STRING rather than an array | 0.6 MB |
| `{{ v.0 }}` / `{{ v.0.username }}` | `qs0` | `''` | `qs0` |
| `{{ v.0.password }}` | `''` | `''` | `''` |

`render_template` protects the queryset into a `_SidecarQuerySetProxy`, whose
`__djust_serialize__` hands back a `list` of identity dicts — declined past
the cap, so `{{ rows }}` became `str()` of djust's own dicts. And the RAW
queryset was declined too, so the live walk subscripted the proxy, which has
no `__getitem__`, and answered `''`. `DjustTemplate.render` auto-serialises a
queryset to that same list before Rust sees it, so it hit the identical
decline one layer up. **Never a floor breach** — `password` is `''` on every
row of that table — but a content and payload change nobody had measured,
because the differential's `queryset` shape is a 3-element duck type and the
floor class only used a `list`.

**The exemption is a TRADE, and the price is not zero.** An earlier version of
this section said the cost was "already sunk". The re-review measured that and
it is false by ~4 GB: `len()` sinks `_fetch_all()` (~140 MB of rows) and NOT
the conversion of those rows into `Value`s. On an **unevaluated**
`User.objects.all()` over a real 150 000-row table, `{{ v|length }}`, with the
exemption gated off and the mutation proven live:

| | peak RSS | seconds |
|---|---|---|
| exemption **ON** (as shipped) | **4 650 MB** | 13.45 |
| exemption **OFF** (decline applies) | **593 MB** | 9.74 |
| `list(range(1_000_000))` ON / OFF | 351 MB / 182 MB | 0.40 / 0.52 |

It is taken anyway because the declined spelling is wrong, and because the
cost is **not new** — `main` never declined a `list` or a `QuerySet` either
(`stated_bound_is_unverifiable` required no `__iter__`), so this restores the
cost those shapes already had rather than adding one. Getting both — decline
the carrier AND spell it correctly at the sink — is filed as **#2717**;
doing it here would have meant designing a lazy QuerySet carrier inside a
review fix-pass. The measurement lives in
`len_call_already_materialised_the_items`'s own doc-comment so the next reader
does not inherit the false justification.

## #2693 — `dictsort` / `dictsortreversed` had iteration of their own

Link N+1 of #2674: the arm matched `Value::List | Value::Tuple |
Value::NamedTuple | Value::DictView` by hand and fell to `_ => None` for
everything else, so a carried collection answered `''` where Django sorts.
Routed through `filters::iter_values`, the sink `{% for %}` / `|join` / `in`
already use, so a one-shot handle is consumed once at whichever sink reaches
it first.

## The structural pin, and the canary that proves it fires (review finding 4)

The first version scanned per top-level **function**, and every one of the ~56
builtin filters lives inside `apply_builtin_filter`, which already contained
an unrelated `Value::Encoded` line. So the assertion held for that function no
matter what any individual filter arm did. It now scans per enclosing
**match**, found by indentation (`cargo fmt` makes that reliable). Same
canaries the reviewer ran, against the new pin:

| source | old pin (per function) | new pin (per match) |
|---|---|---|
| PR head | GREEN | **GREEN** (`failed=0 passed=2`) |
| head minus the whole #2693 arm | GREEN | **RED** (`failed=1`) |
| head + a new filter in #2693's exact shape inside `apply_builtin_filter` | GREEN | **RED** (`failed=1`) |

The other half — `hand_matchers == SEQUENCE_ARM_OWNERS`, which catches a new
top-level function — is unchanged and was already load-bearing.

## The differential (review finding 5)

12 sinks x 19 shapes x both `template_resolve_lazy` settings, against real
Django 5.2 in a subprocess with a deadline and a resident-set ceiling —
because #2691 was reverted once for verifying only the four sinks that never
need the items.

The body previously claimed "lazy mismatches went 58 -> 34; eager 81 -> 75".
Those do not reproduce and are withdrawn. Re-run with the PR's own unmodified
`_render_in_child` + `_batch_cells` on this head:

```
django  cells=218
lazy    common=218  agree=192  MISMATCH=26  |LAZY_PARITY|=192   agree==pinned: True
eager   common=204  agree=148  MISMATCH=56  |EAGER_PARITY|=148  agree==pinned: True
```

There is no comparable "before" number, and that is the point rather than an
omission: on `main` the grid does not FINISH, because the `range_big` column
does not return (`TestASizedSequenceIsNotMaterialisedAtConversion` is exactly
that measurement). The tests themselves were always exact — `agree == pinned`
in both columns — so only the prose was wrong.

`range(10**9)`, before -> after (`template_resolve_lazy` on, the default):

| sink | Django 5.2 | before | after |
|---|---|---|---|
| `{{ v\|length }}` | `1000000000` | runaway | `1000000000` |
| `{{ v.0 }}` | `0` | runaway | `0` |
| `{{ v\|first }}` | `0` | runaway | `0` |
| `{{ v\|last }}` | `999999999` | runaway | `999999999` |
| `{% if 1 in v %}` | `Y` | runaway | `Y` |
| `{% if 987654321 in v %}` | `Y` | runaway | `Y` |
| `{{ v }}` | `range(0, 1000000000)` | runaway | `range(0, 1000000000)` |
| `{{ v\|slice:":3" }}` | `range(0, 3)` | runaway | `[0, 1, 2]` * |
| `{% for %}` / `\|join` / `dictsort` / `dictsortreversed` | does not return | does not return | does not return ** |

\* the pre-existing container-spelling divergence, not a new one: `range(3)`
renders `[0, 1, 2]` here too, and always has, and so do `deque` / `array` /
`bytes` / a QuerySet-shaped object. Independent of the cap and out of scope
here; filed as #2704.

\*\* proven rather than accepted — Django, 60 s deadline / 4 GiB ceiling:
`{% for %}` 60 s with no output (1.43 GiB), `|join` >4 GiB after 32 s,
`dictsort` >4 GiB after 1.1 s. `TestNeitherEngineReturnsFromAWalkOfAStatedBillion`
asserts both engines still fail to return, so if Django ever answers one of
these cells the test goes red rather than quietly leaving djust behind.

`dictsort` over a one-shot iterator (#2693):

| template | Django | before | after |
|---|---|---|---|
| `{{ v\|dictsort:"k" }}`, `v = iter([{"k": 2}, {"k": 1}])` | `[{'k': 1}, {'k': 2}]` | `''` | `[{'k': 1}, {'k': 2}]` |
| `{{ v\|dictsortreversed:"k" }}`, same `v` | `[{'k': 2}, {'k': 1}]` | `''` | `[{'k': 2}, {'k': 1}]` |

Same for a generator, a `map` and a `zip`.

## Deliberately unchanged

* **The eager escape hatch** (`template_resolve_lazy=False`) still enumerates
  and still does not return for either big shape. It has no live handle, so a
  decline would land on `str(o)` and answer `{{ v.0 }}` with a bracket —
  #2678 chose the unfixed cell over the wrong one and this keeps that choice.
  `TestTheEagerHatchStillEnumerates` pins it as a decision.
* **The three test rows #2691 deleted are NOT restored.** They passed only
  because of the over-reach bug and were pinning a regression; the cells they
  covered live in the new file, measured against Django.
* **A LYING `__len__`** — a stated length whose own `__iter__` never ends —
  passes both of `live_walk_terminates`'s conditions and is walked without a
  bound. Said out loud rather than claimed away: `opaque_value`'s enumeration
  has no cap either, so that shape failed to return at the CONVERSION before
  this PR, for `{{ v|length }}` as much as for `{% for %}`. Moving the walk to
  the sink makes it strictly rarer and the big variant strictly better
  (`{{ v|length }}` now answers). `TestALyingLengthIsUnfixedRatherThanNewlyBroken`
  measures all three cells.

## Gate-off, re-measured on this head

Every mechanism reverted separately, rebuilt, re-run over the four touched
test files. The harness asserts the mutation text was found and that the
source differed, counts errors separately from failures, refuses to report a
number if the build broke, and rewrites (never `copy2`s) on restore — a
mtime-preserving restore lets cargo reuse the MUTANT and measures it as if
restored. Baseline: **635 passed, 0 failed, 0 errors**.

| mechanism | reverted | result |
|---|---|---|
| M1 conversion declines a stated length past the cap | the predicate -> `false` | **19 failed, 3 errors**, 613 passed |
| M1b a `list` / `QuerySet` is exempt from that decline | `len_call_already_materialised_the_items` -> `false` | **5 failed**, 122 passed † |
| M2 the sink walks a TERMINATING object past the cap | `capped = !live_walk_terminates(ob)` -> `capped = true` | **7 failed**, 628 passed |
| M2a `live_walk_terminates`, `__iter__` half only | drop the `len.is_some()` conjunct's partner | **2 failed, 3 errors**, 630 passed |
| M2b `live_walk_terminates`, `len` half only | `self.len.is_some()` -> `true` | **1 failed** ‡ |
| M3 `in` asks Python's own `__contains__` first | drop `live_contains(..).or_else(..)` | **1 failed, 3 errors**, 631 passed |
| M4 `first`/`last` subscript the live object | `python_getitem`'s carrier arm gated off | **3 failed**, 632 passed |
| M5 `slice` slices the live object | `apply_slice`'s carrier arm gated off | **2 failed**, 633 passed |
| M6 `dictsort` routes a carrier through `iter_values` | the new `Value::Encoded` arm gated off | **9 failed**, 626 passed |

† M1b was run over the new file plus `test_engine_followups`; the five reds are
`test_the_conversion_bound_is_the_stated_length` and four cells of
`TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap`.

‡ M2b measured against the **new file alone**, where the red is
`TestBothHalvesOfTheSinkTerminationRuleAreCovered::test_an_unbounded_walk_raises_at_the_cap[count-…]`
— which is the whole of review finding 3: that half previously had no
assertion. Run together with `test_engine_followups`, the session still
STALLS rather than reporting, because that file's
`test_an_unbounded_iterator_raises_rather_than_hanging` walks
`itertools.count()` **in process**. That stall is pre-existing and is now
redundant: the new cell reports the same defect as a failure.

## Security

The floor holds, and it is a measurement rather than an inference.

An ordinary sized sequence of models past the cap reaches `Encoded::live`,
which it never did before, so `{{ rows.0.password }}` is answered by
`Context::walk_live` over the RAW object instead of by a `Value::List` whose
elements were denylist-filtered at the conversion.
`TestTheSerializationFloorHoldsOnTheNewHandle` renders the denylisted field on
BOTH sides of the cap and asserts both are empty, with a non-vacuity case
proving the padded collection really is a carrier. That class uses a `deque`
rather than a `list` — the `list` exemption above would otherwise have made it
vacuous, and its own non-vacuity case is what caught that.

`TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap` adds the shape the
review asked for: a real `django.db.models.QuerySet` (stuffed `_result_cache`,
`None` padding), floor field empty on both sides, and no sink spelling djust's
identity keys where the other side does not.

`Encoded::live`'s doc is corrected in place: a `list` and a `QuerySet` cannot
reach the field, now by a stated rule rather than by arm ordering.

## Issue x file x test

| issue | files | covering tests |
|---|---|---|
| #2695 | `crates/djust_core/src/lib.rs` (`stated_len_is_too_large_to_enumerate`, `len_call_already_materialised_the_items`, `Encoded::{live_walk_terminates,live_contains,live_get_item,live_get_slice}`), `crates/djust_templates/src/filters.rs` (`python_getitem`, `apply_slice`), `crates/djust_templates/src/renderer.rs` (`in`) | `TestASizedSequenceIsNotMaterialisedAtConversion`, `TestBothHalvesOfTheSinkTerminationRuleAreCovered`, `TestNeitherEngineReturnsFromAWalkOfAStatedBillion`, `TestTheEagerHatchStillEnumerates`, `TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap`, `TestAStatedBoundIsTrustedOnlyToTheCap2678::test_the_conversion_bound_is_the_stated_length` |
| #2693 | `crates/djust_templates/src/filters.rs` (`dictsort` arm) | `TestDictsortConsumesTheLiveHandle`, `TestEverySequenceArmDecidesTheCarrier`, `test_the_iteration_sink_has_exactly_the_callers_it_claims` |
| both | — | `TestTheDjangoDifferential` (218 comparable cells) |

## Note for #2703

Measuring this branch against `origin/main` for the shard-3 investigation
found the allocation: `test_engine_followups_2674_2670_2678_2657.py`'s
`crosses_as_encoded(range(10**9))` peaks at **33.9 GB** on `main` and
**288 MB** here, and the module is in shard 3 on both refs. Full measurement
posted to #2703.

Closes #2695
Closes #2693

🤖 Generated with [Claude Code](https://claude.com/claude-code)
