### PR TITLE
refactor(templates): share AST traversal and discover nested model fields

### DIFF
--- a/changelog.d/2712.fixed.md
+++ b/changelog.d/2712.fixed.md
@@ -1,0 +1,1 @@
+- **Template AST traversal**: Share exhaustive immutable and mutable child enumeration between inheritance annotations and model-field discovery. Discover literal model bindings inside ifchanged branches and inherited parent scopes while preserving scope-specific renderer behavior.

--- a/crates/djust_templates/src/inheritance.rs
+++ b/crates/djust_templates/src/inheritance.rs
@@ -15,60 +15,6 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use std::time::SystemTime;
 
-// Physical child lists shared by the immutable discovery walk and mutable
-// override walk. Exhaustive matching makes new node variants require a
-// traversal decision; no catch-all may silently hide a new container.
-macro_rules! child_lists {
-    ($node:expr) => {
-        match $node {
-            Node::If {
-                true_nodes,
-                false_nodes,
-                ..
-            } => [Some(true_nodes), Some(false_nodes)],
-            Node::For {
-                nodes, empty_nodes, ..
-            } => [Some(nodes), Some(empty_nodes)],
-            Node::IfChanged {
-                nodes, else_nodes, ..
-            } => [Some(nodes), Some(else_nodes)],
-            Node::BlockSuperScope { super_nodes, nodes } => [Some(super_nodes), Some(nodes)],
-            Node::Located { nodes, .. }
-            | Node::Block { nodes, .. }
-            | Node::With { nodes, .. }
-            | Node::Spaceless { nodes }
-            | Node::AutoEscape { nodes, .. }
-            | Node::Filter { nodes, .. } => [Some(nodes), None],
-            Node::ReactComponent { children, .. }
-            | Node::BlockCustomTag { children, .. }
-            | Node::Language { children, .. }
-            | Node::Timezone { children, .. }
-            | Node::Localize { children, .. }
-            | Node::LocalTime { children, .. } => [Some(children), None],
-            Node::Text(_)
-            | Node::Variable(..)
-            | Node::Extends(_)
-            | Node::Include { .. }
-            | Node::Comment
-            | Node::Load(_)
-            | Node::CsrfToken
-            | Node::Static(_)
-            | Node::RustComponent { .. }
-            | Node::CustomTag { .. }
-            | Node::WidthRatio { .. }
-            | Node::FirstOf { .. }
-            | Node::TemplateTag(_)
-            | Node::Cycle { .. }
-            | Node::ResetCycle { .. }
-            | Node::Now(_)
-            | Node::UnsupportedTag { .. }
-            | Node::AssignTag { .. }
-            | Node::InlineIf { .. }
-            | Node::RawBlockCustomTag { .. } => [None, None],
-        }
-    };
-}
-
 /// Validate literal path syntax before any branch can be selected.
 pub fn validate_relative_references(nodes: &[Node], name: &str) -> Result<()> {
     for node in nodes {
@@ -88,7 +34,7 @@ pub fn validate_relative_references(nodes: &[Node], name: &str) -> Result<()> {
                 construct_relative_path_allow_recursion(Some(origin), token, allow_recursion)?;
             }
         }
-        for children in child_lists!(node).into_iter().flatten() {
+        for children in node.child_lists().into_iter().flatten() {
             validate_relative_references(children, name)?;
         }
     }
@@ -110,7 +56,7 @@ fn attach_include_origins(nodes: &mut [Node], name: &str) {
                 *origin = Some(name.to_string());
             }
         }
-        for children in child_lists!(node).into_iter().flatten() {
+        for children in node.child_lists_mut().into_iter().flatten() {
             attach_include_origins(children, name);
         }
     }
@@ -126,7 +72,7 @@ pub fn set_ifchanged_origins(nodes: &mut [Node], template_origin: &str) {
                 *origin = Some(template_origin.to_string());
             }
         }
-        for children in child_lists!(node).into_iter().flatten() {
+        for children in node.child_lists_mut().into_iter().flatten() {
             set_ifchanged_origins(children, template_origin);
         }
     }
@@ -148,7 +94,7 @@ pub fn set_node_sources(nodes: &mut [Node], source: &Arc<str>, origin: Option<&s
                 *name = origin.map(str::to_owned);
             }
         }
-        for children in child_lists!(node).into_iter().flatten() {
+        for children in node.child_lists_mut().into_iter().flatten() {
             set_node_sources(children, source, origin);
         }
     }
@@ -278,7 +224,7 @@ impl InheritanceChain {
             Node::Extends(_) => return Node::Comment,
             _ => node.clone(),
         };
-        for children in child_lists!(&mut overridden).into_iter().flatten() {
+        for children in overridden.child_lists_mut().into_iter().flatten() {
             *children = self.apply_block_overrides(children);
         }
         overridden
@@ -448,7 +394,7 @@ fn extract_blocks_recursive(node: &Node, blocks: &mut HashMap<String, Vec<Node>>
     if let Node::Block { name, nodes } = node {
         blocks.insert(name.clone(), nodes.clone());
     }
-    for children in child_lists!(node).into_iter().flatten() {
+    for children in node.child_lists().into_iter().flatten() {
         for child in children {
             extract_blocks_recursive(child, blocks);
         }

--- a/crates/djust_templates/src/parser.rs
+++ b/crates/djust_templates/src/parser.rs
@@ -412,7 +412,74 @@ pub const TEMPLATETAG_NAMES: [&str; 8] = [
     "closecomment",
 ];
 
+// Physical child lists shared by the immutable discovery walk and mutable
+// override walk. Exhaustive matching makes new node variants require a
+// traversal decision; no catch-all may silently hide a new container.
+macro_rules! child_lists {
+    ($node:expr) => {
+        match $node {
+            Node::If {
+                true_nodes,
+                false_nodes,
+                ..
+            } => [Some(true_nodes), Some(false_nodes)],
+            Node::For {
+                nodes, empty_nodes, ..
+            } => [Some(nodes), Some(empty_nodes)],
+            Node::IfChanged {
+                nodes, else_nodes, ..
+            } => [Some(nodes), Some(else_nodes)],
+            Node::BlockSuperScope { super_nodes, nodes } => [Some(super_nodes), Some(nodes)],
+            Node::Located { nodes, .. }
+            | Node::Block { nodes, .. }
+            | Node::With { nodes, .. }
+            | Node::Spaceless { nodes }
+            | Node::AutoEscape { nodes, .. }
+            | Node::Filter { nodes, .. } => [Some(nodes), None],
+            Node::ReactComponent { children, .. }
+            | Node::BlockCustomTag { children, .. }
+            | Node::Language { children, .. }
+            | Node::Timezone { children, .. }
+            | Node::Localize { children, .. }
+            | Node::LocalTime { children, .. } => [Some(children), None],
+            Node::Text(_)
+            | Node::Variable(..)
+            | Node::Extends(_)
+            | Node::Include { .. }
+            | Node::Comment
+            | Node::Load(_)
+            | Node::CsrfToken
+            | Node::Static(_)
+            | Node::RustComponent { .. }
+            | Node::CustomTag { .. }
+            | Node::WidthRatio { .. }
+            | Node::FirstOf { .. }
+            | Node::TemplateTag(_)
+            | Node::Cycle { .. }
+            | Node::ResetCycle { .. }
+            | Node::Now(_)
+            | Node::UnsupportedTag { .. }
+            | Node::AssignTag { .. }
+            | Node::InlineIf { .. }
+            | Node::RawBlockCustomTag { .. } => [None, None],
+        }
+    };
+}
+
 impl Node {
+    /// Physical children only; callers decide evaluation order and scope semantics.
+    /// Structural children without executing them (parent-super body before child).
+    /// Analyses must
+    /// still handle scope boundaries (loops, includes, parent blocks) explicitly.
+    /// Evaluation and cache eligibility intentionally keep their own semantics.
+    pub fn child_lists(&self) -> [Option<&Vec<Node>>; 2] {
+        child_lists!(self)
+    }
+    /// Mutable counterpart used when annotating or rewriting the AST in place.
+    pub fn child_lists_mut(&mut self) -> [Option<&mut Vec<Node>>; 2] {
+        child_lists!(self)
+    }
+
     pub fn unlocated(&self) -> &Node {
         match self {
             Self::Located { nodes, .. } => nodes[0].unlocated(),
@@ -2732,47 +2799,7 @@ fn collect_dj_model_fields_depth<L: crate::inheritance::TemplateLoader>(
 ) {
     for node in nodes {
         match node {
-            Node::Located { nodes, .. } => {
-                collect_dj_model_fields_depth(nodes, loader, fields, depth)
-            }
-            // The immune source: developer template text literals.
             Node::Text(text) => scan_dj_model_in_text(text, fields),
-
-            // Recurse into every child-bearing variant so a `dj-model` binding
-            // inside an `{% if %}`/`{% for %}`/`{% block %}`/etc. is captured.
-            // Mirrors the recursion set in `assign_if_marker_ids`.
-            Node::If {
-                true_nodes,
-                false_nodes,
-                ..
-            } => {
-                collect_dj_model_fields_depth(true_nodes, loader, fields, depth);
-                collect_dj_model_fields_depth(false_nodes, loader, fields, depth);
-            }
-            Node::For {
-                nodes: body,
-                empty_nodes,
-                ..
-            } => {
-                collect_dj_model_fields_depth(body, loader, fields, depth);
-                collect_dj_model_fields_depth(empty_nodes, loader, fields, depth);
-            }
-            Node::Block { nodes: body, .. }
-            | Node::With { nodes: body, .. }
-            | Node::Spaceless { nodes: body, .. }
-            | Node::AutoEscape { nodes: body, .. }
-            | Node::Filter { nodes: body, .. } => {
-                collect_dj_model_fields_depth(body, loader, fields, depth);
-            }
-            Node::BlockCustomTag { children, .. } | Node::ReactComponent { children, .. } => {
-                collect_dj_model_fields_depth(children, loader, fields, depth);
-            }
-            Node::Language { children, .. }
-            | Node::Timezone { children, .. }
-            | Node::Localize { children, .. }
-            | Node::LocalTime { children, .. } => {
-                collect_dj_model_fields_depth(children, loader, fields, depth);
-            }
 
             // `{% include "child.html" %}` — load and walk the included
             // template's own text so its `dj-model` bindings are covered. The
@@ -2805,7 +2832,11 @@ fn collect_dj_model_fields_depth<L: crate::inheritance::TemplateLoader>(
             // Leaf / non-child variants carry no template Text. Note
             // `RustComponent`, `CustomTag`, `AssignTag`, `Variable`, etc. never
             // hold raw `dj-model=` markup, so there is nothing to scan.
-            _ => {}
+            _ => {
+                for children in node.child_lists().into_iter().flatten() {
+                    collect_dj_model_fields_depth(children, loader, fields, depth);
+                }
+            }
         }
     }
 }
@@ -4500,6 +4531,31 @@ mod tests {
         let mut got = fields(src);
         got.sort();
         assert_eq!(got, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+    }
+
+    #[test]
+    fn dj_model_ifchanged_branches_inside_wrappers() {
+        let src = r#"{% for item in items %}{% with value=item %}
+            {% ifchanged value %}<input dj-model="changed">
+            {% else %}<input dj-model="unchanged">{% endifchanged %}
+            {% endwith %}{% endfor %}"#;
+        let mut got = fields(src);
+        got.sort();
+        assert_eq!(got, vec!["changed", "unchanged"]);
+    }
+
+    #[test]
+    fn dj_model_super_scope_walks_both_literal_bodies() {
+        let nodes = vec![Node::BlockSuperScope {
+            nodes: vec![Node::Text(r#"<input dj-model="child">"#.into())],
+            super_nodes: vec![Node::Text(r#"<input dj-model="parent">"#.into())],
+        }];
+        let mut got = HashSet::new();
+        collect_dj_model_fields::<NoIncludeLoader>(&nodes, None, &mut got);
+        assert_eq!(
+            got,
+            HashSet::from(["child".to_string(), "parent".to_string()])
+        );
     }
 
     #[test]

--- a/python/tests/test_parse_time_template_syntax_error_2549.py
+++ b/python/tests/test_parse_time_template_syntax_error_2549.py
@@ -212,12 +212,13 @@ class TestPromotedToParseTime:
             _rust.unregister_tag_handler("late_2549_tag")
 
     def test_parser_no_longer_builds_unsupported_tag(self):
-        """Structural pin: outside ``#[cfg(test)]`` the only ``UnsupportedTag`` in
-        parser.rs is the enum variant — no arm constructs it any more."""
+        """No production parser arm constructs UnsupportedTag. The enum and
+        exhaustive structural match patterns remain valid references."""
         src = PARSER_RS.read_text(encoding="utf-8")
         production = src.split("#[cfg(test)]", 1)[0]
         assert "Ok(Some(Node::UnsupportedTag" not in production
-        assert re.findall(r"Node::UnsupportedTag\s*\{", production) == []
+        # A `{ .. }` match is not a value constructor (the shared AST walk).
+        assert re.findall(r"Node::UnsupportedTag\s*\{(?!\s*\.\.\s*\})", production) == []
         assert len(re.findall(r"^\s*UnsupportedTag\s*\{", production, re.MULTILINE)) == 1, (
             "expected exactly the enum declaration"
         )


### PR DESCRIPTION
## Summary

Model-field discovery silently skipped literal bindings inside `{% ifchanged %}` branches and inherited parent scopes. Move the exhaustive child-list definition onto `Node` and share it between inheritance annotations and model-field discovery. New node variants must now make an explicit traversal decision in one common structural definition.

The API returns fixed-size arrays of borrowed child lists without allocating. Scope-sensitive rendering, dependency and cycle analyses retain their own semantics; this change does not make alternative branches execute or make `block.super` lazy.

## Validation

- All `djust_templates` Rust tests passed, including new nested `ifchanged` and parent-scope model-field regressions.
- 171 Python inheritance, block-super, include-context, and ifchanged tests passed; 1 existing skip.
- Clippy with warnings denied and all commit/push hooks passed.
- Existing dynamic model-binding tests continue to fail closed; only trusted template literals populate the allowlist.

Closes #2712

Related: #2710 remains separate because lazy parent rendering requires expression-evaluation changes and side-effect tests, not structural traversal alone.
