### PR TITLE
fix(templates): retain lazy block handlers across body rendering

### DIFF
--- a/changelog.d/2707.fixed.md
+++ b/changelog.d/2707.fixed.md
@@ -1,0 +1,1 @@
+- Retain the same lazy block-tag handler across body rendering, so registry replacement or removal cannot deliver phase-one state to a different handler.

--- a/crates/djust_templates/src/registry.rs
+++ b/crates/djust_templates/src/registry.rs
@@ -1272,6 +1272,13 @@ pub fn block_handler_lazy_body(name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Retain the phase-one handler with its opaque state across body rendering.
+/// Registry mutations in the body cannot hand that state to another handler.
+pub struct PendingBlockBody {
+    handler: Py<PyAny>,
+    state: Py<PyAny>,
+}
+
 /// Phase one of the lazy-body contract (#2658): ask the handler whether it can
 /// answer WITHOUT the body.
 ///
@@ -1290,7 +1297,7 @@ pub fn call_block_handler_before_body(
     context: &HashMap<String, djust_core::Value>,
     raw_py_objects: Option<&HashMap<String, pyo3::Py<PyAny>>>,
     autoescape: bool,
-) -> Result<(Option<String>, Py<PyAny>), DjangoRustError> {
+) -> Result<(Option<String>, PendingBlockBody), DjangoRustError> {
     let handler = clone_block_handler(name)?;
     Python::attach(|py| {
         let py_args = build_py_args(py, args).map_err(DjangoRustError::TemplateError)?;
@@ -1308,11 +1315,11 @@ pub fn call_block_handler_before_body(
         })?;
         let output = output.bind(py);
         if output.is_none() {
-            return Ok((None, state));
+            return Ok((None, PendingBlockBody { handler, state }));
         }
         let html = escape_handler_return(output, "Block handler", name, autoescape)
             .map_err(DjangoRustError::TemplateError)?;
-        Ok((Some(html), state))
+        Ok((Some(html), PendingBlockBody { handler, state }))
     })
 }
 
@@ -1329,10 +1336,10 @@ pub fn call_block_handler_after_body(
     content: &str,
     context: &HashMap<String, djust_core::Value>,
     raw_py_objects: Option<&HashMap<String, pyo3::Py<PyAny>>>,
-    state: &Py<PyAny>,
+    pending: &PendingBlockBody,
     autoescape: bool,
 ) -> Result<String, DjangoRustError> {
-    let handler = clone_block_handler(name)?;
+    let handler = &pending.handler;
     Python::attach(|py| {
         let py_args = build_py_args(py, args).map_err(DjangoRustError::TemplateError)?;
         let py_content = mark_safe_str(py, content).map_err(|e| {
@@ -1344,7 +1351,7 @@ pub fn call_block_handler_after_body(
             .bind(py)
             .call_method1(
                 "after_body",
-                (py_args, py_content, py_context, state.clone_ref(py)),
+                (py_args, py_content, py_context, pending.state.clone_ref(py)),
             )
             .map_err(handler_exception)?;
         escape_handler_return(&result, "Block handler", name, autoescape)

--- a/python/tests/test_cache_tag_django_parity_2658.py
+++ b/python/tests/test_cache_tag_django_parity_2658.py
@@ -260,12 +260,20 @@ class TestReassertKeepsCacheABlockTag:
 
         src = '{% load cache %}{% cache 300 "reassert2658" %}ok{% endcache %}'
         assert str(backend.from_string(src).render({})) == "ok"
-        assert "cache" in template_libraries.owned_tags()
+        from djust._rust import registry_entry_is_local, unregister_block_tag_handler
 
-        template_libraries.reassert()
+        # Backend rendering restores the outer namespace on return. Inspect
+        # and mutate the owning engine, not any process-global fallback.
+        with template_libraries.rendering_with_backend(backend):
+            assert "cache" in template_libraries.owned_tags()
+            unregister_block_tag_handler("cache")
+            assert not registry_entry_is_local("cache", "block")
 
-        assert has_block_tag_handler("cache"), "reassert dropped the block handler"
-        assert not has_tag_handler("cache"), "reassert re-registered cache as an inline tag"
+            template_libraries.reassert()
+
+            assert registry_entry_is_local("cache", "block")
+            assert has_block_tag_handler("cache"), "reassert dropped the block handler"
+            assert not has_tag_handler("cache"), "reassert re-registered cache as an inline tag"
         caches["default"].clear()
         assert str(backend.from_string(src + " ").render({})) == "ok "
 

--- a/python/tests/test_lazy_body_handler_identity_2707.py
+++ b/python/tests/test_lazy_body_handler_identity_2707.py
@@ -1,0 +1,51 @@
+"""A body may mutate registrations without changing its enclosing handler."""
+
+import pytest
+from django.utils.safestring import mark_safe
+from djust import _rust
+
+
+@pytest.mark.parametrize("mutation", ["replace", "remove"])
+def test_lazy_body_keeps_phase_one_handler(mutation):
+    calls = []
+    state = object()
+    name = "identity2707"
+    mutator = "mutate2707"
+
+    class Original:
+        LAZY_BODY = True
+        RESOLVE_ARG_POSITIONS = frozenset()
+
+        def before_body(self, args, context):
+            calls.append("before")
+            return None, state
+
+        def after_body(self, args, content, context, received):
+            assert received is state
+            calls.append("after-original")
+            return mark_safe(content)
+
+    class Replacement(Original):
+        def after_body(self, args, content, context, received):
+            raise AssertionError("Replacement received another handler's state")
+
+    class Mutator:
+        RESOLVE_ARG_POSITIONS = frozenset()
+
+        def render(self, args, context):
+            calls.append("body")
+            if mutation == "replace":
+                _rust.register_block_tag_handler(name, "end" + name, Replacement())
+            else:
+                _rust.unregister_block_tag_handler(name)
+            return "body"
+
+    _rust.register_block_tag_handler(name, "end" + name, Original())
+    _rust.register_tag_handler(mutator, Mutator())
+    try:
+        source = "{% identity2707 %}{% mutate2707 %}{% endidentity2707 %}"
+        assert _rust.render_template(source, {}) == "body"
+        assert calls == ["before", "body", "after-original"]
+    finally:
+        _rust.unregister_block_tag_handler(name)
+        _rust.unregister_tag_handler(mutator)


### PR DESCRIPTION
A lazy block handler was looked up separately before and after body rendering. If the body replaced its registry entry, phase two received the first handler's opaque state on a different object; removal instead aborted the render.

Retain the original handler alongside its phase-one state for the duration of the body. Registry locks are released before application code executes, and both phases preserve their existing escaping rules.

Validation: replacement and removal regressions both fail on unchanged main and pass here; 57 focused tests passed, 5 existing skips. The Rust template suite and all commit/pre-push gates passed, including the full Python suite. Includes the already-merged #2718 cache-test prerequisite.

Closes #2707
