### PR TITLE
perf(templates): a large list/QuerySet is no longer converted at binding time (#2717)

### DIFF
--- a/changelog.d/2717.changed.md
+++ b/changelog.d/2717.changed.md
@@ -1,0 +1,20 @@
+- **Templates:** a large `list` or Django `QuerySet` in a template context is
+  no longer converted at binding time (#2717). The #2695 review had exempted
+  both from the conversion's decline at any length, because their declined
+  spelling was wrong — `{{ rows }}` over a 100 001-row queryset rendered
+  djust's own identity dicts, and `{{ rows.0 }}` answered `''`. That exemption
+  cost 4 GB: on an unevaluated `User.objects.all()` over a real 150 000-row
+  table, `{{ v|length }}` peaked at 4 437 MB / 13.4 s and `{{ v.0 }}` at
+  2 982 MB / 13.3 s. Both defects are fixed at the sink instead —
+  `{{ v }}` / `|pprint` / `|json_script` spell the container from the live
+  handle through the same `consume_live_items` walk `{% for %}` uses, and
+  `_SidecarQuerySetProxy` gained the `__getitem__` the live walk needs — so
+  the exemption is gone and nothing is exempt for its length. The same cells
+  now peak at 568 MB / 9.7 s and 149 MB / 0.9 s, with every rendered byte
+  unchanged either side of the cap. New cases in
+  `TestTheContainerSinksSpellFromTheLiveHandle`,
+  `TestNothingIsConvertedUntilASinkAsksForIt`,
+  `TestTheSidecarQuerySetProxySubscripts`,
+  `TestTheFloorHoldsOnEveryShapeTheDeclineNewlyClaims`,
+  `TestAContainerThatSpellsItselfIsNotRespelledAsAList` and
+  `TestTheContainerSpellingCallSitesAreTheSetNamed`.

--- a/crates/djust_core/src/context.rs
+++ b/crates/djust_core/src/context.rs
@@ -1803,10 +1803,20 @@ impl Context {
                 // path (`{{ block.content.text }}`) — resolved to empty because
                 // `getattr(dict, "text")` raises `AttributeError`. Mirroring
                 // Django's order fixes nested JSONField/dict/list access.
-                // The #1986 proxies (`_SidecarModelProxy`/`_SidecarQuerySetProxy`)
-                // implement no `__getitem__`, so item access on them falls
-                // through to `getattr` and the serialization floor still governs
-                // — this does not open a floor bypass.
+                // `_SidecarModelProxy` implements no `__getitem__`, so item
+                // access on it falls through to `getattr` and the
+                // serialization floor still governs.
+                // `_SidecarQuerySetProxy` DOES implement one since #2717 —
+                // without it `{{ rows.0 }}` was `VariableDoesNotExist` for any
+                // queryset the conversion declined — and it is not a floor
+                // bypass either: every result it hands back is run through
+                // `_protect_sidecar_value` (a slice's elements one at a time),
+                // so the next segment reads a proxy, never a raw model, and a
+                // `.values()` projection refuses as the zero-length sequence
+                // its own `__len__` reports. Pinned by
+                // `TestTheSidecarQuerySetProxySubscripts` and the 112-cell
+                // sweep in `TestTheFloorHoldsOnEveryShapeTheDeclineNewlyClaims`
+                // (`python/tests/test_declined_container_spelling_2717.py`).
                 //
                 // Each step catches EXACTLY the exception set Django catches
                 // there, and no more (#2506). The walk previously used a bare

--- a/crates/djust_core/src/lib.rs
+++ b/crates/djust_core/src/lib.rs
@@ -656,13 +656,18 @@ pub struct Encoded {
     /// **What can never acquire one.** `crosses_as_encoded` / the
     /// `FromPyObject` impl claim a `dict`, a tuple, anything with
     /// `__djust_serialize__` and any `Model` in arms ABOVE [`opaque_value`],
-    /// so no dict, model or manager reaches this field. A `list` and an
-    /// evaluated `QuerySet` are also excluded, but by a RULE rather than by
-    /// the ordering: [`len_call_already_materialised_the_items`] exempts them
-    /// from the conversion's decline at any length, because for those two the
-    /// items exist by the time the length is known and declining could only
-    /// change the spelling (#2695 review — it changed it to 66 MB of djust's
-    /// own serialization dicts).
+    /// so no dict, model or manager reaches this field.
+    ///
+    /// A `list` and a `QuerySet` DO reach it since #2717, and until then did
+    /// not: the #2695 review exempted both from the conversion's decline at
+    /// any length, because their declined spelling was wrong (66 MB of
+    /// djust's own serialization dicts for `{{ rows }}` over a 100 001-row
+    /// queryset). That exemption cost 4 GB on a 150 000-row table and is
+    /// gone; the spelling is answered at the sink instead, by
+    /// [`Encoded::declined_list_spelling`]. So a large `list`/`QuerySet` is
+    /// now an ordinary declined sized sequence here, and the floor question
+    /// below is asked of it too — see
+    /// `TestTheFloorHoldsOnEveryShapeTheDeclineNewlyClaims`.
     ///
     /// An ordinary sized sequence — a `deque`, an `array`, a `range`, a duck
     /// type with a stated `__len__` — DOES arrive here past
@@ -3070,6 +3075,35 @@ impl Value {
     /// `Missing` (`""`, Django's `string_if_invalid` substituted before the
     /// chain runs) and `Object` (its `__str__` for a model, dict repr
     /// otherwise). ONE definition, so no caller re-derives the split (#1646).
+    /// The operand a sink that spells this value WHOLE must use, when the
+    /// value itself cannot spell it (#2717).
+    ///
+    /// The ONE routing point for [`Encoded::declined_list_spelling`], read by
+    /// the three sinks that render a container whole — `{{ v }}`, `pprint`
+    /// and `json_script` — at FOUR call sites, because `{{ v }}` reaches it
+    /// twice: `renderer::localize_if_number` short-circuits `Display` for a
+    /// non-temporal carrier and returns `Encoded::display` directly, so
+    /// patching `Display` alone left the actual `{{ v }}` cell unchanged.
+    /// That fourth site was found by grepping the SINK rather than by listing
+    /// the callers it seemed to have. `None` for every other value and for every
+    /// other carrier, which is the common case and costs one integer compare;
+    /// `None` too when the live walk RAISES, so a caller keeps whatever it
+    /// would have rendered before this existed rather than growing an error
+    /// path (`Display` has no error channel, and the two filters answer their
+    /// own `str()`/JSON spelling as they always did).
+    ///
+    /// Pinned as a SET rather than as a floor by
+    /// `test_the_container_spelling_sinks_are_the_three_named` (#1125): a
+    /// fourth sink that spells a value whole has to be added here, or it
+    /// silently renders djust's own serialization dicts for a declined
+    /// queryset.
+    pub fn container_spelling(&self) -> Option<Value> {
+        match self {
+            Value::Encoded(e) => e.declined_list_spelling()?.ok(),
+            _ => None,
+        }
+    }
+
     pub fn py_str(&self) -> String {
         match self {
             Value::Decimal(d) => d.clone(),
@@ -3218,7 +3252,22 @@ impl fmt::Display for Value {
             Value::String(s) | Value::SafeString(s) => write!(f, "{s}"),
             // See the `legacy_display` arm: the display spelling is `str(o)`
             // on both paths, and only `json_script` reads the other one.
-            Value::Encoded(e) => write!(f, "{}", e.display),
+            //
+            // EXCEPT for a carrier the conversion declined for LENGTH whose
+            // spelling is its items' list repr — a `list`, a `QuerySet`, a
+            // djust queryset proxy (#2717). `str(o)` for those is a `list`
+            // repr djust never renders (66 MB of its own identity dicts for a
+            // serialised queryset), so the items are read from the live handle
+            // HERE, at the sink, rather than enumerated at binding time for
+            // every cell. `declined_list_spelling` answers `None` in one
+            // integer compare for everything else, which is what keeps this
+            // arm cheap; a Python failure mid-walk also answers the old
+            // `display`, because `Display` has no error channel and an
+            // unchanged cell beats a panic.
+            Value::Encoded(e) => match self.container_spelling() {
+                Some(spelled) => write!(f, "{spelled}"),
+                None => write!(f, "{}", e.display),
+            },
             Value::List(items) => {
                 let inner: Vec<String> = items.iter().map(Value::py_repr).collect();
                 write!(f, "[{}]", inner.join(", "))
@@ -3554,70 +3603,78 @@ fn surrogatepass_bytes_to_string(bytes: &[u8]) -> String {
 ///   both #2678's and #2695's hangs stay unfixed there. An unfixed cell
 ///   beats a wrong one.
 ///
-/// * **The object is not one whose declined SPELLING would be wrong**
-///   ([`len_call_already_materialised_the_items`], #2695 review). A `list`
-///   and a Django `QuerySet` are exempt at any length. That exemption is a
-///   TRADE and not a free one — read that function before assuming the
-///   decline costs those two shapes nothing.
-fn stated_len_is_too_large_to_enumerate(ob: &Bound<'_, PyAny>, len: usize) -> bool {
-    len > OPAQUE_ITEM_CAP && resolve_lazy() && !len_call_already_materialised_the_items(ob)
+/// TWO conditions and not three. A `list` and a Django `QuerySet` were
+/// EXEMPT from #2695 until #2717, because their declined spelling was wrong
+/// — `{{ rows }}` over a 100 001-row queryset rendered 66 MB of djust's own
+/// identity dicts where the same queryset one row shorter rendered
+/// `[qs0, qs1, qs2]`. That exemption cost 4 GB on a 150 000-row table
+/// (`{{ v|length }}`: 4 437 MB with it, 565 MB without), so #2717 closed the
+/// spelling defect instead of paying for it — see
+/// [`Encoded::declined_list_spelling`], which answers the three container
+/// sinks from the live handle. Nothing is exempt now.
+fn stated_len_is_too_large_to_enumerate(len: usize) -> bool {
+    len > OPAQUE_ITEM_CAP && resolve_lazy()
 }
 
-/// Are this object's items ALREADY built by the time its length is known?
-/// (#2695 review.)
+/// Is this object's SPELLING its ITEMS' list repr, rather than its own
+/// `str(o)`? (#2717, closing the #2695-review exemption.)
 ///
-/// True for a **`list`** (it holds its elements; `len()` is O(1) and creates
-/// nothing) and for a Django **`QuerySet`** (`__len__` calls `_fetch_all()`,
-/// so the row objects are in `_result_cache` the moment the length is
-/// known). [`stated_len_is_too_large_to_enumerate`] asks it and exempts both
-/// from the decline at any length.
+/// The ONE statement of that question, asked by
+/// [`Encoded::declined_list_spelling`] at the three container sinks that
+/// spell a value whole — `{{ v }}`, `|pprint`, `|json_script` — for a
+/// carrier the conversion DECLINED to enumerate. Two shapes answer yes:
 ///
-/// **The exemption is a TRADE, and the price is NOT zero.** An earlier
-/// version of this comment said the cost was "already sunk, so declining only
-/// changes the SPELLING". That is false, by about 4 GB, and the measurement
-/// is the re-review's (#2706): an UNEVALUATED `User.objects.all()` over a
-/// real 150 000-row table, rendering `{{ v|length }}` —
+/// * a **`list`**. `str(list)` IS its elements' repr, so a declined list has
+///   to be spelled from its elements or not at all.
+/// * a Django **`QuerySet`**. djust has never matched Django's
+///   `<QuerySet [...]>` here — a queryset in a djust context is serialised
+///   to a list of identity dicts, so `{{ rows }}` is `[qs0, qs1, qs2]` — and
+///   that spelling must not change at 100 000 rows.
 ///
-/// ```text
-/// exemption ON  (as shipped)      4 650 MB peak, 13.45 s
-/// exemption OFF (decline applies)   593 MB peak,  9.74 s
-/// ```
+/// **Not a `_SidecarQuerySetProxy`, and it does not need to be.** The object
+/// the `{{ v }}` conversion actually sees for a queryset IS that proxy —
+/// `Context::walk_live` runs `protect_sidecar_strict` over the root — so a
+/// third `hasattr("__djust_serialize__")` arm here looks obviously required.
+/// It is dead: the `FromPyObject` fallback block claims a
+/// `__djust_serialize__` object one arm ABOVE [`opaque_value`] and converts
+/// the `list` it hands back, so the proxy never becomes a carrier and this
+/// predicate is never asked about one. That arm shipped in #2717's first
+/// pass and was removed when its gate-off failed nothing;
+/// `crosses_as_encoded` over a padded proxy answers `False` on both sides of
+/// the cap, which is the same fact from the outside and is asserted in
+/// `TestTheFloorHoldsOnEveryShapeTheDeclineNewlyClaims::test_the_sweep_is_not_vacuous`.
 ///
-/// `len()` sinks the cost of `_fetch_all()` — about 140 MB of row objects —
-/// and NOT the conversion of those rows into [`Value`]s, which is the other
-/// ~4 GB. So what the exemption buys is a correct spelling, and what it pays
-/// is a real per-row conversion the decline would have avoided.
+/// **Why this used to be an exemption instead.** #2695 declined every sized
+/// sequence past the cap; its review found that declining these three
+/// spelled `{{ rows }}` over a 100 001-row queryset as
+/// `[{'id': 1, 'pk': 1, '__str__': 'qs0', '__model__': 'User', …}]` — 66 MB
+/// of djust's own serialization dicts — where the same queryset one row
+/// shorter rendered `[qs0, qs1, qs2]`, and answered `{{ rows.0 }}` with
+/// `''`. So the review exempted a `list` and a `QuerySet` from the decline
+/// at any length, which fixed the spelling and cost 4 GB: on an UNEVALUATED
+/// `User.objects.all()` over a real 150 000-row table, `{{ v|length }}` was
+/// 4 437 MB / 13.4 s with the exemption and 565 MB / 10.1 s without it
+/// (#2717's own measurement; the issue's, on the same shape, was
+/// 4 650 / 593 MB). `len()` sinks `_fetch_all()` — about 140 MB of rows —
+/// and NOT their conversion into [`Value`]s, which is the other ~4 GB.
 ///
-/// It is taken anyway, for two reasons that are about correctness rather than
-/// cost: the declined spelling is WRONG (below), and the exempted cost is not
-/// new — `main` never declined a `list` or a `QuerySet` either
-/// (`stated_bound_is_unverifiable` required the object to have NO `__iter__`),
-/// so this restores exactly the cost those two shapes already had rather than
-/// adding one. Getting both — decline the carrier AND spell it correctly at
-/// the sink — is filed as its own change (#2717); doing it here would have
-/// meant designing a lazy QuerySet carrier inside a review fix-pass.
+/// #2717 keeps the spelling and drops the cost by moving the enumeration to
+/// the three sinks that need it: the decline now applies to these shapes
+/// too, and the sinks re-derive the list through
+/// [`Encoded::consume_live_items`] — the SAME walk `{% for %}` and `|join`
+/// already use, so the spelling is the `Value::List` one by construction
+/// rather than by transcription (#1646). The other half, `{{ rows.0 }}`,
+/// was `_SidecarQuerySetProxy` having no `__getitem__` for the live walk to
+/// subscript; it has one now.
 ///
-/// The shape that found the spelling defect is one object wearing both hats.
-/// A 100 001-row
-/// `QuerySet` in a template context is auto-serialised by
-/// `DjustTemplate.render` into a `list` of djust's own identity dicts;
-/// declining that list spelled `{{ rows }}` as
-/// `[{'id': 1, 'pk': 1, '__str__': 'qs0', '__model__': 'User', …}]` — 66 MB —
-/// where the same queryset one row shorter renders `[qs0, qs1, qs2]`, and
-/// declining the QuerySet itself answered `{{ rows.0 }}` with `''` because
-/// `_SidecarQuerySetProxy` has no `__getitem__` for the live walk to use.
-/// Neither is a floor breach — the rows are denylist-filtered on both sides,
-/// pinned by `TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap` — but
-/// both are a content and payload change on the exact shape
-/// [`Encoded::live`]'s doc names.
-///
-/// Nothing else is exempt, and that is the point of asking about
-/// materialisation rather than listing types: a `tuple` never reaches here
-/// (the tuple arm above [`bounded_sequence_items`] claims it), and `range` /
-/// `bytes` / `array` / `deque` / a numpy array / a duck type with a stated
-/// `__len__` all DESCRIBE or PACK their items, so the decline is a real
-/// saving for them and they keep it.
-fn len_call_already_materialised_the_items(ob: &Bound<'_, PyAny>) -> bool {
+/// Nothing else answers yes, and that is the point of naming the SPELLING
+/// rather than a size: a `tuple` never reaches here (the tuple arm above
+/// [`bounded_sequence_items`] claims it), and `range` / `bytes` / `array` /
+/// `deque` / a numpy array / a duck type with a stated `__len__` each spell
+/// their own container — `str(range(3))` is `range(0, 3)` — so their
+/// declined carrier is already right and must NOT be re-spelled as a list
+/// (#2704).
+fn spelling_is_the_items_list_repr(ob: &Bound<'_, PyAny>) -> bool {
     if ob.is_instance_of::<PyList>() {
         return true;
     }
@@ -3632,10 +3689,21 @@ fn len_call_already_materialised_the_items(ob: &Bound<'_, PyAny>) -> bool {
 
 /// `isinstance(o, django.db.models.QuerySet)`, through a cached `sys.modules`
 /// lookup. ONE statement of the test, because two functions ask it about the
-/// same objects for two different reasons — the cap exemption
-/// ([`len_call_already_materialised_the_items`]) and the list-spelling
-/// exemption ([`list_repr_is_this_objects_own_spelling`]) — and a second copy
-/// is the #1646 shape.
+/// same objects for two different reasons, and a second copy is the #1646
+/// shape:
+///
+/// * [`list_repr_is_this_objects_own_spelling`] (#2704) asks at ANY length,
+///   to decide which conversion ARM claims the object;
+/// * [`spelling_is_the_items_list_repr`] (#2717) asks only PAST
+///   [`OPAQUE_ITEM_CAP`], to decide what an already-declined carrier SPELLS.
+///
+/// The second caller was `len_call_already_materialised_the_items` until
+/// #2717 renamed it and inverted its job (it named the shapes EXEMPT from
+/// the cap; its successor names the shapes whose spelling is their items'
+/// list repr). Both callers survived that change, so the "two reasons"
+/// above is still two — a claim worth re-checking rather than inheriting,
+/// since a rename that drops a caller would leave this comment true-looking
+/// and false.
 fn is_django_queryset(ob: &Bound<'_, PyAny>) -> bool {
     ob.py()
         .import("django.db.models")
@@ -3676,14 +3744,27 @@ fn is_django_queryset(ob: &Bound<'_, PyAny>) -> bool {
 ///   spells. (A `tuple` never reaches here — the tuple arm above
 ///   [`bounded_sequence_items`] claims it and `Value::Tuple` spells itself.)
 /// * **A Django `QuerySet`.** Its Django spelling is `<QuerySet [...]>`, so
-///   it IS divergent — but declining it is #2717's half, not this one: the
-///   `render_template` path hands the conversion a `_SidecarQuerySetProxy`
-///   with no `__getitem__`, so a declined queryset answers `{{ rows.0 }}`
-///   with `''`, and `TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap`
-///   pins that it must not. #2717 is the issue that carries both halves
-///   (a carrier that can spell its own container sinks); doing it here would
-///   mean designing a lazy QuerySet carrier inside a spelling fix. Scoped
-///   deliberately rather than half-done (CLAUDE.md #1079).
+///   it IS divergent, and this arm is what keeps djust's own answer
+///   (`[qs0, qs1, qs2]`) for one.
+///
+///   The reason USED to be a hazard: the `render_template` path hands the
+///   conversion a `_SidecarQuerySetProxy` that had no `__getitem__`, so a
+///   declined queryset answered `{{ rows.0 }}` with `''`. #2717 gave the
+///   proxy one, so that hazard is gone and this comment would be asserting
+///   a defect that no longer exists.
+///
+///   What keeps the arm is narrower and outlives the fix: #2717 governs what
+///   a carrier DECLINED FOR LENGTH spells — [`Encoded::declined_list_spelling`]
+///   opens with `len > OPAQUE_ITEM_CAP` — while this arm governs which arm
+///   claims a queryset at ANY length. Drop it and a THREE-row queryset
+///   crosses as a carrier, whose `{{ rows }}` is `str(...)` rather than
+///   `[qs0, qs1, qs2]`, with nothing in #2717 to re-spell it.
+///   `TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap` pins the two
+///   sides against each other and
+///   `TestASmallQuerySetIsUnmovedByTheDeclineChange2717` pins the small side
+///   against Django directly, because "the two agree" cannot catch both
+///   moving together. Retiring this arm is its own change with its own
+///   before/after, not a side effect of a length fix (CLAUDE.md #1079).
 fn list_repr_is_this_objects_own_spelling(ob: &Bound<'_, PyAny>) -> bool {
     if !resolve_lazy() {
         return true;
@@ -3716,7 +3797,7 @@ fn bounded_sequence_items<'py>(ob: &Bound<'py, PyAny>) -> Option<Vec<Bound<'py, 
         return None;
     }
     let len = ob.len().ok()?;
-    if stated_len_is_too_large_to_enumerate(ob, len) {
+    if stated_len_is_too_large_to_enumerate(len) {
         return None;
     }
     let mut items = Vec::with_capacity(len.min(OPAQUE_ITEM_CAP));
@@ -3940,14 +4021,19 @@ impl<'py> FromPyObject<'_, 'py> for Value {
                     // shapes convert (Object / List). The result carries no
                     // proxies, so this does not re-enter this branch.
                     //
-                    // The list-of-dicts converts IN FULL at any length, and
-                    // that is not a second rule: it is a `list`, and
-                    // `stated_len_is_too_large_to_enumerate` exempts a `list`
-                    // because its items are already materialised (#2695
-                    // review — see that function). Before the exemption a
-                    // 100 001-row queryset's rows were declined HERE and
-                    // spelled `{{ rows }}` as `str()` of djust's own identity
-                    // dicts.
+                    // The list-of-dicts is a `list`, so past
+                    // [`OPAQUE_ITEM_CAP`] it is DECLINED here like any other
+                    // sized sequence and crosses as a carrier over that list
+                    // (#2717). `{{ rows }}` / `|pprint` / `|json_script` then
+                    // spell it through [`Encoded::declined_list_spelling`],
+                    // which re-derives exactly these items from the live
+                    // handle — so the rendered bytes are the same either side
+                    // of the cap, and a template that asks only for
+                    // `{{ rows|length }}` or `{{ rows.0 }}` never pays for
+                    // them. Between the #2695 review and #2717 a `list` was
+                    // EXEMPT from the decline for this reason and the whole
+                    // list converted here at any length, which is the 4 GB
+                    // #2717 measured.
                     if let Ok(v) = result.extract::<Value>() {
                         return Ok(v);
                     }
@@ -4123,12 +4209,12 @@ fn opaque_gate(ob: &Bound<'_, PyAny>) -> Option<OpaqueFacts> {
         // than paying the billion reads that are the reported hang — for a
         // `range(10**9)` as much as for the liar whose `__getitem__` never
         // raises. Every sized collection UNDER the cap — `set`, `range(3)`,
-        // a `deque` — is enumerated in full exactly as before, and so is a
-        // `list` / an evaluated `QuerySet` at ANY length (their items are
-        // already built, so the decline could only change the spelling —
-        // `len_call_already_materialised_the_items`). Over the cap the ITEMS
-        // are read at the sink instead, from the live handle, under the
-        // sink's own termination rule ([`Encoded::live_walk_terminates`]).
+        // a `deque`, a `list`, an evaluated `QuerySet` — is enumerated in
+        // full exactly as before. Over the cap the ITEMS are read at the sink
+        // instead, from the live handle, under the sink's own termination
+        // rule ([`Encoded::live_walk_terminates`]); a `list` and a `QuerySet`
+        // were EXEMPT from that between the #2695 review and #2717, and are
+        // not any more (see [`spelling_is_the_items_list_repr`]).
         //
         // Without a `__len__` there is no bound at all, so walk to the cap: a
         // class whose `__iter__` returns `itertools.count()` is RE-iterable,
@@ -4145,7 +4231,7 @@ fn opaque_gate(ob: &Bound<'_, PyAny>) -> Option<OpaqueFacts> {
         //
         // Counted, not collected: the items are not converted here.
         match len {
-            Some(n) if stated_len_is_too_large_to_enumerate(ob, n) => {
+            Some(n) if stated_len_is_too_large_to_enumerate(n) => {
                 unbounded = true;
             }
             Some(_) => {}
@@ -4278,6 +4364,57 @@ impl Encoded {
             }
             Ok(collected)
         }))
+    }
+
+    /// The `Value::List` the conversion DECLINED to build, materialised at
+    /// the container sink instead of at binding time (#2717).
+    ///
+    /// `{{ v }}`, `|pprint` and `|json_script` are the three sinks that spell
+    /// a value WHOLE. Every other sink over a declined carrier reads only
+    /// what it needs — `|length` is `self.len`, `{{ v.0 }}` is
+    /// [`Encoded::live_get_item`], `|slice` is
+    /// [`Encoded::live_get_slice`], `{% for %}` / `|join` / `in` are
+    /// [`Encoded::consume_live_items`] — so those three are the whole of what
+    /// the #2695-review exemption was protecting, and this is what replaces
+    /// it.
+    ///
+    /// **Only for an object whose spelling IS its items' list repr** —
+    /// [`spelling_is_the_items_list_repr`], the same predicate that used to
+    /// name the exemption, so the rule has one statement (#1646). A `range`,
+    /// a `deque`, an `array`, a `bytes` and a sized user class each spell
+    /// their OWN container (`str(range(3))` is `range(0, 3)`), and re-spelling
+    /// one as a list is the #2704 defect in reverse; they answer `None` here
+    /// and keep `display`.
+    ///
+    /// **Cheap when it does not apply.** The `len` gate is a plain integer
+    /// compare and is FIRST: nothing but a sized sequence past
+    /// [`OPAQUE_ITEM_CAP`] can be a declined one, so an ordinary carrier —
+    /// a `datetime`, a `set`, a `complex`, a user object — never reaches the
+    /// Python probe. That matters because `Display for Value` calls this on
+    /// every `{{ carrier }}` in every render.
+    ///
+    /// **The items are the SAME ones the value stack would have held**,
+    /// because this reuses [`Encoded::consume_live_items`] — the walk
+    /// `{% for %}` already uses — rather than transcribing a second
+    /// enumeration. So the spelling either side of the cap is equal by
+    /// construction, which is exactly what
+    /// `TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap` asserts.
+    ///
+    /// What it buys, measured on an UNEVALUATED `User.objects.all()` over a
+    /// real 150 000-row table: `{{ v|length }}` falls from 4 437 MB / 13.4 s
+    /// to 565 MB / 10.1 s, and `{{ v.0 }}` from 2 982 MB / 13.3 s to
+    /// 148 MB / 0.7 s, because neither cell reaches this method. The three
+    /// cells that DO reach it pay what they always paid — they emit 60-100 MB
+    /// of HTML, so the enumeration is not the expensive half of them.
+    pub fn declined_list_spelling(&self) -> Option<PyResult<Value>> {
+        if !self.len.is_some_and(|n| n > OPAQUE_ITEM_CAP) {
+            return None;
+        }
+        let handle = self.live.as_ref()?;
+        if !Python::attach(|py| spelling_is_the_items_list_repr(handle.bind(py))) {
+            return None;
+        }
+        Some(self.consume_live_items()?.map(Value::List))
     }
 
     /// Python's `needle in o` over the live handle, consuming only as far as

--- a/crates/djust_templates/src/filters.rs
+++ b/crates/djust_templates/src/filters.rs
@@ -2141,6 +2141,14 @@ fn apply_builtin_filter(
                 return Some(Ok(Value::Missing));
             }
             // json_script filter: wrap value as JSON inside a <script> tag.
+            //
+            // Over the whole value, so the same #2717 substitution `pprint`
+            // and `Display` make: a length-declined `list`/`QuerySet` carrier
+            // is spelled from its live handle, or `value_to_json` emits the
+            // carrier's `display` as a JSON *string* where the same queryset
+            // one row shorter emits a JSON *array*.
+            let spelled = value.container_spelling();
+            let value = spelled.as_ref().unwrap_or(value);
             let json_str = value_to_json(value);
             let safe_json = json_escape_for_script(&json_str);
             // Django builds the tag with `format_html`, whose interpolation is
@@ -2318,7 +2326,15 @@ fn apply_builtin_filter(
             // Django's `pprint` filter is `pprint.pformat(value)` — which WRAPS
             // at width 80. The single-line builder this replaced diverged by
             // every newline and every indent space above that width (#2277).
-            Ok(Value::String(crate::pprint::pformat(value)))
+            //
+            // `container_spelling` first: `pformat` reads the value WHOLE, so a
+            // carrier the conversion declined for length must be spelled from
+            // its live handle here or it prints `str(o)` of djust's own
+            // serialization dicts (#2717). One of the three sinks that need
+            // it; the other two are `json_script` below and `Display`.
+            Ok(Value::String(crate::pprint::pformat(
+                value.container_spelling().as_ref().unwrap_or(value),
+            )))
         }
         // `[mark_safe(obj) for obj in value]`. `mark_safe(obj)` is
         // `SafeString(str(obj))`, so it does not merely MARK an item — it

--- a/crates/djust_templates/src/renderer.rs
+++ b/crates/djust_templates/src/renderer.rs
@@ -1976,7 +1976,19 @@ fn localize_if_number(value: &Value) -> Result<String> {
             // Decided in Rust first: a non-temporal Encoded never attaches
             // to Python (this arm runs once per rendered value).
             if encoded.temporal_kind().is_none() {
-                return Ok(encoded.display.clone());
+                // `{{ v }}`'s sink, and the one that short-circuits `Display`
+                // (#2717). A carrier the conversion declined for LENGTH whose
+                // spelling is its items' list repr — a `list`, a `QuerySet`, a
+                // djust queryset proxy — has to be spelled from its live
+                // handle, or this returns `str(o)` of djust's own
+                // serialization dicts. `container_spelling` answers `None` in
+                // one integer compare for every other carrier, which is what
+                // keeps this arm's "never attaches to Python" claim true for
+                // them.
+                return Ok(match value.container_spelling() {
+                    Some(spelled) => spelled.to_string(),
+                    None => encoded.display.clone(),
+                });
             }
             // `localize_temporal` resolved once per process, not per value.
             // `None` remembers that the module is absent (a bare-Rust test

--- a/python/djust/serialization.py
+++ b/python/djust/serialization.py
@@ -1636,6 +1636,43 @@ class _SidecarQuerySetProxy:
             return 0
         return len(object.__getattribute__(self, "_qs"))
 
+    def __getitem__(self, key: Any) -> Any:
+        """``qs[i]`` / ``qs[a:b]``, each result protected (#2717).
+
+        The third half of the sequence protocol this proxy forwards, and the
+        one it was missing. ``__iter__`` and ``__len__`` were here from
+        #1986; ``__getitem__`` was not, and the walk that reads it —
+        ``Context::walk_live``'s Django steps 1 and 3 — therefore answered
+        ``VariableDoesNotExist`` for ``{{ rows.0 }}`` on any queryset the
+        conversion had DECLINED to enumerate, because the object the walk
+        subscripts is this proxy and not the queryset behind it. Below
+        `OPAQUE_ITEM_CAP` the value stack answered instead and the gap never
+        showed; #2717 removed the length exemption that kept every queryset
+        below it, so the gap became the cell.
+
+        Each result is run through ``_protect_sidecar_value`` for the reason
+        ``__iter__`` runs its items through it: a bare ``qs[0]`` is a RAW
+        model and the next segment (``{{ rows.0.password }}``) would read it
+        unwrapped. A SLICE yields a ``list`` of models, which
+        ``_protect_sidecar_value`` returns unchanged (it has no list arm), so
+        the elements are protected here one at a time rather than trusting it
+        to recurse.
+
+        A ``.values()`` / ``.values_list()`` projection behaves exactly as
+        its own ``__len__`` of 0 says it should: every index is out of range
+        and every slice is empty. Same fail-closed refusal as ``__iter__``,
+        spelled as the zero-length sequence the rest of this proxy already
+        reports (vector 5 — a projection row carries no per-field floor).
+        """
+        if object.__getattribute__(self, "_is_projection"):
+            if isinstance(key, slice):
+                return []
+            raise IndexError("index out of range")
+        result = object.__getattribute__(self, "_qs")[key]
+        if isinstance(key, slice):
+            return [_protect_sidecar_value(item) for item in result]
+        return _protect_sidecar_value(result)
+
     def __djust_serialize__(self) -> Any:
         """Denylist-filtered LIST for terminal Value conversion (called by the
         Rust ``FromPyObject``). A ``{% for x in member.groups.all %}`` loop

--- a/python/djust/tests/test_nested_resolve_1997.py
+++ b/python/djust/tests/test_nested_resolve_1997.py
@@ -106,8 +106,14 @@ class TestNestedDictListResolve:
 @pytest.mark.django_db
 class TestFloorNotBypassedByItemAccess:
     """#1986 floor must still hold: item-access-first must not let a model's
-    sensitive field leak (proxies implement no __getitem__, so item access
-    falls through to the floored getattr)."""
+    sensitive field leak.
+
+    The mechanism is `_SidecarModelProxy` implementing no ``__getitem__``, so
+    item access on a MODEL falls through to the floored getattr. Named for the
+    model proxy specifically since #2717: `_SidecarQuerySetProxy` DOES
+    implement one now (the live walk needs it to answer ``{{ rows.0 }}``), and
+    it protects every result it hands back rather than relying on this
+    fall-through."""
 
     def test_password_still_refused_through_walk(self):
         from django.contrib.auth.models import User

--- a/python/tests/test_declined_container_spelling_2717.py
+++ b/python/tests/test_declined_container_spelling_2717.py
@@ -540,9 +540,15 @@ class TestTheContainerSpellingCallSitesAreTheSetNamed:
         `declined_list_spelling` — so "which shapes spell as a list" cannot
         drift between the conversion and the sink (#1646)."""
         text = (REPO_ROOT / "crates/djust_core/src/lib.rs").read_text(encoding="utf-8")
-        calls = re.findall(r"spelling_is_the_items_list_repr\(", text)
-        # One definition + one call.
-        assert len(calls) == 2, f"expected fn + 1 call site, found {len(calls)}"
+        # The definition and the call are counted SEPARATELY, not as one total
+        # of two. A bare `== 2` cannot tell "one fn + one call" from "no fn +
+        # two calls", so a rename that left a stale caller behind would read
+        # as green — the same shape as the matcher that could not distinguish
+        # a rename from a regression during the #2704/#2717 arc.
+        defs = re.findall(r"^fn spelling_is_the_items_list_repr\(", text, re.M)
+        calls = re.findall(r"(?<!fn )spelling_is_the_items_list_repr\(", text)
+        assert len(defs) == 1, f"expected exactly one definition, found {len(defs)}"
+        assert len(calls) == 1, f"expected exactly one call site, found {len(calls)}"
 
 
 class TestTheEagerHatchIsUnchanged:
@@ -596,3 +602,106 @@ class TestTheEagerHatchIsUnchanged:
         assert answer["encoded"] is False, "the hatch must never decline a sized sequence"
         assert answer["head"] == "[0, 1, 2, 3,"
         assert answer["length"] == "100001"
+
+
+@pytest.mark.django_db
+class TestASmallQuerySetIsUnmovedByTheDeclineChange2717:
+    """A SMALL, REAL queryset renders exactly what it rendered before #2717.
+
+    #2704's owner raised this after their PR merged, and it is the right
+    objection: #2704's `list_repr_is_this_objects_own_spelling` keeps a
+    `QuerySet` on the `Value::List` path at **any** length, while #2717's
+    `declined_list_spelling` opens with ``len > OPAQUE_ITEM_CAP`` and so can
+    only re-spell a carrier the cap declined. The two govern different things,
+    and **neither differential had measured the small case** — every queryset
+    cell in this file and in the #2695 file is padded past the cap or asserted
+    only against its own other side.
+
+    "The two sides of the cap agree" cannot catch both sides moving together,
+    which is exactly how the #2706 → #2717 chain started. So this pins the
+    small side against literals, measured on `origin/main` (the merged #2704
+    tree) before this branch was rebased onto it: all 14 cells came back
+    byte-identical after, and `crosses_as_encoded` is `False` on both.
+
+    A REAL queryset over a REAL table, and `filter(...)` rather than a slice:
+    a sliced queryset is a different object with different `__len__` /
+    `__getitem__` semantics, and the question is about the ordinary shape a
+    view puts in a context.
+    """
+
+    @staticmethod
+    def _rows():
+        """Three real rows, UNEVALUATED, deterministically ordered."""
+        from django.contrib.auth.models import User
+
+        return User.objects.filter(username__in=["u0", "u1", "u2"]).order_by("username")
+
+    @classmethod
+    def _render_rows(cls, src: str) -> str:
+        """Bound to the name the cells actually use.
+
+        The module-level `_render` binds `v`; these templates say `rows`, to
+        match the issue's own spelling. Mixing them renders `''` for every
+        cell — an unresolvable name, not an empty queryset — which is how the
+        first version of this class failed.
+        """
+        from djust import _rust
+
+        return _rust.render_template(src, {"rows": cls._rows()})
+
+    @pytest.fixture(autouse=True)
+    def _seed(self, db):
+        # `db` explicitly, not just the class marker: an autouse fixture that
+        # does not depend on it can run BEFORE the database is set up, and the
+        # rows go nowhere. The first version of this class did exactly that
+        # and three of its cells passed VACUOUSLY on an empty queryset
+        # (`{{ rows.0.password }}` is `''` either way, and an empty queryset is
+        # not a carrier either) — the literal cells are what caught it.
+        from django.contrib.auth.models import User
+
+        for i in range(3):
+            User.objects.create_user(
+                username=f"u{i}", email=f"u{i}@b.c", password="pbkdf2_sha256$SECRET"
+            )
+
+    @pytest.mark.parametrize(
+        ("src", "expected"),
+        [
+            # The cell the objection is about: a carrier would spell `str(...)`.
+            ("{{ rows }}", "[u0, u1, u2]"),
+            ("{{ rows.0 }}", "u0"),
+            ("{{ rows.0.username }}", "u0"),
+            ("{{ rows.0.email }}", "u0@b.c"),
+            ("{{ rows.0.password }}", ""),
+            ("{{ rows|length }}", "3"),
+            ("{{ rows|first }}", "u0"),
+            ("{{ rows|last }}", "u2"),
+            ('{{ rows|slice:":2" }}', "[u0, u1]"),
+            ("{% for r in rows %}{{ r.username }}|{% endfor %}", "u0|u1|u2|"),
+            ("{% if rows %}T{% else %}F{% endif %}", "T"),
+        ],
+    )
+    def test_the_cell_is_what_it_was_before_this_branch(self, src: str, expected: str) -> None:
+        assert self._render_rows(src) == expected
+
+    @pytest.mark.parametrize("src", ["{{ rows|pprint }}", '{{ rows|json_script:"x" }}'])
+    def test_the_dump_filters_still_dump_three_identity_maps(self, src: str) -> None:
+        """Asserted structurally rather than byte-for-byte: both dump every
+        field, including a `date_joined` the fixture cannot pin. Three maps is
+        the `Value::List` answer; a carrier would spell one string."""
+        out = self._render_rows(src)
+        assert out.count("__model__") == 3, out[:200]
+        assert "SECRET" not in out
+
+    def test_the_small_queryset_is_not_a_carrier_at_all(self) -> None:
+        """The mechanism behind every row above, and the reason #2717 cannot
+        have moved them: a 3-row queryset never reaches `Encoded::live`, so
+        `declined_list_spelling` is never asked about one.
+
+        This is also the line that would go red if #2704's QuerySet arm were
+        dropped — which is what makes the literals above a pin on that arm
+        rather than a restatement of #2717.
+        """
+        from djust import _rust
+
+        assert _rust.crosses_as_encoded(self._rows()) is False

--- a/python/tests/test_declined_container_spelling_2717.py
+++ b/python/tests/test_declined_container_spelling_2717.py
@@ -1,0 +1,598 @@
+"""#2717 — a large `list` / `QuerySet` is no longer converted at binding time.
+
+The #2695 review made the conversion decline to enumerate a sized sequence
+past ``OPAQUE_ITEM_CAP``, then EXEMPTED a ``list`` and a Django ``QuerySet``
+from that decline at any length, because declining those two produced a wrong
+SPELLING: ``{{ rows }}`` over a 100 001-row queryset rendered 66 MB of djust's
+own identity dicts where the same queryset one row shorter rendered
+``[qs0, qs1, qs2]``, and ``{{ rows.0 }}`` answered ``''``.
+
+The exemption cost, measured on an UNEVALUATED ``User.objects.all()`` over a
+real 150 000-row table (issue #2717, reproduced on this branch):
+
+===========================  ==========  ========
+cell                         peak RSS    seconds
+===========================  ==========  ========
+``{{ v|length }}`` exempt      4 437 MB     13.4
+``{{ v|length }}`` declined      567 MB      9.7
+``{{ v.0 }}``      exempt      2 982 MB     13.3
+``{{ v.0 }}``      declined       149 MB      0.7
+===========================  ==========  ========
+
+#2717 keeps the spelling and drops the cost, with two changes that are
+deliberately narrow:
+
+1. ``Encoded::declined_list_spelling`` answers the THREE sinks that spell a
+   value whole — ``{{ v }}``, ``|pprint``, ``|json_script`` — from the live
+   handle, through the same ``consume_live_items`` walk ``{% for %}`` already
+   uses. Every other sink already read only what it needed.
+2. ``_SidecarQuerySetProxy.__getitem__``, which the live walk needs to
+   subscript a declined queryset and which the proxy never had.
+
+The exemption is then gone, and nothing is exempt for its length.
+
+**What this file does NOT re-pin.** That the rendered bytes are unchanged
+either side of the cap is
+``TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap`` in
+``test_sized_sequence_conversion_2695_2693.py`` — it was written for the
+exemption and passes unchanged against the replacement, which is the strongest
+statement available that the swap is invisible. This file pins the parts that
+are new: the cost, the proxy's subscript, the floor on the shapes the decline
+NEWLY claims, and the boundary against #2704.
+"""
+
+from __future__ import annotations
+
+import array
+import collections
+import datetime
+import functools
+import json
+import pathlib
+import re
+
+import pytest
+
+CAP = 100_000
+PAST = CAP + 1
+SECRET = "pbkdf2_sha256$SUPERSECRETHASH"
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+# --------------------------------------------------------------------------
+# Shapes.
+#
+# `None` padding puts a collection past the cap without building 100 000 real
+# objects — the same device the #2695 file uses, and only element 0 is ever
+# read.
+# --------------------------------------------------------------------------
+#: A FIXED `date_joined`, because `|pprint` and `|json_script` dump every
+#: field and `auto_now_add`'s microseconds would make two builds of the same
+#: fixture differ — a spelling comparison would then fail for a reason that
+#: has nothing to do with the cap.
+_JOINED = datetime.datetime(2020, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)
+
+
+def _users(padding: int) -> list:
+    from django.contrib.auth.models import User
+
+    rows = []
+    for i in range(3):
+        user = User(
+            username="alice",
+            password=SECRET,
+            email="a@b.c",
+            is_superuser=True,
+            is_staff=True,
+            date_joined=_JOINED,
+        )
+        user.pk = i
+        rows.append(user)
+    return rows + [None] * padding
+
+
+def _queryset(padding: int):
+    """A real ``QuerySet`` with its result cache stuffed — the exact state an
+    evaluated queryset is in, with no database."""
+    from django.contrib.auth.models import User
+
+    qs = User.objects.all()
+    qs._result_cache = _users(padding)
+    return qs
+
+
+def _proxy(padding: int):
+    from djust.serialization import _SidecarQuerySetProxy
+
+    return _SidecarQuerySetProxy(_queryset(padding))
+
+
+def _projection(padding: int):
+    """A ``.values()`` projection proxy — rows with no per-field floor, which
+    the proxy refuses wholesale (#1986 vector 5)."""
+    from django.contrib.auth.models import User
+    from djust.serialization import _SidecarQuerySetProxy
+
+    qs = User.objects.values("password")
+    qs._result_cache = [{"password": SECRET}] * (padding + 3)
+    return _SidecarQuerySetProxy(qs)
+
+
+#: The shapes #2717's decline newly claims, and how to build one at a length.
+NEWLY_DECLINED = {
+    "list[Model]": _users,
+    "QuerySet": _queryset,
+    "_SidecarQuerySetProxy": _proxy,
+}
+
+#: The three sinks that spell a value WHOLE. Every other sink reads only what
+#: it needs from the live handle and was never what the exemption protected.
+CONTAINER_SINKS = ["{{ v }}", "{{ v|pprint }}", '{{ v|json_script:"x" }}']
+
+
+@functools.lru_cache(maxsize=None)
+def _shape(name: str, padding: int):
+    """One built collection per (shape, length), reused across the sinks.
+
+    Safe to share: every shape here is RE-iterable and nothing below mutates
+    one, so a second render sees the same object in the same state — and
+    building a 100 001-element collection once per sink rather than once per
+    (shape, length) is most of this file's runtime.
+    """
+    return dict(NEWLY_DECLINED, **{"values()-projection-proxy": _projection})[name](padding)
+
+
+def _render(src: str, value) -> str:
+    from djust import _rust
+
+    return _rust.render_template(src, {"v": value})
+
+
+# --------------------------------------------------------------------------
+
+
+class TestTheContainerSinksSpellFromTheLiveHandle:
+    """The half the exemption existed to protect, done at the sink instead.
+
+    Asserted as "the same spelling either side of the cap" rather than as an
+    expected string, for the reason the #2695 file gives: what a queryset
+    renders as is djust's own answer (``[qs0, qs1, qs2]``, never Django's
+    ``<QuerySet [...]>``), and the claim is that crossing 100 000 rows does
+    not CHANGE it.
+    """
+
+    @pytest.mark.parametrize("shape", sorted(NEWLY_DECLINED))
+    @pytest.mark.parametrize("src", CONTAINER_SINKS)
+    def test_the_spelling_is_the_same_on_both_sides_of_the_cap(self, shape: str, src: str) -> None:
+        under = _render(src, _shape(shape, 0))
+        past = _render(src, _shape(shape, PAST - 3))
+        # The `None` padding is the ONLY thing that may differ: it is what puts
+        # the collection past the cap and it has no counterpart under it.
+        # Deleting the padding elements from the long rendering must give the
+        # short one back, BYTE for byte — a prefix check would not catch a
+        # changed suffix, and `json_script`'s is `]</script>`.
+        padding_free = re.sub(r"(,\s*(None|null))+", "", past)
+        assert padding_free == under, (
+            f"{shape} {src}: past the cap the container is spelled\n"
+            f"  {padding_free[:300]!r}\nwhere under it, it is\n  {under[:300]!r}"
+        )
+        assert SECRET not in under and SECRET not in past
+
+    @pytest.mark.parametrize("shape", sorted(NEWLY_DECLINED))
+    def test_the_payload_is_the_padding_and_not_a_re_spelling(self, shape: str) -> None:
+        """The 66 MB cell.
+
+        The declined spelling before #2717 was ``str()`` of djust's own
+        identity dicts — 66 MB for ``{{ v }}`` against ~0.6 MB here, and every
+        row carrying a ``__model__`` key that the correct spelling shows zero
+        of.
+        """
+        past = _render("{{ v }}", _shape(shape, PAST - 3))
+        assert past.count("__model__") == 0, (
+            f"{shape}: `{{{{ v }}}}` past the cap spelled "
+            f"{past.count('__model__')} identity maps — the decline put djust's "
+            f"own serialization dicts on screen: {past[:200]!r}"
+        )
+        assert len(past) < 5_000_000, f"{shape}: `{{{{ v }}}}` rendered {len(past)} bytes"
+
+    @pytest.mark.parametrize("shape", sorted(NEWLY_DECLINED))
+    def test_the_item_sinks_answer_the_same_on_both_sides(self, shape: str) -> None:
+        """``{{ v.0 }}`` is the other half — ``''`` before #2717 for both
+        queryset shapes, because ``_SidecarQuerySetProxy`` had no
+        ``__getitem__`` for ``Context::walk_live`` to subscript."""
+        for src, expected in (
+            ("{{ v.0 }}", "alice"),
+            ("{{ v.0.username }}", "alice"),
+            ("{{ v|first }}", "alice"),
+            ("{% if v %}T{% else %}F{% endif %}", "T"),
+        ):
+            assert _render(src, _shape(shape, 0)) == expected, f"{shape} {src} under"
+            assert _render(src, _shape(shape, PAST - 3)) == expected, f"{shape} {src} past"
+
+    def test_the_padded_shapes_really_are_carriers(self) -> None:
+        """Non-vacuity for every case above (#1200/#1468).
+
+        A `list` and a `QuerySet` past the cap answer `True` only because
+        #2717 removed the exemption; between the #2695 review and this change
+        both answered `False` and every cell above was measuring the
+        `Value::List` path twice.
+
+        `_SidecarQuerySetProxy` answers `False` and that is correct rather
+        than a gap: the conversion claims it one arm EARLIER, at
+        `__djust_serialize__`, which hands back a `list` — and it is THAT
+        list, past the cap, that is declined. The proxy shape is in this file
+        because it is the object the `{{ v }}` walk actually converts, so a
+        regression there would not show on the other two.
+        """
+        from djust import _rust
+
+        assert _rust.crosses_as_encoded(_users(PAST - 3)) is True
+        assert _rust.crosses_as_encoded(_users(0)) is False
+        assert _rust.crosses_as_encoded(_queryset(PAST - 3)) is True
+        assert _rust.crosses_as_encoded(_queryset(0)) is False
+        # The proxy's own list, which is what the decline claims for it.
+        assert _rust.crosses_as_encoded(_proxy(PAST - 3).__djust_serialize__()) is True
+        assert _rust.crosses_as_encoded(_proxy(0).__djust_serialize__()) is False
+
+
+class TestNothingIsConvertedUntilASinkAsksForIt:
+    """The cost, as a COUNT rather than as a memory threshold.
+
+    An RSS or wall-clock assertion is an outlier-sensitive gate and this repo
+    has retired two of them; the property #2717 actually changed is *how many
+    elements the render converts*, which is exact and load-independent. Each
+    element counts its own conversion — `opaque_value` spells every carried
+    object with `str(o)` — so the counter is the number of elements the
+    conversion touched.
+
+    Before #2717 every cell converted all 100 001; after it, only the cells
+    that spell the container whole do.
+    """
+
+    class Counted:
+        """Sized-sequence element that records each conversion.
+
+        A class rather than a `Mock`: the conversion reaches `str(o)` through
+        `opaque_value`, which a mock's auto-attributes would make unpredictable.
+        """
+
+        conversions = 0
+
+        def __init__(self, i: int) -> None:
+            self.i = i
+
+        def __str__(self) -> str:
+            type(self).conversions += 1
+            return f"c{self.i}"
+
+        def __repr__(self) -> str:
+            # NOT counted, and defined at all only because a carrier records
+            # `str(o)` AND `repr(o)`: counting both would double every number
+            # here for no extra statement, and a class without `__repr__` puts
+            # `<… object at 0x…>` inside the list spelling.
+            return f"c{self.i}"
+
+    def _fresh(self, n: int) -> list:
+        # A dynamic subclass per call, so one test's count cannot leak into
+        # the next (#1109).
+        cls = type("Counted", (TestNothingIsConvertedUntilASinkAsksForIt.Counted,), {})
+        cls.conversions = 0
+        return [cls(i) for i in range(n)], cls
+
+    @pytest.mark.parametrize(
+        ("src", "expected"),
+        [
+            # Answered from `Encoded::len` / `truthy` — nothing is converted.
+            ("{{ v|length }}", 0),
+            ("{% if v %}T{% endif %}", 0),
+            # One `__getitem__` on the live handle, one conversion.
+            ("{{ v.0 }}", 1),
+            ("{{ v|first }}", 1),
+            ("{{ v|last }}", 1),
+        ],
+    )
+    def test_a_cheap_cell_converts_almost_nothing_past_the_cap(
+        self, src: str, expected: int
+    ) -> None:
+        rows, cls = self._fresh(PAST)
+        _render(src, rows)
+        assert cls.conversions == expected, (
+            f"{src} converted {cls.conversions} of {PAST} elements; before #2717 it "
+            f"converted all of them, which is the 4 GB the issue measured"
+        )
+
+    def test_a_container_sink_converts_every_element_exactly_once(self) -> None:
+        """The other side of the trade, stated rather than hidden: spelling
+        the container whole still costs one conversion per element — the same
+        cost the exemption paid for EVERY cell. It is paid here because the
+        cell emits every element, so there is nothing to save."""
+        rows, cls = self._fresh(PAST)
+        out = _render("{{ v }}", rows)
+        assert cls.conversions == PAST
+        assert out.startswith("[c0, c1, c2,")
+
+    def test_under_the_cap_every_cell_converts_everything_as_it_always_did(
+        self,
+    ) -> None:
+        """The bound is on the LENGTH, not on the cell: a short list is still
+        enumerated at the conversion, so this fix cannot have moved the common
+        case."""
+        rows, cls = self._fresh(3)
+        _render("{{ v|length }}", rows)
+        assert cls.conversions == 3
+
+
+class TestTheSidecarQuerySetProxySubscripts:
+    """``_SidecarQuerySetProxy.__getitem__`` (#2717) — the third half of the
+    sequence protocol the proxy forwards, and the one it was missing."""
+
+    def test_an_index_returns_a_protected_model(self) -> None:
+        from djust.serialization import _SidecarModelProxy
+
+        assert isinstance(_proxy(0)[0], _SidecarModelProxy)
+
+    def test_a_slice_protects_every_element(self) -> None:
+        """`_protect_sidecar_value` has no list arm, so a slice's elements are
+        protected here one at a time rather than by trusting it to recurse —
+        a bare `qs[0:2]` is a list of RAW models."""
+        from djust.serialization import _SidecarModelProxy
+
+        sliced = _proxy(0)[0:2]
+        assert len(sliced) == 2
+        assert all(isinstance(item, _SidecarModelProxy) for item in sliced)
+
+    def test_the_floor_holds_through_the_subscript(self) -> None:
+        with pytest.raises(AttributeError):
+            _proxy(0)[0].password
+        assert _proxy(0)[0].username == "alice"
+
+    def test_a_projection_behaves_as_the_zero_length_sequence_it_reports(
+        self,
+    ) -> None:
+        """A `.values()` projection carries no per-field floor, so the proxy
+        refuses it wholesale — `__len__` already reports 0 and `__iter__`
+        already yields nothing, and the subscript says the same thing."""
+        proj = _projection(0)
+        assert len(proj) == 0
+        with pytest.raises(IndexError):
+            proj[0]
+        assert proj[0:2] == []
+
+    def test_the_walk_needs_it(self) -> None:
+        """The cell, not just the method: without `__getitem__` the live walk
+        falls through step 1 (item), step 2 (`getattr('0')`) and step 3
+        (`current[0]`) and answers `VariableDoesNotExist`, which renders
+        empty. That is what `{{ rows.0 }}` did for a declined queryset."""
+        assert _render("{{ v.0 }}", _queryset(PAST - 3)) == "alice"
+        assert _render("{{ v.0.username }}", _queryset(PAST - 3)) == "alice"
+
+
+class TestTheFloorHoldsOnEveryShapeTheDeclineNewlyClaims:
+    """The serialization floor, re-probed on the NEW crossing set (#2717).
+
+    ``TestTheSerializationFloorHoldsOnTheNewHandle`` in the #2695 file sweeps a
+    ``deque`` — the shape that was already carried. #2717 moves three more
+    shapes onto ``Encoded::live`` and adds a new subscript to the proxy, so
+    "unchanged in kind" would be a guess. This is the measurement.
+
+    Every sink that can carry a field to the page, on both sides of the cap,
+    against a model whose ``password`` / ``is_superuser`` / ``is_staff`` are
+    all set — the whole of ``_ALWAYS_EXCLUDED_FIELDS``.
+    """
+
+    FLOOR_SINKS = [
+        "{{ v.0.password }}",
+        "{{ v.0.is_superuser }}",
+        "{{ v.0.is_staff }}",
+        "{{ v.0.get_session_auth_hash }}",
+        "{{ v.0.password|default:'D' }}",
+        "{{ v }}",
+        "{{ v|pprint }}",
+        '{{ v|json_script:"x" }}',
+        "{{ v|first }}",
+        "{{ v|last }}",
+        '{{ v|slice:":2" }}',
+        "{{ v|safeseq|join:',' }}",
+        "{{ v|unordered_list }}",
+        "{% for r in v %}{{ r.password }}|{{ r.is_superuser }}{% endfor %}",
+    ]
+
+    @pytest.mark.parametrize("shape", sorted(list(NEWLY_DECLINED) + ["values()-projection-proxy"]))
+    @pytest.mark.parametrize("side", ["under", "past"])
+    @pytest.mark.parametrize("src", FLOOR_SINKS)
+    def test_no_floor_field_reaches_the_page(self, shape: str, side: str, src: str) -> None:
+        out = _render(src, _shape(shape, 0 if side == "under" else PAST - 3))
+        assert SECRET not in out, f"{shape} {side} the cap: {src} leaked the hash"
+        # The privilege flags are `True` on the model and must render as the
+        # floor's empty string, never as the flag. Matched on the WHOLE cell,
+        # not on a substring: the `{% for %}` row also names `is_superuser`
+        # and its correct output is the separators, not `''`.
+        if src in ("{{ v.0.is_superuser }}", "{{ v.0.is_staff }}"):
+            assert out == "", f"{shape} {side} the cap: {src} rendered {out!r}"
+        if src.startswith("{% for"):
+            # `sep|flag` per row, both halves refused: no hash, no `True`.
+            assert set(out) <= {"|"}, (
+                f"{shape} {side} the cap: the loop emitted {out[:120]!r} — every "
+                f"row must contribute only its separator"
+            )
+
+    def test_the_sweep_is_not_vacuous(self) -> None:
+        """Each shape's crossing bit, so a future change that stops declining
+        one of them cannot leave this class quietly measuring the old path
+        (#1859: a pin that cannot go red is decorative).
+
+        The two direct shapes cross as carriers past the cap; the two proxies
+        are claimed one arm earlier by `__djust_serialize__`, and it is the
+        `list` they hand back that crosses — asserted through that hook so the
+        `False` here is a statement about the ROUTE rather than an unexplained
+        exception.
+        """
+        from djust import _rust
+
+        assert _rust.crosses_as_encoded(_users(PAST - 3)) is True
+        assert _rust.crosses_as_encoded(_queryset(PAST - 3)) is True
+        assert _rust.crosses_as_encoded(_proxy(PAST - 3)) is False
+        assert _rust.crosses_as_encoded(_proxy(PAST - 3).__djust_serialize__()) is True
+        # The projection's hook is empty by refusal, which is why its rows
+        # above are all blank — stated, so a reader does not mistake the blank
+        # cells for the floor working.
+        assert _projection(PAST - 3).__djust_serialize__() == []
+
+    def test_the_model_really_carries_the_fields_being_denied(self) -> None:
+        """Non-vacuity of the payload itself: if the fixture stopped setting
+        `password`, every row above would pass for the wrong reason."""
+        rows = _users(0)
+        assert rows[0].password == SECRET
+        assert rows[0].is_superuser is True
+        assert rows[0].is_staff is True
+
+
+class TestAContainerThatSpellsItselfIsNotRespelledAsAList:
+    """The #2704 boundary, from the other side.
+
+    ``declined_list_spelling`` must claim the shapes whose spelling IS their
+    items' list repr and NOTHING else. A ``range``, a ``deque``, an ``array``
+    and a ``bytes`` each spell their own container, and re-spelling one as a
+    list is #2704's defect with the sign flipped.
+    """
+
+    @pytest.mark.parametrize(
+        ("label", "build"),
+        [
+            ("range", lambda: range(10**9)),
+            ("deque", lambda: collections.deque(range(PAST))),
+            # `array`'s repr carries quotes (`array('i', [...])`), which the
+            # renderer escapes — the reason `expected` is derived rather than
+            # written out.
+            ("array", lambda: array.array("i", [1] * PAST)),
+        ],
+    )
+    def test_a_self_spelling_container_keeps_str_o(self, label: str, build) -> None:
+        from django.utils.html import escape
+
+        obj = build()
+        out = _render("{{ v }}", obj)
+        expected = escape(str(obj))
+        # Compared in three pieces rather than as one `==`. These renderings
+        # are up to 700 KB, and pytest's failure diff over two strings that
+        # size does not come back — a whole-string `assert` turns a one-line
+        # regression into an apparent hang.
+        assert len(out) == len(expected), (
+            f"{label} past the cap rendered {len(out)} bytes against "
+            f"{len(expected)} for `str(o)`: {out[:120]!r}"
+        )
+        assert out[:200] == expected[:200], (
+            f"{label} past the cap starts {out[:200]!r}; it must be its own "
+            f"`str(o)`, not a list repr (#2704)"
+        )
+        assert out[-80:] == expected[-80:], f"{label} ends {out[-80:]!r}"
+
+    def test_the_range_spelling_is_djangos_verbatim(self) -> None:
+        """One literal, so the derived comparison above cannot pass by
+        agreeing with a `str(o)` that is itself wrong."""
+        assert _render("{{ v }}", range(10**9)) == "range(0, 1000000000)"
+
+    def test_the_shapes_above_really_are_carriers(self) -> None:
+        """Non-vacuity: under the cap these are `Value::List`s and the
+        assertions would be about a different mechanism."""
+        from djust import _rust
+
+        assert _rust.crosses_as_encoded(range(10**9)) is True
+        assert _rust.crosses_as_encoded(collections.deque(range(PAST))) is True
+
+
+class TestTheContainerSpellingCallSitesAreTheSetNamed:
+    """A SET, not a floor (#1125).
+
+    Four call sites across three sinks: `{{ v }}` reaches the substitution
+    twice, because `renderer::localize_if_number` short-circuits `Display` for
+    a non-temporal carrier and returns `encoded.display` directly — a fourth
+    site found by grepping the SINK rather than by listing the callers I
+    expected. A fifth sink that spells a value whole has to be added to
+    `container_spelling`'s callers, or it renders djust's own serialization
+    dicts for a declined queryset.
+    """
+
+    EXPECTED = {
+        "crates/djust_core/src/lib.rs": 1,  # Display for Value
+        "crates/djust_templates/src/renderer.rs": 1,  # localize_if_number
+        "crates/djust_templates/src/filters.rs": 2,  # pprint, json_script
+    }
+
+    def test_the_call_sites_are_exactly_these(self) -> None:
+        call = re.compile(r"\.container_spelling\(\)")
+        found = {}
+        for path in sorted((REPO_ROOT / "crates").rglob("*.rs")):
+            text = path.read_text(encoding="utf-8")
+            n = len(call.findall(text))
+            if n:
+                found[str(path.relative_to(REPO_ROOT))] = n
+        assert found == self.EXPECTED, (
+            f"the container-spelling call sites moved: {found} != {self.EXPECTED}. "
+            "A NEW site means a sink learned to spell a declined carrier — add it "
+            "to EXPECTED. A MISSING site means a sink stopped, and a large "
+            "queryset now renders djust's own serialization dicts there."
+        )
+
+    def test_the_one_rule_has_one_statement(self) -> None:
+        """`spelling_is_the_items_list_repr` is asked from exactly one place —
+        `declined_list_spelling` — so "which shapes spell as a list" cannot
+        drift between the conversion and the sink (#1646)."""
+        text = (REPO_ROOT / "crates/djust_core/src/lib.rs").read_text(encoding="utf-8")
+        calls = re.findall(r"spelling_is_the_items_list_repr\(", text)
+        # One definition + one call.
+        assert len(calls) == 2, f"expected fn + 1 call site, found {len(calls)}"
+
+
+class TestTheEagerHatchIsUnchanged:
+    """`template_resolve_lazy: False` has no live handle to spell from, so the
+    decline never applies there and neither does any of this (#2695's own
+    rule, re-asserted because #2717 widened what the decline claims)."""
+
+    def test_the_hatch_still_enumerates_a_large_list(self) -> None:
+        import subprocess
+        import sys
+        import textwrap
+
+        child = textwrap.dedent(
+            """
+            import json, django
+            from django.conf import settings
+            settings.configure(
+                SECRET_KEY="x", DEBUG=False, USE_TZ=False,
+                TEMPLATES=[{"BACKEND": "djust.template_backend.DjustTemplateBackend",
+                            "NAME": "e", "DIRS": [], "APP_DIRS": False, "OPTIONS": {}}],
+                LIVEVIEW_CONFIG={"template_resolve_lazy": False},
+            )
+            django.setup()
+            from djust import _rust
+            from djust.render_env import apply_render_env
+
+            # The engine's thread-local mirror of `LIVEVIEW_CONFIG`, pushed by
+            # the same helper every real render path uses. Without it the Rust
+            # side keeps its DEFAULT (lazy ON) and this child would measure the
+            # shipped mode while claiming to measure the hatch.
+            apply_render_env()
+            v = list(range(100_001))
+            # The RENDER first: `template_resolve_lazy` reaches Rust through a
+            # setter the backend calls, so `crosses_as_encoded` asked before
+            # any render reads the thread-local's DEFAULT (lazy on) and would
+            # answer about the wrong engine mode.
+            head = _rust.render_template("{{ v }}", {"v": v})[:12]
+            length = _rust.render_template("{{ v|length }}", {"v": v})
+            print(json.dumps({
+                "encoded": _rust.crosses_as_encoded(v),
+                "head": head,
+                "length": length,
+            }))
+            """
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", child], capture_output=True, text=True, timeout=300
+        )
+        assert out.returncode == 0, out.stderr[-2000:]
+        answer = json.loads(out.stdout.strip().splitlines()[-1])
+        assert answer["encoded"] is False, "the hatch must never decline a sized sequence"
+        assert answer["head"] == "[0, 1, 2, 3,"
+        assert answer["length"] == "100001"

--- a/python/tests/test_engine_followups_2674_2670_2678_2657.py
+++ b/python/tests/test_engine_followups_2674_2670_2678_2657.py
@@ -325,15 +325,17 @@ class TestAStatedBoundIsTrustedOnlyToTheCap2678:
         (`{% for %}` over 100 001 items is pinned by
         `TestATerminatingCollectionPastTheCapIsUntouched` below).
 
-        So the carried set is now "anything whose stated length exceeds the
-        cap AND has not already materialised its items" — the liar and a
-        `range` included, a `list` and a `QuerySet` excluded, because for
-        those two the decline saves nothing (a `list` holds its elements
-        already; `QuerySet.__len__` calls `_fetch_all()`). See
-        `len_call_already_materialised_the_items` and, for the content change
-        that exemption prevents,
+        So the carried set is "anything whose stated length exceeds the cap"
+        — the liar, a `range`, a `deque`, a `list` and a `QuerySet` alike.
+
+        A `list` and a `QuerySet` were EXEMPT between the #2695 review and
+        #2717, because their declined SPELLING was wrong; #2717 fixed the
+        spelling at the sink instead (`Encoded::declined_list_spelling`) and
+        dropped the exemption, which was costing 4 GB on a 150 000-row
+        table. See `spelling_is_the_items_list_repr` and
         `TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap` in
-        `test_sized_sequence_conversion_2695_2693.py`.
+        `test_sized_sequence_conversion_2695_2693.py`, which pins that the
+        rendered bytes did not move when the exemption went.
         """
         assert _rust.crosses_as_encoded(Liar()) is True
         assert _rust.crosses_as_encoded(range(10**9)) is True
@@ -341,9 +343,17 @@ class TestAStatedBoundIsTrustedOnlyToTheCap2678:
         # nothing about `len(deque)` builds it either — it is the ordinary
         # sized-sequence case, and it is carried.
         assert _rust.crosses_as_encoded(collections.deque(range(100_001))) is True
-        # Already materialised: exempt at any length (#2695 review).
-        assert _rust.crosses_as_encoded(list(range(100_001))) is False
-        # Under the cap: a `list` is unchanged.
+        # A `list` too, since #2717 — no shape is exempt for its LENGTH.
+        assert _rust.crosses_as_encoded(list(range(100_001))) is True
+        # And under the cap a `list` is NOT carried. That is what makes the
+        # line above a statement about the length rather than about `list`,
+        # and it is the whole difference between the two rules that now
+        # decline a sequence: #2704's is about SPELLING and claims a `deque`
+        # at any size, #2717's is about LENGTH and claims a `list` only past
+        # the cap. A `list` spells as its items either way, so only the cap
+        # can carry one.
+        assert _rust.crosses_as_encoded(list(range(3))) is False
+        # Under the cap: unchanged, on both the sized and the ordinary shape.
         assert _rust.crosses_as_encoded(list(range(10))) is False
         # A small `range` used to be `False` here — the cap was the only
         # reason a sequence declined. #2704 added the SPELLING reason, which

--- a/python/tests/test_sized_sequence_conversion_2695_2693.py
+++ b/python/tests/test_sized_sequence_conversion_2695_2693.py
@@ -786,20 +786,25 @@ class TestTheSerializationFloorHoldsOnTheNewHandle:
     It is protected by `Context::protect_sidecar_strict`, which re-wraps after
     EVERY segment; this is the measurement that says so.
 
-    A `deque` and not a `list`: the #2695 review found that declining a
-    `list` spends more than it saves (its items are already built, and the
-    carrier then has to spell `str()` and `repr()` of all of them), so
-    `len_call_already_materialised_the_items` exempts `list` and `QuerySet`
-    and this class would be vacuous on either — see
+    A `deque` and not a `list`, for a reason that has changed twice. The
+    #2695 review EXEMPTED a `list` and a `QuerySet` from the decline, so this
+    class would have been vacuous on either — see
     `test_the_carrier_really_is_the_path_being_tested`, which is what would
-    have caught the substitution. A `deque` is the ordinary sized-sequence
-    case and is carried.
+    have caught the substitution. #2717 removed that exemption, so a `list`
+    past the cap is carried too now and the class would no longer be vacuous
+    on one; the `deque` stays because it is the shape that was never exempt.
 
-    Since #2704 a `deque` is carried at BOTH sizes — the spelling decides
-    that, not the cap — so the parametrization now measures the carrier's
+    Since #2704 a `deque` is carried at BOTH sizes — the SPELLING decides
+    that, not the cap — so the parametrization measures the carrier's
     items-present and items-absent halves rather than carrier-vs-`Value::List`.
     The `Value::List` half is stated explicitly with a `list` in the
-    non-vacuity test below, so both mechanisms are still floored here.
+    non-vacuity test below, and a `list` still takes it UNDER the cap
+    (#2717's rule is about length, #2704's about spelling), so both
+    mechanisms are still floored here.
+
+    The shapes #2717's decline newly claims get their own floor sweep in
+    `TestTheFloorHoldsOnEveryShapeTheDeclineNewlyClaims`
+    (`test_declined_container_spelling_2717.py`).
     """
 
     @staticmethod
@@ -867,11 +872,20 @@ class TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap:
     * ``DjustTemplate.render`` auto-serialises the queryset to that same list
       BEFORE Rust sees it, so it hit the identical decline one layer up.
 
-    Both are closed by `len_call_already_materialised_the_items`: a `list`
-    holds its elements and `QuerySet.__len__` calls `_fetch_all()`, so past
-    the cap the decline can only change the spelling. Not a floor breach on
-    either side — asserted here as well, since the whole point is that the
-    fix moves the rows back onto the `Value::List` path.
+    The #2695 review closed both by EXEMPTING a `list` and a `QuerySet` from
+    the decline at any length. #2717 replaced that exemption — it cost 4 GB
+    on a real 150 000-row table — with two narrower fixes, and the cells
+    below are unchanged by the swap, which is the whole point of keeping them
+    here:
+
+    * the three container sinks are spelled from the LIVE HANDLE
+      (`Encoded::declined_list_spelling`), through the same
+      `consume_live_items` walk `{% for %}` uses, so the items are the ones
+      the `Value::List` held by construction;
+    * `_SidecarQuerySetProxy` gained the `__getitem__` the live walk needs,
+      so `{{ rows.0 }}` resolves instead of answering `''`.
+
+    Not a floor breach on either side — asserted here as well.
     """
 
     @staticmethod
@@ -952,19 +966,28 @@ class TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap:
         assert len(self._queryset(100_001 - 3)) == 100_001
         assert len(self._queryset(0)) == 3
 
-    def test_a_queryset_is_exempt_from_the_conversion_decline_at_any_length(
+    def test_a_queryset_past_the_cap_is_declined_like_any_sized_sequence(
         self,
     ) -> None:
-        """The mechanism, named: `QuerySet.__len__` calls `_fetch_all()`, so
-        by the time the length is known every row exists and the decline can
-        only change the spelling."""
+        """#2717: the exemption is gone, so this is the non-vacuity bit for
+        the two classes above — the cells they pin are now measuring the
+        CARRIER path past the cap and the `Value::List` path under it, which
+        is exactly the asymmetry they exist to deny.
+
+        Between the #2695 review and #2717 both of these were `False`: a
+        `list` and a `QuerySet` were exempt at any length, so `{{ v }}` over
+        a 100 001-row queryset converted every row at binding time. Flipping
+        this line to `True` is the whole of #2717's conversion change; the
+        rendered bytes above are what says the spelling survived it.
+        """
         from djust import _rust
 
-        assert _rust.crosses_as_encoded(self._queryset(100_001 - 3)) is False
+        assert _rust.crosses_as_encoded(self._queryset(100_001 - 3)) is True
         assert _rust.crosses_as_encoded(self._queryset(0)) is False
-        # And the duck type that merely LOOKS like one is not exempt — the
-        # exemption is about the `__len__` contract, not the shape.
+        # The ordinary sized sequence answers the same way, which is the
+        # point: there is one rule now, keyed on the LENGTH.
         assert _rust.crosses_as_encoded(collections.deque(range(100_001))) is True
+        assert _rust.crosses_as_encoded(list(range(100_001))) is True
 
 
 class TestEverySequenceArmDecidesTheCarrier:


### PR DESCRIPTION
Closes #2717.

## What the #2706 exemption traded, reproduced first

#2695 made the conversion decline to enumerate a sized sequence past `OPAQUE_ITEM_CAP`. Its review then **exempted** a `list` and a Django `QuerySet` from that decline at any length (`len_call_already_materialised_the_items`), because declining them produced a wrong *spelling*: `{{ rows }}` over a 100 001-row queryset rendered djust's own identity dicts, and `{{ rows.0 }}` answered `''`.

Reproduced on this branch **before touching anything**, on an *unevaluated* `User.objects.all()` over a real 150 000-row SQLite table, each cell in its own child process under a deadline and an RSS ceiling:

| cell | exemption ON (shipped) | exemption OFF (bare) |
|---|---|---|
| `{{ v\|length }}` | **4 437 MB** / 13.4 s | 565 MB / 10.1 s |
| `{{ v.0 }}` | 2 982 MB / 13.3 s | 148 MB / 0.7 s → **`''`** |
| `{% if v %}` | 2 982 MB / 13.1 s | 147 MB / 0.7 s |
| `{{ v }}` | 4 448 MB / 13.1 s | 994 MB / 10.3 s → **101 MB of identity dicts** |

The issue measured 4 650 / 593 MB on the same shape. Both halves of the trade reproduce.

## Option 1, taken

The exemption is gone. Two narrow fixes replace it, one per defect the decline produced.

**1. `Encoded::declined_list_spelling`** answers the three sinks that spell a value *whole* — `{{ v }}`, `|pprint`, `|json_script` — from the live handle, through the same `consume_live_items` walk `{% for %}` and `|join` already use, so the items are the ones the `Value::List` held *by construction* rather than by transcription (#1646). Every other sink already read only what it needed: `|length` is `Encoded::len`, `{{ v.0 }}` is `live_get_item`, `|slice` is `live_get_slice`.

`spelling_is_the_items_list_repr` is the same predicate the exemption was, repurposed — it now names *which shapes spell as a list* instead of *which shapes are exempt* — and is read from exactly one place, so the conversion and the sink cannot disagree.

A fourth call site turned up by grepping the **sink** rather than the callers it seemed to have: `renderer::localize_if_number` short-circuits `Display` for a non-temporal carrier and returns `Encoded::display` directly, so patching `Display` alone left the actual `{{ v }}` cell unchanged. The call-site set is pinned, not floored (#1125).

**2. `_SidecarQuerySetProxy.__getitem__`** — `Context::walk_live` subscripts *the proxy*, not the queryset behind it, and the proxy forwarded `__iter__` and `__len__` but never `__getitem__`. Every result goes through `_protect_sidecar_value`, a slice's elements one at a time (that helper has no list arm, so a bare `qs[0:2]` is a list of RAW models), and a `.values()` projection refuses as the zero-length sequence its own `__len__` already reported.

## After

Same DB, same harness:

| cell | before | after |
|---|---|---|
| `{{ v\|length }}` | 4 437 MB / 13.4 s | **568 MB / 9.7 s** |
| `{{ v.0 }}` | 2 982 MB / 13.3 s | **149 MB / 0.9 s** |
| `{% if v %}` | 2 982 MB / 13.1 s | **149 MB / 0.9 s** |
| `{{ v\|first }}` | 4 437 MB / 13.7 s | **566 MB / 9.7 s** |
| `{{ v }}` | 4 448 MB / 13.1 s | 1 837 MB / 13.5 s |
| `{{ v\|pprint }}` | 5 149 MB / 15.4 s | 2 486 MB / 14.0 s |
| `{{ v\|json_script }}` | 4 778 MB / 14.5 s | 2 113 MB / 13.0 s |

The three container sinks still pay one conversion per element, because they emit every element — 1 238 890, 106 563 006 and 57 533 398 bytes of HTML, byte-for-byte identical to before. Nothing else does.

## Spelling: nothing moved

A 26-cell differential over `{list, QuerySet} × 12 sinks × {under, past}` the cap, run against the tree before and after: **24 of 26 byte-identical**. The two that changed are the two `crosses_as_encoded` bits — which is the change.

(Two `|pprint` cells drift a few bytes *run to run on the same build*: that ad-hoc script's fixture leaves `date_joined` on `auto_now_add`. Verified by running it twice against one build. The pytest version of the same differential pins `date_joined` and asserts padding-free equality, and passes.)

`TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap` — written *for* the exemption, in #2706 — passes unchanged. That is the strongest available statement that the swap is invisible; its `crosses_as_encoded` assertion is the one line that had to flip, and it now reads `True` with the reason spelled out.

Django parity above and below the cap was checked for `{{ v }}`, `|pprint`, `|json_script`, `{{ v.0 }}` and `{{ v.0.<field> }}` on `list[Model]`, `QuerySet` and `_SidecarQuerySetProxy` — the asymmetry that was the substance of the original bug. `{{ v|dictsort }}` renders `''` past the cap for a `None`-padded collection, and that is the padding, not the carrier: a `deque` does the same, and an unpadded 100 001-row list sorts identically on both sides.

## Security: the floor, re-probed on the NEW crossing set

The previous sweep ran on a `list`, which the exemption then made exempt — its evidence was invalidated by its own fix. This one runs on the shapes the decline **actually** claims now, each carrying its own non-vacuity bit:

| shape | `crosses_as_encoded` under / past | note |
|---|---|---|
| `list[Model]` | False / **True** | newly declined |
| `QuerySet` | False / **True** | newly declined |
| `_SidecarQuerySetProxy` | False / False | claimed one arm earlier by `__djust_serialize__`; **its list** crosses (asserted through the hook) |
| `values()` projection proxy | False / False | refused wholesale |

4 shapes × 14 sinks × 2 sides = **112 cells, 0 leaks** — `password`, `is_superuser`, `is_staff` and `get_session_auth_hash` all refused across `{{ v.0.X }}`, `{{ v }}`, `|pprint`, `|json_script`, `|first`, `|last`, `|slice`, `|safeseq|join`, `|unordered_list` and `{% for %}`. The new `__getitem__` is probed directly as well: an index returns a `_SidecarModelProxy`, a slice returns a list of them, a projection raises `IndexError` / returns `[]`.

**Honest reading of one result.** Gating the slice's per-element protection off (M7) fails only the direct unit test, no leak cell — because the Rust raw-`Model` arm denylist-filters those rows anyway. So that protection is defence-in-depth over a second mechanism, not the sole floor; the projection refusal (M8) *is* the sole floor for its path, and the sweep catches it.

## Gate-off — ten mutations, one mechanism each

Harness rules: assert the mutation text was found, assert the source changed, count `error`s as well as `failed`s, refuse to report a number when the module did not import, and never `shutil.copy2` (mtime preservation makes cargo reuse the mutant). Deadline **and** RSS ceiling on every run, because two of these mutations reproduce the unbounded walk the change prevents.

Baseline: **0 failed, 277 passed.**

| mutation | result |
|---|---|
| M1 the whole decline gated off | **RUNAWAY-MEMORY, 6 342 MB** |
| M2 container sinks stop spelling from the live handle | **13 failed** |
| M3 only `Display` patched; `localize_if_number` still short-circuits | **8 failed** |
| M4 predicate claims nothing | **13 failed** |
| M5 predicate claims everything (`range(10**9)` re-spelled as a list) | **RUNAWAY-MEMORY, 6 229 MB** |
| M6 proxy loses `__getitem__` | **8 failed** |
| M7 slice hands back RAW models | **1 failed** (see above) |
| M8 `values()` projection subscriptable | **5 failed**, incl. the floor sweep |
| M9 only the `__djust_serialize__` arm of the predicate | **0 failed — survived** |
| M10 the exemption reinstated at both sites (exact pre-#2717) | **10 failed** |

**M9 is a finding, not a pass.** A surviving mutation is a question: equivalent, shadowed, or uncovered. The answer here is *unreachable* — `FromPyObject` claims a `__djust_serialize__` object one arm **above** `opaque_value` and converts the `list` it returns, so the proxy never becomes a carrier and the predicate is never asked about one. The arm was deleted rather than tested around (#1859: a decorative arm is worse than none; #2233: delete the redundant mechanism).

**M10 is the sharp one.** M1 gates off #2695's decline, not #2717's change. M10 puts back exactly the deleted third condition, at both sites that ask it. Its expected result was written down before running: *the spelling tests stay green — that is the whole point — and what must go red is the conversion-count class and the crossing pins.* Exactly that happened: `test_a_cheap_cell_converts_almost_nothing_past_the_cap`, `test_the_padded_shapes_really_are_carriers`, `test_the_sweep_is_not_vacuous`, `test_the_one_rule_has_one_statement`, `test_a_queryset_past_the_cap_is_declined_like_any_sized_sequence` and `test_the_conversion_bound_is_the_stated_length` — zero spelling failures.

The conversion cost is pinned as a **count**, not a memory threshold (this repo has retired two outlier-sensitive timing gates): each element records its own conversion, so `{{ v|length }}` and `{% if v %}` convert **0** of 100 001, `{{ v.0 }}` / `|first` / `|last` convert **1**, and `{{ v }}` converts exactly **100 001**.

## Known consequence, stated rather than found later

A `list` past `OPAQUE_ITEM_CAP` placed in **LiveView state** (not only a render context) now crosses as a carrier, so `SerializableViewState`'s msgpack snapshot holds an `Encoded`, which serializes as its `display` string — as every other carried shape has since #2695 (`deque`, `range`, `array`). No floor field is exposed by that string (the rows are either denylist-filtered dicts or model `__str__`s), and a 100 000-row state variable was already a multi-megabyte snapshot. Flagged because it is the one behaviour this change has that the render-path measurements do not cover.

## Coordination with #2704

#2704 is in flight on `fix/2704-2710-templates` (not pushed at time of writing). Its owner and I split the surface explicitly, and confirmed the split in writing:

* **#2704 owns** the *below-cap*, non-`list` container spelling — `range`, `deque`, `array`, `bytes`, a sized user class crossing as the carrier at any length so `{{ v }}` is `str(o)`. It took option (a) of that issue.
* **#2717 (this PR) owns** the *declined* `list` / `QuerySet` spelling. #2704 confirmed it does **not** change how a declined carrier spells `{{ v }}` / `|pprint` / `|json_script`.

They meet at one predicate and do not overlap: `spelling_is_the_items_list_repr` claims exactly the shapes whose spelling *is* their items' list repr, and `TestAContainerThatSpellsItselfIsNotRespelledAsAList` pins the other side — `range(10**9)` still renders `range(0, 1000000000)`, and a `deque` / `array` past the cap still renders its own `str(o)`. #2704's owner ran those pins against their branch as shipped and all four agree.

The two predicates answer **different questions** and neither subsumes the other. #2704's `list_repr_is_this_objects_own_spelling` decides which conversion *arm* claims an object **at any length**; this one decides what an **already-declined** carrier *spells*. The composition depends on ordering: their check runs before `ob.len()` and before the cap gate, so a `range` / `deque` / `array` / `bytes` / sized user class declines at *their* predicate and never reaches mine, while a `list` passes theirs and then meets mine, which past the cap now declines it. That is the intended composition.

An earlier draft of this section said their QuerySet arm "can be simplified once both have landed." **That was wrong and is retracted.** Removing it would make every QuerySet cross as a carrier at *any* length, so `{{ rows }}` on a 3-row queryset would change from `[qs0, qs1, qs2]` to `str(...)` of whatever the carrier holds — this PR's `declined_list_spelling` is gated on `len > OPAQUE_ITEM_CAP` and would not re-spell it. `TestARealQuerySetIsSpelledTheSameOnBothSidesOfTheCap` pins against exactly that on both paths a queryset reaches the engine by. If that arm should go it needs its own change with its own before/after over `{{ rows }}` / `{{ rows.0 }}` / `{% for %}` on both the `render_template` (proxy) and `DjustTemplate.render` (auto-serialised list) paths — not a side effect of this one.

## Rebased onto the merged #2704, and the small-QuerySet objection settled

#2725 merged first. This branch is rebased onto it (`0c6ef310`); the Rust
auto-merged and the composition is the intended one — #2704's
`list_repr_is_this_objects_own_spelling` still runs **before** `ob.len()`, so a
`range` / `deque` / `array` / `bytes` / sized user class declines at their
spelling rule and never pays `len`, while a `list` passes theirs and then meets
this PR's cap rule. Verified, not assumed: the ordering is load-bearing and a
rebase that moved the check below `len()` would silently reintroduce that cost.

**The objection.** #2704's owner pushed back on a sentence in an earlier draft
of this body, which said their QuerySet arm could be simplified once both
landed. **They were right and it is retracted.** Their arm governs which
conversion arm claims a queryset at *any* length; `declined_list_spelling` opens
with `len > OPAQUE_ITEM_CAP` and governs only what an already-declined carrier
spells. Dropping theirs would carry a three-row queryset, and nothing here
re-spells it. Neither differential had measured the small case — every queryset
cell in both files is padded past the cap or asserted only against its own other
side, and "the two sides of the cap agree" cannot catch both sides moving
together. That is how the #2706 → #2717 chain started.

Measured on a **real 3-row queryset over a real table**, on `origin/main` (the
merged #2704 tree) and again after rebasing onto it:

| cell | origin/main | this branch |
|---|---|---|
| `{{ rows }}` | `[u0, u1, u2]` | identical |
| `{{ rows\|pprint }}` | 3 identity maps | identical |
| `{{ rows\|json_script }}` | JSON array, 3 maps | identical |
| `{{ rows.0 }}` / `.username` / `.email` | `u0` / `u0` / `u0@b.c` | identical |
| `{{ rows.0.password }}` | `''` | identical |
| `{{ rows\|length }}` / `\|first` / `\|last` | `3` / `u0` / `u2` | identical |
| `{{ rows\|slice:":2" }}` | `[u0, u1]` | identical |
| `{% for %}` / `{% if %}` | `u0\|u1\|u2\|` / `T` | identical |
| `crosses_as_encoded` | `False` | `False` |

**14 of 14 byte-identical.** A small queryset never reaches `Encoded::live`, so
this PR structurally cannot touch it.
`TestASmallQuerySetIsUnmovedByTheDeclineChange2717` pins those literals — and it
is not merely documentation: forcing #2704's arm to always-false turns its cells
red *first*, so the class is the pin that catches the regression the objection
describes.

Two doc comments in the merged #2704 code asserted things this branch falsifies,
and are rewritten rather than left:

* `is_django_queryset` cited `len_call_already_materialised_the_items`, which
  this PR renamed. **Both callers survived**, so its `#1646` "two reasons"
  justification still holds — it now names them and says which asks at any
  length and which only past the cap.
* `list_repr_is_this_objects_own_spelling`'s QuerySet bullet justified itself
  with "`_SidecarQuerySetProxy` with no `__getitem__`" — a hazard this branch
  removes. Restated on the grounds that outlive the fix.

### Combined-tree gate-off

Both PRs' predicates, mutated on **one** tree — because neither branch's
evidence covered the other's changes. Baseline and restore both 341/341:

| mutation | result |
|---|---|
| C1 — #2704's arm always TRUE | **15 failed** |
| C2 — #2704's arm always FALSE | **25 failed** (small-QuerySet cells first) |
| C3 — `declined_list_spelling` never spells | **13 failed** |
| C4 — the cap exemption reinstated | **10 failed** |

Also strengthens `test_the_one_rule_has_one_statement`: it counted
definition-plus-call as one total of two, which cannot distinguish "one fn + one
call" from "no fn + two calls", so a rename leaving a stale caller would have
read as green. Counted separately now.

Two self-inflicted findings worth recording, both caught by the literal cells
rather than by inspection: the new class's first version used an autouse fixture
without `db`, so it seeded nothing and **three cells passed vacuously** on an
empty queryset; and its cells rendered `''` because the shared `_render` helper
binds `v` while these templates say `rows`.

## Verification

* `pytest tests/ python/tests/ python/djust/tests/ -n auto` — **26 920 passed**, 492 skipped, 0 failed.
* `cargo clippy --release -p djust_core -p djust_templates` — clean. `ruff check` / `ruff format` — clean. `cargo fmt` — clean.
* Rebased on `origin/main` (`04b78adb`) and the extension rebuilt before the final measurement and suite run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116FTX9dXEq8E5cFN7wh1u8
