### PR TITLE
fix(templates): resolve a context callable by Django's rules on the LiveView path — closes ADR-027's last held cells (#2621)

### DIFF
--- a/changelog.d/2621.fixed.md
+++ b/changelog.d/2621.fixed.md
@@ -1,0 +1,49 @@
+- **A callable in a LiveView's context now resolves by Django's rules instead of rendering `None` (#2621, ADR-027).**
+  `normalize_django_value` replaced ANY callable with `None` before the context reached
+  Rust — a "safety net" that pre-dated the resolution sink — so on the LiveView path
+  `{{ callable }}` and `{{ var.callable }}` rendered `None` where Django renders the
+  call's result, `{{ k }}` on a class rendered `None` where Django instantiates it, and
+  a `list`-subclass class fell through to the pre-ADR walk's unguarded string-key
+  `get_item` and rendered a `types.GenericAlias` spelled with the string key. The plain
+  path, which has no `normalize_django_value` in front of it, already answered Django's
+  bytes for all five — the divergence was the arm, not the sink.
+
+  The arm is now gated on `template_resolve_lazy`: under ADR-027 a callable crosses raw
+  and `walk_live`'s root `maybe_call` decides, which is where Django's rules already
+  live — `alters_data` renders `string_if_invalid` without running the mutator,
+  `do_not_call_in_templates` renders the object as is, an arity mismatch renders empty,
+  and a raising body propagates (#2506 never fails open). Normalization itself never
+  invokes what it carries.
+
+  Two boundaries keep the arm, and both are pinned: `state_roundtrip=True` — the session
+  and signed-snapshot channel, written by an encoder-less serializer that cannot hold a
+  live object, so a callable in public state still persists as `None` — and a callable
+  the conversion does not model as a `Value::Encoded`, which has no handle for the sink
+  to walk. The ADR-027 escape hatch (`template_resolve_lazy=False`) is byte-identical to
+  before.
+
+  Unchanged, and pinned so it is not read as wider than it is: a callable assigned as a
+  public LiveView **attribute** still never reaches this arm. The public-attribute walk
+  drops it first (`mixins/context.py`), deliberately — without that, every
+  `@event_handler` on the view would become a context variable — so `{{ cb }}` for
+  `self.cb = fn` renders empty on both settings. This change is about the context dict.
+
+  This closes the last of the six cells ADR-027 movement 3 left held. Both stated sets in
+  the characterization net (`PLAIN_WRONG_UNDER_LAZY`, `LIVEVIEW_WRONG_UNDER_LAZY`) are now
+  empty: rows J, J2, Q, P and P0 move here, row O closed in #2665 via `Encoded::display_safe`
+  and row V in #2613. New cases in `TestTheArmsTruthTable2621`,
+  `TestTheSinkAnswersDjangoOnTheLiveViewPath2621`,
+  `TestNoLiveObjectReachesAChannelThatPersists2621` and `TestTheQuestionHasOneStatement2621`;
+  `TestCallable` in `tests/unit/test_normalize_django_value.py` now states the two channels
+  that still drop. Django's own template suite is unmoved at 98.57% engine / 98.97% whole,
+  with zero per-test OK→FAIL transitions.
+
+  Also `#1646`: the guarded `_rust.crosses_as_encoded` call moved out of
+  `normalize_django_value`'s final fallback into a module-level `_crosses_as_encoded`
+  helper, because two arms now ask that one question and a second copy would drift on the
+  first widening. `TestTheGateHasOneStatement` in
+  `python/tests/test_opaque_collections_2477_2489.py` is restated to match: what must stay
+  singular is the **export**, not the number of arms that consult it, and the pin is now
+  spelled `_rust.crosses_as_encoded` because the bare name is a substring of the helper's
+  and silently counted 1 → 4 at the refactor. Its new sibling
+  `test_the_helper_has_exactly_the_two_arms_that_should_ask_it` pins who asks.

--- a/docs/adr/027-template-variable-resolution-follows-django.md
+++ b/docs/adr/027-template-variable-resolution-follows-django.md
@@ -336,7 +336,27 @@ cannot drift from the shipped default the way #2017's prose did.
 | 4. flip the default | **shipped** |
 | 5. delete the enumeration arms | **not shipped** |
 
-The six cells movement 3 left held (O, V, J, J2, Q, P-liveview) are tracked at **#2621**, which carries the two mechanisms that close five of them: a transient `Encoded.safe` bit and gating `normalize_django_value`'s callable arm on the flag. It blocks step 5.
+The six cells movement 3 left held (O, V, J, J2, Q, P-liveview) were tracked at **#2621** and are
+now **all closed**; both stated sets in the characterization net are empty. It took **four** PRs,
+and only one of them was filed against #2621 — worth recording, because the issue planned two
+mechanisms and the second was the only one it had to build:
+
+| cell | closed by | mechanism |
+|---|---|---|
+| O | PR #2665 (before #2621 was worked) | `Encoded::display_safe` (`crates/djust_core/src/lib.rs:427`) — "runtime safety of `str(o)`, not of `o` itself. Never restored from wire data", read at `:2672` |
+| V | #2613 | `opaque_gate` admits a one-shot iterator with a handle and no items; `{% for %}` consumes it once through `Encoded::consume_live_items` |
+| P-liveview | #2624 (crash) then #2621 (bytes) | the conversion depth ceiling turned the segfault into wrong bytes; the callable gate then gave it Django's |
+| J, J2, Q, P, P0 | #2621 | `normalize_django_value`'s callable arm gated on `template_resolve_lazy` — a callable crosses raw and `walk_live`'s root `maybe_call` decides |
+
+§Security 5 above anticipated exactly the O mechanism, under the name `Encoded.safe`, and the
+shipped `display_safe` matches its constraints (computed at conversion from Python's `SafeData`
+contract; never inferred from the text; never restored from a round trip). What it does NOT have is
+the ADR's twelfth wire slot: the bit does not need to survive a round trip, because the
+post-round-trip bytes for row O are already the escaped ones — degrading to escaped is degrading to
+today, in the fail-safe direction. `the_payload_is_eleven_slots_in_the_documented_order` is
+unedited.
+
+Step 5's prerequisite is therefore met.
 
 ### Erratum (movement 3, 2026-09-03)
 

--- a/python/djust/serialization.py
+++ b/python/djust/serialization.py
@@ -1675,6 +1675,32 @@ def render_form_value(value: Any) -> Any:
     return None
 
 
+def _crosses_as_encoded(value: Any) -> bool:
+    """Does ``impl FromPyObject for Value`` model this object as ``Encoded``?
+
+    ``_rust.crosses_as_encoded`` RUNS the conversion and asks what came out,
+    rather than re-stating its gate: a Python copy would be a second statement
+    of one question and would drift on the first widening (#1646). It answers
+    FALSE for the ``__dict__`` bulk-dump arm and for every EARLIER arm — a
+    ``bytes`` and a ``deque`` are claimed by PyO3's sequence extraction and
+    cross as a ``Value::List``.
+
+    :func:`normalize_django_value` asks it from TWO arms — the callable arm
+    (#2621) and the final fallback (#2477/#2489) — so the guarded import lives
+    here once rather than in each. Both arms want the same fail-SOFT answer
+    when the compiled extension is missing (a pure-Python install, or a build
+    predating the export): ``False``, i.e. keep the historical behaviour.
+    Raising would turn "we could not serialize it" into a 500 on the branch
+    least likely to be exercised.
+    """
+    try:
+        from . import _rust
+
+        return bool(_rust.crosses_as_encoded(value))
+    except (ImportError, AttributeError):
+        return False
+
+
 def normalize_django_value(value: Any, _depth: int = 0, *, state_roundtrip: bool = False) -> Any:
     """Convert Django/Python types to values djust's serializers can carry.
 
@@ -1739,7 +1765,14 @@ def normalize_django_value(value: Any, _depth: int = 0, *, state_roundtrip: bool
     - QuerySet                     -- list of normalized models
     - FieldFile / file-like        -- .url or None
     - Component / LiveComponent    -- str() (renders HTML)
-    - callable                     -- None (safety net, matches encoder)
+    - callable                     -- carried through UNCONVERTED under ADR-027
+                                      (#2621), so the resolution sink applies
+                                      Django's own call rules; None on the two
+                                      channels that cannot hold a live object —
+                                      ``state_roundtrip=True`` and a callable
+                                      the conversion does not model as an
+                                      ``Encoded``. None on both, with
+                                      ``template_resolve_lazy`` off
     - anything that crosses as a
       ``Value::Encoded`` (a dict
       view, a ``complex``, a
@@ -1970,8 +2003,42 @@ def normalize_django_value(value: Any, _depth: int = 0, *, state_roundtrip: bool
     except ImportError:
         pass  # components module is optional; skip check if not installed
 
-    # Safety net: skip callables (matches encoder behavior)
+    # Safety net: skip callables (matches encoder behavior) -- EXCEPT under
+    # ADR-027, where the resolution sink decides instead of this arm (#2621).
+    #
+    # This arm is why the LiveView path answered `None` for `{{ callable }}`,
+    # `{{ var.callable }}` and `{{ k }}`-on-a-class (rows J / J2 / Q of the
+    # characterization net) while the plain path -- which has no
+    # `normalize_django_value` in front of it -- answered Django's bytes with
+    # the flag ON. The value never reached Rust at all: `None` IS a `Value`,
+    # so the value stack answered first and the sidecar's raw object was never
+    # consulted. Rows P / P0 are the same cause with a sharper edge: with no
+    # handle to walk, the pre-ADR sidecar walk's unguarded string-key
+    # `get_item` reached `__class_getitem__` and rendered a `types.GenericAlias`
+    # spelled with the STRING key (a segfault until the #2624 depth ceiling).
+    #
+    # Under the flag the callable crosses RAW and `walk_live`'s root
+    # `maybe_call` decides, which is where Django's own rules already live:
+    # `alters_data` -> `CallOutcome::Empty`, `do_not_call_in_templates` -> as
+    # is, a raising body propagates (#2506 never fails open), and a component
+    # mutator is a bound method reached by LOOKUP, so the
+    # `TemplateMutatorGuard` re-stamp (#2507) governs it unchanged. Nothing
+    # here invokes the callable; the arm only stops dropping it.
+    #
+    # Two boundaries keep the arm:
+    #
+    # * `state_roundtrip=True` -- the session / signed-snapshot channel is
+    #   written by an encoder-less serializer and CANNOT hold a live object,
+    #   the same reason the `Decimal` / `datetime` / `set` branches above split
+    #   on it. A callable in public state still persists as `None`.
+    # * `crosses_as_encoded` false -- a callable the conversion does NOT model
+    #   as an `Encoded` (there is no handle to walk) keeps today's answer
+    #   rather than taking the `str()` fallback below.
     if callable(value):
+        from .config import template_resolve_lazy_enabled
+
+        if not state_roundtrip and template_resolve_lazy_enabled() and _crosses_as_encoded(value):
+            return value
         logger.debug(
             "Skipping callable %s during normalization",
             type(value).__name__,
@@ -2041,18 +2108,8 @@ def normalize_django_value(value: Any, _depth: int = 0, *, state_roundtrip: bool
     # object, for the reason the `Decimal` / `datetime` / `set` branches above
     # record: its output is written to the Django session by an encoder-less
     # serializer.
-    if not state_roundtrip:
-        try:
-            from . import _rust
-
-            if _rust.crosses_as_encoded(value):
-                return value
-        except (ImportError, AttributeError):
-            # No compiled extension (a pure-Python install, or a build that
-            # predates the export): fall through to the historical `str()`.
-            # Failing SOFT here matters because this is the fallback branch —
-            # raising would turn "we could not serialize it" into a 500.
-            pass
+    if not state_roundtrip and _crosses_as_encoded(value):
+        return value
 
     return str(value)
 

--- a/python/tests/test_adr027_callable_arm_2621.py
+++ b/python/tests/test_adr027_callable_arm_2621.py
@@ -1,0 +1,601 @@
+"""ADR-027 #2621 — ``normalize_django_value``'s callable arm, gated on the flag.
+
+The six cells movement 3 (#2539, PR #2620) left held were, by the time this
+landed, five — rows **J**, **J2**, **Q**, **P** and **P0** on the LiveView
+path — and all five were ONE cause. ``normalize_django_value`` replaced ANY
+callable with ``None`` before Rust saw the context ("safety net: skip
+callables"), so on the LiveView path:
+
+* ``{{ callable }}`` and ``{{ var.callable }}`` rendered ``None`` where Django
+  renders the CALL's result (J / J2);
+* ``{{ k }}`` on a class rendered ``None`` where Django INSTANTIATES it (Q);
+* and with no value to hold a handle, ``{{ class_var.class_property }}`` fell
+  to the pre-ADR sidecar walk's unguarded string-key ``get_item``, which
+  honours ``__class_getitem__`` and rendered a ``types.GenericAlias`` spelled
+  with the STRING key (P / P0 — a segfault until #2624's depth ceiling).
+
+The plain path has no ``normalize_django_value`` in front of it and answered
+Django's bytes for all five under the flag, which is what made the cause
+legible: the arm, not the sink.
+
+The other two cells this issue inherited closed before it: **O** (a ``__str__``
+returning ``SafeData``) via ``Encoded::display_safe``, PR #2665 — runtime-only
+metadata, never restored from wire data, so no twelfth wire slot — and
+**V** (a generator) via #2613's one-shot-iterator handle. The
+characterization net (``test_adr027_characterization_net_2539.py``) carries
+the per-cell bytes; this file carries what the net does not — the arm's TRUTH
+TABLE, the guard rails a raw callable now meets at the sink, and the two
+channels that must NOT widen.
+
+Gate-off (#1468): every ON-column assertion here has an OFF-column sibling in
+the same test asserting ``"None"``. Restoring the unconditional ``return
+None`` makes the ON half fail while the OFF half keeps passing, so neither
+half can be green for the wrong reason.
+"""
+
+from __future__ import annotations
+
+import collections
+import contextlib
+import functools
+import json
+import re
+from typing import Any, Callable
+
+import pytest
+from django.template import Context as DjangoContext
+from django.template import Template as DjangoTemplate
+from django.test import RequestFactory
+from django.contrib.sessions.middleware import SessionMiddleware
+
+from djust import LiveView, _rust
+from djust.serialization import _crosses_as_encoded, normalize_django_value
+from djust.testing import LiveViewTestClient
+
+DJ_ROOT = re.compile(r"<div[^>]*dj-root[^>]*>(.*)</div>", re.S)
+#: Addresses differ per run; the ONE thing a repr-carrying cell may not pin.
+HEX = re.compile(r"0x[0-9a-f]+")
+
+
+def scrub(text: str) -> str:
+    return HEX.sub("0x…", text)
+
+
+@contextlib.contextmanager
+def resolve_lazy(enabled: bool):
+    """Flip the ADR-027 flag through the REAL wiring and ASSERT it landed.
+
+    Copied in shape from the characterization net's context manager for the
+    reason that file gives: a fixture that sets the config and ASSUMES the
+    push would make every flag-ON assertion vacuous if the wiring broke.
+    """
+    from djust.config import config
+    from djust.render_env import apply_render_env
+
+    previous = config.get("template_resolve_lazy", False)
+    config.update({"template_resolve_lazy": enabled})
+    apply_render_env()
+    assert _rust.resolve_lazy_enabled() is enabled, (
+        "the ADR-027 flag did not reach Rust — apply_render_env() is not wiring it"
+    )
+    try:
+        yield
+    finally:
+        config.update({"template_resolve_lazy": previous})
+        apply_render_env()
+
+
+# ---------------------------------------------------------------------------
+# The shapes. Each is a CALLABLE that reaches the arm, and each answers a
+# different one of Django's `_resolve_lookup` call rules.
+# ---------------------------------------------------------------------------
+CALLS: list[str] = []
+
+
+def plain_lambda() -> str:
+    CALLS.append("plain_lambda")
+    return "foo bar"
+
+
+def mutator() -> str:
+    CALLS.append("mutator")
+    return "MUTATED"
+
+
+mutator.alters_data = True  # type: ignore[attr-defined]
+
+
+def marked() -> str:
+    CALLS.append("marked")
+    return "CALLED"
+
+
+marked.do_not_call_in_templates = True  # type: ignore[attr-defined]
+
+
+def loud() -> str:
+    CALLS.append("loud")
+    raise RuntimeError("boom from the callable body")
+
+
+def needs_args(a: Any, b: Any) -> str:
+    CALLS.append("needs_args")
+    return f"{a}{b}"
+
+
+class Cls:
+    def __str__(self) -> str:
+        return "<Cls>"
+
+
+class CallableBytes(bytes):
+    """A callable the CONVERSION does not model as an ``Encoded``.
+
+    PyO3's sequence extraction claims a ``bytes`` subclass before
+    ``opaque_gate`` is consulted, so ``crosses_as_encoded`` is False and there
+    is no handle for the sink to walk — the second half of the arm's gate.
+    """
+
+    def __call__(self) -> str:
+        CALLS.append("CallableBytes")
+        return "CB-called"
+
+
+class CallableDeque(collections.deque):
+    """The same, via the other sequence spelling."""
+
+    def __call__(self) -> str:
+        CALLS.append("CallableDeque")
+        return "CD-called"
+
+
+# ---------------------------------------------------------------------------
+# The three columns, as the net spells them.
+# ---------------------------------------------------------------------------
+def django_render(source: str, context: dict) -> str:
+    return DjangoTemplate(source).render(DjangoContext(dict(context)))
+
+
+def plain_render(source: str, context: dict) -> str:
+    from djust.template_backend import DjustTemplateBackend
+
+    backend = DjustTemplateBackend(
+        params={"NAME": "djust", "DIRS": [], "APP_DIRS": False, "OPTIONS": {}}
+    )
+    return backend.from_string(source).render(context=dict(context), request=None)
+
+
+def liveview_render(source: str, context: dict) -> str:
+    """The REAL LiveView entry — the path the arm sits on. Needs `django_db`."""
+
+    class _V(LiveView):
+        def mount(self, request, **kwargs):
+            pass
+
+        def get_context_data(self, **kwargs):
+            ctx = super().get_context_data(**kwargs)
+            ctx.update(context)
+            return ctx
+
+    _V.template = f"<div dj-root>{source}</div>"
+    client = LiveViewTestClient(_V)
+    client.mount()
+    html = client.render()
+    match = DJ_ROOT.search(html)
+    assert match is not None, html
+    return match.group(1)
+
+
+def observe(render: Callable[[str, dict], str], source: str, context: dict) -> str:
+    """Rendered bytes with addresses scrubbed, or a named raise."""
+    try:
+        return scrub(render(source, context))
+    except Exception as exc:  # noqa: BLE001 — the raise IS the observation
+        return f"RAISES {type(exc).__name__}"
+
+
+class TestTheArmsTruthTable2621:
+    """``normalize_django_value`` on a callable, across the three inputs that
+    decide the arm. Unit level, no template — the arm's contract on its own.
+
+    Both gate conditions are independently reachable, which is what keeps this
+    a truth table rather than one condition plus a decoration (the shadowing
+    trap): a lambda flips on the FLAG, and — on this ``main`` — a
+    ``CallableBytes`` flips on ``crosses_as_encoded`` with the flag ON. That
+    second one is reachable BY VALUE today and structurally always (a missing
+    compiled extension); see the note on
+    ``test_a_real_shape_agrees_with_whatever_the_gate_answers``.
+    """
+
+    #: Callables the conversion DOES model as an `Encoded` — the ones the sink
+    #: can walk. Every callable a template is realistically handed lands here;
+    #: the exceptions are the sequence-subclass spellings below.
+    CROSSING = [
+        pytest.param(lambda: "x", id="lambda"),
+        pytest.param(Cls, id="class"),
+        pytest.param(len, id="builtin"),
+        pytest.param("abc".upper, id="bound-method"),
+        pytest.param(functools.partial(len, "ab"), id="partial"),
+        pytest.param(mutator, id="alters_data"),
+        pytest.param(marked, id="do_not_call_in_templates"),
+    ]
+    #: Callables it does NOT — an earlier conversion arm claims them.
+    NOT_CROSSING = [
+        pytest.param(CallableBytes(b"ab"), id="CallableBytes"),
+        pytest.param(CallableDeque([1, 2]), id="CallableDeque"),
+    ]
+
+    @pytest.mark.parametrize("value", CROSSING)
+    def test_a_crossing_callable_is_carried_with_the_flag_on(self, value: Any) -> None:
+        with resolve_lazy(True):
+            assert normalize_django_value(value) is value, (
+                "the arm still dropped a callable the sink can resolve"
+            )
+
+    @pytest.mark.parametrize("value", CROSSING)
+    def test_the_same_callable_is_dropped_with_the_flag_off(self, value: Any) -> None:
+        """The gate-off sibling, in the suite (#1468): OFF is byte-identical
+        to the pre-#2621 behaviour, which is what makes the ON assertion above
+        a claim about the FLAG rather than about callables in general."""
+        with resolve_lazy(False):
+            assert normalize_django_value(value) is None
+
+    def test_the_no_handle_half_of_the_gate_drops_rather_than_carries(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The second half of the gate, pinned on the CONDITION.
+
+        With nothing for the sink to walk, the arm must keep today's answer
+        rather than hand the renderer an object it does not model. Stated
+        against the condition (not a shape) because WHICH shapes decline is
+        the conversion's business and moves: #2704 moves every non-``list``
+        sequence onto the carrier, so the ``bytes``/``deque`` spellings below
+        stop declining the moment it lands. A fixture-shaped pin would go red
+        on that merge and read as a regression in the wrong file.
+        """
+        monkeypatch.setattr(
+            "djust.serialization._crosses_as_encoded", lambda _value: False, raising=True
+        )
+        with resolve_lazy(True):
+            assert normalize_django_value(lambda: "x") is None
+
+    @pytest.mark.parametrize("value", NOT_CROSSING)
+    def test_a_real_shape_agrees_with_whatever_the_gate_answers(self, value: Any) -> None:
+        """The arm must never disagree with the conversion about a shape.
+
+        A DIFFERENTIAL against ``_crosses_as_encoded``, not a recorded answer,
+        because WHICH shapes decline is the conversion's business and moves:
+        on ``main`` today a callable ``bytes``/``deque`` subclass declines
+        (PyO3's sequence extraction claims it before ``opaque_gate``), and
+        #2704 moves every non-``list`` sequence onto the carrier, at which
+        point these same two start crossing and the arm must start carrying
+        them. Both readings are correct; disagreeing with the conversion is
+        the only thing that is not.
+
+        Note on reachability, so the ``crosses_as_encoded`` term is not read
+        as decoration: it answers False by two routes, and only ONE is
+        by-value. The other — no compiled extension — is structural and
+        always reachable, and is pinned by
+        ``TestTheQuestionHasOneStatement2621``. That is why the term stays
+        even on a ``main`` where no callable shape declines by value.
+        """
+        crosses = _crosses_as_encoded(value)
+        with resolve_lazy(True):
+            carried = normalize_django_value(value)
+        if crosses:
+            assert carried is value, "a modelled callable was dropped anyway"
+        else:
+            assert carried is None, "an unmodelled callable was handed to the renderer"
+
+    @pytest.mark.parametrize("value", CROSSING)
+    def test_the_state_channel_drops_it_on_both_settings(self, value: Any) -> None:
+        """``state_roundtrip=True`` is the session / signed-snapshot boundary:
+        an encoder-less serializer writes it, so it CANNOT hold a live object.
+        Same reason the ``Decimal`` / ``datetime`` / ``set`` branches split on
+        this flag."""
+        for enabled in (True, False):
+            with resolve_lazy(enabled):
+                assert normalize_django_value(value, state_roundtrip=True) is None
+
+    def test_the_arm_never_invokes_what_it_carries(self) -> None:
+        """Normalization only stops DROPPING the callable — deciding whether
+        to call it is the sink's job (`walk_live`'s root `maybe_call`). If
+        normalization called it, `alters_data` would already have been
+        violated one layer too early."""
+        CALLS.clear()
+        with resolve_lazy(True):
+            for fn in (plain_lambda, mutator, marked, loud, needs_args):
+                normalize_django_value(fn)
+        assert CALLS == [], f"normalization CALLED something: {CALLS}"
+
+
+@pytest.mark.django_db
+class TestTheSinkAnswersDjangoOnTheLiveViewPath2621:
+    """The end-to-end half: with the callable reaching the sink, Django's own
+    call rules answer — the ones `maybe_call` already implements.
+
+    The net pins rows J / J2 / Q / P / P0. These are the neighbouring rules
+    the net does not sample, which is where a curated table blinds you: the
+    five cells all exercise the *plain call* arm, and `alters_data`,
+    `do_not_call_in_templates`, a raising body and an arity mismatch are four
+    separate branches of `_resolve_lookup`'s callable block.
+    """
+
+    #: id -> (source, context factory). Every entry is asserted against the
+    #: REAL Django engine in the same test, so nothing here is a recorded
+    #: expectation that can drift away from Django.
+    SHAPES: dict[str, Callable[[], dict]] = {
+        "plain": lambda: {"f": plain_lambda},
+        "alters_data": lambda: {"f": mutator},
+        "do_not_call_in_templates": lambda: {"f": marked},
+        "raises": lambda: {"f": loud},
+        "needs_args": lambda: {"f": needs_args},
+        "builtin": lambda: {"f": len},
+        "bound_method": lambda: {"f": "abc".upper},
+        "partial": lambda: {"f": functools.partial(lambda: "P")},
+        "class": lambda: {"f": Cls},
+        "nested_in_a_dict": lambda: {"f": {"inner": plain_lambda}},
+    }
+
+    def _source(self, key: str) -> str:
+        return "{{ f.inner }}" if key == "nested_in_a_dict" else "{{ f }}"
+
+    @pytest.mark.parametrize("key", sorted(SHAPES))
+    def test_the_liveview_path_answers_django_with_the_flag_on(self, key: str) -> None:
+        source, make_ctx = self._source(key), self.SHAPES[key]
+        expected = observe(django_render, source, make_ctx())
+        actual = observe(liveview_render, source, make_ctx())
+        assert actual == expected, (
+            f"{key}: the LiveView path answers {actual!r}, Django answers {expected!r}"
+        )
+
+    @pytest.mark.parametrize("key", sorted(SHAPES))
+    def test_the_flag_off_column_is_still_none(self, key: str) -> None:
+        """The gate-off sibling. Every one of these rendered ``None`` before
+        #2621, and still does with the flag OFF — so the ON assertions above
+        measure the change rather than a property callables always had."""
+        source, make_ctx = self._source(key), self.SHAPES[key]
+        with resolve_lazy(False):
+            assert observe(liveview_render, source, make_ctx()) == "None"
+
+    @pytest.mark.parametrize("key", sorted(SHAPES))
+    def test_the_two_djust_paths_agree_with_the_flag_on(self, key: str) -> None:
+        """#1646: the arm was a LiveView-only divergence, so the closing claim
+        is that the divergence is GONE, not merely that one path improved."""
+        source, make_ctx = self._source(key), self.SHAPES[key]
+        with resolve_lazy(True):
+            plain = observe(plain_render, source, make_ctx())
+            liveview = observe(liveview_render, source, make_ctx())
+        assert plain == liveview, f"{key}: plain={plain!r} liveview={liveview!r}"
+
+    def test_a_mutator_is_refused_rather_than_run(self) -> None:
+        """#2506/#2507 never fail OPEN. Presence AND silence: the render
+        reaches the name (the neighbouring cell proves the lookup ran) and the
+        mutator segment is empty, with no call recorded."""
+        CALLS.clear()
+        with resolve_lazy(True):
+            out = liveview_render("[{{ ok }}][{{ f }}]", {"ok": plain_lambda, "f": mutator})
+        assert out == "[foo bar][]", out
+        assert "mutator" not in CALLS, f"the alters_data callable RAN: {CALLS}"
+
+    def test_a_raising_body_propagates_rather_than_rendering_empty(self) -> None:
+        """A swallowed exception here would be the fail-open shape #2506
+        exists to refuse — and would be INVISIBLE, since the cell would render
+        the empty string a legitimately-empty callable also renders."""
+        with resolve_lazy(True):
+            with pytest.raises(RuntimeError, match="boom from the callable body"):
+                liveview_render("{{ f }}", {"f": loud})
+
+    def test_a_no_handle_callable_renders_what_the_gate_decided(self) -> None:
+        """The no-handle half, end to end — asserted against the gate.
+
+        Two premises were WRONG when this test was first written, and both are
+        recorded here rather than quietly fixed, because either would have
+        made a plausible-looking green assertion:
+
+        1. *"the two djust paths agree here"* — they do not, and not because
+           of #2621. PyO3's sequence extraction claims a ``bytes`` subclass
+           and gives the plain path a ``Value::List``, so ``{{ f }}`` renders
+           ``[97, 98]`` there while the LiveView path renders ``None``. That
+           divergence pre-dates this change and belongs to the conversion
+           (#2704's subject), not to the arm.
+        2. *"the LiveView answer is ``None``"* — true on this ``main`` and
+           only because the shape declines ``crosses_as_encoded``. #2704 moves
+           every non-``list`` sequence onto the carrier, at which point this
+           shape crosses, the arm carries it, and the sink CALLS it — the
+           Django answer. Hard-coding ``None`` would go red on that merge and
+           read as a regression in the wrong file.
+
+        What holds either way: the render agrees with what the gate decided,
+        and the escape hatch is unmoved.
+        """
+
+        def ctx() -> dict:
+            return {"f": CallableBytes(b"ab")}
+
+        django_bytes = observe(django_render, "{{ f }}", ctx())
+        assert django_bytes == "CB-called", (
+            "the Django side of the differential stopped being what it was measured to be"
+        )
+        crosses = _crosses_as_encoded(CallableBytes(b"ab"))
+        with resolve_lazy(False):
+            assert observe(liveview_render, "{{ f }}", ctx()) == "None", (
+                "the ADR-027 escape hatch moved — it drops every callable, unconditionally"
+            )
+        with resolve_lazy(True):
+            rendered = observe(liveview_render, "{{ f }}", ctx())
+        if crosses:
+            assert rendered == django_bytes, (
+                f"the arm carried it to the sink but the render is {rendered!r}, "
+                f"not Django's {django_bytes!r}"
+            )
+        else:
+            assert rendered == "None", (
+                f"the arm handed a handle-less callable to the renderer: {rendered!r}"
+            )
+
+
+@pytest.mark.django_db
+class TestNoLiveObjectReachesAChannelThatPersists2621:
+    """The two boundaries the widening must not cross.
+
+    A handle-bearing ``Encoded`` crosses back to Python as its ``display``
+    string, which for a lambda is ``<function <lambda> at 0x…>`` — an address.
+    Neither the session snapshot nor the client payload may carry one.
+    """
+
+    def test_the_session_snapshot_holds_no_function_address(self) -> None:
+        """The REAL GET path: `mixins/request.py` writes
+        `request.session[view_key]` through
+        `normalize_django_value(..., state_roundtrip=True)`."""
+
+        class _CallableStateView(LiveView):
+            template = "<div dj-root>{{ cb }}</div>"
+
+            def mount(self, request, **kwargs):
+                self.cb = plain_lambda
+
+            def get_context_data(self, **kwargs):
+                return {"cb": self.cb}
+
+        factory = RequestFactory()
+        request = factory.get("/callable-2621/")
+        SessionMiddleware(lambda _r: None).process_request(request)
+        request.session.save()
+        with resolve_lazy(True):
+            _CallableStateView().get(request)
+
+        saved = request.session["liveview_/callable-2621/"]
+        assert saved["cb"] is None, f"a live callable reached the session: {saved['cb']!r}"
+        # The strong form: the whole snapshot is JSON-encodable with no
+        # address anywhere in it, which is what the encoder-less session
+        # serializer actually requires.
+        blob = json.dumps(saved)
+        assert "0x" not in blob and "<function" not in blob, blob
+
+    def test_the_client_state_payload_holds_no_function_address(self) -> None:
+        """The other outbound channel, measured rather than assumed.
+
+        `get_state()` is what the client is given. A carried callable is a
+        `Value::Encoded` whose display for a lambda is
+        `<function … at 0x…>` — a server address — so "no address reaches the
+        client" is a claim that needs a measurement, not an inference from the
+        session pin above (a different channel, built by different code).
+
+        Honest about its own category: this is a BOUNDARY pin, not a change
+        pin. It stays green with the change gated off, because `get_state()`
+        reads the view's public attributes and the attribute walk drops a
+        callable before this arm ever sees it (the sibling below). The value
+        is that the claim in this class's docstring is measured on both
+        settings rather than reasoned from the session channel — and that a
+        future change routing context values into client state has to come
+        here and face it.
+        """
+
+        class _StateView(LiveView):
+            template = "<div dj-root>{{ cb }}{{ plain }}</div>"
+
+            def mount(self, request, **kwargs):
+                self.cb = plain_lambda
+                self.plain = "visible"
+
+        for enabled in (True, False):
+            with resolve_lazy(enabled):
+                client = LiveViewTestClient(_StateView)
+                client.mount()
+                client.render()
+                assert client.view_instance is not None
+                state = client.view_instance.get_state()
+            blob = json.dumps(state)
+            assert "0x" not in blob and "<function" not in blob, (
+                f"a function address reached the client payload with the flag {enabled}: {blob}"
+            )
+            assert state == {"plain": "visible"}, state
+
+    def test_a_public_callable_ATTRIBUTE_is_still_dropped_before_the_arm(self) -> None:
+        """The boundary #2621 does NOT move, stated so nobody reads the gate
+        as wider than it is.
+
+        A callable assigned as a public LiveView **attribute** never reaches
+        ``normalize_django_value`` at all: the public-attribute walk drops it
+        first (``mixins/context.py``'s ``if callable(value): continue``), and
+        that exclusion is deliberate and load-bearing — without it every
+        ``@event_handler`` on the view would become a context variable. So
+        ``{{ cb }}`` for ``self.cb = fn`` renders EMPTY on both flag settings,
+        where Django's ``Context({"cb": fn})`` renders the call's result.
+
+        #2621 is about the context DICT — what ``get_context_data`` returns,
+        which is what the characterization net's rows exercise. A future
+        change that widens the attribute walk has to come here and say so.
+        """
+
+        class _AttrView(LiveView):
+            template = "<div dj-root>[{{ cb }}][{{ plain }}]</div>"
+
+            def mount(self, request, **kwargs):
+                self.cb = plain_lambda
+                self.plain = "visible"
+
+        for enabled in (True, False):
+            with resolve_lazy(enabled):
+                client = LiveViewTestClient(_AttrView)
+                client.mount()
+                html = client.render()
+            match = DJ_ROOT.search(html)
+            assert match is not None, html
+            assert match.group(1) == "[][visible]", (
+                f"the public-attribute walk changed with the flag {enabled}: {match.group(1)!r}"
+            )
+
+    def test_the_display_string_is_what_a_handle_hands_back_not_the_object(self) -> None:
+        """A carried callable is a `Value::Encoded` with a transient handle,
+        and `IntoPyObject` maps an `Encoded` to its DISPLAY string — so a
+        custom-tag handler receives text, never the live function (#2509)."""
+        with resolve_lazy(True):
+            carried = normalize_django_value(plain_lambda)
+        assert carried is plain_lambda
+        assert _rust.crosses_as_encoded(carried) is True
+
+
+class TestTheQuestionHasOneStatement2621:
+    """#1646, structurally: ``normalize_django_value`` asks
+    "does this cross as an ``Encoded``?" from TWO arms now, and both must
+    route through the one helper — including its fail-SOFT answer when the
+    compiled extension is absent."""
+
+    def _serialization_source(self) -> str:
+        from djust import serialization
+
+        assert serialization.__file__ is not None
+        with open(serialization.__file__, encoding="utf-8") as handle:
+            return handle.read()
+
+    # The "one statement" half of this claim — the Rust export named exactly
+    # once, and the helper's two arms — is pinned NEXT DOOR, in
+    # `test_opaque_collections_2477_2489.py::TestTheGateHasOneStatement`, the
+    # class that already owned this gate's structural pins and that #2621
+    # extended. Restating it here would be two pins for one invariant, and the
+    # canon on shadowing says delete the redundant one rather than test around
+    # it. What is left below is what only #2621 introduced.
+
+    def test_a_missing_extension_answers_false_rather_than_raising(self, monkeypatch) -> None:
+        """The fallback branch is the one least likely to be exercised, so it
+        must never turn "we could not serialize it" into a 500. Both callers
+        want the same soft answer, which is why it lives in the helper."""
+        import djust
+
+        monkeypatch.delattr(djust._rust, "crosses_as_encoded", raising=True)
+        assert _crosses_as_encoded(lambda: 1) is False
+        with resolve_lazy(True):
+            # With the question unanswerable, the callable arm falls back to
+            # the historical drop rather than propagating the AttributeError.
+            assert normalize_django_value(lambda: 1) is None
+
+    def test_the_flag_is_read_through_the_config_helper(self) -> None:
+        """`config.py` is the only file allowed to spell the settings key
+        (`test_the_config_reader_is_the_only_one`), so the arm must call the
+        reader rather than reach for `LIVEVIEW_CONFIG` itself."""
+        source = self._serialization_source()
+        assert "template_resolve_lazy_enabled" in source
+        assert '"template_resolve_lazy"' not in source
+        assert "'template_resolve_lazy'" not in source

--- a/python/tests/test_adr027_characterization_net_2539.py
+++ b/python/tests/test_adr027_characterization_net_2539.py
@@ -707,32 +707,40 @@ FLOOR_ROWS = frozenset("E1 E2 E3 E4".split())
 #: Django engine every run. A row still in the set must keep TODAY's recorded
 #: bytes, so "wrong in a new way" fails too.
 #:
-#: The remaining disagreements are measured against Django below; each
-#: retained row has a named reason:
+#: **Both sets are now empty** (#2621): with the flag ON every non-floor row
+#: answers Django's bytes on both paths. The set is kept — not deleted — for
+#: two reasons: it is what ``assert_lazy_column`` reads, so a future
+#: regression has a named place to land rather than a diff that edits an
+#: assertion; and movement 4 (#2628) is the PR that deletes both sets with
+#: the flag itself. An empty stated set is a stronger claim than a populated
+#: one, and ``TestTheTableIsLoadBearing`` still exercises the held-row branch
+#: against a synthetic row so the machinery cannot rot while unused.
 #:
-#: Row O now agrees on both paths and both flag settings: Encoded keeps
-#: string-conversion safety as runtime-only metadata, without a wire grant.
+#: How each of the six cells #2621 inherited was closed:
 #:
-#: Row V (a generator) agrees on both paths with the flag ON since #2613:
-#: ``opaque_gate`` admits a ONE-SHOT iterator with a live handle and no
-#: items, and the ``{% for %}`` sink consumes it once through
-#: ``Encoded::consume_live_items`` — Django's ``list(values)``. With the flag
-#: OFF there is no handle, so the recorded (declined) bytes stand there.
-#: * ``J`` / ``J2`` / ``Q``, LiveView only — ``normalize_django_value``
-#:   replaces ANY callable with ``None`` before Rust sees it
-#:   (``serialization.py``'s "safety net: skip callables"), so a lambda and a
-#:   class never reach the sink on that path at all. The same shape as the
-#:   Component arm #2513 turns on, and deferred with it: lifting it changes
-#:   the LiveView STATE channel, not the resolution sink.
+#: * Row **O** (a ``__str__`` returning ``SafeData``) — closed before #2621
+#:   opened: ``Encoded`` keeps string-conversion safety as runtime-only
+#:   metadata, without a wire grant.
 #:
-#: * ``P`` / ``P0``, LiveView only — the same callable arm: the class is
-#:   replaced before Rust sees it, no handle exists, and the pre-ADR walk's
-#:   unguarded string-key item call answers (#2624 made that an answer
-#:   rather than a segfault). Closes with J / J2 / Q.
+#: * Row **V** (a generator) — closed by #2613: ``opaque_gate`` admits a
+#:   ONE-SHOT iterator with a live handle and no items, and the ``{% for %}``
+#:   sink consumes it once through ``Encoded::consume_live_items`` — Django's
+#:   ``list(values)``. With the flag OFF there is no handle, so the recorded
+#:   (declined) bytes stand there.
 #:
-#: Remaining callable and iterator differences are tracked at #2621.
+#: * Rows **J** / **J2** / **Q** / **P** / **P0**, LiveView only — closed by
+#:   #2621. ``normalize_django_value`` replaced ANY callable with ``None``
+#:   before Rust saw it (``serialization.py``'s "safety net: skip callables"),
+#:   so a lambda and a class never reached the sink on that path at all, and
+#:   for P / P0 the absent handle left the pre-ADR walk's unguarded string-key
+#:   item call to answer (#2624 made that an answer rather than a segfault).
+#:   That arm is now gated on the flag, so under ADR-027 a callable crosses
+#:   RAW and ``walk_live``'s root ``maybe_call`` decides — Django's own rules,
+#:   at the sink. The arm still fires for ``state_roundtrip=True`` (the
+#:   session channel cannot hold a live object) and for a callable the
+#:   conversion does not model as an ``Encoded``.
 PLAIN_WRONG_UNDER_LAZY: frozenset[str] = frozenset()
-LIVEVIEW_WRONG_UNDER_LAZY = frozenset("J J2 P P0 Q".split())
+LIVEVIEW_WRONG_UNDER_LAZY: frozenset[str] = frozenset()
 
 
 def recorded(row: Row, path: str) -> Any:
@@ -979,8 +987,11 @@ class TestTheDifferentialTable:
         )
         # 27 at the flip, 29 since #2613 moved row V on both paths, 31 since
         # #2624: P-plain and P0-plain joined once they stopped crashing (the
-        # flag's metaclass guard answers both with Django's bytes).
-        assert len(moved) == 31, f"expected 31 cells to move, got {len(moved)}: {sorted(moved)}"
+        # flag's metaclass guard answers both with Django's bytes). 36 since
+        # #2621 gated `normalize_django_value`'s callable arm on the flag,
+        # which moved the five LiveView cells that arm was dropping —
+        # J, J2, Q, P and P0 — leaving `held` empty.
+        assert len(moved) == 36, f"expected 36 cells to move, got {len(moved)}: {sorted(moved)}"
 
 
 class TestThePlainEntriesAgree:
@@ -1111,7 +1122,9 @@ class TestTheTableIsLoadBearing:
         with pytest.raises(AssertionError, match="SECURITY pin"):
             assert_wrong_rows_are_wrong_and_right_rows_are_right(row, "plain", row.django)
 
-    def test_the_lazy_check_reddens_in_all_three_directions(self) -> None:
+    def test_the_lazy_check_reddens_in_all_three_directions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """``assert_lazy_column`` is the flag-ON half and needs the same
         treatment: a claimed row that does NOT reach Django, a held row that
         silently DOES, and a floor row that leaks must each fail by name."""
@@ -1121,11 +1134,19 @@ class TestTheTableIsLoadBearing:
         assert_lazy_column(claimed, "plain", claimed.django)  # the genuine answer passes
         with pytest.raises(AssertionError, match="does not answer Django's bytes"):
             assert_lazy_column(claimed, "plain", claimed.plain)
-        # A HELD row (row J, LiveView — the plain held set emptied when #2613
-        # closed row V) that starts matching Django must fail loudly, so the
+        # A HELD row that starts matching Django must fail loudly, so the
         # residue set cannot rot into a floor.
+        #
+        # BOTH stated sets are empty since #2621, so there is no real held row
+        # left to point at — and a branch with no exercise is a branch that
+        # rots. The set is therefore SUBSTITUTED for the duration of these
+        # three assertions, which keeps the held arm load-bearing against a
+        # REAL row's real recorded bytes (row J on LiveView, whose recorded
+        # column is still `"None"`) rather than a hand-built fixture. The
+        # production sets stay empty; `monkeypatch` restores them.
         held = ROW_BY_ID["J"]
-        assert "J" in LIVEVIEW_WRONG_UNDER_LAZY
+        monkeypatch.setitem(globals(), "LIVEVIEW_WRONG_UNDER_LAZY", frozenset({"J"}))
+        assert "J" in wrong_under_lazy("liveview"), "the substitution did not reach the reader"
         assert_lazy_column(held, "liveview", held.liveview)
         with pytest.raises(AssertionError, match="WRONG_UNDER_LAZY"):
             assert_lazy_column(held, "liveview", held.django)

--- a/python/tests/test_opaque_collections_2477_2489.py
+++ b/python/tests/test_opaque_collections_2477_2489.py
@@ -794,21 +794,57 @@ class TestTheGateHasOneStatement:
         assert self._call_sites(added, "opaque_value") == 2
 
     def test_crosses_as_encoded_is_consulted_exactly_once_by_the_normalizer(self) -> None:
+        """The Rust export is named ONCE; the normalizer asks through a helper.
+
+        This pin used to count the bare name and read the answer as "the
+        normalizer consults the conversion at its final fallback, and nowhere
+        else". #2621 gave the question a SECOND asker — the callable arm — so
+        the invariant needed restating rather than relaxing: the one statement
+        moved into ``_crosses_as_encoded``, and what must stay singular is the
+        **export**, not the number of arms that consult it. Two arms asking one
+        helper is the #1646 cure; two arms each spelling the guarded import is
+        the #1646 bug.
+
+        Note the substring trap this pin walked into: ``_crosses_as_encoded(``
+        CONTAINS ``crosses_as_encoded(``, so the bare-name count silently went
+        1 -> 4 at the refactor and the failure read as a policy regression
+        rather than a rename. Both readers below are therefore spelled with
+        the prefix that disambiguates them.
+        """
         source = SERIALIZATION_PY.read_text(encoding="utf-8")
-        assert self._call_sites(source, "crosses_as_encoded") == 1, (
-            "the normalizer must consult the conversion at ONE place — its "
-            "final fallback. A second consultation is a second policy (#1646)"
+        assert self._call_sites(source, "_rust.crosses_as_encoded") == 1, (
+            "the module must name the Rust export at ONE place — inside "
+            "`_crosses_as_encoded`. A second spelling of the guarded import is a "
+            "second policy for one question (#1646)"
         )
-        removed = source.replace("if _rust.crosses_as_encoded(value):", "if False:", 1)
+        # The canary, both ways: a count that cannot move is not a pin.
+        removed = source.replace("return bool(_rust.crosses_as_encoded(value))", "return False", 1)
         assert removed != source, "the mutation text did not match"
-        assert self._call_sites(removed, "crosses_as_encoded") == 0
+        assert self._call_sites(removed, "_rust.crosses_as_encoded") == 0
         added = source.replace(
-            "if _rust.crosses_as_encoded(value):",
-            "_ = _rust.crosses_as_encoded(value)\n            if _rust.crosses_as_encoded(value):",
+            "return bool(_rust.crosses_as_encoded(value))",
+            "_ = _rust.crosses_as_encoded(value)\n"
+            "        return bool(_rust.crosses_as_encoded(value))",
             1,
         )
         assert added != source
-        assert self._call_sites(added, "crosses_as_encoded") == 2
+        assert self._call_sites(added, "_rust.crosses_as_encoded") == 2
+
+    def test_the_helper_has_exactly_the_two_arms_that_should_ask_it(self) -> None:
+        """And the other half: WHO asks. The callable arm (#2621) and the final
+        fallback (#2477/#2489) — a third asker is a new policy and has to come
+        here and say so."""
+        source = SERIALIZATION_PY.read_text(encoding="utf-8")
+        body = source.split("def normalize_django_value", 1)[1]
+        assert body.count("_crosses_as_encoded(value)") == 2, (
+            "expected exactly two call sites inside `normalize_django_value`: the "
+            "callable arm and the final fallback"
+        )
+        removed = body.replace(
+            "if not state_roundtrip and _crosses_as_encoded(value):", "if False:", 1
+        )
+        assert removed != body, "the mutation text did not match"
+        assert removed.count("_crosses_as_encoded(value)") == 1
 
     def test_the_predicate_asks_the_shared_gate_and_converts_nothing(self) -> None:
         """Both mistakes this predicate has already made, pinned as source.

--- a/tests/unit/test_normalize_django_value.py
+++ b/tests/unit/test_normalize_django_value.py
@@ -1,5 +1,6 @@
 """Tests for normalize_django_value() in djust.serialization."""
 
+import contextlib
 import json
 from datetime import datetime, date, time, timedelta, timezone
 from decimal import Decimal
@@ -278,20 +279,60 @@ class TestMaxRecursionDepth:
 
 
 class TestCallable:
-    """callable -> None."""
+    """callable -> None, on the two channels that still drop it (#2621).
+
+    The arm used to be unconditional, and that is what made the LiveView path
+    render ``None`` for ``{{ callable }}`` where Django renders the CALL's
+    result — rows J / J2 / Q / P / P0 of the ADR-027 characterization net.
+    Since #2621 it is gated on ``template_resolve_lazy``: under the flag a
+    callable crosses RAW and the resolution sink applies Django's own call
+    rules (``alters_data``, ``do_not_call_in_templates``, a propagating
+    raise).
+
+    Two channels keep the drop, and they are what these cases now assert:
+    the ADR-027 escape hatch, and ``state_roundtrip=True`` — the session /
+    signed-snapshot boundary, written by an encoder-less serializer that
+    cannot hold a live object.
+
+    The flag-ON behaviour is pinned in
+    ``python/tests/test_adr027_callable_arm_2621.py`` rather than duplicated
+    here: this file's subject is the encoder-parity contract, and the sink is
+    that file's.
+    """
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _resolve_lazy(enabled):
+        from djust.config import config
+        from djust.render_env import apply_render_env
+
+        previous = config.get("template_resolve_lazy", False)
+        config.update({"template_resolve_lazy": enabled})
+        apply_render_env()
+        try:
+            yield
+        finally:
+            config.update({"template_resolve_lazy": previous})
+            apply_render_env()
 
     def test_function_returns_none(self):
         def my_func():
             return 42
 
-        assert normalize_django_value(my_func) is None
+        with self._resolve_lazy(False):
+            assert normalize_django_value(my_func) is None
+        assert normalize_django_value(my_func, state_roundtrip=True) is None
 
     def test_lambda_returns_none(self):
-        assert normalize_django_value(lambda: 42) is None
+        with self._resolve_lazy(False):
+            assert normalize_django_value(lambda: 42) is None
+        assert normalize_django_value(lambda: 42, state_roundtrip=True) is None
 
     def test_builtin_returns_none(self):
         # len is callable
-        assert normalize_django_value(len) is None
+        with self._resolve_lazy(False):
+            assert normalize_django_value(len) is None
+        assert normalize_django_value(len, state_roundtrip=True) is None
 
 
 class MyCustom:


### PR DESCRIPTION
Closes #2621.

ADR-027 movement 3 left **six cells held**. By the time this was worked two of them had
already closed elsewhere — **O** in PR #2665 and **V** in #2613 — and #2624 had turned
**P-liveview**'s segfault into merely wrong bytes. What was left was **five cells with one
cause**, and this PR closes them with the one mechanism they share. Both stated sets in
the characterization net are now empty.

The issue's own framing is the thing that moved most: it described six cells and two
mechanisms, and the honest answer was five cells and one, because the other mechanism had
shipped under a different name in a PR filed against a different issue. Reproducing every
cell before touching anything is what surfaced that; the issue body alone would have had
me building a `safe` bit that already existed.

## Per-cell verdict

Reproduced against real Django 5.2 in-process before changing anything, then again
after. Addresses scrubbed. (The probe scripts live under the gitignored `scratch/`, so
they are not in this diff; every claim they produced is pinned by a test that is.)

| cell | shape | Django | LiveView **before** | LiveView **after** | verdict |
|---|---|---|---|---|---|
| **J** | `{{ callable }}`, a lambda | `foo bar` | `None` | `foo bar` | **closed here** |
| **J2** | `{{ var.callable }}` in a dict | `foo bar` | `None` | `foo bar` | **closed here** |
| **Q** | `{{ k }}`, a class object | `<Cls>` | `None` | `<Cls>` | **closed here** |
| **P** | `{{ cls.class_property }}`, a `list`-subclass class | `class_property \| ` | `MyClass['class_property'] \| MyClass['class_method']` | `class_property \| ` | **closed here** |
| **P0** | `{{ cls.0 }}`, same class | `MyClass[0]` | `MyClass['0']` | `MyClass[0]` | **closed here** |
| **O** | `__str__` returning `SafeData` | `<b>s</b>` | — | — | **already closed** (PR #2665, `Encoded::display_safe`) |
| **V** | a generator in `{% for %}` | `12` | — | — | **already closed** (#2613, one-shot handle) |

The plain-path column is unchanged throughout (it already answered Django for all five
under the flag — which is what made the cause legible: the arm, not the sink). The
flag-OFF column is byte-identical to before for every row.

`P-liveview` was filed as a *crash* cell; #2624's conversion depth ceiling had already
turned the segfault into wrong bytes, and this PR gives it Django's.

## The mechanism (one, not two)

The issue proposed two mechanisms. The first — a transient `Encoded.safe` bit for row O —
**had already shipped** in PR #2665 as `Encoded::display_safe`
(`crates/djust_core/src/lib.rs:427`, read at `:2672`), without the ADR's "twelfth wire
slot"; `the_payload_is_eleven_slots_in_the_documented_order` is unedited. So only the
second was left:

```python
if callable(value):
    if not state_roundtrip and template_resolve_lazy_enabled() and _crosses_as_encoded(value):
        return value
    return None            # unchanged otherwise
```

`normalize_django_value`'s "safety net: skip callables" replaced ANY callable with `None`
before the context reached Rust. `None` **is** a `Value`, so the value stack answered
first and the sidecar's raw object was never consulted. Under the flag the callable now
crosses raw and `walk_live`'s root `maybe_call` decides — where Django's rules already
live. Nothing in normalization invokes it; the arm only stops dropping it.

Verified at the sink against real Django, all on the LiveView path with the flag ON, and
pinned in `TestTheSinkAnswersDjangoOnTheLiveViewPath2621`:

| rule | Django | after |
|---|---|---|
| `alters_data` | `''`, not called | `''`, not called |
| `do_not_call_in_templates` | rendered as is | rendered as is |
| raising body | propagates | propagates (#2506 never fails open) |
| arity mismatch | `''` | `''` |
| bound method / builtin / `functools.partial` / nested in a dict | called | called |

## What was deliberately NOT done

- **Movement 4 (#2628) not pulled forward.** Deferred to 1.3.0 by the recorded lead
  decision; nothing here needs it, and the escape hatch stays.
- **No wire move.** No twelfth `Encoded` slot, no `Serialize` change, no client-JSON change.
- **The public-attribute walk not widened.** A callable assigned as `self.cb = fn` still
  never reaches this arm — `mixins/context.py`'s `if callable(value): continue` drops it
  first, deliberately, or every `@event_handler` would become a context variable. Pinned
  in `test_a_public_callable_ATTRIBUTE_is_still_dropped_before_the_arm` so nobody reads
  the gate as wider than it is.
- **A callable `bytes`/`deque` subclass left where it is.** It declines
  `crosses_as_encoded`, so it has no handle and keeps its answer. Its djust-vs-Django
  difference is the conversion's (PyO3's sequence extraction claims it) and belongs to
  #2704, not here — #1079.

## Two boundaries the widening does not cross

Both pinned, both independently reachable, neither shadowing the other:

- **`state_roundtrip=True`** — the session / signed-snapshot channel, written by an
  encoder-less serializer. A callable in public state still persists as `None`; asserted
  through the **real GET path** (`mixins/request.py` writing
  `request.session["liveview_/…"]`), with the whole snapshot `json.dumps`-ed and checked
  for `0x` / `<function`.
- **`crosses_as_encoded` false** — no handle for the sink to walk, so today's answer stands.
  Reachable two ways: by value on this `main`, and structurally when the compiled
  extension is absent (that arm fails **soft** to `False` rather than raising, so the
  fallback branch cannot turn "we could not serialize it" into a 500).

`get_state()` — the client payload — was measured on both settings and is
`{'plain': 'visible'}` either way; pinned in
`test_the_client_state_payload_holds_no_function_address`, which is honest in its own
docstring about being a boundary pin rather than a change pin.

## Gate-off (#1468, harness per #2129/#2135)

The harness asserts the mutation text was found, asserts the source
changed, counts pytest **errors** as well as failures, refuses to report a number when
the module did not import, clears `__pycache__` between iterations, and bounds each child
by a deadline **and** a polled RSS ceiling (killed by pid).

Run against all three affected test files.

| mutation | result | reddened |
|---|---|---|
| baseline | clean | — |
| **C1** restore the unconditional `return None` | **43 failed** | the five net cells + every flag-ON assertion |
| **C2** drop the `state_roundtrip` boundary | **11 failed** | only the persisted-channel pins + `TestCallable` |
| **C3** drop the flag condition | **22 failed** | only the flag-OFF siblings + `TestCallable` |
| **C4** drop `crosses_as_encoded` | **5 failed** | only the no-handle pins |
| **C5** make the helper raise instead of failing soft | **1 failed** | only the missing-extension pin |
| restored | clean | — |

No survivors, no INVALIDs, and each mechanism has a test that goes red when **only** that
mechanism is removed — the two-mechanisms-shadowing check.

One test in the new file is a **boundary** pin rather than a change pin and says so in its
own docstring: `test_the_client_state_payload_holds_no_function_address` stays green with
the change gated off, because `get_state()` reads public attributes and the attribute walk
drops a callable before this arm sees it. It is there so the "no address reaches the
client" claim is measured on both settings rather than inferred from the session channel.

## Scoreboard

`98.57%` engine / `98.97%` whole — unmoved. `compare` reports **no drop against the
baseline**. `compare` is percent-only, so the per-test audit was done by running the
scoreboard twice — once with the change gated off, once with it on — and diffing the
1,476 parsed per-test lines: **zero differences**, so 0 OK→FAIL and 0 FAIL→OK. (The Django
suite exercises the plain backend, which already answered these correctly; the five cells
this PR moves are LiveView-path, which that suite does not reach. The audit's job here is
to prove nothing else moved.)

## Two premises I got wrong, recorded rather than quietly fixed

Both are in the test docstrings, because either would have made a plausible green assertion:

1. *"the two djust paths agree on a handle-less callable"* — they do not, and not because
   of this change: PyO3's sequence extraction gives the plain path a `Value::List`, so
   `{{ f }}` renders `[97, 98]` there. Pre-existing, and the conversion's.
2. *"the LiveView answer for that shape is `None`"* — true only while it declines
   `crosses_as_encoded`. #2704 moves it, so the tests assert against the gate's actual
   answer rather than a literal.

## Coordination

`fix/2704-2710-templates` (PR #2725) moves every non-`list` sequence onto the carrier, so
a callable `bytes`/`deque` subclass flips from declining `crosses_as_encoded` to crossing
it — at which point this gate carries it and the sink calls it, which is Django's answer.
Confirmed with that PR's author; the fixtures here assert against the gate rather than a
literal, so this is correct on either side of the merge. No second mechanism, no conflict.

Both PRs rebased onto `04b78adb`, and both edit
`python/tests/test_opaque_collections_2477_2489.py` — in different classes
(`TestTheGateHasOneStatement` here, `_Members`/`CARRIED`/`EARLIER` there), so git should
merge them, but **whoever lands second should re-run that whole file, not just their own
class.** Two named things to expect after #2725 lands on top of this:

- `test_a_real_shape_agrees_with_whatever_the_gate_answers` and
  `test_a_no_handle_callable_renders_what_the_gate_decided` take their *other* branch and
  assert `CallableBytes` renders `CB-called` rather than `None`. Both should stay green;
  a red there is a real finding, and the assertion messages say which.
- The "at least one shape still declines by value" canary is deliberately **not** in this
  PR: post-#2704 no callable that reaches this arm declines by value (a callable
  `list`/`dict`/`tuple` subclass is claimed by an earlier `isinstance` branch in
  `normalize_django_value` and never gets there), so it would have fired on that merge and
  read as a regression in the wrong file. The `crosses_as_encoded` term keeps its place via
  the structurally-always-reachable route — no compiled extension — pinned separately.

## One pre-existing flake found, filed not buried

The first full three-root run reported
`test_template_conditions.py::TestIsIdentityOperators::test_is_not_none_with_non_none_value`.
It is not this PR's, and that was established by measurement rather than assertion: the
file alone is green (49), `python/tests/` alone is green (18312), the same three-root run
with **this change gated off** did not reproduce it (the 44 failures there were all this
PR's own tests reddening), and a rerun on the committed tree is green (26871 / 0).
Structurally it also cannot be: the test calls `_rust.render_template` directly, which
never reaches `normalize_django_value`, and the flag renders that cell identically on both
settings. Filed as **#2728** with the reproduction matrix and the two candidate
thread-locals.

## Files

| file | why |
|---|---|
| `python/djust/serialization.py` | the gate; `_crosses_as_encoded` extracted so two arms ask one question (#1646) |
| `python/tests/test_adr027_callable_arm_2621.py` | new — truth table, sink rules, persisted channels, structural pins |
| `python/tests/test_adr027_characterization_net_2539.py` | both stated sets empty; moved-cell count 31 → 36; the held-arm branch kept exercised by substitution |
| `python/tests/test_opaque_collections_2477_2489.py` | `TestTheGateHasOneStatement` restated — it counted the bare name, which is a **substring** of the helper's, so the count silently went 1 → 4 at the refactor and read as a policy regression rather than a rename. Now counts `_rust.crosses_as_encoded` (the export is what must stay singular), both canaries retargeted, plus a sibling pinning *who* asks |
| `tests/unit/test_normalize_django_value.py` | `TestCallable` now states the two channels that still drop |
| `docs/adr/027-…md` | held-cell paragraph replaced with the per-cell closure table |
| `changelog.d/2621.fixed.md` | fragment |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
