### PR TITLE
docs: map how a value crosses the Python/Rust boundary and becomes rendered output

### DIFF
--- a/crates/djust_core/src/context.rs
+++ b/crates/djust_core/src/context.rs
@@ -1777,10 +1777,26 @@ impl Context {
         //
         // Placing it first is safe in the direction that matters: the arm
         // fires ONLY where the deepest resolvable prefix is an `Encoded`
-        // carrying a handle, and nothing acquires a handle unless the flag is
-        // on (`opaque_value`). A `list`, a `dict`, a tuple, a `Model`, a
-        // `__djust_serialize__` object and the whole datetime family never
-        // carry one, so their resolution is untouched under either flag state.
+        // carrying a handle. A `list`, a `dict`, a tuple, a `Model` and a
+        // `__djust_serialize__` object never carry one — the `FromPyObject`
+        // arms ABOVE `opaque_value` claim all five — so their resolution is
+        // untouched under either flag state.
+        //
+        // The DATETIME family is the exception, and this comment asserted the
+        // opposite until `docs/architecture/VALUE_BOUNDARY.md` falsification-
+        // tested it (#1867). `django_json_encoded` (`lib.rs`) sets
+        // `live: Some(..)` for every `datetime` / `date` / `time` /
+        // `timedelta` UNCONDITIONALLY — there is no `resolve_lazy()` guard on
+        // that construction site, unlike `opaque_value`'s. So a temporal value
+        // DOES reach this arm, and its resolution IS flag-dependent: `.year` is
+        // answered by `Encoded::attrs` either way (`ENCODED_ATTR_NAMES`), while
+        // `.min` / `.max` / `.resolution` — deliberately in NEITHER name table,
+        // because their values are themselves `datetime`s and collecting them
+        // would not terminate — are answered ONLY here, and render empty with
+        // the flag off. Measured through a filtered-operand rebinding
+        // (`{% with q=xs|first %}`), which is the one binding shape the by-name
+        // sidecar cannot reach via `Context::aliases`; through any other
+        // spelling the sidecar answers and the difference is invisible.
         if crate::resolve_lazy() {
             if let Some(answer) = self.walk_from_handle(key)? {
                 return Ok(answer);

--- a/crates/djust_core/src/lib.rs
+++ b/crates/djust_core/src/lib.rs
@@ -2852,11 +2852,35 @@ pub fn set_resolve_lazy(enabled: bool) {
 /// since movement 3; `LIVEVIEW_CONFIG["template_resolve_lazy"] = False` is
 /// the escape hatch.
 ///
-/// Read at exactly two sites, and that is the whole of the routing:
-/// [`opaque_gate`]'s attribute-bearing decline (which decides whether an
-/// ordinary object CARRIES a live handle rather than being bulk-dumped) and
-/// `Context::resolve_without_builtins` (which decides whether a dotted lookup
-/// WALKS that handle). Exposed so the setter can be tested end to end (#2017).
+/// Read at EIGHT functional sites, in two crates. This said "read at exactly
+/// two sites, and that is the whole of the routing" until
+/// `docs/architecture/VALUE_BOUNDARY.md`'s review grepped it (#1867); the two
+/// it named are the two the ADR discusses, not the two that exist. Naming a
+/// subset as if it were the set is what lets a later reader conclude a
+/// behaviour is unreachable when it is not — and that doc acquired the same
+/// false claim by citing THIS comment instead of running the case.
+///
+/// In `djust_core`:
+/// * [`stated_len_is_too_large_to_enumerate`] — the over-cap decline is
+///   lazy-only.
+/// * [`Encoded::list_repr_is_this_objects_own_spelling`] — the declined
+///   container's spelling.
+/// * [`opaque_gate`] ×3: the one-shot-iterator arm, the over-cap walk arm, and
+///   the attribute-bearing decline (which decides whether an ordinary object
+///   CARRIES a live handle rather than being bulk-dumped).
+/// * [`opaque_value`] — the handle ATTACH itself.
+/// * `Context::resolve_without_builtins` — whether a dotted lookup WALKS the
+///   handle.
+///
+/// In `djust_templates`:
+/// * `renderer::get_value_safe`'s `ignore_failures` arm — a filtered TAG
+///   operand that resolves to `Missing` becomes `None` under the flag, so
+///   `{% firstof nope|default_if_none:"X" "Y" %}` renders `X` with the flag on
+///   and `Y` with it off. Behaviourally observable, and in a different crate
+///   from every other read.
+///
+/// `djust_live`'s `resolve_lazy_enabled` is a PyO3 getter, not a routing read:
+/// it exists so the setter can be tested end to end (#2017).
 pub fn resolve_lazy() -> bool {
     RESOLVE_LAZY.with(|c| c.get())
 }

--- a/crates/djust_core/src/lib.rs
+++ b/crates/djust_core/src/lib.rs
@@ -522,9 +522,16 @@ pub struct Encoded {
     /// `datetime`s, so collecting them would convert a `datetime` whose own
     /// `min` is a `datetime` — `datetime.min.min is datetime.min` is `True` —
     /// and the conversion would not terminate. Measured, not reasoned about.
-    /// So `{{ p.max }}` stays empty where Django renders it; that cell is
-    /// unchanged by this field rather than closed by it, and is recorded as
-    /// such rather than quietly widened.
+    /// So that cell is unchanged by THIS field rather than closed by it, and is
+    /// recorded as such rather than quietly widened.
+    ///
+    /// It is no longer empty, though. This said "`{{ p.max }}` stays empty
+    /// where Django renders it" until `docs/architecture/VALUE_BOUNDARY.md`
+    /// falsification-tested it (#1867): ADR-027's live handle closed the cell
+    /// from the other side. `{{ p.max }}` renders
+    /// `Dec. 31, 9999, 11:59 p.m.`, answered by [`Context::walk_live`] off the
+    /// handle [`django_json_encoded`] attaches — not by this map, which still
+    /// deliberately omits all three names.
     ///
     /// **Nullary METHODS are in this map too since #2485**, put there by the
     /// SECOND producer [`collect_called_attrs`] from its own table
@@ -632,7 +639,17 @@ pub struct Encoded {
     /// alive at once, so their addresses are distinct.
     pub eq_class: Option<EqClass>,
     /// The LIVE object this value was measured from — ADR-027's handle
-    /// (#2539). `None` unless [`resolve_lazy`] was on at the conversion.
+    /// (#2539).
+    ///
+    /// [`opaque_value`] attaches one only when [`resolve_lazy`] is on;
+    /// [`django_json_encoded`] attaches one UNCONDITIONALLY, so a temporal
+    /// value carries a handle under either flag state. The observable
+    /// behaviour is still gated, because the SINK is
+    /// (`Context::resolve_without_builtins`) — which is why this field read
+    /// "`None` unless `resolve_lazy` was on at the conversion" for as long as
+    /// it did. Corrected by reading the two construction sites, not by
+    /// running: the field is not exposed to Python and the two cases are
+    /// behaviourally indistinguishable from there.
     ///
     /// **TRANSIENT.** It is not serialized (the `ENCODED_TAG` payload stays
     /// ELEVEN slots), not compared (`PartialEq for Encoded` does not mention
@@ -686,10 +703,19 @@ pub struct Encoded {
     ///
     /// [`Context::walk_live`]: crate::Context::walk_live
     ///
-    /// **When it is `Some`, [`Encoded::attrs`] is EMPTY** — see
-    /// [`opaque_value`]. The handle is the authority for attribute lookups,
+    /// **On an [`opaque_value`] carrier, [`Encoded::attrs`] is EMPTY when this
+    /// is `Some`.** The handle is the authority for attribute lookups there,
     /// and the eager `__dict__` dump it replaces is the unbounded recursion
     /// that segfaults on a reference cycle (#2516).
+    ///
+    /// It is NOT a property of the field. This said "when it is `Some`,
+    /// `attrs` is EMPTY" without the qualifier until
+    /// `docs/architecture/VALUE_BOUNDARY.md` falsification-tested it (#1867):
+    /// a [`django_json_encoded`] carrier has BOTH — `attrs` populated from
+    /// [`ENCODED_ATTR_NAMES`] + [`ENCODED_CALL_NAMES`], and a handle. Both
+    /// answer on one value: `{{ q.year }}` comes from the map and
+    /// `{{ q.resolution }}` from the handle, and gating the handle off leaves
+    /// the first standing.
     pub live: Option<std::sync::Arc<Py<PyAny>>>,
 }
 

--- a/crates/djust_core/src/lib.rs
+++ b/crates/djust_core/src/lib.rs
@@ -2863,8 +2863,10 @@ pub fn set_resolve_lazy(enabled: bool) {
 /// In `djust_core`:
 /// * [`stated_len_is_too_large_to_enumerate`] — the over-cap decline is
 ///   lazy-only.
-/// * [`Encoded::list_repr_is_this_objects_own_spelling`] — the declined
-///   container's spelling.
+/// * [`list_repr_is_this_objects_own_spelling`] — which conversion ARM claims
+///   a `list`/queryset, at ANY length. NOT the declined spelling: that is
+///   [`Encoded::declined_list_spelling`], which opens with
+///   `len > OPAQUE_ITEM_CAP` and does not read this flag.
 /// * [`opaque_gate`] ×3: the one-shot-iterator arm, the over-cap walk arm, and
 ///   the attribute-bearing decline (which decides whether an ordinary object
 ///   CARRIES a live handle rather than being bulk-dumped).

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,9 @@ This directory contains comprehensive documentation for djust organized by topic
 - **[VDOM Patching Issue](vdom/VDOM_PATCHING_ISSUE.md)** - Form value preservation
 - **[VDOM Root Cause](vdom/VDOM_ROOT_CAUSE.md)** - Deep dive into VDOM issues
 
+### 🏗️ Architecture
+- **[The Value Boundary](architecture/VALUE_BOUNDARY.md)** - How a Python value crosses into Rust and becomes rendered output: the conversion, the `Value`/`Encoded` carriers, the ADR-027 live handle vs the by-name sidecar, where `OPAQUE_ITEM_CAP` governs, change detection, the partial-render dependency path, and the threading/GIL reality
+
 ### 📄 Templates
 - **[Template Inheritance Design](templates/TEMPLATE_INHERITANCE_DESIGN.md)** - Inheritance system design
 - **[Template Inheritance Integration](templates/TEMPLATE_INHERITANCE_INTEGRATION.md)** - Integration guide

--- a/docs/architecture/VALUE_BOUNDARY.md
+++ b/docs/architecture/VALUE_BOUNDARY.md
@@ -428,12 +428,12 @@ dicts *first*, so the structural walk has something to walk.
 `python/djust/mixins/rust_bridge.py:797`) against
 `_prev_context_fingerprints` and sends only what moved.
 
-> `CLAUDE.md`'s PR #1206 / #1205 case study says this comparison is
+> `CLAUDE.md`'s PR #1206 / #1205 case study said this comparison is
 > `Model.__eq__` (pk-only). That was true when it was written and stopped being
-> true at #2664. The correction is being made in PR #2742 rather than here, to
-> avoid two concurrent edits to the same five lines (#1172); this document was
-> written independently and reached the same conclusion, which is some
-> evidence the reading is right. The case study itself — reproducer-first TDD
+> true at #2664. Corrected in PR #2742 rather than here, to avoid two concurrent
+> edits to the same five lines (#1172); this document was written independently
+> and reached the same conclusion, which is some evidence the reading is right.
+> The case study itself — reproducer-first TDD
 > found the real path, the reporter-cited method was dead code — is unchanged
 > and still the point.
 
@@ -447,8 +447,9 @@ top-level node, the set of **top-level context roots** the node's subtree reads
 > Extraction from a **tag operand carrying a filter chain** was incomplete
 > until #2738 — `{% for x in items|slice:n %}` recorded one bogus root spelled
 > `items|slice:n` and lost both real names, so a partial render could emit stale
-> bytes. Being fixed in PR #2742; the structure described here (parse-time
-> extraction, the wildcard set, the intersection rule) is unchanged by it.
+> bytes. Fixed in PR #2742 (merged), which routes every operand site through
+> `extract_from_operand`; the structure described here (parse-time extraction,
+> the wildcard set, the intersection rule) is unchanged by it.
 
 **Eight** node types get the wildcard `"*"` because their dependencies cannot be
 inferred (`parser.rs:2944` and `:2950`–`2959`): `Include` on its own, then the

--- a/docs/architecture/VALUE_BOUNDARY.md
+++ b/docs/architecture/VALUE_BOUNDARY.md
@@ -1,0 +1,692 @@
+# The value boundary: how a Python value becomes rendered output
+
+How a value in a `LiveView`'s state crosses into Rust, what shape it takes on
+the other side, how a template lookup is answered, and how the result gets back
+to the browser.
+
+Read top-down and stop when you have what you need. Section 1 is the picture,
+section 2 is the story, section 3 is the mechanism with line numbers, section 4
+is the invariants and the tests that pin them, section 5 is threading and the
+GIL. Section 6 records exactly which claims in this document were verified by
+running code and which were not.
+
+> **Why this document exists.** In one session, nine separate claims about this
+> boundary — in shipped Rust doc comments, in `CLAUDE.md`, in issue bodies and
+> in PR descriptions — turned out to be false. Every one of them was an
+> *absolute*: "never", "always", "cannot", "the only". The machinery that was
+> undocumented and the machinery that attracted false claims are the same
+> machinery. So every absolute below was falsification-tested by constructing
+> the case that would disprove it and running it; section 6 says which, and
+> names the ones that were not.
+
+---
+
+## 1. The picture
+
+### 1.1 End to end
+
+```mermaid
+flowchart TD
+    A["LiveView state<br/>(Python attributes)"] --> B["get_context_data()"]
+    B --> C["_sync_state_to_rust<br/>python/djust/mixins/rust_bridge.py"]
+    C --> C1["_normalize_db_values<br/>Model / QuerySet / list of Model -> floored dicts"]
+    C1 --> C2["deep_fingerprint per key<br/>python/djust/change_detection.py:90"]
+    C2 -->|"changed keys only"| D["RustLiveView.set_changed_keys / update_state<br/>(PyO3)"]
+
+    D --> E["impl FromPyObject for Value<br/>crates/djust_core/src/lib.rs:3890"]
+    E --> F["Value<br/>(13 variants; lib.rs:221)"]
+    E -.->|"objects no variant models"| G["Encoded<br/>(lib.rs:418) — measured facts<br/>+ optional live handle"]
+    G --> F
+
+    F --> H["Context<br/>crates/djust_core/src/context.rs:280"]
+    H --> I["render: full, collecting, or partial<br/>crates/djust_templates/src/renderer.rs"]
+    I --> J["HTML string"]
+    J --> K["VDOM diff -> patches"]
+    K --> L["client.js applies the patches"]
+
+    style G fill:#fde,stroke:#c39
+    style F fill:#def,stroke:#39c
+```
+
+### 1.2 Which carrier does a Python object become?
+
+The order below **is** the code's order, and the order is load-bearing: several
+arms are only correct because an earlier one already claimed the type.
+(`crates/djust_core/src/lib.rs:3890`–`4144`.)
+
+```mermaid
+flowchart TD
+    S["a Python object arrives at<br/>FromPyObject for Value"] --> D0{"recursion depth<br/>>= MAX_CONVERSION_DEPTH?"}
+    D0 -->|yes| STR["Value::String(str(o))"]
+    D0 -->|no| D1{"None / bool / int / big int /<br/>Decimal / float / str"}
+    D1 -->|yes| PRIM["the matching scalar variant"]
+    D1 -->|no| D2{"tuple / namedtuple /<br/>bounded sequence /<br/>MultiValueDict / dict"}
+    D2 -->|yes| CONT["Tuple / NamedTuple /<br/>List / Object"]
+    D2 -->|no| FB["the fallback block<br/>(lib.rs:4029)"]
+
+    FB --> F1{"datetime / date /<br/>time / timedelta?"}
+    F1 -->|yes| ENC1["Encoded via django_json_encoded<br/>lib.rs:2100 — attrs from the two<br/>name tables, AND a live handle"]
+    F1 -->|no| F2{"has __djust_serialize__?"}
+    F2 -->|yes| SER["recurse on the floored<br/>dict / list-of-dicts"]
+    F2 -->|no| F3{"isinstance(models.Model)?"}
+    F3 -->|yes| MOD["normalize_django_value<br/>then recurse (the floor)"]
+    F3 -->|no| F4{"opaque_gate admits it?<br/>lib.rs:4203"}
+    F4 -->|yes| ENC2["Encoded via opaque_value<br/>lib.rs:4855 — items maybe,<br/>live handle iff resolve_lazy()"]
+    F4 -->|no| F5{"public __dict__ attrs?"}
+    F5 -->|yes| OBJ["Value::Object<br/>(the bulk dump)"]
+    F5 -->|no| STR2["Value::String(str(o))"]
+
+    style ENC1 fill:#fde,stroke:#c39
+    style ENC2 fill:#fde,stroke:#c39
+```
+
+Under the shipped default (`resolve_lazy()` is `true`), `opaque_gate`'s last
+decline is lifted, so the `Value::Object` bulk-dump arm is reached only when
+`opaque_value` returns `None` — that is, when one of `bool(o)`, `iter(o)`,
+`str(o)`, `repr(o)` or `type(o).__name__` fails. See §3.4.
+
+### 1.3 How `{{ a.b.c }}` is answered
+
+Three mechanisms, tried in this order, in
+`Context::resolve_without_builtins` (`crates/djust_core/src/context.rs:1755`).
+Two of them reach live Python; they are **different mechanisms** and conflating
+them is how a gate-off test becomes vacuous (§6.1).
+
+```mermaid
+flowchart TD
+    Q["resolve('a.b.c')"] --> M1{"resolve_lazy() AND<br/>some prefix is an Encoded<br/>carrying a live handle?"}
+    M1 -->|yes| W["walk_from_handle -> walk_live<br/>context.rs:2181 / :2300<br/>Django's _resolve_lookup over the REAL object"]
+    M1 -->|no| M2{"the value stack answers it?<br/>Context::get"}
+    M2 -->|yes| V["the Value / Encoded::attrs entry"]
+    M2 -->|no| M3{"a raw-Python SIDECAR<br/>entry for the head name?<br/>context.rs:1834"}
+    M3 -->|yes| SW["the sidecar walk<br/>(keyed by TOP-LEVEL name;<br/>reaches rebindings via<br/>Context::aliases, context.rs:1873)"]
+    M3 -->|no| MISS["Missing -> string_if_invalid"]
+
+    W --> OUT["a Value"]
+    V --> OUT
+    SW --> OUT
+
+    style W fill:#fde,stroke:#c39
+    style SW fill:#efd,stroke:#7a3
+```
+
+### 1.4 The partial-render dependency path
+
+```mermaid
+flowchart LR
+    P1["_sync_state_to_rust computes<br/>the changed key set"] --> P2["RustLiveView::set_changed_keys<br/>crates/djust_live/src/lib.rs:336"]
+    P2 --> P3["render_with_loader_partial<br/>djust_live/src/lib.rs:766, :1182"]
+    P3 --> P4["render_nodes_partial<br/>djust_templates/src/renderer.rs:2193"]
+    T1["parse"] --> T2["extract_per_node_deps<br/>djust_templates/src/parser.rs:2934<br/>per node: the TOP-LEVEL roots it reads"]
+    T2 --> P4
+    P4 --> P5{"per node i:<br/>deps ∩ changed_keys ≠ ∅<br/>or deps contains '*'<br/>or no cached fragment?"}
+    P5 -->|yes| R1["re-render the node"]
+    P5 -->|no| R2["reuse node_html_cache[i]"]
+```
+
+---
+
+## 2. The narrative
+
+djust's boundary is not "Python objects go to Rust". It is closer to the
+opposite: **almost nothing crosses as itself.** At the boundary, every context
+value is *measured* — its `str()`, its `repr()`, its truthiness, its length, its
+Django-JSON spelling, its comparison key — and it is those measurements that
+cross, as an inert `Value` (`crates/djust_core/src/lib.rs:221`). The render
+engine is a pure Rust program over inert data, and it can produce most of a page
+without ever touching the interpreter.
+
+That works right up until a template asks something the measurements cannot
+answer. `{{ post.published.year }}` needs an attribute; `{{ obj.get_label }}`
+needs a call; `{{ d.resolution }}` needs a class attribute nobody thought to
+measure. Django's `Variable._resolve_lookup` answers all of these against the
+live object, and reproducing it over inert data is not possible in general — you
+cannot enumerate an arbitrary object's attributes ahead of time without walking
+its `__dict__` into a queryset and down through *its* `__dict__` until the stack
+overflows, which is exactly what an earlier version did.
+
+So the boundary is porous in one specific, bounded way: a converted value may
+carry a **live handle** — a refcount on the original Python object
+(`Encoded::live`, `lib.rs:719`) — and a dotted lookup that the inert data cannot
+answer walks that handle back into Python, one segment at a time, applying
+Django's exact rules and re-applying djust's serialization floor after every
+step. This is ADR-027. The handle rides *inside* the value rather than beside it
+by name, which is what makes it survive `{% for r in rows %}` and
+`{% with q=p %}` — the older by-name sidecar could not (#2504, #2505, #2542).
+
+Three things stay deliberately eager, and each for a stated reason
+(ADR-027 (b)): Django **models, managers and querysets** become floored dicts
+before they ever reach the conversion, because the client needs a JSON shape, a
+rolling deploy needs msgpack compatibility, and the serialization floor needs a
+materialised form; **containers and scalars** (`dict`, `list`, `tuple`, `set`,
+`Decimal`, `datetime`, `bytes`) keep the variants they already had; and a
+**list of models** is served by the JIT channel and stays there.
+
+Getting back out is the mirror image. The rendered HTML is diffed against the
+previous render, and only the patches travel. On the way *in*, the same economy
+applies one level up: Python fingerprints each context key
+(`deep_fingerprint`, `python/djust/change_detection.py:90`) and hands Rust only
+the keys whose fingerprint moved; Rust intersects that key set with each
+template node's statically-extracted dependency set and re-renders only the
+nodes that overlap. Change detection therefore happens **on the Python side of
+the boundary**, before conversion — which is why it compares Python objects, not
+`Value`s.
+
+---
+
+## 3. The mechanism
+
+Every `file:line` below was grepped at the commit this document was written
+against. If a line has drifted, grep the symbol name — the names are stable, the
+numbers are not.
+
+### 3.1 The stages
+
+| # | stage | where |
+|---|---|---|
+| 1 | Gather state | `LiveView.get_context_data()` |
+| 2 | Normalize DB values | `_normalize_db_values`, `python/djust/mixins/rust_bridge.py:83` |
+| 3 | Detect change | `deep_fingerprint`, `python/djust/change_detection.py:90` |
+| 4 | Hand across (PyO3) | `RustLiveView::set_changed_keys`, `crates/djust_live/src/lib.rs:336` |
+| 5 | Convert | `impl FromPyObject for Value`, `crates/djust_core/src/lib.rs:3890` |
+| 6 | Bind | `Context`, `crates/djust_core/src/context.rs:280` |
+| 7 | Resolve | `Context::resolve_without_builtins`, `context.rs:1755` |
+| 8 | Render | `render_nodes_partial` / `render_nodes_collecting`, `crates/djust_templates/src/renderer.rs:2193` / `:2173` |
+| 9 | Diff and send | VDOM patches → `client.js` |
+
+### 3.2 The types
+
+**`Value`** (`crates/djust_core/src/lib.rs:221`) — the inert carrier. Thirteen
+variants: `Missing`, `None`, `Bool`, `Integer`, `Float`, `String`, `SafeString`,
+`List`, `Tuple`, `NamedTuple`, `Object`, `Decimal`, `BigInt`, `Encoded`.
+`Missing` is *not* Python's `None`: an absent key arrives as `Option::None` from
+the resolver and `Missing` is what `string_if_invalid` substitutes.
+
+**`Encoded`** (`crates/djust_core/src/lib.rs:418`) — the carrier for a Python
+object that no other variant models. It holds the facts measured at conversion:
+
+| field | line | what it is |
+|---|---|---|
+| `type_name` | `:422` | CPython's `tp_name`, as a `TypeError` spells it |
+| `display` | `:425` | `str(o)` — what `{{ p }}` renders |
+| `display_safe` | `:427` | whether `str(o)` is `SafeData`; never restored from the wire |
+| `json` | `:429` | `DjangoJSONEncoder.default(o)` |
+| `truthy` | `:432` | `bool(o)` — Python's own answer, not a Rust guess |
+| `len` | `:462` | `len(o)`, or `None` where Python raises |
+| `iterable` | `:484` | `iter(o)` succeeded |
+| `repr` | `:500` | `repr(o)`, measured rather than copied from `display` (#2472) |
+| `cmp_key` | `:504` | Python's ordering key, for `{% if a < b %}` |
+| `attrs` | `:551` | the named attributes reached by a dotted lookup, see §3.3 |
+| `items` | `:589` | `list(o)`, enumerated at conversion — or `None`, see §3.5 |
+| `eq_class` | `:640` | which of Python's equality contracts this value obeys |
+| `live` | `:719` | **the live handle** — `Arc<Py<PyAny>>`, see §3.4 |
+
+The handle is transient: not serialized (the `ENCODED_TAG` wire payload stays
+eleven slots), not compared by `PartialEq for Encoded` (`:955`), dropped by a
+msgpack round trip, re-attached on every render.
+
+### 3.3 `Encoded::attrs` and the two name tables
+
+A `datetime` is a C type with no `__dict__`, so no bulk dump can reach `.year`.
+Two constant tables state the whole policy:
+
+- **`ENCODED_ATTR_NAMES`** (`lib.rs:764`) — *data* attributes, per `tp_name`.
+  `datetime.datetime` → `year month day hour minute second microsecond fold
+  tzinfo convert_to_local_time`; `datetime.date` → `year month day`;
+  `datetime.time` → `hour minute second microsecond fold tzinfo`;
+  `datetime.timedelta` → `days seconds microseconds`.
+- **`ENCODED_CALL_NAMES`** (`lib.rs:850`) — *nullary methods*, which Django
+  reaches through its auto-call (ADR-024). `datetime.datetime` → `isoformat
+  ctime weekday isoweekday toordinal timestamp utcoffset tzname dst`, and
+  shorter lists for the others.
+
+Both are merged into the same `attrs` map by `django_json_encoded`
+(`lib.rs:2197` and `:2200`) so `lookup_segment` (`context.rs:134`) stays the one
+reader. `min` / `max` / `resolution` are deliberately in **neither** table: their
+values are themselves `datetime`s and `datetime.min.min is datetime.min`, so
+collecting them would not terminate (`lib.rs:520`–`534`).
+
+They render anyway — through the live handle. See §6.2.
+
+### 3.4 The live handle: who gets one
+
+Two functions build an `Encoded` **at the Python→Rust conversion**, and they
+attach the handle differently. (Seven further sites — `lib.rs:1655`, `:1718`,
+`:1773`, `:1825`, `:1881`, `:1939`, `:1988` — reconstruct one from an
+`ENCODED_TAG` wire payload rather than from a live object, and every one of them
+sets `live: None`. That is the handle's transience, mechanically: nothing
+restored from state can carry one.)
+
+**`opaque_value`** (`lib.rs:4855`) — the general carrier. It attaches a handle
+**iff** the thread-local flag is on (`lib.rs:4911`–`4916`):
+
+```rust
+let lazy = resolve_lazy();
+let live = if lazy { Some(std::sync::Arc::new(ob.clone().unbind())) } else { None };
+```
+
+Attaching costs no Python call: `Bound::unbind` is a refcount bump plus an `Arc`
+allocation.
+
+**`django_json_encoded`** (`lib.rs:2100`) — the datetime family. It attaches a
+handle **unconditionally** (`lib.rs:2236`):
+
+```rust
+live: Some(std::sync::Arc::new(ob.clone().unbind())),
+```
+
+There is no `resolve_lazy()` guard on that line. The behaviour is still gated,
+because the *sink* is gated (`context.rs:1800`) — but the field is populated
+either way. See §6.3.
+
+**Who does not get one.** The arms *above* `opaque_value` in the fallback block
+claim their types first, so nothing they claim can reach the handle: a `dict`, a
+`tuple`, a `list`, a `NamedTuple`, a `MultiValueDict`, anything with
+`__djust_serialize__` (`lib.rs:4054`), and any `models.Model` (`lib.rs:4089`).
+That last pair is the serialization floor: routing a model through the
+`__dict__` bulk dump would filter only `_`-prefixed keys and leak `password`.
+ADR-027 states it as an explicit non-goal: *"`Value::Object` never carries a
+handle."*
+
+**The sink.** `walk_from_handle` (`context.rs:2181`) tries the **longest**
+resolvable prefix first, so for `{{ p.child.name }}` where both `p` and
+`p.child` carry a handle the walk starts at `p.child` and asks Python for one
+segment instead of two. It then calls `walk_live` (`context.rs:2300`), which is
+Django's `_resolve_lookup` transcribed: the callable block (`maybe_call`,
+`context.rs:2089`) for the root bit, then per segment `walk_one_segment`
+(`context.rs:2341`) — dict item, attribute, integer index, each with Django's
+catch set — with `protect_sidecar_strict` (`context.rs:2077`) re-applying the
+serialization floor after **every** segment.
+
+### 3.5 Where `OPAQUE_ITEM_CAP` actually governs
+
+`OPAQUE_ITEM_CAP = 100_000` (`lib.rs:4159`). It governs **whether the items are
+enumerated at conversion time**, and nothing else. It does *not* gate the live
+handle, and it does not gate whether an object gets an `Encoded` at all.
+
+`opaque_gate` (`lib.rs:4203`) measures four facts without converting anything —
+`truthy`, `len`, `iterable`, `unbounded` — and sets `unbounded` when either
+axis passes the cap:
+
+- a **sized** object whose stated `__len__` exceeds it
+  (`stated_len_is_too_large_to_enumerate`, `lib.rs:3641`; the check is at
+  `lib.rs:4271`);
+- an **unsized** iterable whose walk passes it (`lib.rs:4282`).
+
+`opaque_value` then leaves `items: None` for an unbounded object, for a one-shot
+iterator (`iter(o) is o` — reading it at conversion would consume the caller's
+object), and for a non-iterable. The *sinks* read such an object through the
+handle instead — `Encoded::consume_live_items` (`lib.rs:4387`) for `{% for %}`,
+`Encoded::declined_list_spelling` (`lib.rs:4446`) for `{{ v }}` / `pprint` /
+`json_script` — under their own termination rule,
+`Encoded::live_walk_terminates` (`lib.rs:4364`).
+
+The practical consequence: **rendered output is the same on both sides of the
+cap**; what differs is whether the work happens at conversion or at the sink.
+Verified in §6.4.
+
+On the eager escape hatch (`resolve_lazy()` false) there is no handle to read
+later, so an unbounded object is *declined* by the gate instead and falls to
+`Value::String(str(o))`.
+
+### 3.6 What is deliberately eager
+
+Per ADR-027 (b) (`docs/adr/027-template-variable-resolution-follows-django.md:227`):
+
+1. **Django models, managers, querysets** — a floored dict as the value, with a
+   by-name proxied handle for misses. Four reasons are given: the client's JSON
+   shape, msgpack rolling-deploy compatibility, container `!=` change detection,
+   and the floor's materialised form. On the LiveView path the normalization is
+   `_normalize_db_values` (`python/djust/mixins/rust_bridge.py:83`); on the plain
+   conversion path it is the `models.Model` arm at `lib.rs:4089`, which calls
+   `djust.serialization.normalize_django_value`.
+   *(The ADR cites `lib.rs:3073-3089` for this. That range has since drifted onto
+   an unrelated `Decimal`/`Display` doc comment — grep `normalize_django_value`
+   instead. The mechanism is unchanged; only the ADR's line numbers are stale.)*
+2. **`dict` / `list` / `tuple` / `set` / scalars / `Decimal` / `datetime` /
+   `bytes`** — the variants they already had.
+3. **`Component` / `LiveComponent`** — a handle whose `display` is `str(c)`,
+   with the SafeData bit set.
+4. **A list of models** — served entirely by the JIT channel; the handle exists
+   for objects the JIT skips.
+
+### 3.7 Change detection: which side of the boundary
+
+**The Python side, before conversion.** `deep_fingerprint`
+(`python/djust/change_detection.py:90`) walks a value and returns a hashable
+fingerprint that shares no reference with it, plus a `truncated` flag. `_walk`
+(`:102`) has four rules:
+
+| input | fingerprint |
+|---|---|
+| budget exhausted | `(_TAG_TRUNCATED, id(value))` — `:105` |
+| `None` or an immutable leaf | `(_TAG_VALUE, type(value), value)` — `:107` |
+| `dict` / `list` / `tuple` / `set` / `frozenset` | recursed structurally — `:114`–`:128` |
+| too deep, or a cycle back onto an ancestor | `(_TAG_ID, id(value))` — `:112` |
+| **anything else** | `(_TAG_ID, id(value))` — `:129` |
+
+That last row is the one worth internalising: **a Django `Model` is an `id()`
+leaf.** A `list[Model]` fingerprints as a list of identities, so replacing an
+element with a different object is seen and mutating a field in place is not.
+This is why step 2 exists at all — `_normalize_db_values` turns models into
+dicts *first*, so the structural walk has something to walk.
+
+`_sync_state_to_rust` compares each key's fingerprint (via the `_fp_of` helper,
+`python/djust/mixins/rust_bridge.py:797`) against
+`_prev_context_fingerprints` and sends only what moved.
+
+> `CLAUDE.md`'s PR #1206 / #1205 case study says this comparison is
+> `Model.__eq__` (pk-only). That was true when it was written and stopped being
+> true at #2664. The correction is being made in PR #2742 rather than here, to
+> avoid two concurrent edits to the same five lines (#1172); this document was
+> written independently and reached the same conclusion, which is some
+> evidence the reading is right. The case study itself — reproducer-first TDD
+> found the real path, the reporter-cited method was dead code — is unchanged
+> and still the point.
+
+### 3.8 The render-partial dependency path
+
+Per-node dependencies are extracted **at parse time**, once, by
+`extract_per_node_deps` (`crates/djust_templates/src/parser.rs:2934`): for each
+top-level node, the set of **top-level context roots** the node's subtree reads
+(`{{ x.name }}` contributes `x`).
+
+> Extraction from a **tag operand carrying a filter chain** was incomplete
+> until #2738 — `{% for x in items|slice:n %}` recorded one bogus root spelled
+> `items|slice:n` and lost both real names, so a partial render could emit stale
+> bytes. Being fixed in PR #2742; the structure described here (parse-time
+> extraction, the wildcard set, the intersection rule) is unchanged by it.
+
+Three node classes get the wildcard `"*"`
+because their dependencies cannot be inferred — `Node::Include`, and the custom
+tag family (`CustomTag`, `BlockCustomTag`, `RawBlockCustomTag`, `Language`,
+`Timezone`, `Localize`, `LocalTime`), whose raw bodies are re-parsed by Django
+(#2558).
+
+`render_nodes_partial` (`renderer.rs:2193`) re-renders node `i` when
+(`renderer.rs:2212`–`2217`):
+
+- `deps` contains `"*"`, or
+- `deps` intersects `changed_keys`, or
+- there is no cached fragment for `i`, or
+- an earlier wildcard node may have rebound names this node reads
+  (`context_may_have_changed`, `renderer.rs:2211`) **and** this node has any
+  deps at all — literal text stays reusable.
+
+Otherwise `node_html_cache[i]` is reused verbatim. The entry point is
+`render_with_loader_partial` (`crates/djust_templates/src/lib.rs:264`), which
+falls back to a full collecting render when `{% extends %}` has not been
+resolved yet (`:271`).
+
+### 3.9 The other live-object mechanism: the by-name sidecar
+
+Do not confuse it with the handle. The **raw-Python sidecar** (#2501) is a
+`HashMap<String, Py<PyAny>>` keyed by **top-level context name**
+(`Context::raw_py_objects`, `context.rs:292`). It is built by
+`djust.serialization.build_render_sidecar` (`python/djust/serialization.py:1136`)
+and attached at the standalone render entry points by `entry_sidecar`
+(`crates/djust_live/src/lib.rs:2115`).
+
+It is consulted **after** the value stack (`context.rs:1834`) and it reaches
+rebound names through `Context::aliases` (#2375): `{% with q=p %}` registers
+`q` → `p`, and the walk expands the alias (`context.rs:1873`). An alias is
+registered only for a bare dotted path over an **unfiltered** operand
+(`context.rs:1850`–`1857`), so `{% with q=xs|first %}` registers nothing.
+
+That detail is not trivia — it is the only reliable way to test the handle in
+isolation, and getting it wrong makes a gate-off silently vacuous (§6.1).
+
+Note also `entry_sidecar`'s own caveat (`crates/djust_live/src/lib.rs:2105`–`2114`):
+`DjustTemplateBackend` runs `serialize_context()` *before* calling into Rust, so
+what the sidecar holds on that path is the **serialized** dict, not live models.
+Do not assume live models on the backend path.
+
+---
+
+## 4. Invariants, and the test that pins each
+
+Where there is no test, this table says so rather than implying coverage.
+
+| # | invariant | pinned by |
+|---|---|---|
+| I1 | The handle never reaches the wire | `TestTheHandleNeverReachesTheWire2539`, `python/tests/test_adr027_characterization_net_2539.py:2006` |
+| I2 | `ENCODED_ATTR_NAMES` and `ENCODED_CALL_NAMES` share no name | `test_the_two_tables_are_disjoint` (cited at `crates/djust_core/src/lib.rs:2207`) |
+| I3 | The ADR-027 sink reads no `Encoded` attribute map and calls no `lookup_segment` | `TestTheSinkHasExactlyTheReadersItClaims`, `python/tests/test_encoded_attributes_2481.py:654` (cited at `context.rs:2299`) |
+| I4 | The conversion body has exactly the callers it claims | `TestTheSinkHasExactlyTheCallersItClaims`, `python/tests/test_encoded_truthiness_2458.py:445` and `python/tests/test_json_script_datetime_value_2448.py:643` (cited at `lib.rs:3899`) |
+| I5 | The serialization floor holds on the handle path, on both sides of the cap | `TestTheSerializationFloorHoldsOnTheNewHandle`, `python/tests/test_sized_sequence_conversion_2695_2693.py:775` |
+| I6 | The build-time sidecar pass's documented limit is pinned, not assumed | `test_the_limit_of_the_build_time_pass_is_pinned_not_assumed`, `python/tests/test_sidecar_on_all_render_paths_2501.py` |
+| I7 | A partial render skips nodes whose deps are disjoint from `changed_keys` | `test_render_nodes_partial_skips_unchanged`, `crates/djust_templates/src/lib.rs:733` |
+| I8 | `deep_fingerprint` warns when the budget truncates | `python/tests/test_snapshot_truncation_warning.py:143` |
+| I9 | The `Encoded` wire layout and field positions are pinned | `crates/djust_core/tests/test_encoded_wire_positions_2471_2472.rs` |
+| I10 | Django's lookup rules at the sink | `crates/djust_core/tests/test_django_lookup_sink_2539.rs` |
+| **I11** | **The datetime family carries a live handle** | **no test.** The behaviour is observable (§6.2) but nothing asserts it, which is how a comment in `context.rs` could contradict `django_json_encoded`'s own `live: Some(..)` (`lib.rs:2236`) for as long as it did. |
+| **I12** | **`OPAQUE_ITEM_CAP` does not gate the handle** | **no direct test.** `test_sized_sequence_conversion_2695_2693.py` and `test_declined_container_spelling_2717.py` exercise the cap's *item* behaviour; none asserts that a sub-cap or non-sequence object also carries a handle. |
+| **I13** | **`RESOLVE_LAZY` is per-thread** | **no test found** for the cross-thread default. `python/tests/test_adr027_wiring_security_2539.py` covers the setter's wiring; §6.5 exercises the thread-locality directly. |
+
+---
+
+## 5. Threading and the GIL
+
+Two claims were made twice in the record and are both false: *"no `Context`
+crosses a thread"* and, by implication, *"the render runs on the thread that
+configured it"*. Here is what actually happens.
+
+### 5.1 Every WebSocket and HTTP render runs on an asgiref worker thread
+
+`python/djust/runtime.py` wraps the render in `sync_to_async`, which executes it
+in a thread-pool executor, not on the event loop:
+
+| line | call |
+|---|---|
+| `python/djust/runtime.py:3781` | `html, _patches, version = await sync_to_async(view.render_with_diff)()` |
+| `python/djust/runtime.py:3856` | `html, patches, version = await sync_to_async(self.view_instance.render_with_diff)()` |
+| `python/djust/runtime.py:4272` | `html, patches, version = await sync_to_async(view.render_with_diff)()` |
+| `python/djust/runtime.py:4786` | `html, patches, version = await sync_to_async(view.render_with_diff)()` |
+
+`_sync_state_to_rust` is wrapped the same way (`runtime.py:2475`, `:3854`,
+`:4785`), as is `mount` (`:2328`) and essentially every other sync view method.
+There are ~50 `sync_to_async` call sites in that file.
+
+### 5.2 The actor path renders from a tokio task
+
+`crates/djust_live/src/actors/view.rs:560` does `tokio::spawn(actor.run())`, and
+the actor reaches Python by acquiring the GIL from inside that task —
+`Python::attach` at `crates/djust_live/src/actors/view.rs:413` (the event
+handler) and `:687` (the component-event handler). So a render on this path is
+driven from a tokio worker thread, not from the thread that set the view up.
+
+### 5.3 The render itself acquires the GIL, repeatedly
+
+A render is not GIL-free. Every dotted lookup that falls to a live mechanism
+takes the GIL for the duration of the walk:
+
+- `Python::attach` at `crates/djust_core/src/context.rs:2199` — the ADR-027
+  handle walk;
+- `Python::attach` at `crates/djust_core/src/context.rs:1892` — the by-name
+  sidecar walk.
+
+`Context` itself is `#[derive(Debug)]` only (`context.rs:280`) with no
+`unsafe impl Send`; it is `Send` because `Py<PyAny>` is, and its sidecar is
+behind an `Arc` precisely so `Context::clone` needs no GIL (`context.rs:288`–`291`).
+
+### 5.4 The consequence: ambient render settings are thread-local, and default
+
+`RESOLVE_LAZY` is a **thread-local** `Cell<bool>` initialised to `true`
+(`crates/djust_core/src/lib.rs:2821`), read at exactly two sites
+(`lib.rs:2860`'s doc says so): `opaque_gate`'s attribute-bearing decline, and
+`Context::resolve_without_builtins`'s handle walk. It is pushed per render by
+`djust.render_env.apply_render_env`, alongside the timezone (#2209) and the
+number format (#2221) — that module exists so a render path cannot acquire one
+ambient setting and miss another.
+
+Because it is thread-local rather than global, **a thread that never called
+`apply_render_env` reads the shipped default, not the project's configured
+value.** Verified in §6.5. The same is true of the render timezone and number
+format, which is the reason they live in one module.
+
+The design note at `lib.rs:2826`–`2846` states the reason it is not a `Context`
+field: half the work it gates is inside `impl FromPyObject for Value`, a trait
+method with no `Context` in reach, so a `Context` field would need two mechanisms
+seeded from one reader — the #1646 shape.
+
+---
+
+## 6. What was verified, and how
+
+Everything below was run against a release build of this checkout. The harness
+is reproducible from the descriptions; each block states the template, the
+expected answer, and the gate-off that proves the assertion is not tautological
+(#1468).
+
+### 6.1 First, the isolation problem — because it invalidated the obvious test
+
+The obvious way to prove a value carries a live handle is to resolve an
+attribute only the handle can reach, then flip `set_resolve_lazy(False)` and see
+it go blank. **That test is vacuous as usually written**, because the by-name
+sidecar (§3.9) answers the same lookup and is not gated by that flag.
+
+Measured, on `{{ q.resolution }}` with `resolve_lazy` **off**:
+
+| binding | result | why |
+|---|---|---|
+| `{{ d.resolution }}` (top level) | `0:00:00.000001` | sidecar, keyed by `d` |
+| `{% with q=d %}` (unfiltered) | `0:00:00.000001` | sidecar via the `q`→`d` alias |
+| `{% for q in items %}` (unfiltered) | `0:00:00.000001` | sidecar via the alias |
+| `{% with q=items\|first %}` (**filtered**) | `''` | no alias registered → sidecar cannot reach it |
+| `{% for q in items\|slice:":1" %}` (**filtered**) | `''` | same |
+
+So a **filtered-operand rebinding** is the isolating shape, and every gate-off
+below uses it. The non-vacuity of the gate is itself asserted: with the flag off
+the filtered form is blank *while the unfiltered form still resolves*, proving
+the gate is doing something and the blank is not an unrelated failure.
+
+### 6.2 FALSE: "the whole datetime family never carry [a live handle]"
+
+`crates/djust_core/src/context.rs:1782`–`1783` **as of the commit before this
+PR** asserted that a `list`, a `dict`, a tuple, a `Model`, a
+`__djust_serialize__` object *and the whole datetime family* never carry a
+handle, "so their resolution is untouched under either flag state". (That line
+now carries the correction, so grep the phrase rather than the number.)
+
+`min`, `max` and `resolution` are in neither name table (§3.3), so nothing but a
+handle can answer them. Through the isolating binding:
+
+| lookup | result |
+|---|---|
+| `datetime.resolution` | `0:00:00.000001` |
+| `datetime.max` | `Dec. 31, 9999, 11:59 p.m.` |
+| `datetime.min` | `Jan. 1, 0001, midnight` |
+| `timedelta.max` | `999999999 days, 23:59:59.999999` |
+| `date.max` | `Dec. 31, 9999` |
+| `time.max` | `11:59 p.m.` |
+
+All six blank with `resolve_lazy` off. **The datetime half of that claim is
+false**, and so is its conclusion — datetime resolution *is* touched by the flag
+state. The other five types listed are correct, and were re-verified: a `dict`,
+a `list`, a `tuple` and a `__djust_serialize__` object all fail to resolve a
+live-only attribute through the isolating binding, while a control class
+*without* `__djust_serialize__` resolves it. **Fixed in this PR** — the comment
+now states the datetime case rather than contradicting it.
+
+This also falsifies the narrower claim on `Encoded::attrs` (pre-PR
+`lib.rs:520`–`527`) that `{{ p.max }}` "stays empty where Django renders it". It
+did when that was written; the handle closed the cell from the other side.
+**Fixed in this PR.**
+
+### 6.3 FALSE: "When [`live`] is `Some`, `Encoded::attrs` is EMPTY"
+
+The `Encoded::live` doc (pre-PR `lib.rs:689`; now `lib.rs:706`, reworded) stated
+this without qualification, citing `opaque_value` — where it *is* true. It is
+false for the datetime family:
+`django_json_encoded` populates `attrs` from both name tables (`lib.rs:2197`,
+`:2210`) **and** sets `live: Some(...)` (`lib.rs:2236`).
+
+Observed on one value: `{{ q.year }}|{{ q.resolution }}` renders
+`2024|0:00:00.000001`, and with the handle gated off renders `2024|` — the
+`attrs` answer survives, proving `attrs` is non-empty while `live` is `Some`.
+**Fixed in this PR** (scoped to the field's doc; the `opaque_value` case it
+describes is unchanged).
+
+Relatedly, the same field's doc said `live` is "`None` unless `resolve_lazy` was
+on at the conversion". `django_json_encoded` has no such guard, so that is false
+too. **This one is verified by reading the construction site, not by running** —
+the field is not exposed to Python, and the observable behaviour is identical
+because the *sink* is separately gated. **Fixed in this PR.**
+
+### 6.4 FALSE: "the live mechanism is gated to sequences past `OPAQUE_ITEM_CAP`"
+
+From issue #2737's body. Three objects, each resolving a `@property` (which is
+never in a `__dict__`, so only a live walk can reach it) through the isolating
+binding:
+
+| object | `__len__` | result |
+|---|---|---|
+| no `__len__`, not iterable, zero instance attributes | — | resolved |
+| sized, 3 items (under the cap) | 3 | resolved |
+| sized, states 200 000 (over the cap) | 200 000 | resolved |
+
+All three carry a handle. What the cap governs is *item enumeration*, and that
+was measured too: `{% for %}` over the over-cap and under-cap objects produced
+byte-identical output (`0,1,2,`), and `|length` answered `200000` and `3`
+respectively. **Output is the same on both sides of the cap; only where the work
+happens differs.** No code change — the issue body is not in the repo; the
+successors filed off #2737 should carry the correction.
+
+### 6.5 VERIFIED: `RESOLVE_LAZY` is thread-local, and a fresh thread reads the default
+
+With `set_resolve_lazy(False)` on the main thread:
+
+- main thread: `resolve_lazy_enabled()` → `False`, the isolated lookup → `''`;
+- a fresh `threading.Thread` that never touched the flag:
+  `resolve_lazy_enabled()` → `True`, the same lookup → `0:00:00.000001`.
+
+So the worker did not inherit the configuration. Combined with §5.1 — every
+WS/HTTP render runs on a `sync_to_async` worker thread — this is why
+`apply_render_env` is pushed *per render* rather than once at startup.
+
+### 6.6 VERIFIED: the `Value::Object` bulk-dump arm is not reached under the default
+
+`opaque_gate`'s final decline (`lib.rs:4309`) is
+`!resolve_lazy() && truthy && !iterable && has_public_dict_attrs(ob)`. With the
+flag on, that decline never fires, so `opaque_value` claims the object and the
+bulk-dump arm at `lib.rs:4136` is reached only when `opaque_value` returns
+`None`. A truthy, non-iterable object with public attributes was measured under
+both flag states: it resolves either way, **by different carriers** — an
+`Encoded` with a handle under the default, a `Value::Object` on the escape
+hatch.
+
+### 6.7 Not verified by running
+
+Stated plainly rather than smoothed over:
+
+- **§5.2, the actor path.** The `tokio::spawn` and `Python::attach` sites were
+  read, not exercised. No actor-path render was driven end to end.
+- **§3.6's JIT claim** (a list of models is served by the JIT channel) is taken
+  from ADR-027 (b)(4); the JIT path itself was not traced for this document.
+- **§3.8's wildcard set.** The seven node types that get `"*"` were read from
+  `parser.rs:2934`; the partial-render skip behaviour is pinned by I7 but this
+  document did not run its own case per node type.
+- **The `Encoded::live` "`None` unless `resolve_lazy`" claim** — see §6.3,
+  verified by reading the two construction sites only.
+- **The `Encoded` field table in §3.2** lists doc-comment summaries; the fields
+  were read, not individually exercised.
+
+### 6.8 A false path in the brief itself
+
+The task that produced this document cited the datetime comment as
+`crates/djust_templates/src/context.rs:1782-1783`. **There is no such file**; it
+was `crates/djust_core/src/context.rs:1782-1783`. Recorded because it is the same
+failure mode the document is about — a citation that reads as authoritative and
+was never grepped.
+
+---
+
+## Related
+
+- `docs/adr/027-template-variable-resolution-follows-django.md` — the decision
+  this document maps the implementation of
+- `docs/TEMPLATE_BACKEND.md` — using the Rust engine from a plain Django view
+- `docs/RUST_TEMPLATE_API.md` — the template API surface
+- `docs/JIT_SERIALIZATION_PATTERN.md` — the model/queryset channel §3.6 defers to
+- `docs/SECURE_DEFAULTS.md` — the serialization floor `protect_sidecar_strict` applies
+- Open issues on this machinery: #2735, #2736, and the successors filed off #2737

--- a/docs/architecture/VALUE_BOUNDARY.md
+++ b/docs/architecture/VALUE_BOUNDARY.md
@@ -20,9 +20,12 @@ running code and which were not.
 > names the ones that were not.
 >
 > The first version of this document then shipped a **tenth**, by citing a
-> shipped doc comment instead of running the case (§6.9). It is recorded rather
-> than quietly fixed, because it is the sharpest available evidence for the rule
-> this document exists to carry: **a doc comment is not evidence.**
+> shipped doc comment instead of running the case (§6.9) — and the fix for that
+> landed an **eleventh** one symbol over (§6.10). Both are recorded rather than
+> quietly fixed, because together they are the sharpest available evidence for
+> the rule this document exists to carry: **a doc comment is not evidence for a
+> checkable claim — a count, an absolute, a reachability statement — because
+> those can be run.** It remains the best evidence for intent, which cannot be.
 
 ---
 
@@ -38,7 +41,7 @@ flowchart TD
     C1 --> C2["deep_fingerprint per key<br/>python/djust/change_detection.py:90"]
     C2 -->|"changed keys only"| D["RustLiveView.set_changed_keys / update_state<br/>(PyO3)"]
 
-    D --> E["impl FromPyObject for Value<br/>crates/djust_core/src/lib.rs:3914"]
+    D --> E["impl FromPyObject for Value<br/>crates/djust_core/src/lib.rs:3916"]
     E --> F["Value<br/>(15 variants; lib.rs:221)"]
     E -.->|"objects no variant models"| G["Encoded<br/>(lib.rs:418) — measured facts<br/>+ optional live handle"]
     G --> F
@@ -57,7 +60,7 @@ flowchart TD
 
 The order below **is** the code's order, and the order is load-bearing: several
 arms are only correct because an earlier one already claimed the type.
-(`crates/djust_core/src/lib.rs:3914`–`4168`.)
+(`crates/djust_core/src/lib.rs:3916`–`4168`.)
 
 ```mermaid
 flowchart TD
@@ -67,7 +70,7 @@ flowchart TD
     D1 -->|yes| PRIM["the matching scalar variant"]
     D1 -->|no| D2{"tuple / namedtuple /<br/>bounded sequence /<br/>MultiValueDict / dict"}
     D2 -->|yes| CONT["Tuple / NamedTuple /<br/>List / Object"]
-    D2 -->|no| FB["the fallback block<br/>(lib.rs:4053)"]
+    D2 -->|no| FB["the fallback block<br/>(lib.rs:4055)"]
 
     FB --> F1{"datetime / date /<br/>time / timedelta?"}
     F1 -->|yes| ENC1["Encoded via django_json_encoded<br/>lib.rs:2100 — attrs from the two<br/>name tables, AND a live handle"]
@@ -75,7 +78,7 @@ flowchart TD
     F2 -->|yes| SER["recurse on the floored<br/>dict / list-of-dicts"]
     F2 -->|no| F3{"isinstance(models.Model)?"}
     F3 -->|yes| MOD["normalize_django_value<br/>then recurse (the floor)"]
-    F3 -->|no| F4{"opaque_value returns Some?<br/>lib.rs:4879 (gate at :4227)"}
+    F3 -->|no| F4{"opaque_value returns Some?<br/>lib.rs:4881 (gate at :4227)"}
     F4 -->|yes| ENC2["Encoded via opaque_value<br/>items maybe,<br/>live handle iff resolve_lazy()"]
     F4 -->|no| F5{"public __dict__ attrs?"}
     F5 -->|yes| OBJ["Value::Object<br/>(the bulk dump)"]
@@ -90,7 +93,7 @@ decline is lifted, so the `Value::Object` bulk-dump arm is reached only when
 `opaque_value` returns `None`. That happens when a probe on the object raises:
 `bool(o)`, `str(o)`, `repr(o)` or `type(o).__name__` — **or, and this is the
 one that is easy to miss, a failure while ENUMERATING the items** (`item.is_err()`
-at `lib.rs:4302`, and `item.ok()?` / `extract::<Value>().ok()?` in
+at `lib.rs:4304`, and `item.ok()?` / `extract::<Value>().ok()?` in
 `opaque_value`). `iter(o)` *failing* is not on that list: `try_iter().ok()`
 just sets `iterable = false`, which is the ordinary non-iterable case — and a
 non-iterable object does get a handle. Both halves measured in §6.6.
@@ -222,7 +225,7 @@ numbers are not.
 | 2 | Normalize DB values | `_normalize_db_values`, `python/djust/mixins/rust_bridge.py:83` |
 | 3 | Detect change | `deep_fingerprint`, `python/djust/change_detection.py:90` |
 | 4 | Hand across (PyO3) | `RustLiveView::set_changed_keys`, `crates/djust_live/src/lib.rs:336` |
-| 5 | Convert | `impl FromPyObject for Value`, `crates/djust_core/src/lib.rs:3914` |
+| 5 | Convert | `impl FromPyObject for Value`, `crates/djust_core/src/lib.rs:3916` |
 | 6 | Bind | `Context`, `crates/djust_core/src/context.rs:280` |
 | 7 | Resolve | `Context::resolve_without_builtins`, `context.rs:1755` |
 | 8 | Render | `render_nodes_partial` / `render_nodes_collecting`, `crates/djust_templates/src/renderer.rs:2193` / `:2173` |
@@ -296,8 +299,8 @@ attach the handle differently. (Seven further sites — `lib.rs:1655`, `:1718`,
 sets `live: None`. That is the handle's transience, mechanically: nothing
 restored from state can carry one.)
 
-**`opaque_value`** (`lib.rs:4879`) — the general carrier. It attaches a handle
-**iff** the thread-local flag is on (`lib.rs:4935`–`4916`):
+**`opaque_value`** (`lib.rs:4881`) — the general carrier. It attaches a handle
+**iff** the thread-local flag is on (`lib.rs:4937`–`4916`):
 
 ```rust
 let lazy = resolve_lazy();
@@ -321,7 +324,7 @@ either way. See §6.3.
 **Who does not get one.** The arms *above* `opaque_value` in the fallback block
 claim their types first, so nothing they claim can reach the handle: a `dict`, a
 `tuple`, a `list`, a `NamedTuple`, a `MultiValueDict`, anything with
-`__djust_serialize__` (`lib.rs:4078`), and any `models.Model` (`lib.rs:4113`).
+`__djust_serialize__` (`lib.rs:4080`), and any `models.Model` (`lib.rs:4115`).
 That last pair is the serialization floor: routing a model through the
 `__dict__` bulk dump would filter only `_`-prefixed keys and leak `password`.
 ADR-027 states it as an explicit non-goal: *"`Value::Object` never carries a
@@ -340,33 +343,39 @@ after each segment (`:2329`).
 
 ### 3.5 Where `OPAQUE_ITEM_CAP` actually governs
 
-`OPAQUE_ITEM_CAP = 100_000` (`lib.rs:4183`). Its primary job is **whether the
+`OPAQUE_ITEM_CAP = 100_000` (`lib.rs:4185`). Its primary job is **whether the
 items are enumerated at conversion time**. It does *not* gate the live handle,
 and it does not gate whether an object gets an `Encoded` at all — those are the
 two things it is most often assumed to do (§6.4).
 
 It is not *only* about enumeration, though: the same threshold feeds
-`stated_len_is_too_large_to_enumerate` (`lib.rs:3666`) and
-`Encoded::list_repr_is_this_objects_own_spelling` (`lib.rs:3819`), so it also
-participates in how a declined container is *spelled*. Both of those reads are
-themselves `resolve_lazy()`-conditional.
+`stated_len_is_too_large_to_enumerate` (`lib.rs:3667`) and
+`Encoded::declined_list_spelling` (`lib.rs:4472`, which opens with
+`len > OPAQUE_ITEM_CAP` at `:4473`), so it also participates in how a declined
+container is *spelled*.
 
-`opaque_gate` (`lib.rs:4227`) measures four facts without converting anything —
+Do not confuse the latter with `list_repr_is_this_objects_own_spelling`
+(`lib.rs:3820`), which reads similarly and is **length-independent** — it has no
+`OPAQUE_ITEM_CAP` in it at all, and decides which conversion *arm* claims a
+`list`/queryset at ANY length. `lib.rs:3808`–`3811` states the split. An earlier
+version of this paragraph named that one; see §6.10.
+
+`opaque_gate` (`lib.rs:4229`) measures four facts without converting anything —
 `truthy`, `len`, `iterable`, `unbounded` — and sets `unbounded` when either
 axis passes the cap:
 
 - a **sized** object whose stated `__len__` exceeds it
-  (`stated_len_is_too_large_to_enumerate`, `lib.rs:3665`; the check is at
-  `lib.rs:4295`);
-- an **unsized** iterable whose walk passes it (`lib.rs:4306`).
+  (`stated_len_is_too_large_to_enumerate`, `lib.rs:3667`; the check is at
+  `lib.rs:4297`);
+- an **unsized** iterable whose walk passes it (`lib.rs:4308`).
 
 `opaque_value` then leaves `items: None` for an unbounded object, for a one-shot
 iterator (`iter(o) is o` — reading it at conversion would consume the caller's
 object), and for a non-iterable. The *sinks* read such an object through the
-handle instead — `Encoded::consume_live_items` (`lib.rs:4411`) for `{% for %}`,
-`Encoded::declined_list_spelling` (`lib.rs:4470`) for `{{ v }}` / `pprint` /
+handle instead — `Encoded::consume_live_items` (`lib.rs:4413`) for `{% for %}`,
+`Encoded::declined_list_spelling` (`lib.rs:4472`) for `{{ v }}` / `pprint` /
 `json_script` — under their own termination rule,
-`Encoded::live_walk_terminates` (`lib.rs:4388`).
+`Encoded::live_walk_terminates` (`lib.rs:4390`).
 
 The intent is that rendered output not depend on which side of the cap a value
 falls — the work moves from the conversion to the sink, and #2717 exists because
@@ -390,7 +399,7 @@ Per ADR-027 (b) (`docs/adr/027-template-variable-resolution-follows-django.md:22
    shape, msgpack rolling-deploy compatibility, container `!=` change detection,
    and the floor's materialised form. On the LiveView path the normalization is
    `_normalize_db_values` (`python/djust/mixins/rust_bridge.py:83`); on the plain
-   conversion path it is the `models.Model` arm at `lib.rs:4113`, which calls
+   conversion path it is the `models.Model` arm at `lib.rs:4115`, which calls
    `djust.serialization.normalize_django_value`.
    *(The ADR cites lines 3073–3089 of that file for this. That range has since
    drifted onto an unrelated `Decimal`/`Display` doc comment — grep
@@ -512,7 +521,7 @@ Where there is no test, this table says so rather than implying coverage.
 | I1 | The handle never reaches the wire | `TestTheHandleNeverReachesTheWire2539`, `python/tests/test_adr027_characterization_net_2539.py:2006` |
 | I2 | `ENCODED_ATTR_NAMES` and `ENCODED_CALL_NAMES` share no name | `test_the_two_tables_are_disjoint` (cited at `crates/djust_core/src/lib.rs:2207`) |
 | I3 | The ADR-027 sink reads no `Encoded` attribute map and calls no `lookup_segment` | `TestTheSinkHasExactlyTheReadersItClaims`, `python/tests/test_encoded_attributes_2481.py:654` (cited at `context.rs:2299`) |
-| I4 | The conversion body has exactly the callers it claims | `TestTheSinkHasExactlyTheCallersItClaims`, `python/tests/test_encoded_truthiness_2458.py:445` and `python/tests/test_json_script_datetime_value_2448.py:643` (cited at `lib.rs:3923`) |
+| I4 | The conversion body has exactly the callers it claims | `TestTheSinkHasExactlyTheCallersItClaims`, `python/tests/test_encoded_truthiness_2458.py:445` and `python/tests/test_json_script_datetime_value_2448.py:643` (cited at `lib.rs:3925`) |
 | I5 | The serialization floor holds on the handle path, on both sides of the cap | `TestTheSerializationFloorHoldsOnTheNewHandle`, `python/tests/test_sized_sequence_conversion_2695_2693.py:775` |
 | I6 | The build-time sidecar pass's documented limit is pinned, not assumed | `test_the_limit_of_the_build_time_pass_is_pinned_not_assumed`, `python/tests/test_sidecar_on_all_render_paths_2501.py` |
 | I7 | A partial render skips nodes whose deps are disjoint from `changed_keys` | `test_render_nodes_partial_skips_unchanged`, `crates/djust_templates/src/lib.rs:733` |
@@ -585,12 +594,12 @@ two crates:
 
 | site | what it decides |
 |---|---|
-| `lib.rs:3666` | `stated_len_is_too_large_to_enumerate` — the over-cap decline is lazy-only |
-| `lib.rs:3819` | `list_repr_is_this_objects_own_spelling` — a declined container's spelling |
-| `lib.rs:4254` | `opaque_gate`, the one-shot-iterator arm |
-| `lib.rs:4307` | `opaque_gate`, the over-cap walk arm |
-| `lib.rs:4333` | `opaque_gate`, the attribute-bearing decline |
-| `lib.rs:4935` | `opaque_value` — the handle **attach** (§3.4 documents this one) |
+| `lib.rs:3668` | `stated_len_is_too_large_to_enumerate` — the over-cap decline is lazy-only |
+| `lib.rs:3821` | `list_repr_is_this_objects_own_spelling` — which conversion ARM claims a `list`/queryset, at any length (§3.5: *not* the declined spelling) |
+| `lib.rs:4256` | `opaque_gate`, the one-shot-iterator arm |
+| `lib.rs:4309` | `opaque_gate`, the over-cap walk arm |
+| `lib.rs:4335` | `opaque_gate`, the attribute-bearing decline |
+| `lib.rs:4937` | `opaque_value` — the handle **attach** (§3.4 documents this one) |
 | `context.rs:1800` | whether a dotted lookup **walks** the handle |
 | `crates/djust_templates/src/renderer.rs:5461` | `get_value_safe`'s `ignore_failures` arm: a filtered tag operand resolving to `Missing` becomes `None` under the flag |
 
@@ -601,7 +610,7 @@ observable — `{% firstof nope|default_if_none:"X" "Y" %}` renders `X` with the
 flag on and `Y` with it off (§6.9).
 
 > An earlier version of this section said "read at exactly two sites", and
-> sourced it to `lib.rs:2884`'s own doc comment, which said the same thing. Both
+> sourced it to `lib.rs:2886`'s own doc comment, which said the same thing. Both
 > were false. See §6.9 — this is the tenth false absolute on this boundary, and
 > the document acquired it in exactly the way it was written to prevent.
 
@@ -766,10 +775,10 @@ that push is what keeps the configured value honoured on the real path (§5.4).
 
 ### 6.6 The `Value::Object` bulk-dump arm — reachable under the default, and my first enumeration of how was wrong
 
-`opaque_gate`'s final decline (`lib.rs:4333`) is
+`opaque_gate`'s final decline (`lib.rs:4335`) is
 `!resolve_lazy() && truthy && !iterable && has_public_dict_attrs(ob)`. With the
 flag on that decline never fires, so `opaque_value` claims the object and the
-bulk-dump arm at `lib.rs:4160` is reached only when `opaque_value` returns
+bulk-dump arm at `lib.rs:4162` is reached only when `opaque_value` returns
 `None`. A truthy, non-iterable object with public attributes resolves under both
 flag states, **by different carriers** — an `Encoded` with a handle under the
 default, a `Value::Object` on the escape hatch.
@@ -797,7 +806,7 @@ class Boom:
 `bool`, `iter`, `str`, `repr` and `type().__name__` all succeed. `{{ v }}`
 renders `{&#x27;x&#x27;: 1}` — the `Value::Object` bulk dump. Through the
 isolating binding, `q.x` → `1` and `q.p` → `''`: no handle. The arm that
-declined it is `item.is_err()` at `lib.rs:4302`, with `item.ok()?` /
+declined it is `item.is_err()` at `lib.rs:4304`, with `item.ok()?` /
 `extract::<Value>().ok()?` in `opaque_value`.
 
 **And `iter(o)` failing is not a decline at all.** `ob.try_iter().ok()` merely
@@ -835,7 +844,7 @@ was never grepped.
 
 The nine failures this document was written against were all absolutes taken on
 trust. The first version of §5.4 added a tenth: *"read at exactly two sites"*,
-with `lib.rs:2884`'s own doc comment cited as the source. Both were false, and
+with `lib.rs:2886`'s own doc comment cited as the source. Both were false, and
 review found it by grepping.
 
 There are **eight** functional reads, in two crates (§5.4). The one that makes
@@ -851,19 +860,55 @@ and appears nowhere in the first version of this document:
 a filtered operand that resolves to nothing takes a different branch. That is
 observable output, changed by a flag the document said had two readers.
 
-**The lesson, stated as a rule because it cost this document its own standard: a
-doc comment is not evidence.** Citing one is the same act as citing an issue
-body or a PR description — it is someone's claim, and the nine failures in the
-opening note are what that is worth on this boundary. §3.4 already contradicted
-§5.4 by documenting `lib.rs:4935` as a third read; nobody noticed, because both
-sentences read as authoritative. The rule that catches this is the one already
-stated at the top and applied everywhere else here: **construct the case that
-would disprove the claim, and run it.** For a flag, that means finding output
-that changes when it flips — not counting call sites in the file you happen to
-be reading, and certainly not repeating the count a neighbouring comment
-asserts.
+**The lesson, stated as a rule because it cost this document its own standard:**
 
-`lib.rs:2884`'s comment is corrected in the same commit as the other four.
+> A doc comment is not evidence for a **checkable** claim — a count, an
+> absolute, a reachability statement — because those can be run. It remains the
+> best evidence for **intent**, which cannot be run.
+
+The distinction is load-bearing, and the first draft of this rule did not have
+it. "A doc comment is not evidence", full stop, would invalidate two things this
+document does legitimately: §3.2's `Encoded` field table (doc-comment summaries
+of what each field *means*) and §5.4's citation of the design rationale for the
+thread-local. Both are intent, both are flagged as read-not-run in §6.7, and
+both are fine. What is not fine is sourcing a *count* to a comment. A section
+about over-strong rules should not close on one.
+
+For a checkable claim the rule is the one already stated at the top and applied
+everywhere else here: **construct the case that would disprove it, and run it.**
+For a flag, that means finding output that changes when it flips — not counting
+call sites in the file you happen to be reading, and certainly not repeating the
+count a neighbouring comment asserts. §3.4 already contradicted §5.4 by
+documenting `lib.rs:4937` as a third read; nobody noticed, because both
+sentences read as authoritative.
+
+`lib.rs:2886`'s comment is corrected in the same commit as the other four.
+
+### 6.10 The eleventh — my fix for the tenth, one step over
+
+The correction to §5.4 (above) came with a self-found correction to §3.5: "the
+cap governs item enumeration, and **nothing else**" was too strong, because the
+threshold also participates in how a declined container is spelled. That is
+right. The predicate I named for it was not:
+`list_repr_is_this_objects_own_spelling` (`lib.rs:3820`) contains no
+`OPAQUE_ITEM_CAP` and is **length-independent** — it decides which conversion
+*arm* claims a `list`/queryset at any length. The cap-reading spelling predicate
+is `Encoded::declined_list_spelling` (`lib.rs:4472`), which §3.5 cited
+correctly twelve lines further down, and which `lib.rs:3808`–`3811` distinguishes
+from the other in as many words.
+
+I picked the neighbour, and it was a `resolve_lazy()` reader with "spelling" in
+its name — plausible enough to survive a re-read, and wrong.
+
+**This is the closing example because it is my own and it is the cleanest: a
+fix for a false absolute landed a new false claim one step over** — the
+chain-shaped failure `CLAUDE.md` names at #2142, and the third instance of it on
+this document. It is also the sharpest argument for the rule above. Two of the
+three false claims here (this one, and "read at exactly two sites") would have
+been caught by the same move and were not: pick the symbol you are about to
+name, open it, and check that the thing you are claiming about it is in the
+body. A neighbouring symbol with the right-sounding name is exactly what a
+careful re-read fails to catch.
 
 ---
 

--- a/docs/architecture/VALUE_BOUNDARY.md
+++ b/docs/architecture/VALUE_BOUNDARY.md
@@ -18,6 +18,11 @@ running code and which were not.
 > machinery. So every absolute below was falsification-tested by constructing
 > the case that would disprove it and running it; section 6 says which, and
 > names the ones that were not.
+>
+> The first version of this document then shipped a **tenth**, by citing a
+> shipped doc comment instead of running the case (§6.9). It is recorded rather
+> than quietly fixed, because it is the sharpest available evidence for the rule
+> this document exists to carry: **a doc comment is not evidence.**
 
 ---
 
@@ -33,8 +38,8 @@ flowchart TD
     C1 --> C2["deep_fingerprint per key<br/>python/djust/change_detection.py:90"]
     C2 -->|"changed keys only"| D["RustLiveView.set_changed_keys / update_state<br/>(PyO3)"]
 
-    D --> E["impl FromPyObject for Value<br/>crates/djust_core/src/lib.rs:3890"]
-    E --> F["Value<br/>(13 variants; lib.rs:221)"]
+    D --> E["impl FromPyObject for Value<br/>crates/djust_core/src/lib.rs:3914"]
+    E --> F["Value<br/>(15 variants; lib.rs:221)"]
     E -.->|"objects no variant models"| G["Encoded<br/>(lib.rs:418) — measured facts<br/>+ optional live handle"]
     G --> F
 
@@ -52,7 +57,7 @@ flowchart TD
 
 The order below **is** the code's order, and the order is load-bearing: several
 arms are only correct because an earlier one already claimed the type.
-(`crates/djust_core/src/lib.rs:3890`–`4144`.)
+(`crates/djust_core/src/lib.rs:3914`–`4168`.)
 
 ```mermaid
 flowchart TD
@@ -62,7 +67,7 @@ flowchart TD
     D1 -->|yes| PRIM["the matching scalar variant"]
     D1 -->|no| D2{"tuple / namedtuple /<br/>bounded sequence /<br/>MultiValueDict / dict"}
     D2 -->|yes| CONT["Tuple / NamedTuple /<br/>List / Object"]
-    D2 -->|no| FB["the fallback block<br/>(lib.rs:4029)"]
+    D2 -->|no| FB["the fallback block<br/>(lib.rs:4053)"]
 
     FB --> F1{"datetime / date /<br/>time / timedelta?"}
     F1 -->|yes| ENC1["Encoded via django_json_encoded<br/>lib.rs:2100 — attrs from the two<br/>name tables, AND a live handle"]
@@ -70,8 +75,8 @@ flowchart TD
     F2 -->|yes| SER["recurse on the floored<br/>dict / list-of-dicts"]
     F2 -->|no| F3{"isinstance(models.Model)?"}
     F3 -->|yes| MOD["normalize_django_value<br/>then recurse (the floor)"]
-    F3 -->|no| F4{"opaque_gate admits it?<br/>lib.rs:4203"}
-    F4 -->|yes| ENC2["Encoded via opaque_value<br/>lib.rs:4855 — items maybe,<br/>live handle iff resolve_lazy()"]
+    F3 -->|no| F4{"opaque_value returns Some?<br/>lib.rs:4879 (gate at :4227)"}
+    F4 -->|yes| ENC2["Encoded via opaque_value<br/>items maybe,<br/>live handle iff resolve_lazy()"]
     F4 -->|no| F5{"public __dict__ attrs?"}
     F5 -->|yes| OBJ["Value::Object<br/>(the bulk dump)"]
     F5 -->|no| STR2["Value::String(str(o))"]
@@ -82,33 +87,62 @@ flowchart TD
 
 Under the shipped default (`resolve_lazy()` is `true`), `opaque_gate`'s last
 decline is lifted, so the `Value::Object` bulk-dump arm is reached only when
-`opaque_value` returns `None` — that is, when one of `bool(o)`, `iter(o)`,
-`str(o)`, `repr(o)` or `type(o).__name__` fails. See §3.4.
+`opaque_value` returns `None`. That happens when a probe on the object raises:
+`bool(o)`, `str(o)`, `repr(o)` or `type(o).__name__` — **or, and this is the
+one that is easy to miss, a failure while ENUMERATING the items** (`item.is_err()`
+at `lib.rs:4302`, and `item.ok()?` / `extract::<Value>().ok()?` in
+`opaque_value`). `iter(o)` *failing* is not on that list: `try_iter().ok()`
+just sets `iterable = false`, which is the ordinary non-iterable case — and a
+non-iterable object does get a handle. Both halves measured in §6.6.
 
 ### 1.3 How `{{ a.b.c }}` is answered
 
-Three mechanisms, tried in this order, in
-`Context::resolve_without_builtins` (`crates/djust_core/src/context.rs:1755`).
-Two of them reach live Python; they are **different mechanisms** and conflating
-them is how a gate-off test becomes vacuous (§6.1).
+**Five** arms, tried in this order, in `Context::resolve_without_builtins`
+(`crates/djust_core/src/context.rs:1755`). Two of them reach live Python; those
+two are **different mechanisms**, and conflating them is how a gate-off test
+becomes vacuous (§6.1). The middle two are neither, and are easy to mistake for
+the sidecar — the code spends twenty lines (`context.rs:1808`–`1830`) on why
+they sit between `get` and the sidecar guard.
 
 ```mermaid
 flowchart TD
-    Q["resolve('a.b.c')"] --> M1{"resolve_lazy() AND<br/>some prefix is an Encoded<br/>carrying a live handle?"}
+    Q["resolve('a.b.c')"] --> M1{"resolve_lazy() AND<br/>some prefix is an Encoded<br/>carrying a live handle?<br/>context.rs:1800"}
     M1 -->|yes| W["walk_from_handle -> walk_live<br/>context.rs:2181 / :2300<br/>Django's _resolve_lookup over the REAL object"]
-    M1 -->|no| M2{"the value stack answers it?<br/>Context::get"}
+    M1 -->|no| M2{"the value stack answers it?<br/>Context::get, context.rs:1805"}
     M2 -->|yes| V["the Value / Encoded::attrs entry"]
-    M2 -->|no| M3{"a raw-Python SIDECAR<br/>entry for the head name?<br/>context.rs:1834"}
+    M2 -->|no| M2A{"a dict view?<br/>context.rs:1822"}
+    M2A -->|yes| DV["Value::DictView<br/>{{ m.items }} / .keys / .values (#2334)"]
+    M2A -->|no| M2B{"an integer index<br/>into a String?<br/>context.rs:1831"}
+    M2B -->|yes| SI["one character<br/>{{ s.0 }} — Django's step 3 (#2373)"]
+    M2B -->|no| M3{"a raw-Python SIDECAR<br/>entry for the head name?<br/>context.rs:1834"}
     M3 -->|yes| SW["the sidecar walk<br/>(keyed by TOP-LEVEL name;<br/>reaches rebindings via<br/>Context::aliases, context.rs:1873)"]
     M3 -->|no| MISS["Missing -> string_if_invalid"]
 
     W --> OUT["a Value"]
     V --> OUT
+    DV --> OUT
+    SI --> OUT
     SW --> OUT
 
     style W fill:#fde,stroke:#c39
     style SW fill:#efd,stroke:#7a3
+    style DV fill:#eef,stroke:#77c
+    style SI fill:#eef,stroke:#77c
 ```
+
+The two middle arms are genuinely reachable and are neither the handle nor the
+sidecar — measured, because an earlier draft of this section drew three arms and
+a reader would have concluded `{{ m.items }}` is a sidecar answer:
+
+| template | context | renders |
+|---|---|---|
+| `{{ m.items }}` | `{"a": 1}` | `dict_items([('a', 1)])` |
+| `{{ s.0 }}` | `"abc"` | `a` |
+| `{% with t=xs\|first %}{{ t.1 }}{% endwith %}` | `["abc"]` | `b` |
+
+The third is the proof: a *filtered* binding, so the sidecar cannot reach it
+(§6.1), and the value stack cannot answer `.1` on a `String` — and it renders
+`b` with the handle flag both on and off, so it is not the handle either.
 
 ### 1.4 The partial-render dependency path
 
@@ -188,7 +222,7 @@ numbers are not.
 | 2 | Normalize DB values | `_normalize_db_values`, `python/djust/mixins/rust_bridge.py:83` |
 | 3 | Detect change | `deep_fingerprint`, `python/djust/change_detection.py:90` |
 | 4 | Hand across (PyO3) | `RustLiveView::set_changed_keys`, `crates/djust_live/src/lib.rs:336` |
-| 5 | Convert | `impl FromPyObject for Value`, `crates/djust_core/src/lib.rs:3890` |
+| 5 | Convert | `impl FromPyObject for Value`, `crates/djust_core/src/lib.rs:3914` |
 | 6 | Bind | `Context`, `crates/djust_core/src/context.rs:280` |
 | 7 | Resolve | `Context::resolve_without_builtins`, `context.rs:1755` |
 | 8 | Render | `render_nodes_partial` / `render_nodes_collecting`, `crates/djust_templates/src/renderer.rs:2193` / `:2173` |
@@ -196,11 +230,15 @@ numbers are not.
 
 ### 3.2 The types
 
-**`Value`** (`crates/djust_core/src/lib.rs:221`) — the inert carrier. Thirteen
+**`Value`** (`crates/djust_core/src/lib.rs:221`) — the inert carrier. **Fifteen**
 variants: `Missing`, `None`, `Bool`, `Integer`, `Float`, `String`, `SafeString`,
-`List`, `Tuple`, `NamedTuple`, `Object`, `Decimal`, `BigInt`, `Encoded`.
+`List`, `Tuple`, `NamedTuple`, `Object`, `DictView` (`:298`), `Decimal`,
+`BigInt`, `Encoded`.
+
 `Missing` is *not* Python's `None`: an absent key arrives as `Option::None` from
-the resolver and `Missing` is what `string_if_invalid` substitutes.
+the resolver and `Missing` is what `string_if_invalid` substitutes. `DictView`
+is the carrier §1.3's third arm produces — `{{ m.items }}` / `.keys` /
+`.values` (#2334), with `DictViewKind` (`:203`) recording which of the three.
 
 **`Encoded`** (`crates/djust_core/src/lib.rs:418`) — the carrier for a Python
 object that no other variant models. It holds the facts measured at conversion:
@@ -241,7 +279,8 @@ Two constant tables state the whole policy:
   shorter lists for the others.
 
 Both are merged into the same `attrs` map by `django_json_encoded`
-(`lib.rs:2197` and `:2200`) so `lookup_segment` (`context.rs:134`) stays the one
+(built at `lib.rs:2197`, second table merged in at `:2210`) so
+`lookup_segment` (`context.rs:134`) stays the one
 reader. `min` / `max` / `resolution` are deliberately in **neither** table: their
 values are themselves `datetime`s and `datetime.min.min is datetime.min`, so
 collecting them would not terminate (`lib.rs:520`–`534`).
@@ -257,8 +296,8 @@ attach the handle differently. (Seven further sites — `lib.rs:1655`, `:1718`,
 sets `live: None`. That is the handle's transience, mechanically: nothing
 restored from state can carry one.)
 
-**`opaque_value`** (`lib.rs:4855`) — the general carrier. It attaches a handle
-**iff** the thread-local flag is on (`lib.rs:4911`–`4916`):
+**`opaque_value`** (`lib.rs:4879`) — the general carrier. It attaches a handle
+**iff** the thread-local flag is on (`lib.rs:4935`–`4916`):
 
 ```rust
 let lazy = resolve_lazy();
@@ -282,7 +321,7 @@ either way. See §6.3.
 **Who does not get one.** The arms *above* `opaque_value` in the fallback block
 claim their types first, so nothing they claim can reach the handle: a `dict`, a
 `tuple`, a `list`, a `NamedTuple`, a `MultiValueDict`, anything with
-`__djust_serialize__` (`lib.rs:4054`), and any `models.Model` (`lib.rs:4089`).
+`__djust_serialize__` (`lib.rs:4078`), and any `models.Model` (`lib.rs:4113`).
 That last pair is the serialization floor: routing a model through the
 `__dict__` bulk dump would filter only `_`-prefixed keys and leak `password`.
 ADR-027 states it as an explicit non-goal: *"`Value::Object` never carries a
@@ -296,34 +335,47 @@ Django's `_resolve_lookup` transcribed: the callable block (`maybe_call`,
 `context.rs:2089`) for the root bit, then per segment `walk_one_segment`
 (`context.rs:2341`) — dict item, attribute, integer index, each with Django's
 catch set — with `protect_sidecar_strict` (`context.rs:2077`) re-applying the
-serialization floor after **every** segment.
+serialization floor to the root before the loop (`context.rs:2314`) and again
+after each segment (`:2329`).
 
 ### 3.5 Where `OPAQUE_ITEM_CAP` actually governs
 
-`OPAQUE_ITEM_CAP = 100_000` (`lib.rs:4159`). It governs **whether the items are
-enumerated at conversion time**, and nothing else. It does *not* gate the live
-handle, and it does not gate whether an object gets an `Encoded` at all.
+`OPAQUE_ITEM_CAP = 100_000` (`lib.rs:4183`). Its primary job is **whether the
+items are enumerated at conversion time**. It does *not* gate the live handle,
+and it does not gate whether an object gets an `Encoded` at all — those are the
+two things it is most often assumed to do (§6.4).
 
-`opaque_gate` (`lib.rs:4203`) measures four facts without converting anything —
+It is not *only* about enumeration, though: the same threshold feeds
+`stated_len_is_too_large_to_enumerate` (`lib.rs:3666`) and
+`Encoded::list_repr_is_this_objects_own_spelling` (`lib.rs:3819`), so it also
+participates in how a declined container is *spelled*. Both of those reads are
+themselves `resolve_lazy()`-conditional.
+
+`opaque_gate` (`lib.rs:4227`) measures four facts without converting anything —
 `truthy`, `len`, `iterable`, `unbounded` — and sets `unbounded` when either
 axis passes the cap:
 
 - a **sized** object whose stated `__len__` exceeds it
-  (`stated_len_is_too_large_to_enumerate`, `lib.rs:3641`; the check is at
-  `lib.rs:4271`);
-- an **unsized** iterable whose walk passes it (`lib.rs:4282`).
+  (`stated_len_is_too_large_to_enumerate`, `lib.rs:3665`; the check is at
+  `lib.rs:4295`);
+- an **unsized** iterable whose walk passes it (`lib.rs:4306`).
 
 `opaque_value` then leaves `items: None` for an unbounded object, for a one-shot
 iterator (`iter(o) is o` — reading it at conversion would consume the caller's
 object), and for a non-iterable. The *sinks* read such an object through the
-handle instead — `Encoded::consume_live_items` (`lib.rs:4387`) for `{% for %}`,
-`Encoded::declined_list_spelling` (`lib.rs:4446`) for `{{ v }}` / `pprint` /
+handle instead — `Encoded::consume_live_items` (`lib.rs:4411`) for `{% for %}`,
+`Encoded::declined_list_spelling` (`lib.rs:4470`) for `{{ v }}` / `pprint` /
 `json_script` — under their own termination rule,
-`Encoded::live_walk_terminates` (`lib.rs:4364`).
+`Encoded::live_walk_terminates` (`lib.rs:4388`).
 
-The practical consequence: **rendered output is the same on both sides of the
-cap**; what differs is whether the work happens at conversion or at the sink.
-Verified in §6.4.
+The intent is that rendered output not depend on which side of the cap a value
+falls — the work moves from the conversion to the sink, and #2717 exists because
+an earlier exemption broke exactly that. What was **measured** here is narrower
+than the intent: `{% for %}` over a duck-typed iterable that *states* a length
+past the cap produced byte-identical output to the same iterable under it
+(§6.4). That is one shape over one sink; treat the general claim as the design's
+goal, pinned by `test_declined_container_spelling_2717.py`, not as something
+this document measured.
 
 On the eager escape hatch (`resolve_lazy()` false) there is no handle to read
 later, so an unbounded object is *declined* by the gate instead and falls to
@@ -338,11 +390,12 @@ Per ADR-027 (b) (`docs/adr/027-template-variable-resolution-follows-django.md:22
    shape, msgpack rolling-deploy compatibility, container `!=` change detection,
    and the floor's materialised form. On the LiveView path the normalization is
    `_normalize_db_values` (`python/djust/mixins/rust_bridge.py:83`); on the plain
-   conversion path it is the `models.Model` arm at `lib.rs:4089`, which calls
+   conversion path it is the `models.Model` arm at `lib.rs:4113`, which calls
    `djust.serialization.normalize_django_value`.
-   *(The ADR cites `lib.rs:3073-3089` for this. That range has since drifted onto
-   an unrelated `Decimal`/`Display` doc comment — grep `normalize_django_value`
-   instead. The mechanism is unchanged; only the ADR's line numbers are stale.)*
+   *(The ADR cites lines 3073–3089 of that file for this. That range has since
+   drifted onto an unrelated `Decimal`/`Display` doc comment — grep
+   `normalize_django_value` instead. The mechanism is unchanged; only the ADR's
+   line numbers are stale.)*
 2. **`dict` / `list` / `tuple` / `set` / scalars / `Decimal` / `datetime` /
    `bytes`** — the variants they already had.
 3. **`Component` / `LiveComponent`** — a handle whose `display` is `str(c)`,
@@ -397,11 +450,11 @@ top-level node, the set of **top-level context roots** the node's subtree reads
 > bytes. Being fixed in PR #2742; the structure described here (parse-time
 > extraction, the wildcard set, the intersection rule) is unchanged by it.
 
-Three node classes get the wildcard `"*"`
-because their dependencies cannot be inferred — `Node::Include`, and the custom
-tag family (`CustomTag`, `BlockCustomTag`, `RawBlockCustomTag`, `Language`,
-`Timezone`, `Localize`, `LocalTime`), whose raw bodies are re-parsed by Django
-(#2558).
+**Eight** node types get the wildcard `"*"` because their dependencies cannot be
+inferred (`parser.rs:2944` and `:2950`–`2959`): `Include` on its own, then the
+custom-tag family whose raw bodies are re-parsed by Django (#2558) —
+`CustomTag`, `BlockCustomTag`, `RawBlockCustomTag`, `Language`, `Timezone`,
+`Localize`, `LocalTime`.
 
 `render_nodes_partial` (`renderer.rs:2193`) re-renders node `i` when
 (`renderer.rs:2212`–`2217`):
@@ -430,11 +483,17 @@ and attached at the standalone render entry points by `entry_sidecar`
 It is consulted **after** the value stack (`context.rs:1834`) and it reaches
 rebound names through `Context::aliases` (#2375): `{% with q=p %}` registers
 `q` → `p`, and the walk expands the alias (`context.rs:1873`). An alias is
-registered only for a bare dotted path over an **unfiltered** operand
-(`context.rs:1850`–`1857`), so `{% with q=xs|first %}` registers nothing.
+registered only for a bare dotted path over an **unfiltered, non-dict-view**
+operand (`context.rs:1850`–`1857`), so neither `{% with q=xs|first %}` nor
+`{% for q in m.values %}` registers one.
 
-That detail is not trivia — it is the only reliable way to test the handle in
-isolation, and getting it wrong makes a gate-off silently vacuous (§6.1).
+That detail is not trivia — those are the **two** binding shapes that test the
+handle in isolation, and using any other makes a gate-off silently vacuous
+(§6.1). The repo's own `TestFilteredAndDictViewOperands2504`
+(`python/tests/test_adr027_characterization_net_2539.py:1498`) is named for both.
+Measured: `{% for q in m.values %}{{ q.resolution }}{% endfor %}` over
+`{"k": <datetime>}` renders `0:00:00.000001` with the flag on and `''` with it
+off, exactly as the filtered-operand shape does.
 
 Note also `entry_sidecar`'s own caveat (`crates/djust_live/src/lib.rs:2105`–`2114`):
 `DjustTemplateBackend` runs `serialize_context()` *before* calling into Rust, so
@@ -452,7 +511,7 @@ Where there is no test, this table says so rather than implying coverage.
 | I1 | The handle never reaches the wire | `TestTheHandleNeverReachesTheWire2539`, `python/tests/test_adr027_characterization_net_2539.py:2006` |
 | I2 | `ENCODED_ATTR_NAMES` and `ENCODED_CALL_NAMES` share no name | `test_the_two_tables_are_disjoint` (cited at `crates/djust_core/src/lib.rs:2207`) |
 | I3 | The ADR-027 sink reads no `Encoded` attribute map and calls no `lookup_segment` | `TestTheSinkHasExactlyTheReadersItClaims`, `python/tests/test_encoded_attributes_2481.py:654` (cited at `context.rs:2299`) |
-| I4 | The conversion body has exactly the callers it claims | `TestTheSinkHasExactlyTheCallersItClaims`, `python/tests/test_encoded_truthiness_2458.py:445` and `python/tests/test_json_script_datetime_value_2448.py:643` (cited at `lib.rs:3899`) |
+| I4 | The conversion body has exactly the callers it claims | `TestTheSinkHasExactlyTheCallersItClaims`, `python/tests/test_encoded_truthiness_2458.py:445` and `python/tests/test_json_script_datetime_value_2448.py:643` (cited at `lib.rs:3923`) |
 | I5 | The serialization floor holds on the handle path, on both sides of the cap | `TestTheSerializationFloorHoldsOnTheNewHandle`, `python/tests/test_sized_sequence_conversion_2695_2693.py:775` |
 | I6 | The build-time sidecar pass's documented limit is pinned, not assumed | `test_the_limit_of_the_build_time_pass_is_pinned_not_assumed`, `python/tests/test_sidecar_on_all_render_paths_2501.py` |
 | I7 | A partial render skips nodes whose deps are disjoint from `changed_keys` | `test_render_nodes_partial_skips_unchanged`, `crates/djust_templates/src/lib.rs:733` |
@@ -461,7 +520,7 @@ Where there is no test, this table says so rather than implying coverage.
 | I10 | Django's lookup rules at the sink | `crates/djust_core/tests/test_django_lookup_sink_2539.rs` |
 | **I11** | **The datetime family carries a live handle** | **no test.** The behaviour is observable (§6.2) but nothing asserts it, which is how a comment in `context.rs` could contradict `django_json_encoded`'s own `live: Some(..)` (`lib.rs:2236`) for as long as it did. |
 | **I12** | **`OPAQUE_ITEM_CAP` does not gate the handle** | **no direct test.** `test_sized_sequence_conversion_2695_2693.py` and `test_declined_container_spelling_2717.py` exercise the cap's *item* behaviour; none asserts that a sub-cap or non-sequence object also carries a handle. |
-| **I13** | **`RESOLVE_LAZY` is per-thread** | **no test found** for the cross-thread default. `python/tests/test_adr027_wiring_security_2539.py` covers the setter's wiring; §6.5 exercises the thread-locality directly. |
+| I13 | `RESOLVE_LAZY` is per-thread, and a thread that never pushed reads the Rust default | `test_a_thread_that_never_pushed_reads_the_default`, `python/tests/test_adr027_wiring_security_2539.py:835` (spawns a `Thread` and asserts it does not see the flag pushed on the main thread) and `test_the_rust_default_tracks_the_python_default`, `python/tests/test_adr027_characterization_net_2539.py:2184`. §6.5 re-derives an invariant that is already pinned — this row said "no test found" until review grepped it. |
 
 ---
 
@@ -471,10 +530,18 @@ Two claims were made twice in the record and are both false: *"no `Context`
 crosses a thread"* and, by implication, *"the render runs on the thread that
 configured it"*. Here is what actually happens.
 
-### 5.1 Every WebSocket and HTTP render runs on an asgiref worker thread
+### 5.1 The WebSocket and ASGI paths render on an asgiref worker thread
 
-`python/djust/runtime.py` wraps the render in `sync_to_async`, which executes it
-in a thread-pool executor, not on the event loop:
+**Not every path.** `RequestMixin.get` (`python/djust/mixins/request.py:133`) is
+an ordinary sync Django view that renders on the calling thread, and its own
+docstring says so: *"On WSGI deployments, or when `streaming_render = False`,
+this is the only path."* An earlier version of this section said "every
+WebSocket and HTTP render", which is the over-generalisation this document is
+supposed to catch.
+
+What is verified is the ASGI/WebSocket spine: `python/djust/runtime.py` wraps
+the render in `sync_to_async`, which executes it in a thread-pool executor, not
+on the event loop:
 
 | line | call |
 |---|---|
@@ -512,17 +579,49 @@ behind an `Arc` precisely so `Context::clone` needs no GIL (`context.rs:288`–`
 ### 5.4 The consequence: ambient render settings are thread-local, and default
 
 `RESOLVE_LAZY` is a **thread-local** `Cell<bool>` initialised to `true`
-(`crates/djust_core/src/lib.rs:2821`), read at exactly two sites
-(`lib.rs:2860`'s doc says so): `opaque_gate`'s attribute-bearing decline, and
-`Context::resolve_without_builtins`'s handle walk. It is pushed per render by
+(`crates/djust_core/src/lib.rs:2821`), read at **eight** functional sites across
+two crates:
+
+| site | what it decides |
+|---|---|
+| `lib.rs:3666` | `stated_len_is_too_large_to_enumerate` — the over-cap decline is lazy-only |
+| `lib.rs:3819` | `list_repr_is_this_objects_own_spelling` — a declined container's spelling |
+| `lib.rs:4254` | `opaque_gate`, the one-shot-iterator arm |
+| `lib.rs:4307` | `opaque_gate`, the over-cap walk arm |
+| `lib.rs:4333` | `opaque_gate`, the attribute-bearing decline |
+| `lib.rs:4935` | `opaque_value` — the handle **attach** (§3.4 documents this one) |
+| `context.rs:1800` | whether a dotted lookup **walks** the handle |
+| `crates/djust_templates/src/renderer.rs:5461` | `get_value_safe`'s `ignore_failures` arm: a filtered tag operand resolving to `Missing` becomes `None` under the flag |
+
+`djust_live/src/lib.rs:1901` is the PyO3 getter, not a routing read.
+
+That last row is in a different crate from every other, and it is behaviourally
+observable — `{% firstof nope|default_if_none:"X" "Y" %}` renders `X` with the
+flag on and `Y` with it off (§6.9).
+
+> An earlier version of this section said "read at exactly two sites", and
+> sourced it to `lib.rs:2884`'s own doc comment, which said the same thing. Both
+> were false. See §6.9 — this is the tenth false absolute on this boundary, and
+> the document acquired it in exactly the way it was written to prevent.
+
+It is pushed per render by
 `djust.render_env.apply_render_env`, alongside the timezone (#2209) and the
 number format (#2221) — that module exists so a render path cannot acquire one
 ambient setting and miss another.
 
 Because it is thread-local rather than global, **a thread that never called
 `apply_render_env` reads the shipped default, not the project's configured
-value.** Verified in §6.5. The same is true of the render timezone and number
-format, which is the reason they live in one module.
+value.** Verified in §6.5, and pinned by I13. The same is true of the render
+timezone and number format, which is the reason they live in one module.
+
+This is a property of the mechanism, **not a live bug**: `_sync_state_to_rust`
+calls `_apply_render_env()` per render (`python/djust/mixins/rust_bridge.py:657`)
+on whatever thread runs it, so a real `LiveView` render honours the configured
+value on the worker thread too. Review confirmed this directly — with the config
+`False` and the thread-local deliberately poisoned `True` first, a real render
+returned the flag-off answer and left the flag `False`, both synchronously and
+across `sync_to_async(thread_sensitive=True)`. The rule to take away is about
+*direct* `_rust.render_template` callers and embedders, which push nothing.
 
 The design note at `lib.rs:2826`–`2846` states the reason it is not a `Context`
 field: half the work it gates is inside `impl FromPyObject for Value`, a trait
@@ -542,8 +641,9 @@ expected answer, and the gate-off that proves the assertion is not tautological
 
 The obvious way to prove a value carries a live handle is to resolve an
 attribute only the handle can reach, then flip `set_resolve_lazy(False)` and see
-it go blank. **That test is vacuous as usually written**, because the by-name
-sidecar (§3.9) answers the same lookup and is not gated by that flag.
+it go blank. **Written with the obvious binding, that test is vacuous**, because
+the by-name sidecar (§3.9) answers the same lookup and is not gated by that
+flag.
 
 Measured, on `{{ q.resolution }}` with `resolve_lazy` **off**:
 
@@ -555,10 +655,26 @@ Measured, on `{{ q.resolution }}` with `resolve_lazy` **off**:
 | `{% with q=items\|first %}` (**filtered**) | `''` | no alias registered → sidecar cannot reach it |
 | `{% for q in items\|slice:":1" %}` (**filtered**) | `''` | same |
 
-So a **filtered-operand rebinding** is the isolating shape, and every gate-off
-below uses it. The non-vacuity of the gate is itself asserted: with the flag off
-the filtered form is blank *while the unfiltered form still resolves*, proving
-the gate is doing something and the blank is not an unrelated failure.
+So a **filtered-operand rebinding** is an isolating shape (a **dict-view
+operand** is the other — §3.9), and every gate-off below uses one. The
+non-vacuity of the gate is itself asserted: with the flag off the filtered form
+is blank *while the unfiltered form still resolves*, proving the gate is doing
+something and the blank is not an unrelated failure.
+
+**This is a trap for future tests, not an indictment of existing ones.** Review
+checked the stronger version of the question — not flipping the flag but
+deleting `walk_from_handle` from `resolve_without_builtins` entirely and
+rebuilding release — and ran the full ADR-027 suite: **116 failures across 19
+distinct tests.** Every test that should go red does
+(`TestFilteredAndDictViewOperands2504::test_the_shipped_default_closes_2504`,
+`TestTheSwitch2539::test_the_switch_is_what_gates_the_behaviour`,
+`TestTheSinkHasExactlyOneCaller2539::test_the_pin_goes_red_in_every_direction`,
+`test_an_alias_less_operand_reaches_the_object_under_the_default`), and the
+handle-named tests that stay green stay green for sound reasons — they pin wire
+serialization, GC-after-teardown, source structure, or `crosses_as_encoded`
+probes, none of which the sidecar could be quietly answering. **No shipped test
+is vacuous from this.** The suite already uses the isolating shapes; the hazard
+is for the next test someone writes without knowing why.
 
 ### 6.2 FALSE: "the whole datetime family never carry [a live handle]"
 
@@ -628,9 +744,11 @@ binding:
 All three carry a handle. What the cap governs is *item enumeration*, and that
 was measured too: `{% for %}` over the over-cap and under-cap objects produced
 byte-identical output (`0,1,2,`), and `|length` answered `200000` and `3`
-respectively. **Output is the same on both sides of the cap; only where the work
-happens differs.** No code change — the issue body is not in the repo; the
-successors filed off #2737 should carry the correction.
+respectively — the objects' own lengths, not a cap effect. For that shape and
+that sink the work moves from the conversion to the sink without changing the
+bytes; §3.5 says why the general form of that claim is the design's goal rather
+than something measured here. No code change for #2737 — the issue body is not
+in the repo; the successors filed off it should carry the correction.
 
 ### 6.5 VERIFIED: `RESOLVE_LAZY` is thread-local, and a fresh thread reads the default
 
@@ -640,20 +758,51 @@ With `set_resolve_lazy(False)` on the main thread:
 - a fresh `threading.Thread` that never touched the flag:
   `resolve_lazy_enabled()` → `True`, the same lookup → `0:00:00.000001`.
 
-So the worker did not inherit the configuration. Combined with §5.1 — every
-WS/HTTP render runs on a `sync_to_async` worker thread — this is why
-`apply_render_env` is pushed *per render* rather than once at startup.
+So the worker did not inherit the configuration. Combined with §5.1 — the
+ASGI/WebSocket spine renders on a `sync_to_async` worker thread — this is why
+`apply_render_env` is pushed *per render* rather than once at startup, and why
+that push is what keeps the configured value honoured on the real path (§5.4).
 
-### 6.6 VERIFIED: the `Value::Object` bulk-dump arm is not reached under the default
+### 6.6 The `Value::Object` bulk-dump arm — reachable under the default, and my first enumeration of how was wrong
 
-`opaque_gate`'s final decline (`lib.rs:4309`) is
+`opaque_gate`'s final decline (`lib.rs:4333`) is
 `!resolve_lazy() && truthy && !iterable && has_public_dict_attrs(ob)`. With the
-flag on, that decline never fires, so `opaque_value` claims the object and the
-bulk-dump arm at `lib.rs:4136` is reached only when `opaque_value` returns
-`None`. A truthy, non-iterable object with public attributes was measured under
-both flag states: it resolves either way, **by different carriers** — an
-`Encoded` with a handle under the default, a `Value::Object` on the escape
-hatch.
+flag on that decline never fires, so `opaque_value` claims the object and the
+bulk-dump arm at `lib.rs:4160` is reached only when `opaque_value` returns
+`None`. A truthy, non-iterable object with public attributes resolves under both
+flag states, **by different carriers** — an `Encoded` with a handle under the
+default, a `Value::Object` on the escape hatch.
+
+An earlier version then enumerated the ways `opaque_value` can return `None` as
+"`bool(o)`, `iter(o)`, `str(o)`, `repr(o)` or `type(o).__name__` fails". That
+list is wrong in both directions, and both halves were measured:
+
+**It omits the item-enumeration failure.** A class that is truthy, an unsized
+iterable, and has a public `__dict__`, whose `__iter__` yields once and then
+raises:
+
+```python
+class Boom:
+    def __init__(self): self.x = 1
+    def __iter__(self):
+        def g():
+            yield 1
+            raise RuntimeError("boom")
+        return g()
+    @property
+    def p(self): return "P"
+```
+
+`bool`, `iter`, `str`, `repr` and `type().__name__` all succeed. `{{ v }}`
+renders `{&#x27;x&#x27;: 1}` — the `Value::Object` bulk dump. Through the
+isolating binding, `q.x` → `1` and `q.p` → `''`: no handle. The arm that
+declined it is `item.is_err()` at `lib.rs:4302`, with `item.ok()?` /
+`extract::<Value>().ok()?` in `opaque_value`.
+
+**And `iter(o)` failing is not a decline at all.** `ob.try_iter().ok()` merely
+sets `iterable = false`. A class that raises `TypeError` on `iter()` resolves a
+live-only `@property` through the isolating binding (`'REACHED'`) — it has a
+handle. §6.4's first row is that same case.
 
 ### 6.7 Not verified by running
 
@@ -663,9 +812,11 @@ Stated plainly rather than smoothed over:
   read, not exercised. No actor-path render was driven end to end.
 - **§3.6's JIT claim** (a list of models is served by the JIT channel) is taken
   from ADR-027 (b)(4); the JIT path itself was not traced for this document.
-- **§3.8's wildcard set.** The seven node types that get `"*"` were read from
-  `parser.rs:2934`; the partial-render skip behaviour is pinned by I7 but this
-  document did not run its own case per node type.
+- **§3.8's wildcard set.** The eight node types that get `"*"` were read from
+  `parser.rs:2944`/`:2950`; the partial-render skip behaviour is pinned by I7,
+  but this document did not run its own case per node type. (The count was
+  wrong three different ways in the first version — "three node classes", a
+  list of eight, and "seven node types" in this very bullet.)
 - **The `Encoded::live` "`None` unless `resolve_lazy`" claim** — see §6.3,
   verified by reading the two construction sites only.
 - **The `Encoded` field table in §3.2** lists doc-comment summaries; the fields
@@ -678,6 +829,40 @@ The task that produced this document cited the datetime comment as
 was `crates/djust_core/src/context.rs:1782-1783`. Recorded because it is the same
 failure mode the document is about — a citation that reads as authoritative and
 was never grepped.
+
+### 6.9 The tenth false absolute — and this document produced it
+
+The nine failures this document was written against were all absolutes taken on
+trust. The first version of §5.4 added a tenth: *"read at exactly two sites"*,
+with `lib.rs:2884`'s own doc comment cited as the source. Both were false, and
+review found it by grepping.
+
+There are **eight** functional reads, in two crates (§5.4). The one that makes
+it a behavioural error rather than a counting error lives in `djust_templates`
+and appears nowhere in the first version of this document:
+
+| template | flag on | flag off |
+|---|---|---|
+| `{% firstof nope\|default_if_none:"X" "Y" %}` | `X` | `Y` |
+| `{% if nope\|default_if_none:"X" %}T{% else %}F{% endif %}` | `T` | `F` |
+
+`renderer.rs:5461` turns a `Missing` tag operand into `None` under the flag, so
+a filtered operand that resolves to nothing takes a different branch. That is
+observable output, changed by a flag the document said had two readers.
+
+**The lesson, stated as a rule because it cost this document its own standard: a
+doc comment is not evidence.** Citing one is the same act as citing an issue
+body or a PR description — it is someone's claim, and the nine failures in the
+opening note are what that is worth on this boundary. §3.4 already contradicted
+§5.4 by documenting `lib.rs:4935` as a third read; nobody noticed, because both
+sentences read as authoritative. The rule that catches this is the one already
+stated at the top and applied everywhere else here: **construct the case that
+would disprove the claim, and run it.** For a flag, that means finding output
+that changes when it flips — not counting call sites in the file you happen to
+be reading, and certainly not repeating the count a neighbouring comment
+asserts.
+
+`lib.rs:2884`'s comment is corrected in the same commit as the other four.
 
 ---
 


### PR DESCRIPTION
## What this is

`docs/architecture/VALUE_BOUNDARY.md` — the missing map of how a Python value
crosses into Rust and becomes rendered output. Linked from `docs/README.md`
under a new Architecture section.

Two commits: the document, then the code-comment corrections it turned up.

## Why

There was no map of this machinery, and it showed. In one session, **nine
separate mechanism claims about this exact boundary turned out to be false** —
in shipped Rust doc comments, in `CLAUDE.md`, in issue bodies, in PR
descriptions. Every one was an absolute ("never", "always", "cannot").
Meanwhile `ENCODED_ATTR_NAMES` and `render_nodes_partial` appeared in **zero**
doc files, `deep_fingerprint` in one, `walk_live` and `Encoded` in two. The
undocumented machinery and the false claims are the same machinery.

## Outline

Layered so a human reads top-down and stops when satisfied, while someone
debugging at 2am can keep going.

1. **The picture** — four mermaid diagrams, one idea each: end-to-end;
   the carrier decision tree (which `Value` variant a Python object becomes,
   in the code's actual arm order); how `{{ a.b.c }}` is answered (the three
   mechanisms, in order); the partial-render dependency path.
2. **The narrative** — ~450 words: what crosses, what stays, and why.
3. **The mechanism** — `file:line` for every claim. The nine stages; `Value`
   and `Encoded` field-by-field; the two name tables; who gets a live handle
   and who cannot; where `OPAQUE_ITEM_CAP` actually governs; what is
   deliberately eager per ADR-027 (b)(1); which side of the boundary change
   detection runs on; the render-partial dependency path; and the *other*
   live-object mechanism (the by-name sidecar) that is routinely conflated
   with the handle.
4. **Invariants** — 13, each with the test that pins it. **Three are marked
   as having no test**, explicitly, rather than implying coverage.
5. **Threading and the GIL.**
6. **What was verified, and how** — including what was not.

## Verification

All **144** `file:line` citations were mechanically re-verified against the
working tree after the source edits shifted line numbers (remapped via a
`difflib` old→new map from `git show HEAD:<path>`, never by offset guessing).

Every absolute was falsification-tested — the case that would disprove it was
constructed and run. **24/24 checks matched expectation**, with a
proven-non-vacuous gate-off.

### The isolation problem — worth reading before you trust any gate-off here

The obvious way to prove a value carries a live handle is to resolve an
attribute only the handle can reach, then flip `set_resolve_lazy(False)` and
watch it blank. **That test is vacuous as usually written.** djust has *two*
live-Python mechanisms: the ADR-027 handle riding in the value, and the
by-name sidecar (#2501), which reaches rebindings through `Context::aliases`
(#2375) and is **not** gated by that flag.

Measured, on `{{ q.resolution }}` with `resolve_lazy` **off**:

| binding | result |
|---|---|
| `{{ d.resolution }}` (top level) | `0:00:00.000001` — sidecar |
| `{% with q=d %}` (unfiltered) | `0:00:00.000001` — sidecar via the alias |
| `{% for q in items %}` (unfiltered) | `0:00:00.000001` — sidecar via the alias |
| `{% with q=items\|first %}` (**filtered**) | `''` |
| `{% for q in items\|slice:":1" %}` (**filtered**) | `''` |

An alias is registered only over an *unfiltered* operand, so only a
filtered-operand rebinding isolates the handle. Every gate-off in §6 uses that
shape and asserts its own non-vacuity (with the flag off the filtered form
blanks *while the unfiltered form still resolves*).

### Falsification-tested and FALSE — fixed in commit 2

1. **"the whole datetime family never carry [a live handle]"**
   (`crates/djust_core/src/context.rs`). `django_json_encoded` sets
   `live: Some(..)` for every `datetime`/`date`/`time`/`timedelta`
   **unconditionally** — no `resolve_lazy()` guard, unlike `opaque_value`'s.
   `min`/`max`/`resolution` are in neither name table, so only a handle can
   answer them; all six probes resolve and all six blank under the gate-off.
   The five non-temporal types in that same sentence *are* right, and were
   re-verified (with a control class that resolves, so the negative results
   are not vacuous).
2. **`{{ p.max }}` "stays empty where Django renders it"** (`Encoded::attrs`).
   True when written; the handle closed the cell. It renders
   `Dec. 31, 9999, 11:59 p.m.`.
3. **"When [`live`] is `Some`, `Encoded::attrs` is EMPTY"** (`Encoded::live`).
   A property of the `opaque_value` carrier, not of the field: a
   `django_json_encoded` carrier has both, and both answer on one value —
   `{{ q.year }}|{{ q.resolution }}` → `2024|0:00:00.000001`, and `2024|`
   under the gate-off.
4. **`live` is "`None` unless `resolve_lazy` was on at the conversion"**.
   False for the same reason as (1).
5. **#2737's "the live mechanism is gated to sequences past
   `OPAQUE_ITEM_CAP`"**. A zero-attribute object with no `__len__` carries a
   handle; so do sub-cap and over-cap objects. The cap governs *item
   enumeration*: `{% for %}` over the over-cap and under-cap objects produced
   byte-identical output. No code change — the issue body is not in the repo;
   the successors filed off #2737 should carry this.
6. **"No `Context` crosses a thread"**. Every WS/HTTP render runs on a
   `sync_to_async` worker thread (`runtime.py:3781`, `:3856`, `:4272`,
   `:4786` — all four verified), and the actor path renders from a
   `tokio::spawn`ed task acquiring the GIL. Additionally: `RESOLVE_LAZY` is a
   **thread-local** defaulting to `true`, so a thread that never called
   `apply_render_env` reads the default, not the configured value — measured
   across a real thread boundary (main `False` → `''`; worker `True` →
   resolves).

Also found while writing: **"there are exactly two construction sites for
`Encoded`" was my own false absolute**, caught by grepping it. Seven more
restore one from the wire (all `live: None`). The doc says so, and the fact is
a better statement of the handle's transience than the claim it replaced.

### Verified by reading only, not by running

Stated in §6.7 rather than smoothed over:

- The actor path's `tokio::spawn` / `Python::attach` sites were read, not
  exercised — no actor-path render was driven end to end.
- Correction (4) above: the field is not exposed to Python and the two cases
  are behaviourally indistinguishable from there, because the sink is
  separately gated. The comment now says so.
- ADR-027 (b)(4)'s JIT claim is taken from the ADR; the JIT path was not
  traced.
- The wildcard node-type set was read from `parser.rs`, not exercised per type.

### One false path in the brief itself

The task cited the datetime comment as
`crates/djust_templates/src/context.rs:1782-1783`. There is no such file — it
was `crates/djust_core/src/context.rs`. Recorded in §6.8 because it is the same
failure mode the document is about.

## Concurrency with #2742

- **`CLAUDE.md`'s #1206 mechanism sentence** (`Model.__eq__`, stale since
  #2664 → `deep_fingerprint`, where a `Model` is an `id()` leaf) is **left to
  #2742**, which was already correcting those same five lines. Two concurrent
  edits there is the #1172 collision shape. This document reached the same
  conclusion independently and documents the current mechanism in §3.7.
- **#2742 also fixes tag-operand dependency extraction** (#2738). §3.8 notes
  it; the structure documented there (parse-time extraction, the wildcard set,
  the intersection rule) is unchanged by that fix.

Verified `git rev-list --count HEAD..origin/main` = 0 before pushing.

## Checks

- `scripts/check-doc-snippets.py` — OK
- `scripts/check-doc-api-references.py` — OK
- `cargo fmt --check` — clean; `cargo clippy` — clean (pre-commit)
- `cargo test -p djust_core` — pass
- Full Python suite (`tests/ python/tests/ python/djust/tests/ -n auto`) —
  **27134 passed, 493 skipped, 0 failed**

Docs and comments only; no behaviour change, so no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116FTX9dXEq8E5cFN7wh1u8
