### PR TITLE
fix(tests): a live-handler spy no longer leaves a bound method shadowing render() (#2749)

### DIFF
--- a/changelog.d/2749.fixed.md
+++ b/changelog.d/2749.fixed.md
@@ -1,0 +1,1 @@
+- `reset_djust_globals()` now strips an instance-level `render` shadow from every built-in tag handler, and the two `regroup` spies that planted one (a bound method "restored" as an instance attribute) restore with `del` — five `test_tag_bridge_object_parity_2731` cases were red on serial `main` because a later class-level patch was never reached (#2749).

--- a/python/djust/test_isolation.py
+++ b/python/djust/test_isolation.py
@@ -299,6 +299,20 @@ def _reset_builtin_template_tags() -> None:
         reregister_builtins()
     except Exception:  # noqa: BLE001
         pass
+    # A test that spied on the LIVE handler instance — `h.render = spy` then
+    # `h.render = original` — "restored" a bound method as an INSTANCE attribute,
+    # which shadows the class-level `render` for the rest of the process and
+    # makes every later class-level patch invisible (#2749: five
+    # `test_tag_bridge_object_parity_2731` cases red on serial `main`). Strip
+    # the shadow so class lookup applies again; genuine instance state such as
+    # the `_bridge` marker is untouched.
+    try:
+        from djust.template_tags import _registered_handlers
+    except Exception:  # noqa: BLE001
+        return
+    for handler in _registered_handlers.values():
+        if "render" in vars(handler):
+            del handler.render
 
 
 def _reset_template_libraries() -> None:

--- a/python/tests/test_regroup_non_iterable_2463.py
+++ b/python/tests/test_regroup_non_iterable_2463.py
@@ -308,7 +308,10 @@ class TestABoolSourceReachesTheHandlerAsAValue:
                     _rust.render_template_with_dirs(REGROUP, {"p": value}, [], None)
             assert seen == [("p", True), ("p", False)]
         finally:
-            handler.render = original
+            # `original` is a BOUND method; assigning it back would leave an
+            # instance attribute that shadows the class-level `render` on the
+            # live handler for the rest of the process (#2749).
+            del handler.render
 
     def test_the_encoder_has_a_Bool_arm(self) -> None:
         source = production(RENDERER)

--- a/python/tests/test_regroup_string_source_2385_2394.py
+++ b/python/tests/test_regroup_string_source_2385_2394.py
@@ -312,7 +312,10 @@ class TestRawRegroupBridge:
                 "{% regroup nope by k as g %}[{{ g|length }}]", {"s": "ab"}, [], None
             )
         finally:
-            handler.render = original
+            # `original` is a BOUND method; assigning it back would leave an
+            # instance attribute that shadows the class-level `render` on the
+            # live handler for the rest of the process (#2749).
+            del handler.render
         assert seen == [("s", "ab"), ("nope", "ab")]
 
     @pytest.mark.parametrize(

--- a/tests/test_reset_fixture_hygiene_2234.py
+++ b/tests/test_reset_fixture_hygiene_2234.py
@@ -313,3 +313,25 @@ def test_every_scanned_test_root_actually_has_the_autouse_reset():
         "these roots are scanned by the guards above but have no autouse "
         f"reset_djust_globals fixture, so nothing protects them: {missing}"
     )
+
+
+def test_reset_djust_globals_strips_an_instance_level_render_shadow_2749():
+    """A spy that "restored" a bound method as an instance attribute.
+
+    ``h.render = h.render`` looks like a no-op and is not: it plants an
+    instance attribute that shadows the class-level ``render`` for the rest
+    of the process, so a later ``RegroupTagHandler.render = spy`` is never
+    called (#2749 — five ``test_tag_bridge_object_parity_2731`` cases, red on
+    serial ``main``). The reset must strip it and must leave genuine instance
+    state alone.
+    """
+    from djust.template_tags import _registered_handlers
+    from djust.test_isolation import reset_djust_globals
+
+    handler = _registered_handlers["regroup"]
+    before = set(vars(handler))
+    handler.render = handler.render  # the #2749 shape
+    assert "render" in vars(handler)
+    reset_djust_globals()
+    assert "render" not in vars(handler)
+    assert set(vars(handler)) == before, "only the shadow may be stripped"


### PR DESCRIPTION
Closes #2749. Also the cause of the `test_tag_bridge_object_parity_2731.py` reds on #2744 (shard 2) and during #2752's runs — and the mechanism #2747 hypothesised as "the tag registry" (it is not the registry).

## The polluter, found empirically

An after-every-test probe (renders `{% regroup %}` through a class-level spy, the exact shape the five victims use) over the **serial** three-root suite — the ordering `main-health.yml` runs — reports the first test after which the shape breaks:

```
python/tests/test_regroup_non_iterable_2463.py::TestABoolSourceReachesTheHandlerAsAValue::test_the_handler_receives_the_original_bool
```

and stays broken for the remaining 10,509 tests. The pair alone reproduces (`1 failed, 1 passed`); the same five tests fail as on `main`.

## Mechanism

```python
handler = _LIVE_HANDLERS["regroup"]
original = handler.render          # a BOUND method
handler.render = spy
try: ...
finally:
    handler.render = original      # plants an INSTANCE attribute
```

Assigning the bound method back "restores" it as an instance attribute on the live registered instance. Instance attributes win over class attributes, so every later `RegroupTagHandler.render = spy` — all five `test_tag_bridge_object_parity_2731` victims — is never called → `KeyError: 'tags'`. Rendering still succeeds, which is why only the spying tests go red. Registries, class identity and `sys.modules` are all intact throughout (the probe logged them), which is why the #2427 reload theory did not reproduce: `importlib.reload` + cache + spy in one process still works.

Two tests had the pattern: `test_regroup_non_iterable_2463.py:311` and `test_regroup_string_source_2385_2394.py:315`.

## Fix (two mechanisms, each independently reachable)

1. Both spies restore with `del handler.render`.
2. `reset_djust_globals()` strips an instance-level `render` shadow from every built-in handler before each test — the structural cure (#1646): no ordering can matter, and the next spy written this way is harmless. Genuine instance state (`_bridge`) is untouched, pinned.

Gate-off, run per mechanism:

| state | pair (polluter → victim) | hygiene test |
|---|---|---|
| both on | green | green |
| test fix off, reset on | green | — |
| reset off, test fix on | green | **red** |
| both off | **red** | — |

## Verification

- Full serial three-root suite (the red ordering) with the fix: see comment below.
- Pre-push hook (full `-n auto` suite + cargo): passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116FTX9dXEq8E5cFN7wh1u8
