### PR TITLE
fix(tests): four i18n-bridge tests read the tag registries at their own backend's namespace (#2747)

### DIFF
--- a/changelog.d/2747.fixed.md
+++ b/changelog.d/2747.fixed.md
@@ -1,0 +1,12 @@
+- **Four i18n-bridge tests went red whenever xdist reshuffled the corpus — the
+  second failing set in #2747, not the Rust tag registry (#2747).** A
+  `DjustTemplateBackend` registers the tags its `{% load %}` bridges into its
+  own registry namespace (#2709) and restores namespace 0 when the render
+  returns; the four tests rendered through the module's backend and then read
+  `_rust.has_*_tag_handler` / `owned_tags()` at namespace 0, which holds
+  `blocktranslate` only after a LiveView-entry sibling has rendered on the same
+  worker. They now read inside `rendering_with_backend(DJUST)` and pass alone.
+  Pinned by the parametrised
+  `test_i18n_registry_reader_passes_alone_in_a_fresh_process_2747` in
+  `tests/test_reset_fixture_hygiene_2234.py`, which runs each in a process of
+  its own. The first set was #2749 (PR #2753).

--- a/python/tests/test_i18n_tags_bridge_2558.py
+++ b/python/tests/test_i18n_tags_bridge_2558.py
@@ -144,6 +144,31 @@ def plain_render(source: str, context: dict) -> str:
     return str(DJUST.from_string(source).render(dict(context)))
 
 
+def in_djust_scope():
+    """The registry namespace a `plain_render` registered its `{% load %}` into.
+
+    A `DjustTemplateBackend` owns a registry namespace (#2709): the tags its
+    `{% load i18n %}` bridges live THERE, and `rendering_with_backend` restores
+    namespace 0 when the render returns. So a test that renders through
+    `DJUST` and then reads `_rust.has_*_tag_handler` / `owned_tags()` at the
+    top level is reading namespace 0 — which holds `blocktranslate` only after
+    a LiveView-entry render (no backend in scope) has run on the SAME worker.
+    Four tests here did exactly that and were green only because a
+    `test_liveview_entry_matches_django[...]` sibling happened to precede them;
+    xdist `--dist load` splits a module across workers, so any corpus reshuffle
+    could strand them (#2747's second failing set, red when run alone). Read
+    the registries inside this scope and the test is self-contained.
+    """
+    return template_libraries.rendering_with_backend(DJUST)
+
+
+def owned_handler(name: str):
+    """The handler `DJUST`'s `{% load %}` registered for `name`."""
+    with in_djust_scope():
+        owned = template_libraries._engine_state("_owned_tags", template_libraries._owned_tags)
+        return owned[name][1]
+
+
 def liveview_render(source: str, context: dict) -> str:
     """The REAL LiveView entry: ``LiveViewTestClient.mount()`` + ``.render()``
     → ``_sync_state_to_rust`` → ``RustLiveView.render`` (#1650)."""
@@ -512,7 +537,7 @@ def test_string_if_invalid_reaches_a_blocktranslate_placeholder():
         debug = False
 
     plain_render(L + "{% blocktranslate %}x{% endblocktranslate %}", CTX)
-    handler = template_libraries._owned_tags["blocktranslate"][1]
+    handler = owned_handler("blocktranslate")
     with translation.override(None):
         with template_libraries.rendering_with_backend(_Backend()):
             assert handler.render([], "{{ missing }}", dict(CTX))[0] == "INVALID"
@@ -1011,22 +1036,19 @@ def test_no_library_filter_is_refused_any_more():
 
 def test_blocktranslate_is_registered_through_the_raw_body_kind_only():
     plain_render(L + "{% blocktranslate %}x{% endblocktranslate %}", CTX)
-    for name in ("blocktranslate", "blocktrans"):
-        assert _rust.has_raw_block_tag_handler(name)
-        assert not _rust.has_tag_handler(name)
-        assert not _rust.has_block_tag_handler(name)
-        assert not _rust.has_assign_tag_handler(name)
-    owned = template_libraries.owned_tags()
+    with in_djust_scope():
+        for name in ("blocktranslate", "blocktrans"):
+            assert _rust.has_raw_block_tag_handler(name)
+            assert not _rust.has_tag_handler(name)
+            assert not _rust.has_block_tag_handler(name)
+            assert not _rust.has_assign_tag_handler(name)
+        owned = template_libraries.owned_tags()
     assert owned["blocktranslate"] == owned["blocktrans"] == "i18n"
 
 
 def test_the_two_legacy_spellings_get_distinct_handlers_with_their_own_end_tag():
     plain_render(L + "{% blocktrans %}x{% endblocktrans %}", CTX)
-    handlers = {
-        name: handler
-        for name, (label, handler) in template_libraries._owned_tags.items()
-        if name in ("blocktranslate", "blocktrans")
-    }
+    handlers = {name: owned_handler(name) for name in ("blocktranslate", "blocktrans")}
     assert isinstance(handlers["blocktranslate"], template_libraries.LibraryRawBlockTagHandler)
     assert handlers["blocktranslate"] is not handlers["blocktrans"]
     assert handlers["blocktranslate"].end_name == "endblocktranslate"
@@ -1121,7 +1143,7 @@ def test_underscore_literal_is_consulted_at_every_filter_argument_site():
 
 def test_raw_block_handler_declares_bindings_and_marks_output_safe():
     plain_render(L + "{% blocktranslate %}x{% endblocktranslate %}", CTX)
-    handler = template_libraries._owned_tags["blocktranslate"][1]
+    handler = owned_handler("blocktranslate")
     assert handler.RETURNS_BINDINGS is True
     with translation.override(None):
         output, bindings = handler.render([], "<b>{{ hostile }}</b>", dict(CTX))

--- a/tests/test_reset_fixture_hygiene_2234.py
+++ b/tests/test_reset_fixture_hygiene_2234.py
@@ -335,3 +335,44 @@ def test_reset_djust_globals_strips_an_instance_level_render_shadow_2749():
     reset_djust_globals()
     assert "render" not in vars(handler)
     assert set(vars(handler)) == before, "only the shadow may be stripped"
+
+
+#: The i18n-bridge tests that read the tag registries after a render through
+#: the module's own `DjustTemplateBackend` (#2747). Each must pass ALONE.
+I18N_REGISTRY_READERS_2747 = (
+    "test_string_if_invalid_reaches_a_blocktranslate_placeholder",
+    "test_blocktranslate_is_registered_through_the_raw_body_kind_only",
+    "test_the_two_legacy_spellings_get_distinct_handlers_with_their_own_end_tag",
+    "test_raw_block_handler_declares_bindings_and_marks_output_safe",
+)
+
+
+@pytest.mark.parametrize("name", I18N_REGISTRY_READERS_2747)
+def test_i18n_registry_reader_passes_alone_in_a_fresh_process_2747(name):
+    """A registry assertion made at the wrong namespace passes only after a
+    sibling (#2747).
+
+    A `DjustTemplateBackend` registers the tags its `{% load %}` bridges into
+    its OWN registry namespace (#2709) and restores namespace 0 when the render
+    returns. Four `test_i18n_tags_bridge_2558` tests rendered through the
+    module's backend and then asserted `_rust.has_*_tag_handler` /
+    `owned_tags()` at the top level — namespace 0 — which holds
+    `blocktranslate` only after a LiveView-entry sibling has rendered on the
+    same worker. Green in file order, red the moment xdist `--dist load`
+    stranded them on another worker (#2747's second failing set, blamed on the
+    Rust registry). The pin is the literal property: each passes in a process
+    of its own, with no sibling before it.
+    """
+    import subprocess
+    import sys
+
+    nodeid = f"python/tests/test_i18n_tags_bridge_2558.py::{name}"
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", nodeid, "-q", "-p", "no:cacheprovider"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, f"{nodeid} is not self-contained:\n{proc.stdout[-3000:]}"
+    assert "1 passed" in proc.stdout, proc.stdout[-500:]


### PR DESCRIPTION
Closes #2747. The second failing set in that issue — the two `test_i18n_tags_bridge_2558.py` cases — explained and fixed. The first set was #2749 (PR #2753). Neither was the Rust tag registry.

## Step 1 — #2747's own reproduction on current `main` (343a1020, includes #2753)

Full three-root suite, `pytest tests/ python/tests/ python/djust/tests/ -n auto`, release build:

| corpus | result |
|---|---|
| nothing added | **27,152 passed**, 493 skipped, 0 failed |
| + 11 `assert True` no-ops under `python/tests/` | **27,163 passed**, 493 skipped, 0 failed |

Both green — but that only shows *these two* shuffles do not strand the i18n cases; it does not explain the reds #2747 saw. So the mechanism was traced rather than declared fixed.

## Step 2 — the mechanism, found empirically

Run **alone**, all four of these fail on `main`:

```
python/tests/test_i18n_tags_bridge_2558.py::test_string_if_invalid_reaches_a_blocktranslate_placeholder
python/tests/test_i18n_tags_bridge_2558.py::test_blocktranslate_is_registered_through_the_raw_body_kind_only
python/tests/test_i18n_tags_bridge_2558.py::test_the_two_legacy_spellings_get_distinct_handlers_with_their_own_end_tag
python/tests/test_i18n_tags_bridge_2558.py::test_raw_block_handler_declares_bindings_and_marks_output_safe
```

So they are not victims of a polluter: they **depend on a sibling**. An after-every-test probe over the module (checking the exact predicate the victims assert — `has_raw_block_tag_handler`/`has_tag_handler`/`has_block_tag_handler`/`has_assign_tag_handler` for both spellings, the `owned_tags()` labels, the handler class, distinctness and `end_name`s — at teardown and again before the next body, per worker) logs the predicate flipping from unseen to healthy after:

```
test_liveview_entry_matches_django[bt-adjacent-placeholders-de]
```

Why: a `DjustTemplateBackend` registers the tags its `{% load %}` bridges into its **own** registry namespace (#2709 — `registry_scope.rs`, `rendering_with_backend`) and restores namespace 0 when the render returns. The four tests render through the module's `DJUST` backend and then assert at the top level, i.e. at namespace 0 — which holds `blocktranslate` only after a LiveView-entry render (no backend in scope) has run on the **same worker**. Green in file order; red the moment xdist `--dist load` splits the module and strands them without that sibling, which is what any corpus reshuffle can do. Confirmed with a deliberate render through a fresh backend: after it returns, `current_registry_namespace() == 0` and `owned_tags() == {}`.

The other files that read `owned_tags()` (`test_load_imports_django_libraries_2547.py`, `test_cache_tag_django_parity_2658.py`) already do it inside `rendering_with_backend(...)`; the dependency is confined to these four.

## Fix

- The four tests read inside `rendering_with_backend(DJUST)` via `in_djust_scope()` / `owned_handler()` (documented in the file). Each now passes alone.
- Hygiene pin beside the #2749 one: `test_i18n_registry_reader_passes_alone_in_a_fresh_process_2747` in `tests/test_reset_fixture_hygiene_2234.py`, parametrised over the four, runs each in a fresh `pytest` subprocess and asserts `1 passed`.

No reset in `test_isolation.py`: there is nothing to reset — no state leaks *out* of these tests; they were reading the wrong namespace *in*. A scoped reset cannot supply a prerequisite.

## Gate-off

| state | four tests alone | hygiene pin |
|---|---|---|
| fix on | 4 passed | 4 passed |
| fix reverted (checkout of the test file) | 4 failed | **4 failed** |

## Verification — three clean full runs, each on a different corpus so the shuffle differs

| corpus | result |
|---|---|
| plain | 27,156 passed, 0 failed |
| + 11 no-ops | 27,167 passed, 0 failed |
| + 5 no-ops | 27,161 passed, 0 failed |

(No-op files deleted after each run; never committed.) Pre-push hook (full suite) passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116FTX9dXEq8E5cFN7wh1u8
