### PR TITLE
fix(tests): retire a tautological cross-backend registry-sharing test (#2785)

### DIFF
--- a/changelog.d/2785.fixed.md
+++ b/changelog.d/2785.fixed.md
@@ -1,0 +1,1 @@
+- A tautological test (`test_both_paths_share_one_registry`, #2547) pinned a cross-backend registry-sharing claim PR #2716 deliberately removed, and only passed because an earlier test in the same file primed it; replaced with the narrower, still-true, self-contained claim (#2785).

--- a/python/tests/test_load_imports_django_libraries_2547.py
+++ b/python/tests/test_load_imports_django_libraries_2547.py
@@ -501,12 +501,34 @@ def test_options_builtins_need_no_load():
     assert ours == theirs == "builtin_only - Expected result"
 
 
-@pytest.mark.django_db
-def test_both_paths_share_one_registry():
-    """Load on the plain path, render (a different source, no `{% load %}`)
-    on the LiveView path: the registration is process-global (#1051)."""
+def test_a_backends_registration_persists_without_reloading():
+    """Load once, render a DIFFERENT source with no `{% load %}` on the SAME
+    backend: the registration survives the render that created it.
+
+    Was `test_both_paths_share_one_registry` (#1051), asserting the
+    registration is process-global — visible on the LiveView path's OWN
+    `DjustTemplateBackend`, a DIFFERENT instance from `DJUST` (the plain
+    path's, constructed by this file), after loading only on the plain
+    path. PR #2716 ("isolate engine bindings and compile caches")
+    deliberately scoped tag/filter registries to the OWNING backend so two
+    backends mapping the same name to different implementations cannot
+    interfere with each other — `test_backend_registry_isolation_2709.py`'s
+    `test_unloaded_engine_does_not_gain_tags` pins exactly that, correctly.
+    The old assertion here should have gone red the day #2716 landed; it
+    didn't, because `test_liveview_entry_matches_django[shape]`, several
+    parametrized cases earlier in THIS SAME FILE, already renders
+    `{% load lib2547_tags %}{% one_param2547 ... %}` through the LiveView
+    path, priming that backend's own namespace as a side effect — so the
+    old test passed for a reason unrelated to what it claimed to test (a
+    file-order-coupled tautology, #1200/#1468; #2785).
+
+    This is the part of the original #1051 claim that is still true and
+    still worth pinning: within ONE backend, djust's registry does not
+    forget a mapping between renders the way Django's own `{% load %}`
+    (a per-template directive) might suggest it should.
+    """
     assert plain_render(L + "shared-2547-a", {}) == "shared-2547-a"
-    assert liveview_render("{% one_param2547 7 %}shared-2547-b", {}) == (
+    assert plain_render("{% one_param2547 7 %}shared-2547-b", {}) == (
         "one_param - Expected result: 7shared-2547-b"
     )
 


### PR DESCRIPTION
Closes #2785.

Found while pushing an unrelated PR: the pre-push hook's merge-base check flagged `main` itself as red on `test_load_imports_django_libraries_2547.py::test_both_paths_share_one_registry` — reproducible in isolation on unmodified `main`, and NOT a flake (deterministic either way).

## Why it was green in every full-suite run

The test asserted a cross-backend registry-sharing claim (#1051): loading a library on the **plain** path's `DjustTemplateBackend` (`DJUST`) makes its tags visible on a **different** `DjustTemplateBackend` instance — the one the LiveView path uses, configured by `settings.TEMPLATES`.

PR #2716 ("isolate engine bindings and compile caches") deliberately scoped tag/filter registries to the *owning* backend, specifically so two backends mapping the same name to different implementations cannot interfere with each other — the opposite claim, and it's already correctly pinned by `test_backend_registry_isolation_2709.py::test_unloaded_engine_does_not_gain_tags`.

`test_both_paths_share_one_registry` should have gone red the day #2716 landed. It didn't, because several parametrized cases of `test_liveview_entry_matches_django`, earlier in the **same file**, already render `{% load lib2547_tags %}{% one_param2547 ... %}` through the LiveView path — priming that backend's own namespace as a side effect. The test then passed for a reason unrelated to what it claimed to test: a file-order-coupled tautology (#1200/#1468).

## Fix

Replaced with the part of the original #1051 claim that is still true and doesn't depend on cross-backend sharing: within **one** backend, a registration persists across renders that don't repeat `{% load %}`. Self-contained — verified in isolation, as part of the whole file, and with `-k` selecting only the new test (no earlier sibling to prime anything).

**Gate-off:** every render allocated a fresh registry namespace instead of reusing the backend's own (removing the persistence mechanism) → the new test goes red.

**Verification (3 clean runs, since this is the test-order-pollution class, #182/#1174):** the file alone, twice more via the pre-push hook's full-suite runs (this branch's initial push and this one), all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116FTX9dXEq8E5cFN7wh1u8
