### PR TITLE
test: eliminate duplicate native builds and batch exhaustive Unicode checks

### DIFF
--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -50,20 +50,20 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install uv
-          # Mirrors .github/workflows/test.yml:138-139 exactly, rather than
+          # Mirrors the test.yml Python job installation, rather than
           # inventing a second install recipe. The hand-rolled version failed
           # on its first scheduled run: `uv venv` does not create a `pip`, so
           # `.venv/bin/pip install maturin` had no interpreter to run — and
           # maturin is already a dev dependency, so the line was redundant as
           # well as broken. See #2155.
-          uv sync --extra dev
+          uv sync --frozen --extra dev --no-install-project
           # Deliberately NOT `|| true`. A failed Rust build yields hundreds of
           # import errors, which would otherwise be reported as "main is RED"
           # and send people hunting for a test regression that does not exist.
           # Failing here makes it a job failure, which the report job renders
           # as "could not run" — which is exactly what happened, correctly, on
           # the run that surfaced this bug.
-          uv run maturin develop --release
+          uv run --no-sync maturin develop --release
 
       - name: Run the suite
         id: run
@@ -91,7 +91,7 @@ jobs:
           # of `main`, not of whatever branch someone is pushing, so a daily
           # scheduled run reports it to the person who can act on it instead of
           # blocking an unrelated push.
-          uv run python -m pytest tests/ python/tests/ python/djust/tests/ -q \
+          uv run --no-sync python -m pytest tests/ python/tests/ python/djust/tests/ -q \
             > /tmp/suite.txt 2>&1
           STATUS=$?
           set -e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,8 +221,10 @@ jobs:
 
       - name: Install Python dependencies and build extension
         run: |
-          uv sync --extra dev
-          uv run maturin develop --release
+          # Install dependencies without building the project through uv's
+          # PEP 517 backend, then build the native extension exactly once.
+          uv sync --frozen --extra dev --no-install-project
+          uv run --no-sync maturin develop --release
 
       # pytest-split is also in the [dev] extra; installing it here as well
       # mirrors the existing pytest-xdist belt-and-braces so a stale uv.lock

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -349,7 +349,7 @@ jobs:
 
       - name: Run Python linter
         if: matrix.group == 1
-        run: uv run ruff check python/
+        run: uv run --no-sync ruff check python/
 
       # mypy type-check — incremental enforcement gate (ADR-023).
       # The pyproject [tool.mypy] config is lenient globally (legacy baseline
@@ -813,14 +813,14 @@ jobs:
 
       - name: Install
         run: |
-          uv sync --extra dev
-          uv run maturin develop --release
+          uv sync --frozen --extra dev --no-install-project
+          uv run --no-sync maturin develop --release
 
       - name: Run benchmarks serially with thresholds enforced
         run: |
           # No -n auto: xdist disables stats collection, which is exactly how
           # these thresholds came to be unenforced everywhere.
-          uv run python -m pytest tests/benchmarks/ --benchmark-only -q
+          uv run --no-sync python -m pytest tests/benchmarks/ --benchmark-only -q
 
   # Django's own template_tests against DjustTemplateBackend — the v1.2.0
   # conformance scoreboard (#2517). Clones django/django at the installed
@@ -860,12 +860,12 @@ jobs:
 
       - name: Install
         run: |
-          uv sync --extra dev
-          uv run maturin develop --release
+          uv sync --frozen --extra dev --no-install-project
+          uv run --no-sync maturin develop --release
 
       - name: Run Django's template_tests through djust
         run: |
-          uv run python scripts/run-django-template-suite.py \
+          uv run --no-sync python scripts/run-django-template-suite.py \
             --parsed-output .django-src/last-run.txt \
             --json .django-src/last-run.json
           {
@@ -877,13 +877,13 @@ jobs:
 
       - name: Compare against the stored baseline (blocking ratchet)
         run: |
-          uv run python scripts/run-django-template-suite.py compare \
+          uv run --no-sync python scripts/run-django-template-suite.py compare \
             --json .django-src/last-run.json \
             --baseline scripts/django-template-suite-baseline.json
 
       - name: Runner self-tests against the real checkout
         run: |
-          uv run python -m pytest python/tests/test_django_template_suite_2517.py -q
+          uv run --no-sync python -m pytest python/tests/test_django_template_suite_2517.py -q
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         pass_filenames: false
         args: [--all, --check]
 
-      # Rust linting (clippy)
+      # Compile-heavy lint runs once before push; commits keep cargo fmt.
       - id: cargo-clippy
         name: cargo clippy
         entry: cargo clippy
@@ -35,6 +35,7 @@ repos:
         types: [rust]
         pass_filenames: false
         args: [--all-targets, --all-features, --, -D, warnings]
+        stages: [pre-push]
 
   # General file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -103,12 +104,14 @@ repos:
         types: [javascript]
         pass_filenames: false
 
+      # Full JS suite runs before push and in CI, not on every local commit.
       - id: npm-test
         name: npm test
         entry: npm test
         language: system
         types: [javascript]
         pass_filenames: false
+        stages: [pre-push]
 
       - id: eslint
         name: eslint

--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ gen-vdom-fixtures: ## Regenerate client-faithful VDOM diff fixtures (CI gates fr
 test: ## Run all tests (Python + JavaScript + Rust) in parallel
 	@echo "$(GREEN)Running all tests in parallel...$(NC)"
 	@PY_EXIT=0; RS_EXIT=0; JS_EXIT=0; \
-	PYTHONPATH=. $(PYTHON) -m pytest tests/ python/tests/ -n auto -q > /tmp/djust-test-py.log 2>&1 & PY_PID=$$!; \
+	PYTHONPATH=. $(PYTHON) -m pytest tests/ python/tests/ python/djust/tests/ -n auto -q > /tmp/djust-test-py.log 2>&1 & PY_PID=$$!; \
 	PYO3_PYTHON=$(EMBEDDABLE_PYTHON) sh -c "cargo test --workspace --exclude djust_live -q && cargo test -p djust_live --no-default-features -q" > /tmp/djust-test-rs.log 2>&1 & RS_PID=$$!; \
 	npm test > /tmp/djust-test-js.log 2>&1 & JS_PID=$$!; \
 	wait $$PY_PID || PY_EXIT=$$?; \

--- a/changelog.d/test-performance.fixed.md
+++ b/changelog.d/test-performance.fixed.md
@@ -1,0 +1,1 @@
+- **Reduce test overhead:** Build the native extension once per Python CI job, batch every exhaustive Unicode title-filter comparison, and include every Python test root in `make test`.

--- a/changelog.d/test-performance.fixed.md
+++ b/changelog.d/test-performance.fixed.md
@@ -1,1 +1,1 @@
-- **Reduce test overhead:** Build the native extension once per Python CI job, batch every exhaustive Unicode title-filter comparison, and include every Python test root in `make test`.
+- **Reduce test overhead:** Build the native extension once per Python CI job, batch every exhaustive Unicode title-filter comparison, and include every Python test root in `make test`. Full JavaScript tests and Clippy run at push time instead of repeating on both commit and push.

--- a/docs/development/CI_OPTIMIZATION.md
+++ b/docs/development/CI_OPTIMIZATION.md
@@ -79,6 +79,32 @@ runner results should be recorded separately.
 paths override configured discovery, so omitting a root is lost coverage, not an
 optimization. A dry-run test checks the command that make actually expands.
 
+## Local hooks and CI responsibilities
+
+Tests are separated by language and execution stage, but the Python CI gate still
+runs the complete collection rather than excluding slow tests.
+
+| Stage | Responsibility |
+| --- | --- |
+| Commit | Formatting, linting, secret detection, generated assets, and quick consistency checks on relevant files. |
+| Push | Affected Python tests, Rust crate tests, full JavaScript tests for JS changes, compile-heavy Clippy, and applicable audits. Shared-engine/harness changes fall back to the full local suite. |
+| PR CI | Full Python 3.12 shards, Rust/JS suites, integration/security gates, serial benchmarks, Django compatibility scoreboard, and free-threaded smoke checks. |
+| Main / scheduled CI | Additional Python versions on main and the daily serial Python run that exposes execution-order dependencies. |
+
+Full JavaScript tests and Clippy now explicitly use the `pre-push` stage, matching
+the existing Python and Rust test hooks. They previously inherited all stages and
+therefore ran on both commit and push. Their commands, arguments, and file filters
+are unchanged. A real pre-commit dispatch probe confirmed that they do not execute
+at commit, still execute at push, and still reject a push when a check fails.
+
+Cheap checks can run again on push because the pushed range may contain multiple
+commits. Expensive suites should not repeat at both local stages. CI remains
+necessary because it checks the complete branch in a clean runner environment.
+Local hooks do not replace it, and green targeted tests do not prove the full
+suite passes. Clippy currently has stricter local flags than the CI invocation;
+keep its push gate until any proposed CI-only policy establishes equivalent
+coverage.
+
 ## Alternatives worth investigating next
 
 | Alternative | Expected benefit | Tradeoff / verification needed |

--- a/docs/development/CI_OPTIMIZATION.md
+++ b/docs/development/CI_OPTIMIZATION.md
@@ -1,318 +1,113 @@
-# CI Optimization Guide
+# Test performance
 
-This document explains the CI test parallelization strategy and performance improvements.
+Optimize repeated work before reducing coverage. CI remains the full gate; local
+pre-push selection is already available through `scripts/select-tests.py`, with
+`DJUST_PREPUSH_FULL=1` to request the full suite.
 
-## Overview
+## Measured baseline
 
-The test suite has been optimized to run tests in parallel, significantly reducing CI execution time.
+[Main run 34554928145](https://github.com/djust-org/djust/actions/runs/34554928145)
+completed successfully on 2026-09-11 UTC at `acf38531`. It took 11m55s from creation
+to completion, including runner scheduling. Its Python jobs spent 165–197 seconds
+installing dependencies/building the extension and 224–367 seconds in pytest.
+These are observations from one run, not a fixed CI duration or a promise about
+future speedups.
 
-## Parallelization Strategy
+The current architecture already runs language-specific jobs concurrently, uses
+four duration-balanced Python shards, runs xdist inside each shard, and caches
+identical differential corpus inputs within a pytest session. PRs use Python 3.12;
+main also exercises 3.13 and 3.14. A separate job exercises free-threaded Python.
 
-### Before: Sequential Execution
-```
-┌─────────────────────────────────────┐
-│ Setup (1 min)                       │
-├─────────────────────────────────────┤
-│ Rust tests (2 min)                  │
-├─────────────────────────────────────┤
-│ Python tests (3 min)                │
-├─────────────────────────────────────┤
-│ JavaScript tests (1 min)            │
-├─────────────────────────────────────┤
-│ Linting (1 min)                     │
-└─────────────────────────────────────┘
-Total: ~8 minutes
-```
+The downloaded Python 3.12 duration artifacts contained 27,453 node IDs and about
+2,975 aggregate test-seconds. The largest file totals were:
 
-### After: Parallel Execution
-```
-┌──────────────┐  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐
-│ Rust tests   │  │ Python tests │  │ JS tests     │  │ Playwright   │
-│ + linting    │  │ + linting    │  │ + linting    │  │ (browser)    │
-│ (2.5 min)    │  │ (2 min)      │  │ (1 min)      │  │ (2 min)      │
-└──────────────┘  └──────────────┘  └──────────────┘  └──────────────┘
-         ↓               ↓               ↓               ↓
-         └───────────────┴───────────────┴───────────────┘
-                              ↓
-                     ┌──────────────────┐
-                     │ Summary (5 sec)  │
-                     └──────────────────┘
-Total: ~2.5 minutes (70% faster!)
-```
+| Area | Recorded aggregate seconds |
+| --- | ---: |
+| Differential reachability manifest | 793 |
+| Exhaustive Unicode title test and related filter tests | 178 |
+| `make doctor` checks | 174 |
+| Refusal-comparison tests | 160 |
+| System checks | 160 |
+| Tag bridge object parity | 144 |
+| CI shard self-tests | 70 |
 
-## Optimizations Implemented
+Aggregate seconds include time waiting on shared fixture results; they are not
+CPU measurements. In particular, a cached corpus sweep is shared across workers
+in **one pytest session**, not across four independent CI shard jobs. Adding up
+its readers' durations can exaggerate the amount of distinct computation.
 
-### 1. Job-Level Parallelization
+## Changes in this iteration
 
-**Four parallel test jobs:**
-- `rust-tests` - Rust tests + clippy + fmt
-- `python-tests` - Python tests + ruff
-- `javascript-tests` - JS tests + linter (if configured)
-- `playwright-tests` - Browser automation tests (@loading, @cache, DraftMode)
+### Build the extension once per Python job
 
-**Benefits:**
-- Tests run simultaneously on separate runners
-- Failures in one job don't block others
-- Clearer separation of concerns
-
-### 2. Python Test Parallelization (pytest-xdist)
-
-**Within Python tests:**
-```bash
-pytest tests/ python/tests/ -n auto
-```
-
-The `-n auto` flag:
-- Detects available CPU cores
-- Distributes tests across workers
-- Runs ~4x faster on 4-core runner
-
-**Test Distribution:**
-```
-Worker 1: tests/unit/test_forms.py
-Worker 2: tests/unit/test_live_view.py
-Worker 3: tests/e2e/test_phase5_decorators.py
-Worker 4: python/tests/test_actor_integration.py
-... (parallel execution)
-```
-
-### 3. Dependency Caching
-
-**Cached artifacts:**
-- Rust dependencies (`~/.cargo/`)
-- Python dependencies (`.venv/`)
-- Node modules (`node_modules/`)
-
-**Cache keys based on:**
-- `Cargo.lock` hash
-- `pyproject.toml` hash
-- `package-lock.json` hash
-
-**Benefits:**
-- Faster setup (30 sec → 10 sec)
-- Reduced network usage
-- More reliable builds
-
-### 4. Optimized Build Steps
-
-**Rust optimizations:**
-- `--release` flag for faster test execution
-- Skip `djust_live` (tested via Python)
-- Parallel compilation (default)
-
-**Python optimizations:**
-- `uv sync` with minimal dependencies
-- Separate dev/prod dependency sets
-- Maturin release builds
-
-## Performance Metrics
-
-### Expected CI Times
-
-| Metric | Before | After | Improvement |
-|--------|--------|-------|-------------|
-| **Total time** | ~8 min | ~2.5 min | **70% faster** |
-| **Python tests** | 3 min | 45 sec | **75% faster** |
-| **Setup time** | 1 min | 10 sec | **83% faster** |
-| **Feedback time** | 8 min | 2.5 min | **69% faster** |
-
-### Test Count
-
-- **172 Python tests** - Distributed across 4+ workers (pytest-xdist)
-- **218 JavaScript tests** - Vitest parallel by default
-- **3 Playwright tests** - Browser automation (Phase 5 features)
-- **Rust tests** - Cargo parallel by default
-
-## Local Development
-
-### Run Tests Locally (Parallel)
+The Python 3.12 shard 1 log showed `uv sync` building the project for about 121
+seconds, followed by a separate 73-second `maturin develop` build. Install only
+dependencies first, then explicitly build the release extension:
 
 ```bash
-# Python tests in parallel
-make test-python-parallel
-
-# All tests (still sequential between suites)
-make test
-
-# Individual test suites
-make test-rust
-make test-js
-make test-python
+uv sync --frozen --extra dev --no-install-project
+uv run --no-sync maturin develop --release
 ```
 
-### Install pytest-xdist
+`--no-sync` matters: an ordinary `uv run` can synchronize the project again before
+executing maturin. The isolated worktree was installed and tested with this exact
+sequence. Avoid interpreting the eliminated 121-second step as a guaranteed
+end-to-end saving: cache state and scheduling still affect the workflow.
 
-```bash
-uv pip install pytest-xdist
-# or
-pip install pytest-xdist
-```
+### Batch the exhaustive Unicode inputs
 
-### Run Specific Test in Parallel
+The title differential still tests every Unicode scalar in four contexts: alone,
+preceded by `a`, followed by `a`, and surrounded by `a`. That is exactly 4,448,256
+comparisons. It now sends bounded batches through both template engines, with the
+same title filter and autoescape behavior. Cell delimiters and exact result
+counts prevent missing outputs from disappearing into concatenated strings.
 
-```bash
-# Run unit tests in parallel
-pytest tests/unit/ -n auto
+A separate test compares batching with individual template renders. Replacing the
+batch's title filter with a lower filter makes that test fail. The original skew
+allowance and global skew bound remain intact.
 
-# Run with specific worker count
-pytest tests/ -n 8
+On the same local Python 3.12 release build, the exhaustive test's call time went
+from 39.74s to 26.46s (33% less time). This is a local before/after measurement;
+runner results should be recorded separately.
 
-# Disable parallelization (for debugging)
-pytest tests/ -n 0
-```
+### Keep local coverage complete
 
-## CI Configuration Files
+`make test` now includes `python/djust/tests/` alongside `tests/` and
+`python/tests/`, matching the CI and dedicated Python targets. Explicit pytest
+paths override configured discovery, so omitting a root is lost coverage, not an
+optimization. A dry-run test checks the command that make actually expands.
 
-### GitHub Actions
+## Alternatives worth investigating next
 
-Two workflow files:
+| Alternative | Expected benefit | Tradeoff / verification needed |
+| --- | --- | --- |
+| Keep expensive corpus readers in the same CI shard | Avoid one full identical sweep per independent shard | Schedule by shared fixture cost, not inflated per-reader waits; prove shard union and disjointness and benchmark the longest shard. |
+| Build one wheel per Python version, then distribute it to shards | Reduce repeated native builds and runner minutes | Adds a prerequisite job and artifact transfers; may improve cost more than wall time. Verify ABI, commit identity, installed package path, and Python source under test. |
+| Collect once for the shard self-tests | Avoid five repeated full collections | Exercise the actual pytest-split plugin and actual collected IDs, preserving staleness, coverage, and balance checks; do not replace it with a handwritten approximation. |
+| Separate one real doctor smoke run from scenario tests | Avoid repeatedly timing out on a cold Cargo smoke build | Scenario tests can control unrelated tools, but retain a real integration run and tests for actual timeout/error behavior. |
+| Partition the Unicode sweep into balanced chunks | Distribute its remaining serial tail | Preserve every scalar/context and the global skew limit; account for extra collection and fixture overhead. |
+| Tune local worker budgets by workload | Reduce CPU/RAM contention when Python, Rust, and JS run together | Compare fixed worker counts with `auto`; more workers can make subprocess-heavy tests slower. |
+| Persistent content-addressed corpus artifacts | Reuse expensive sweeps across runs | Invalidation must cover native build, Python source, interpreter, settings, script input, and environment; session-only caching is currently easier to trust. |
+| Move exhaustive tests to nightly only | Faster PR checks | Loses pre-merge evidence. Do not make this the default while template compatibility is an active release concern. |
 
-1. **`.github/workflows/test.yml`** (Current)
-   - Sequential execution
-   - Simple, reliable
-   - Use for stable releases
+The first follow-up to measure is corpus affinity. A build-once wheel job is the
+next infrastructure experiment. Neither should be claimed faster without a
+current-head CI comparison.
 
-2. **`.github/workflows/test-parallel.yml`** (New)
-   - Parallel execution
-   - Faster feedback
-   - Use for active development
+## Measurement workflow
 
-### Switching to Parallel CI
+1. Download step timings and all four `test-durations-shard-*` artifacts from a
+   successful run. Separate job setup, execution, queue time, and aggregate test
+   duration.
+2. Reproduce the largest avoidable cost in an isolated worktree with its own uv
+   environment and a release native build.
+3. Run the same correctness checks before and after. For a changed harness, keep
+   a control or mutation that proves it still detects the original failure.
+4. Run normal commit/push hooks and inspect the new commit's complete CI rollup.
+5. After a representative successful CI run, refresh runner-specific timings with
+   `make test-durations-from-ci RUN=<run-id>`. Do not replace them with local
+   machine durations to claim runner balance.
 
-**Option 1: Rename files**
-```bash
-mv .github/workflows/test.yml .github/workflows/test-sequential.yml
-mv .github/workflows/test-parallel.yml .github/workflows/test.yml
-```
-
-**Option 2: Keep both (recommended for testing)**
-- Both workflows run on PR
-- Compare performance
-- Verify reliability
-
-## Troubleshooting
-
-### Tests Fail Only in Parallel
-
-**Symptom:** Tests pass with `pytest` but fail with `pytest -n auto`
-
-**Common causes:**
-1. **Shared state** - Tests modifying global state
-2. **Database conflicts** - Multiple workers writing to same DB
-3. **File system** - Tests creating/deleting same files
-
-**Solution:**
-```python
-# Use pytest-django's transactional tests
-@pytest.mark.django_db(transaction=True)
-def test_concurrent_safe():
-    # Each worker gets isolated transaction
-    pass
-```
-
-### Slow Test Detection
-
-**Find slow tests:**
-```bash
-pytest --durations=10 tests/
-```
-
-**Optimize slow tests:**
-- Use fixtures for common setup
-- Mock external services
-- Skip integration tests in unit suites
-
-### Cache Issues
-
-**Clear cache if builds fail:**
-```bash
-# Locally
-rm -rf ~/.cache/uv .venv node_modules target/
-
-# GitHub Actions
-# Go to repo → Actions → Caches → Delete specific cache
-```
-
-## Future Improvements
-
-### Potential Optimizations
-
-1. **Test Sharding** - Split tests across multiple CI jobs
-   ```yaml
-   strategy:
-     matrix:
-       shard: [1, 2, 3, 4]
-   ```
-
-2. **Matrix Testing** - Test multiple Python/Node versions
-   ```yaml
-   strategy:
-     matrix:
-       python: ['3.10', '3.11', '3.12']
-   ```
-
-3. **Test Result Caching** - Skip unchanged tests
-   - Use `pytest --lf` (last failed)
-   - Use `pytest --cache-show`
-
-## Best Practices
-
-### Writing Parallel-Safe Tests
-
-**DO:**
-- ✅ Use fixtures for test data
-- ✅ Use unique identifiers
-- ✅ Clean up resources in teardown
-- ✅ Use transactional tests
-
-**DON'T:**
-- ❌ Modify global state
-- ❌ Hard-code file paths
-- ❌ Assume test execution order
-- ❌ Share mutable objects
-
-### Example: Parallel-Safe Test
-
-```python
-import pytest
-from django.test import RequestFactory
-
-@pytest.mark.django_db(transaction=True)
-def test_parallel_safe():
-    # Each worker gets unique factory
-    factory = RequestFactory()
-
-    # Each worker gets unique user
-    user = User.objects.create(
-        username=f"user_{uuid.uuid4()}"
-    )
-
-    # Test logic...
-
-    # Cleanup (optional with transaction=True)
-    user.delete()
-```
-
-## Monitoring
-
-### CI Performance Dashboard
-
-Track these metrics:
-- Total CI time (target: <3 min)
-- Test pass rate (target: >99%)
-- Cache hit rate (target: >80%)
-- Flaky test count (target: 0)
-
-### Alerts
-
-Set up alerts for:
-- CI time > 5 minutes (regression)
-- Test failures > 5% (instability)
-- Cache misses > 50% (configuration issue)
-
-## Resources
-
-- [pytest-xdist documentation](https://pytest-xdist.readthedocs.io/)
-- [GitHub Actions optimization](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs)
-- [Cargo parallel compilation](https://doc.rust-lang.org/cargo/reference/build-scripts.html)
-- [Vitest performance](https://vitest.dev/guide/improving-performance.html)
+Keep full logs in `context/terminal/` and temporary measurement scripts in
+`scratch/`. Record negative results too: an optimization that merely moves time
+into another job or lets tests disappear is not a faster test suite.

--- a/docs/development/CI_OPTIMIZATION.md
+++ b/docs/development/CI_OPTIMIZATION.md
@@ -50,8 +50,8 @@ uv run --no-sync maturin develop --release
 ```
 
 `--no-sync` matters: an ordinary `uv run` can synchronize the project again before
-executing maturin. The Python matrix, serial benchmark job, and Django scoreboard
-use this install sequence; their later uv commands also use `--no-sync` so they
+executing maturin. The Python matrix, serial benchmark job, Django scoreboard, and scheduled
+main-health job use this install sequence; their later uv commands also use `--no-sync` so they
 cannot undo it. The isolated worktree was installed and tested with this exact
 sequence. Avoid interpreting the eliminated 121-second step as a guaranteed
 end-to-end saving: cache state and scheduling still affect the workflow.

--- a/docs/development/CI_OPTIMIZATION.md
+++ b/docs/development/CI_OPTIMIZATION.md
@@ -38,7 +38,7 @@ its readers' durations can exaggerate the amount of distinct computation.
 
 ## Changes in this iteration
 
-### Build the extension once per Python job
+### Build the extension once per native Python job
 
 The Python 3.12 shard 1 log showed `uv sync` building the project for about 121
 seconds, followed by a separate 73-second `maturin develop` build. Install only
@@ -50,7 +50,9 @@ uv run --no-sync maturin develop --release
 ```
 
 `--no-sync` matters: an ordinary `uv run` can synchronize the project again before
-executing maturin. The isolated worktree was installed and tested with this exact
+executing maturin. The Python matrix, serial benchmark job, and Django scoreboard
+use this install sequence; their later uv commands also use `--no-sync` so they
+cannot undo it. The isolated worktree was installed and tested with this exact
 sequence. Avoid interpreting the eliminated 121-second step as a guaranteed
 end-to-end saving: cache state and scheduling still affect the workflow.
 

--- a/python/tests/test_truncate_slugify_parity_2262.py
+++ b/python/tests/test_truncate_slugify_parity_2262.py
@@ -276,7 +276,12 @@ _SUITES = [
         [1, 2, 5, 8, 20],
         _gen_html,
     ),
-    ("truncatewords_html", "{{ p|%struncatewords_html:%s }}", [1, 2, 3, 5, 10], _gen_html),
+    (
+        "truncatewords_html",
+        "{{ p|%struncatewords_html:%s }}",
+        [1, 2, 3, 5, 10],
+        _gen_html,
+    ),
 ]
 
 #: Chains worth exercising. `escape|`, `striptags|` and `safe|` are absent, and
@@ -381,29 +386,77 @@ class TestTitleExhaustive:
     def _cpython_knows_no_case(char: str) -> bool:
         return char.upper() == char and char.lower() == char and char.title() == char
 
+    # None of the one-codepoint probes (at most three characters) can contain
+    # this delimiter. Split and count both outputs so an omitted/extra result
+    # cannot be hidden by concatenating adjacent cells.
+    _separator = "\x00DJUST_CASE\x00"
+    _batch_template = "{% for p in probes %}{{ p|title }}" + _separator + "{% endfor %}"
+
+    @classmethod
+    def _render_batch(cls, probes: list[str], compiled: DjangoTemplate) -> list[tuple[str, str]]:
+        context = {"probes": probes}
+        django_out = compiled.render(DjangoContext(context))
+        djust_out = _rust.render_template(cls._batch_template, normalize_django_value(context))
+        outputs = []
+        for result in (django_out, djust_out):
+            cells = result.split(cls._separator)
+            assert cells[-1] == "" and len(cells) == len(probes) + 1, (
+                "batched rendering lost cell boundaries",
+                len(probes),
+                len(cells),
+            )
+            outputs.append(cells[:-1])
+        return list(zip(*outputs, strict=True))
+
+    def test_batch_matches_individual_template_renders(self) -> None:
+        probes = [
+            "",
+            "a",
+            "ß",
+            "aßa",
+            "Σ",
+            "aΣ",
+            "²A",
+            "1A",
+            "<",
+            "&",
+            "\x00",
+            "\U0001f600",
+        ]
+        batched = self._render_batch(probes, DjangoTemplate(self._batch_template))
+        individual = [render_both("{{ p|title }}", probe) for probe in probes]
+        assert batched == individual
+
     def test_every_codepoint(self) -> None:
-        template = "{{ p|title }}"
-        compiled = DjangoTemplate(template)
+        compiled = DjangoTemplate(self._batch_template)
         unexpected = []
         skew = 0
         checked = 0
-        for cp in range(0x110000):
-            if 0xD800 <= cp <= 0xDFFF:
+        # Render the same four probes for EVERY Unicode scalar, in bounded
+        # batches. Both engines still execute their template title filter and
+        # autoescape for each probe; only per-render setup is shared.
+        for start in range(0, 0x110000, 1024):
+            cases = []
+            for cp in range(start, min(start + 1024, 0x110000)):
+                if 0xD800 <= cp <= 0xDFFF:
+                    continue
+                char = chr(cp)
+                for probe in (char, "a" + char, char + "a", "a" + char + "a"):
+                    cases.append((cp, probe))
+            if not cases:
                 continue
-            char = chr(cp)
-            for probe in (char, "a" + char, char + "a", "a" + char + "a"):
-                django_out = compiled.render(DjangoContext({"p": probe}))
-                djust_out = _rust.render_template(template, normalize_django_value({"p": probe}))
+            results = self._render_batch([probe for _, probe in cases], compiled)
+            for (cp, probe), (django_out, djust_out) in zip(cases, results, strict=True):
                 checked += 1
                 if django_out == djust_out:
                     continue
-                if self._cpython_knows_no_case(char):
+                if self._cpython_knows_no_case(chr(cp)):
                     skew += 1
                     continue
                 unexpected.append(
                     f"  U+{cp:04X} {probe!r}: django={django_out!r} djust={djust_out!r}"
                 )
-        assert checked > 4_000_000, checked
+        assert checked == 4 * (0x110000 - 0x800), checked
         assert not unexpected, (
             f"{len(unexpected)} codepoints diverge for a reason other than "
             f"Unicode-version skew:\n" + "\n".join(unexpected[:20])

--- a/tests/test_ci_python_test_roots.py
+++ b/tests/test_ci_python_test_roots.py
@@ -22,6 +22,7 @@ bug.
 from __future__ import annotations
 
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -88,3 +89,17 @@ def test_the_gating_invocation_runs_in_parallel() -> None:
     assert re.search(r"-n\s+(auto|\d+)", cmd), (
         f"the gating pytest invocation lost its `-n auto`: {cmd}"
     )
+
+
+def test_make_test_runs_every_python_root() -> None:
+    result = subprocess.run(
+        ["make", "--dry-run", "test"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    commands = [line for line in result.stdout.splitlines() if "-m pytest" in line]
+    assert len(commands) == 1, commands
+    for root in REQUIRED_ROOTS:
+        assert root in commands[0].split(), (root, commands[0])

--- a/tests/test_main_health_workflow_2139.py
+++ b/tests/test_main_health_workflow_2139.py
@@ -236,16 +236,19 @@ def test_the_install_mirrors_the_proven_ci_recipe():
     src = "\n".join(
         ln for ln in WORKFLOW.read_text().splitlines() if not ln.lstrip().startswith("#")
     )
-    assert "uv sync --extra dev" in src, "must use the same install as test.yml"
-    assert "uv run maturin develop --release" in src
+    assert "uv sync --frozen --extra dev --no-install-project" in src, (
+        "must use the same install as test.yml"
+    )
+    assert "uv run --no-sync maturin develop --release" in src
     assert ".venv/bin/pip" not in src, (
         "`uv venv` creates no pip; invoking .venv/bin/pip fails the job and "
         "reports 'could not run' every single day"
     )
     test_yml = (ROOT / ".github/workflows/test.yml").read_text()
-    assert "uv sync --extra dev" in test_yml and "uv run maturin develop --release" in test_yml, (
-        "this pin is only meaningful while test.yml still uses that recipe"
-    )
+    assert (
+        "uv sync --frozen --extra dev --no-install-project" in test_yml
+        and "uv run --no-sync maturin develop --release" in test_yml
+    ), "this pin is only meaningful while test.yml still uses that recipe"
 
 
 def test_a_failed_rust_build_fails_the_job_rather_than_reporting_a_red_main():


### PR DESCRIPTION
## Summary

Python CI builds the same native extension through `uv sync` and then through `maturin develop`. In main run 34554928145, the Python 3.12 shard 1 log recorded about 121 seconds for the first build and another 73 seconds for the second. Install dependencies without the project, build the release extension once, and keep later uv commands from resynchronizing it. Apply the same sequence to the benchmark, Django scoreboard, and scheduled main-health jobs; retain the scheduled serial suite.

The exhaustive Unicode title differential retains all 4,448,256 comparisons but shares render setup in bounded batches. On the same local Python 3.12 release build, its call time fell from 39.74s to 26.46s; a repeat measured 26.71s. These are local measurements, not a claim about total CI speedup.

## Changes

- Use `uv sync --frozen --extra dev --no-install-project` followed by `uv run --no-sync maturin develop --release` in all four affected job groups; keep subsequent commands on that installed environment.
- Batch every original Unicode scalar/context probe, verify exact cell counts, preserve the global Unicode skew bound, and compare batching against individual template renders.
- Include the omitted `python/djust/tests/` root in `make test` and check make's expanded invocation.
- Run compile-heavy Clippy and the full JavaScript suite at pre-push only. Keep quick commit checks and existing pre-push Python/Rust test selection.
- Replace the outdated CI optimization guide with current timings, measurement discipline, and ranked alternatives including corpus affinity, shared wheel builds, fewer repeated collections, and controlled doctor scenarios.

## Type of Change

- [x] Bug fix
- [x] Performance improvement
- [x] Documentation update

## Test Plan

- [x] 97 focused filter and CI configuration tests passed.
- [x] The exhaustive test still checks exactly 4,448,256 cases; batching matches individual template renders on boundary/casing/escaping inputs.
- [x] A deliberate batch-only `title` to `lower` mutation makes the equivalence guard fail.
- [x] Fresh isolated uv environment successfully installed and tested using the single-build commands.
- [x] Real pre-commit dispatch verified: commit skips Clippy/JS tests, push runs them, and failures block push.
- [x] 32 focused scheduled-health and shard/root checks passed after aligning the scheduled install recipe.
- [x] Final commit and push hooks passed without bypass, including the full local Python suite triggered by the hook configuration change.
- [x] Current-head CI passed on `57ae80241351d121da39debab9dec1ab404aee8f`: 21 successful checks, 2 skipped, no failures. [Successful run](https://github.com/djust-org/djust/actions/runs/34558168863).
- [x] Successful-run comparison: workflow elapsed 8m09s versus baseline 11m55s (about 32% lower); Python 3.12 shard setup 86–97s versus 173–197s. This is one run against one baseline, with runner/cache variability, not a guaranteed speedup. Baseline run: https://github.com/djust-org/djust/actions/runs/34554928145.

## Checklist

- [x] Code follows project conventions.
- [x] Self-reviewed for correctness, boundaries, and security.
- [x] Documentation updated.
- [x] No public API changes or reduced test selection.

## Related Issues

Test-performance work requested during release preparation. No release issue is closed by this PR.
