### PR TITLE
test: avoid repeated doctor builds and shard collections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,6 +311,11 @@ test-python-parallel: ## Run Python tests in parallel (requires pytest-xdist)
 	@echo "$(GREEN)Running Python tests in parallel...$(NC)"
 	@PYTHONPATH=. $(PYTHON) -m pytest tests/ python/tests/ python/djust/tests/ -n auto
 
+.PHONY: test-harness
+test-harness: ## Validate and time doctor scenarios and CI shard collection
+	@PYTHONPATH=. $(PYTHON) -m pytest python/djust/tests/test_make_doctor_2061.py \
+		tests/test_ci_python_test_shards.py tests/test_collect_test_shards.py -q --durations=10
+
 # CI runs python-tests as four pytest-split shards balanced by the durations
 # recorded in .test_durations (committed). pytest-split falls back to
 # splitting by test COUNT when an entry is missing, so a stale file only

--- a/changelog.d/test-harness-performance.fixed.md
+++ b/changelog.d/test-harness-performance.fixed.md
@@ -1,0 +1,1 @@
+- **Reduce test harness overhead:** Collect the Python suite once for shard validation, preserve configured exclusions, and reject partial collections. Keep one real doctor smoke run while testing verdict scenarios with controlled external tools and explicit failure/timeout checks.

--- a/docs/development/CI_OPTIMIZATION.md
+++ b/docs/development/CI_OPTIMIZATION.md
@@ -105,14 +105,41 @@ suite passes. Clippy currently has stricter local flags than the CI invocation;
 keep its push gate until any proposed CI-only policy establishes equivalent
 coverage.
 
+## Doctor scenarios and shard validation
+
+`make test-harness` runs the doctor and shard-collection checks with timings.
+The doctor suite retains one real tool integration smoke test. Its verdict
+scenarios execute the same shell script with controlled Cargo/Node commands on
+PATH, so an unrelated cold Cargo build no longer repeats for each scenario.
+Additional cases cover successful Cargo execution, bootstrap/link/probe failures,
+a generic failure, and a real timeout with a shortened deadline. They continue
+to assert that later checks run and the expected verdict/remedy appears.
+
+The shard guard now uses `scripts/collect-test-shards.py` to collect the configured
+suite once and call the installed pytest-split selection hook for each group.
+It checks collection success, duration staleness, shard balance, exact coverage,
+and absence of duplicate assignments. The former helper cleared pytest's
+configured exclusions and accepted partial node IDs even when collection failed;
+the new probe preserves those exclusions and refuses a partial snapshot.
+Small-corpus tests compare both supported splitting algorithms against ordinary
+CLI invocations, and verify that the probe collects only once and never runs test
+bodies. The helper depends on pytest-split's plugin API; these comparisons must
+continue to pass when upgrading that dependency.
+
+On a local Python 3.12 release build, the previous two full-collection checks took
+42.74 seconds combined; the new combined guard took 5.64 seconds. The expanded
+focused suite passed 34 tests in 13.77 seconds. The old suite passed 22 tests in
+64.07 seconds, but its first doctor run also warmed the Cargo cache, so that total
+comparison is not an isolated measure of the code change. In the preceding
+successful CI run, six doctor calls each took about 30 seconds. Verify savings
+on the next successful CI run; these local timings do not predict its wall time.
+
 ## Alternatives worth investigating next
 
 | Alternative | Expected benefit | Tradeoff / verification needed |
 | --- | --- | --- |
 | Keep expensive corpus readers in the same CI shard | Avoid one full identical sweep per independent shard | Schedule by shared fixture cost, not inflated per-reader waits; prove shard union and disjointness and benchmark the longest shard. |
 | Build one wheel per Python version, then distribute it to shards | Reduce repeated native builds and runner minutes | Adds a prerequisite job and artifact transfers; may improve cost more than wall time. Verify ABI, commit identity, installed package path, and Python source under test. |
-| Collect once for the shard self-tests | Avoid five repeated full collections | Exercise the actual pytest-split plugin and actual collected IDs, preserving staleness, coverage, and balance checks; do not replace it with a handwritten approximation. |
-| Separate one real doctor smoke run from scenario tests | Avoid repeatedly timing out on a cold Cargo smoke build | Scenario tests can control unrelated tools, but retain a real integration run and tests for actual timeout/error behavior. |
 | Partition the Unicode sweep into balanced chunks | Distribute its remaining serial tail | Preserve every scalar/context and the global skew limit; account for extra collection and fixture overhead. |
 | Tune local worker budgets by workload | Reduce CPU/RAM contention when Python, Rust, and JS run together | Compare fixed worker counts with `auto`; more workers can make subprocess-heavy tests slower. |
 | Persistent content-addressed corpus artifacts | Reuse expensive sweeps across runs | Invalidation must cover native build, Python source, interpreter, settings, script input, and environment; session-only caching is currently easier to trust. |

--- a/python/djust/tests/test_make_doctor_2061.py
+++ b/python/djust/tests/test_make_doctor_2061.py
@@ -10,7 +10,9 @@ is a dev-environment self-diagnosis script that runs every check regardless
 of earlier failures and reports ``[OK]``/``[WARN]``/``[FAIL] <name>: <finding>``
 plus a one-line remedy, exiting non-zero iff any check FAILs.
 
-These tests run the REAL script via subprocess against the repo checkout.
+All tests run the REAL script via subprocess against the repo checkout. One
+integration smoke keeps real external tools; verdict scenarios replace only
+Cargo/Node on PATH so unrelated cold builds do not repeat for every scenario.
 Per the task brief, asserting exit 0 in a "healthy" environment is
 explicitly NOT required — a CI/dev box may legitimately WARN (no
 ``node_modules/`` yet, a venv shared with a different checkout, etc.), and a
@@ -35,6 +37,8 @@ from __future__ import annotations
 
 import os
 import re
+import shlex
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -64,6 +68,8 @@ SUBPROCESS_TIMEOUT = 150
 
 def _run_doctor(extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
+    for name in ("DOCTOR_FAKE_STALE_SO", "DOCTOR_FAKE_PTH_BAD", "DOCTOR_FAKE_UV_BASE"):
+        env.pop(name, None)
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -75,6 +81,34 @@ def _run_doctor(extra_env: dict[str, str] | None = None) -> subprocess.Completed
         env=env,
         timeout=SUBPROCESS_TIMEOUT,
     )
+
+
+@pytest.fixture
+def doctor_tools(tmp_path: Path) -> dict[str, str]:
+    """Control expensive external tools while executing the real doctor script.
+
+    The integration smoke below keeps the real PATH. Scenario tests replace
+    Cargo/Node only; interpreter, extension, hook and verdict logic stay real.
+    """
+    cargo = tmp_path / "cargo"
+    cargo.write_text(
+        "#!/bin/sh\n"
+        'printf "%s\\n" "$*" >> "$DJUST_TEST_CARGO_CALLS"\n'
+        'if [ -n "${DJUST_TEST_CARGO_SLEEP:-}" ]; then sleep "$DJUST_TEST_CARGO_SLEEP"; fi\n'
+        'printf "%s\\n" "${DJUST_TEST_CARGO_OUTPUT:-}"\n'
+        'exit "${DJUST_TEST_CARGO_STATUS:-0}"\n'
+    )
+    cargo.chmod(0o755)
+    npx = tmp_path / "npx"
+    npx.write_text('#!/bin/sh\nprintf "vitest/doctor-test\\n"\n')
+    npx.chmod(0o755)
+    return {
+        "PATH": str(tmp_path) + os.pathsep + os.environ.get("PATH", ""),
+        "DJUST_TEST_CARGO_CALLS": str(tmp_path / "cargo-calls.txt"),
+        "DJUST_TEST_CARGO_STATUS": "0",
+        "DJUST_TEST_CARGO_OUTPUT": "",
+        "DJUST_TEST_CARGO_SLEEP": "",
+    }
 
 
 def _status_line_pattern(check_name: str) -> re.Pattern[str]:
@@ -116,6 +150,7 @@ def test_makefile_has_doctor_target() -> None:
     assert "scripts/doctor.sh" in makefile
 
 
+@pytest.mark.integration
 def test_doctor_runs_to_completion_and_reports_every_check() -> None:
     """The load-bearing structural test: the script runs to completion (no
     crash/hang/traceback) and every one of the seven checks reports a
@@ -152,12 +187,12 @@ def test_doctor_runs_to_completion_and_reports_every_check() -> None:
         assert result.returncode == 0
 
 
-def test_stale_so_gate_off_no_forced_marker_by_default() -> None:
+def test_stale_so_gate_off_no_forced_marker_by_default(doctor_tools: dict[str, str]) -> None:
     """Gate-off half of the non-tautology proof (#1468/#1200): WITHOUT the
     test-hook env var, the stale-extension line must never contain the
     test-hook marker. This is what makes the forced-FAIL assertion below
     meaningful rather than a check that always reports the same thing."""
-    result = _run_doctor()
+    result = _run_doctor(doctor_tools)
     stale_line = next(
         (
             line
@@ -173,10 +208,10 @@ def test_stale_so_gate_off_no_forced_marker_by_default() -> None:
     )
 
 
-def test_stale_so_force_fail_is_detected() -> None:
+def test_stale_so_force_fail_is_detected(doctor_tools: dict[str, str]) -> None:
     """Forced-failure half: with DOCTOR_FAKE_STALE_SO=1, the stale-extension
     check FAILs with its remedy line, and the overall script exits non-zero."""
-    result = _run_doctor({"DOCTOR_FAKE_STALE_SO": "1"})
+    result = _run_doctor({**doctor_tools, "DOCTOR_FAKE_STALE_SO": "1"})
 
     assert result.returncode != 0, (
         f"doctor.sh should exit non-zero with a forced FAIL. stdout={result.stdout!r}"
@@ -196,9 +231,9 @@ def test_stale_so_force_fail_is_detected() -> None:
         )
 
 
-def test_pth_gate_off_no_forced_marker_by_default() -> None:
+def test_pth_gate_off_no_forced_marker_by_default(doctor_tools: dict[str, str]) -> None:
     """Gate-off half for the djust.pth check (#1468/#1200)."""
-    result = _run_doctor()
+    result = _run_doctor(doctor_tools)
     pth_line = next(
         (
             line
@@ -214,10 +249,10 @@ def test_pth_gate_off_no_forced_marker_by_default() -> None:
     )
 
 
-def test_pth_force_fail_is_detected() -> None:
+def test_pth_force_fail_is_detected(doctor_tools: dict[str, str]) -> None:
     """Forced-failure half: with DOCTOR_FAKE_PTH_BAD=1, the djust.pth check
     FAILs with its remedy line, and the overall script exits non-zero."""
-    result = _run_doctor({"DOCTOR_FAKE_PTH_BAD": "1"})
+    result = _run_doctor({**doctor_tools, "DOCTOR_FAKE_PTH_BAD": "1"})
 
     assert result.returncode != 0, (
         f"doctor.sh should exit non-zero with a forced FAIL. stdout={result.stdout!r}"
@@ -235,7 +270,7 @@ def test_pth_force_fail_is_detected() -> None:
         )
 
 
-def test_uv_base_gate_off_no_forced_marker_by_default() -> None:
+def test_uv_base_gate_off_no_forced_marker_by_default(doctor_tools: dict[str, str]) -> None:
     """Gate-off half for the #2072 uv-standalone-base detection hook
     (``DOCTOR_FAKE_UV_BASE``, #1468/#1200): WITHOUT the env override, the
     embedded-pyo3 line must never contain the test-hook's own marker text.
@@ -243,7 +278,7 @@ def test_uv_base_gate_off_no_forced_marker_by_default() -> None:
     genuine uv-standalone venv on this machine — that's a different message
     that doesn't name the env var — so this only excludes the forced-hook
     marker string, not "uv-standalone"/"#2072" generally.)"""
-    result = _run_doctor()
+    result = _run_doctor(doctor_tools)
     embedded_line = next(
         (
             line
@@ -259,12 +294,12 @@ def test_uv_base_gate_off_no_forced_marker_by_default() -> None:
     )
 
 
-def test_uv_base_force_warn_is_detected() -> None:
+def test_uv_base_force_warn_is_detected(doctor_tools: dict[str, str]) -> None:
     """Forced-WARN half: with DOCTOR_FAKE_UV_BASE=1, the embedded-pyo3 check
     WARNs (not FAILs — detection is informational, not itself an error) with
     the #2072 explanation + remedy, and every other check still runs to
     completion."""
-    result = _run_doctor({"DOCTOR_FAKE_UV_BASE": "1"})
+    result = _run_doctor({**doctor_tools, "DOCTOR_FAKE_UV_BASE": "1"})
 
     assert re.search(
         r"^\[WARN\] embedded-pyo3: .*DOCTOR_FAKE_UV_BASE", result.stdout, re.MULTILINE
@@ -295,6 +330,65 @@ def test_uv_base_force_warn_is_detected() -> None:
         "checks — DOCTOR_FAKE_UV_BASE must short-circuit with a SINGLE verdict "
         "call, not add an extra one on top of the real cargo-test verdict"
     )
+
+
+@pytest.mark.parametrize(
+    ("status", "output", "verdict", "diagnosis"),
+    [
+        (0, "", r"OK|WARN", "passed"),
+        (1, "init_fs_encoding: '/install'", "FAIL", "embedded CPython bootstrap failed"),
+        (1, "undefined symbol: _Py_Dealloc", "FAIL", "link failure referencing _Py_Dealloc"),
+        (1, "rustc probe SIGABRT", "FAIL", "rustc build probe crashed"),
+        (1, "unclassified failure", "FAIL", "unclassified failure"),
+    ],
+)
+def test_cargo_result_is_diagnosed(
+    doctor_tools: dict[str, str], status: int, output: str, verdict: str, diagnosis: str
+) -> None:
+    result = _run_doctor(
+        {
+            **doctor_tools,
+            "DJUST_TEST_CARGO_STATUS": str(status),
+            "DJUST_TEST_CARGO_OUTPUT": output,
+        }
+    )
+    calls = Path(doctor_tools["DJUST_TEST_CARGO_CALLS"]).read_text().splitlines()
+    assert len(calls) == 1 and calls[0].startswith("test -p djust_templates --test ")
+    assert re.search(
+        rf"^\[({verdict})\] embedded-pyo3: .*{re.escape(diagnosis)}", result.stdout, re.MULTILINE
+    ), result.stdout
+    if status:
+        assert result.returncode == 1
+    for name in CHECK_NAMES:
+        assert _status_line_pattern(name).search(result.stdout), result.stdout
+
+
+def test_cargo_timeout_is_reported_without_stopping_other_checks(
+    doctor_tools: dict[str, str], tmp_path: Path
+) -> None:
+    timeout = shutil.which("timeout") or shutil.which("gtimeout")
+    if timeout is None:
+        pytest.skip("real timeout utility unavailable on this platform")
+    # Exercise a real deadline and return code, without waiting 30 seconds.
+    # Check the production deadline before shortening only the Cargo probe.
+    wrapper = tmp_path / "timeout"
+    wrapper.write_text(
+        "#!/bin/sh\n"
+        'if [ "$2" = cargo ]; then\n'
+        '  [ "$1" = 30 ] || exit 98\n'
+        "  shift\n"
+        f'  exec {shlex.quote(timeout)} 0.1 "$@"\n'
+        "fi\n"
+        f'exec {shlex.quote(timeout)} "$@"\n'
+    )
+    wrapper.chmod(0o755)
+    result = _run_doctor({**doctor_tools, "DJUST_TEST_CARGO_SLEEP": "10"})
+    assert re.search(
+        r"^\[WARN\] embedded-pyo3: .*timed out after 30s", result.stdout, re.MULTILINE
+    ), result.stdout
+    assert "cargo build -p djust_templates --tests" in result.stdout
+    for name in CHECK_NAMES:
+        assert _status_line_pattern(name).search(result.stdout), result.stdout
 
 
 def test_every_check_name_has_a_dedicated_check_function() -> None:

--- a/scripts/collect-test-shards.py
+++ b/scripts/collect-test-shards.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Collect once and ask the installed pytest-split plugin for every shard.
+
+This is a read-only probe for the CI configuration tests, not a replacement
+scheduler. Each group goes through pytest-split's real collection hook using
+the same collected Item objects and durations as a normal invocation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+
+class ShardSnapshot:
+    def __init__(self, splits: int) -> None:
+        self.splits = splits
+        self.result: dict | None = None
+
+    def pytest_collection_finish(self, session: pytest.Session) -> None:
+        if session.testsfailed:
+            return
+        from pytest_split.plugin import PytestSplitPlugin
+
+        config = session.config
+        items = list(session.items)
+        groups = []
+        # Leave normal collection unsplit. Only the probe calls the real
+        # splitter, after other collection hooks have finished their work.
+        original = config.option.splits, config.option.group
+        try:
+            config.option.splits = self.splits
+            splitter = PytestSplitPlugin(config)
+            for group in range(1, self.splits + 1):
+                config.option.group = group
+                selected = items.copy()
+                splitter.pytest_collection_modifyitems(config, selected)
+                groups.append([item.nodeid for item in selected])
+        finally:
+            config.option.splits, config.option.group = original
+        self.result = {"collected": [item.nodeid for item in items], "groups": groups}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--splits", type=int, required=True)
+    parser.add_argument("--splitting-algorithm", required=True)
+    parser.add_argument("--durations-path", type=Path, required=True)
+    parser.add_argument("paths", nargs="+")
+    args = parser.parse_args()
+    if args.splits < 1:
+        parser.error("--splits must be positive")
+    # A failed collection must never leave an earlier successful snapshot.
+    args.output.unlink(missing_ok=True)
+    probe = ShardSnapshot(args.splits)
+    status = pytest.main(
+        [
+            *args.paths,
+            "--collect-only",
+            "-q",
+            "-p",
+            "no:randomly",
+            "--splitting-algorithm",
+            args.splitting_algorithm,
+            "--durations-path",
+            str(args.durations_path),
+        ],
+        plugins=[probe],
+    )
+    if status == pytest.ExitCode.OK and probe.result is not None:
+        args.output.write_text(json.dumps(probe.result), encoding="utf-8")
+        return 0
+    return int(status) or 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_python_test_shards.py
+++ b/tests/test_ci_python_test_shards.py
@@ -268,93 +268,67 @@ STALE_FRACTION_MAX = 0.10  # CONTRIBUTING: regenerate past ~10% shift
 IMBALANCE_RATIO_MAX = 2.0  # largest shard vs smallest, by recorded time
 
 
-def _collected_nodeids(group: int | None = None, splits: int | None = None) -> list[str]:
-    """The exact ids CI shards, collected the way CI collects them.
+def _validate_snapshot(snapshot: dict, data: dict[str, float], n: int) -> None:
+    collected = snapshot["collected"]
+    per_group = snapshot["groups"]
+    assert collected, "collection produced no ids — the harness is broken, not the file"
+    assert len(collected) == len(set(collected)), "full collection contains duplicate ids"
+    assert len(per_group) == n, "snapshot does not contain every configured shard"
+    flattened = [nodeid for group in per_group for nodeid in group]
+    assert len(flattened) == len(set(flattened)), "shards assign a test more than once"
+    assert set(flattened) == set(collected), "shards omit or invent collected tests"
+    missing = [t for t in collected if t not in data]
+    fraction = len(missing) / len(collected)
+    assert fraction <= STALE_FRACTION_MAX, (
+        f"{len(missing)} of {len(collected)} collected tests ({fraction:.0%}) have no "
+        f"recorded duration, over the {STALE_FRACTION_MAX:.0%} threshold. "
+        f"Run make test-durations-from-ci RUN=<run-id>. First missing: {missing[:3]}"
+    )
+    counts = [len(g) for g in per_group]
+    assert all(counts), f"a shard would collect nothing: {counts}"
+    default = (sum(data.values()) / len(data)) if data else 0.0
+    times = [sum(data.get(t, default) for t in g) for g in per_group]
+    lo, hi = min(times), max(times)
+    assert lo > 0 and hi / lo <= IMBALANCE_RATIO_MAX, (
+        f"pytest-split would deal these shards {counts} tests / "
+        f"{[round(t) for t in times]}s — exceeds {IMBALANCE_RATIO_MAX}x balance limit. "
+        "Run make test-durations-from-ci RUN=<run-id>."
+    )
 
-    With `group`/`splits`, returns just that shard's share — pytest-split's
-    own answer, not a reimplementation of it, and under the SAME
-    `--splitting-algorithm` the workflow passes. Measuring the default
-    algorithm's deal while CI runs another one is a pin on a different
-    program: `duration_based_chunks` and `least_duration` disagreed
-    1.70x vs 1.00x on the very file this asserts about (#2584).
+
+@pytest.mark.slow
+def test_shards_cover_current_collection_with_balanced_durations(tmp_path: Path) -> None:
+    """One full collection verifies staleness, coverage, and real plugin balance.
+
+    The helper calls pytest-split's installed collection hook for every group;
+    it does not copy the algorithm. Its small-corpus tests compare this probe
+    against normal --splits/--group CLI invocations.
     """
-    shard = (
+    output = tmp_path / "shards.json"
+    n = len(_matrix_groups())
+    proc = subprocess.run(
         [
+            sys.executable,
+            str(ROOT / "scripts/collect-test-shards.py"),
+            "--output",
+            str(output),
             "--splits",
-            str(splits),
-            "--group",
-            str(group),
+            str(n),
             "--splitting-algorithm",
             _splitting_algorithm(),
             "--durations-path",
             str(DURATIONS),
-        ]
-        if group is not None
-        else []
-    )
-    proc = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "pytest",
             "tests/",
             "python/tests/",
             "python/djust/tests/",
-            "--collect-only",
-            "-q",
-            "-p",
-            "no:randomly",
-            "-o",
-            "addopts=",
-            *shard,
         ],
         cwd=ROOT,
         capture_output=True,
         text=True,
         env={**os.environ, "PYTHONPATH": "."},
+        timeout=180,
     )
-    return [ln.strip() for ln in proc.stdout.splitlines() if "::" in ln]
-
-
-@pytest.mark.slow
-def test_durations_file_is_not_stale() -> None:
-    collected = _collected_nodeids()
-    assert collected, "collection produced no ids — the harness is broken, not the file"
-    data = json.loads(DURATIONS.read_text())
-    missing = [t for t in collected if t not in data]
-    fraction = len(missing) / len(collected)
-    assert fraction <= STALE_FRACTION_MAX, (
-        f"{len(missing)} of {len(collected)} collected tests ({fraction:.0%}) have no "
-        f"recorded duration, over the {STALE_FRACTION_MAX:.0%} threshold. pytest-split "
-        f"count-balances those, which unbalances the shards until one is killed by the "
-        f"runner. Run `make test-durations` and commit .test_durations (#2703).\n"
-        f"first missing: {missing[:3]}"
+    assert proc.returncode == 0, (
+        f"shard collection failed ({proc.returncode}):\n{proc.stdout[-8000:]}\n{proc.stderr[-8000:]}"
     )
-
-
-@pytest.mark.slow
-def test_shards_are_balanced_by_recorded_time() -> None:
-    """Staleness is the usual cause of imbalance, but not the only one — a
-    single very slow new module skews the split with every duration present.
-    Assert the OUTCOME directly.
-
-    Asks pytest-split itself what each group contains rather than
-    reimplementing its algorithm. The first version of this test did
-    reimplement it, got a different answer, and passed green while the real
-    split was dealing shard 3 5.2x shard 2 — a pin that cannot see the
-    condition it exists for (#1859).
-    """
-    n = len(_matrix_groups())
-    per_group = [_collected_nodeids(group=g, splits=n) for g in range(1, n + 1)]
-    counts = [len(g) for g in per_group]
-    assert all(counts), f"a shard would collect nothing: {counts}"
-    data = json.loads(DURATIONS.read_text())
-    default = (sum(data.values()) / len(data)) if data else 0.0
-    times = [sum(data.get(t, default) for t in g) for g in per_group]
-    lo, hi = min(times), max(times)
-    assert hi / lo <= IMBALANCE_RATIO_MAX, (
-        f"pytest-split would deal these shards {counts} tests / "
-        f"{[round(t) for t in times]}s — the largest is {hi / lo:.1f}x the "
-        f"smallest, over {IMBALANCE_RATIO_MAX}x. One overloaded shard is what "
-        f"gets killed by the runner. Run `make test-durations` (#2703)."
-    )
+    _validate_snapshot(json.loads(output.read_text()), json.loads(DURATIONS.read_text()), n)

--- a/tests/test_collect_test_shards.py
+++ b/tests/test_collect_test_shards.py
@@ -1,0 +1,118 @@
+"""Check the fast shard probe against real pytest-split CLI invocations."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.test_ci_python_test_shards import _validate_snapshot
+
+PROBE = Path(__file__).resolve().parents[1] / "scripts/collect-test-shards.py"
+
+
+def _run(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    # The tiny corpus is independent of project plugins/settings. Explicitly
+    # load the installed splitter just as its entry point normally would.
+    env = {**os.environ, "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1"}
+    env.pop("PYTEST_ADDOPTS", None)
+    env["PYTEST_PLUGINS"] = "pytest_split.plugin"
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize("algorithm", ["least_duration", "duration_based_chunks"])
+def test_snapshot_matches_real_split_cli(tmp_path: Path, algorithm: str) -> None:
+    # Collection counter proves the probe imports this module exactly once.
+    # Bodies must never run in either collection path.
+    (tmp_path / "test_sample.py").write_text(
+        "from pathlib import Path\n"
+        "with Path('collections.txt').open('a') as f: f.write('collected\\n')\n"
+        + "\n".join(f"def test_{i}(): raise AssertionError('executed')" for i in range(12))
+    )
+    (tmp_path / "pytest.ini").write_text("[pytest]\naddopts = --ignore=ignored\n")
+    (tmp_path / "ignored").mkdir()
+    (tmp_path / "ignored/test_broken.py").write_text("raise RuntimeError('must stay excluded')\n")
+    durations = tmp_path / "durations.json"
+    # Uneven times, one missing test, and a stale id exercise plugin defaults.
+    durations.write_text(
+        json.dumps({**{f"test_sample.py::test_{i}": i + 1 for i in range(11)}, "stale": 40})
+    )
+    output = tmp_path / "snapshot.json"
+    common = (
+        "--splits",
+        "4",
+        "--splitting-algorithm",
+        algorithm,
+        "--durations-path",
+        str(durations),
+    )
+    result = _run(tmp_path, str(PROBE), "--output", str(output), *common, ".")
+    assert result.returncode == 0, result.stdout + result.stderr
+    snapshot = json.loads(output.read_text())
+    assert (tmp_path / "collections.txt").read_text() == "collected\n"
+    assert len(snapshot["collected"]) == 12
+    for group in range(1, 5):
+        cli = _run(
+            tmp_path,
+            "-m",
+            "pytest",
+            "test_sample.py",
+            "--collect-only",
+            "-q",
+            *common,
+            "--group",
+            str(group),
+        )
+        assert cli.returncode == 0, cli.stdout + cli.stderr
+        ids = [line for line in cli.stdout.splitlines() if line.startswith("test_sample.py::")]
+        assert snapshot["groups"][group - 1] == ids
+
+
+def test_failed_collection_cannot_publish_partial_or_stale_snapshot(tmp_path: Path) -> None:
+    (tmp_path / "test_good.py").write_text("def test_good(): pass\n")
+    (tmp_path / "test_broken.py").write_text("raise RuntimeError('broken collection')\n")
+    output = tmp_path / "snapshot.json"
+    output.write_text('{"collected": ["old"]}')
+    result = _run(
+        tmp_path,
+        str(PROBE),
+        "--output",
+        str(output),
+        "--splits",
+        "2",
+        "--splitting-algorithm",
+        "least_duration",
+        "--durations-path",
+        str(tmp_path / "absent.json"),
+        ".",
+    )
+    assert result.returncode != 0
+    assert "broken collection" in result.stdout
+    assert not output.exists()
+
+
+@pytest.mark.parametrize(
+    ("groups", "durations", "message"),
+    [
+        ([["a"], ["a", "b"]], {"a": 1, "b": 1}, "more than once"),
+        ([["a"], []], {"a": 1, "b": 1}, "omit or invent"),
+        ([["a"], ["b"]], {"a": 1}, "no recorded duration"),
+        ([["a"], ["b"]], {"a": 1, "b": 10}, "balance limit"),
+    ],
+)
+def test_validation_rejects_broken_shards(groups: list, durations: dict, message: str) -> None:
+    good = {"collected": ["a", "b"], "groups": [["a"], ["b"]]}
+    _validate_snapshot(good, {"a": 1, "b": 1}, 2)
+    with pytest.raises(AssertionError, match=message):
+        _validate_snapshot({**good, "groups": groups}, durations, 2)


### PR DESCRIPTION
## Summary

Doctor verdict scenarios repeatedly execute an unrelated Cargo smoke build, and the CI shard guards launch five full Python collections. In the previous successful CI run, six doctor calls each took about 30 seconds and shard validation accumulated 97 seconds. Keep a real doctor integration smoke, control external tools in the scenario tests, and collect the configured Python suite once for all shard checks.

The new collection failure check also exposes and fixes a correctness gap: the previous helper cleared pytest's configured exclusions and parsed partial node IDs even when collection failed. The new probe preserves those exclusions and rejects unsuccessful collections.

## Changes

- Use temporary Cargo/Node commands only in doctor scenario tests. Retain the real integration smoke, existing forced-verdict controls, and add success, bootstrap/link/probe/generic error, and real shortened-timeout checks.
- Ask the installed pytest-split collection hook for all groups from one collection. Preserve staleness and balance checks; additionally require exact coverage with no duplicate assignments.
- Compare the probe with normal pytest-split CLI collection for both algorithms, uneven/missing/stale duration entries, configured exclusions, and failed collection. Verify collection happens once and test bodies never execute.
- Add `make test-harness`, document measurements and limitations, and include a changelog fragment. This branch starts after merged #2787; application code, CI test selection, and doctor behavior are unchanged.

## Type of Change

- [x] Bug fix
- [x] Performance improvement
- [x] Documentation update

## Test Plan

- [x] 34 focused tests passed in 13.77s.
- [x] Local shard validation call time fell from 42.74s combined to 5.64s, on Python 3.12 with a release extension.
- [x] Deliberately assigning group 1 repeatedly makes the CLI comparison tests fail; deliberately treating Cargo failures as healthy makes four classification cases fail.
- [x] Ruff check/format and diff checks passed.
- [x] Complete Python suite: 26,986 passed, 486 skipped in 204.13s via `make test-python-parallel`.
- [x] Normal commit hooks passed.
- [x] Normal push hooks passed; no hooks bypassed.
- [x] Current-head CI passed on `cf81c67bf7d5fad656361066e59bc63ef625c877`: 21 successful checks, 2 skipped, no failures. [Successful run](https://github.com/djust-org/djust/actions/runs/34559799610).
- [x] Successful-run comparison against #2787 run 34558168863: doctor tests 182.82s → 34.35s aggregate; shard validation including new controls 97.20s → 23.70s aggregate. The real doctor smoke remains (30.29s). Workflow elapsed 8m09s → 7m23s. These are individual run observations affected by runner/cache conditions; aggregate test durations overlap across workers.

The old focused suite passed 22 tests in 64.07s, but its first doctor call also warmed Cargo's cache. Do not interpret that total comparison as isolated savings or extrapolate it to CI. The real timeout control requires timeout/gtimeout and skips only where neither is installed.

## Checklist

- [x] Code follows project conventions.
- [x] Self-reviewed for correctness, boundaries, subprocess safety, and security.
- [x] Documentation updated.
- [x] No public API changes or reduced CI test selection.

## Related Issues

Follow-up to #2787, implementing the doctor-scenario and repeated-collection improvements requested during test-performance work. No release issue is closed by this PR.
