### PR TITLE
fix: preserve model data and scoped paths in JIT serialization

### DIFF
--- a/changelog.d/jit-model-data.fixed.md
+++ b/changelog.d/jit-model-data.fixed.md
@@ -1,0 +1,1 @@
+- **Preserve model-backed JIT template data.** Model-backed templates now retain dict/list properties in the Rust queryset serializer, avoid joins for scalar foreign-key IDs, and safely serialize guarded empty files. Static include arguments retain scoped alias paths during JIT extraction, including nested includes and `only` contexts (#2802, #2803, #2804, #2805).

--- a/crates/djust_live/src/lib.rs
+++ b/crates/djust_live/src/lib.rs
@@ -3714,6 +3714,9 @@ fn build_field_tree(paths: &[String]) -> std::collections::HashMap<String, PathN
                         .entry(part.to_string())
                         .or_insert_with(|| PathNode::Object(HashMap::new()));
 
+                    if matches!(entry, PathNode::Leaf) {
+                        *entry = PathNode::Object(HashMap::new());
+                    }
                     match entry {
                         PathNode::Object(nested_map) => {
                             current = nested_map;
@@ -3748,6 +3751,9 @@ fn add_path_to_tree(tree: &mut std::collections::HashMap<String, PathNode>, path
             let entry = current
                 .entry(part.to_string())
                 .or_insert_with(|| PathNode::Object(HashMap::new()));
+            if matches!(entry, PathNode::Leaf) {
+                *entry = PathNode::Object(HashMap::new());
+            }
             match entry {
                 PathNode::Object(nested_map) => {
                     current = nested_map;
@@ -3863,9 +3869,16 @@ fn serialize_object_with_paths(
                 }
             }
             PathNode::Object(nested_tree) => {
-                // Nested object
-                let nested_result =
-                    serialize_object_with_paths(py, &attr_value, nested_tree, gate)?;
+                // JSONField and computed containers carry data keys, not model
+                // attributes. Preserve them just as the codegen root path does.
+                let nested_result = if attr_value.is_instance_of::<PyDict>()
+                    || attr_value.is_instance_of::<PyList>()
+                    || attr_value.is_instance_of::<PyTuple>()
+                {
+                    python_to_json(py, &attr_value)?
+                } else {
+                    serialize_object_with_paths(py, &attr_value, nested_tree, gate)?
+                };
                 result.insert(attr_name.clone(), nested_result);
             }
             PathNode::List(nested_tree) => {
@@ -3917,6 +3930,43 @@ fn serialize_object_with_paths(
 
 /// Convert Python value to JSON value
 fn python_to_json(_py: Python, value: &Bound<'_, PyAny>) -> PyResult<serde_json::Value> {
+    queryset_value_to_json(value, 0)
+}
+
+fn queryset_value_to_json(value: &Bound<'_, PyAny>, depth: usize) -> PyResult<serde_json::Value> {
+    // Properties can return cyclic containers. Refuse before exhausting the
+    // native stack, matching Python's recursion-error failure mode.
+    if depth >= 64 {
+        return Err(pyo3::exceptions::PyRecursionError::new_err(
+            "queryset property exceeds the container nesting limit",
+        ));
+    }
+    if let Ok(dict) = value.cast::<PyDict>() {
+        let pairs =
+            djust_core::multi_value_dict_pairs(value).unwrap_or_else(|| dict.iter().collect());
+        let mut result = serde_json::Map::with_capacity(pairs.len());
+        for (key, item) in pairs {
+            result.insert(
+                key.extract::<String>()?,
+                queryset_value_to_json(&item, depth + 1)?,
+            );
+        }
+        return Ok(serde_json::Value::Object(result));
+    }
+    let items: Option<Vec<Bound<'_, PyAny>>> = if let Ok(list) = value.cast::<PyList>() {
+        Some(list.iter().collect())
+    } else if let Ok(tuple) = value.cast::<PyTuple>() {
+        Some(tuple.iter().collect())
+    } else {
+        None
+    };
+    if let Some(items) = items {
+        return items
+            .iter()
+            .map(|item| queryset_value_to_json(item, depth + 1))
+            .collect::<PyResult<Vec<_>>>()
+            .map(serde_json::Value::Array);
+    }
     // Handle None
     if value.is_none() {
         return Ok(serde_json::Value::Null);

--- a/crates/djust_templates/src/parser.rs
+++ b/crates/djust_templates/src/parser.rs
@@ -3120,12 +3120,42 @@ fn extract_from_nodes(
                 extract_from_nodes(nodes, variables);
             }
             Node::With { assignments, nodes } => {
-                // Extract from with assignments: {% with x=variable.path %}
-                for (_var_name, expr) in assignments {
+                // Bindings evaluate in the OUTER scope, simultaneously. Resolve
+                // body paths separately so shadowed aliases cannot consume paths
+                // from preceding siblings or leak into following siblings.
+                let mut body = HashMap::new();
+                extract_from_nodes(nodes, &mut body);
+                for (name, expr) in assignments {
                     extract_from_operand(expr, variables);
+                    if let Some(paths) = body.remove(name) {
+                        let parts = crate::filter_lexer::split_pipes(expr);
+                        let source = parts.first().copied().unwrap_or(expr).trim();
+                        let mut source_vars = HashMap::new();
+                        extract_from_operand(source, &mut source_vars);
+                        for (root, prefixes) in source_vars {
+                            let prefixes = if prefixes.is_empty() {
+                                vec![String::new()]
+                            } else {
+                                prefixes
+                            };
+                            for prefix in prefixes {
+                                for path in &paths {
+                                    let full = if prefix.is_empty() {
+                                        path.clone()
+                                    } else if path.is_empty() {
+                                        prefix.clone()
+                                    } else {
+                                        format!("{prefix}.{path}")
+                                    };
+                                    variables.entry(root.clone()).or_default().push(full);
+                                }
+                            }
+                        }
+                    }
                 }
-                // Recurse into with body
-                extract_from_nodes(nodes, variables);
+                for (root, paths) in body {
+                    variables.entry(root).or_default().extend(paths);
+                }
             }
             Node::ReactComponent {
                 props,
@@ -5119,7 +5149,17 @@ mod tests {
         let vars = extract_template_variables(template).unwrap();
         assert!(vars.contains_key("items"));
         assert!(vars.get("items").unwrap().contains(&"count".to_string()));
-        assert!(vars.contains_key("total"));
+        assert!(!vars.contains_key("total")); // local binding, not context state
+    }
+
+    #[test]
+    fn test_extract_with_scoped_simultaneous_bindings() {
+        let vars = extract_template_variables(
+            r#"{{ a.before }}{% with a=row b=a %}{{ a.title }}{{ b.name }}{% endwith %}{{ a.after }}"#,
+        ).unwrap();
+        assert_eq!(vars["row"], vec!["title"]);
+        assert_eq!(vars["a"], vec!["after", "before", "name"]);
+        assert!(!vars.contains_key("b"));
     }
 
     // Edge case tests

--- a/docs/JIT_SERIALIZATION_PATTERN.md
+++ b/docs/JIT_SERIALIZATION_PATTERN.md
@@ -639,3 +639,20 @@ clear_jit_cache()  # Returns number of entries cleared
 - **Documentation**:
   - `CLAUDE.md` - Project overview and architecture
   - `README.md` - User-facing documentation
+
+## Template access through JIT
+
+Static includes preserve their `with` aliases during field extraction. For example,
+`{% include "author.html" with author=entry.owner only %}` and
+`{{ author.avatar.layers }}` in the partial request `owner.avatar.layers` from each
+entry. Aliases are local to the include, and `only` excludes unbound outer-context
+names. Nested static includes are resolved with a bounded depth; dynamic include
+names still cannot be inferred statically.
+
+Dictionary and list properties retain their structure, so their contents can be
+used in template lookups and loops. Scalar FK IDs such as `entry.owner_id` do not
+add a join; accessing `entry.owner.name` does. Optional `FileField` and `ImageField`
+values support the usual `{% if entry.image %}{{ entry.image.url }}{% endif %}`
+guard, including when serialization falls back to generated Python code. The
+Rust queryset converter refuses property containers nested 64 levels deep,
+including cycles, rather than exhausting its native stack.

--- a/python/djust/mixins/jit.py
+++ b/python/djust/mixins/jit.py
@@ -25,8 +25,10 @@ _expected_keys_cache: Dict[Tuple[str, str], int] = {}
 
 # Pre-compiled regex for {% include %} — handles normal and doubled quotes from Rust resolver
 _INCLUDE_RE = re.compile(
-    r'\{%\s*include\s+"{1,2}([^"]+)"{1,2}\s*%\}|\{%\s*include\s+\'{1,2}([^\']+)\'{1,2}\s*%\}'
+    r"\{%\s*include\s+(?:\"{1,2}([^\"]+)\"{1,2}|'{1,2}([^']+)'{1,2})(.*?)%\}",
+    re.DOTALL,
 )
+
 
 try:
     from .._rust import extract_template_variables
@@ -167,8 +169,10 @@ class JITMixin:
     def _inline_includes(template_content: str, template_dirs: List[str]) -> str:
         """Inline {% include "..." %} directives for variable extraction.
 
-        Only handles simple static includes (not variable includes).
-        Recursively resolves nested includes up to 5 levels deep.
+        Static include arguments become scoped ``with`` bindings for extraction.
+        ``only`` masks unbound roots in the partial. This is extraction source,
+        never the template passed to the renderer. Variable includes remain
+        unresolved; nested static includes are bounded to five levels.
         """
 
         def resolve(content: str, depth: int = 0) -> str:
@@ -176,14 +180,40 @@ class JITMixin:
                 return content
 
             def replacer(match: "re.Match[str]") -> str:
+                from django.utils.text import smart_split
+
                 include_path = match.group(1) or match.group(2)
+                bits = list(smart_split(match.group(3).strip()))
+                only = "only" in bits
+                if only:
+                    bits.remove("only")
+                assignments = {}
+                if bits:
+                    if bits.pop(0) != "with":
+                        return match.group(0)
+                    for bit in bits:
+                        name, sep, value = bit.partition("=")
+                        if not sep or not name.isidentifier() or not value:
+                            return match.group(0)
+                        assignments[name] = value
                 for tpl_dir in template_dirs:
                     full_path = os.path.join(tpl_dir, include_path)
                     if os.path.isfile(full_path):
                         try:
                             with open(full_path, "r") as f:
                                 included = f.read()
-                            return resolve(included, depth + 1)
+                            included = resolve(included, depth + 1)
+                            if only:
+                                roots = _cached_extract_template_variables(included)
+                                if roots is None:
+                                    return match.group(0)
+                                for root in roots:
+                                    if root.isidentifier() and root not in assignments:
+                                        assignments[root] = '""'
+                            if assignments:
+                                bindings = " ".join(f"{k}={v}" for k, v in assignments.items())
+                                return "{% with " + bindings + " %}" + included + "{% endwith %}"
+                            return included
                         except Exception as e:
                             logger.debug("Failed to read included template %s: %s", full_path, e)
                 return match.group(0)  # Keep original if not found

--- a/python/djust/optimization/codegen.py
+++ b/python/djust/optimization/codegen.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, FrozenSet, Iterable, List
 if TYPE_CHECKING:  # pragma: no cover - import cycle at runtime, fine for typing
     from ..serialization import DjangoJSONEncoder
 
+from django.db.models.fields.files import FieldFile
+
 logger = logging.getLogger(__name__)
 
 #: Memoized :func:`emittable_names` decisions (#2685 perf).
@@ -108,6 +110,11 @@ def emittable_names(obj: Any, names: Iterable[str]) -> FrozenSet[str]:
     except Exception:
         logger.debug("attribute gate failed for %s; refusing every name", type(obj).__name__)
         return frozenset()
+
+
+def _empty_file(value: Any) -> bool:
+    """An empty Django file has no readable URL, size, or path."""
+    return isinstance(value, FieldFile) and not value
 
 
 def _gate_line(indent: int, gate_var: str, obj_expr: str, names: List[str]) -> str:
@@ -295,7 +302,7 @@ def _generate_nested_access(
         # shipped.
         lines.append(
             f"{ind}if '{root_attr}' in {gate_var} and "
-            f"hasattr({obj_var}, '{root_attr}') and {obj_access} is not None:"
+            f"not _djust_empty_file({obj_var}) and hasattr({obj_var}, '{root_attr}') and {obj_access} is not None:"
         )
 
         if tree:
@@ -407,7 +414,7 @@ def _generate_nested_access(
         # its own gate above.
         lines.append(
             f"{ind}if '{attr_name}' in {gate_var} and "
-            f"hasattr({obj_var}, '{attr_name}') and {obj_access} is not None:"
+            f"not _djust_empty_file({obj_var}) and hasattr({obj_var}, '{attr_name}') and {obj_access} is not None:"
         )
 
         if subtree:
@@ -467,7 +474,10 @@ def _generate_nested_access(
             else:
                 # Has nested attributes - create nested dict and recurse
                 dict_path = _build_dict_path(result_var, current_path)
-                lines.append(f"{ind}    {dict_path}['{attr_name}'] = {{}}")
+                lines.append(f"{ind}    if isinstance({obj_access}, dict):")
+                lines.append(f"{ind}        {dict_path}['{attr_name}'] = {obj_access}")
+                lines.append(f"{ind}    else:")
+                lines.append(f"{ind}        {dict_path}['{attr_name}'] = {{}}")
 
                 _generate_nested_access(
                     lines,
@@ -476,7 +486,7 @@ def _generate_nested_access(
                     obj_access,
                     result_var,
                     None,
-                    indent + 1,
+                    indent + 2,
                     gate_var="",
                     counter=counter,
                 )
@@ -545,6 +555,7 @@ def compile_serializer(code: str, func_name: str) -> Callable:
         # (#2685). Bound here, not looked up per call, so a generated
         # serializer can never run without it.
         "_djust_gate": emittable_names,
+        "_djust_empty_file": _empty_file,
     }
 
     try:

--- a/python/djust/optimization/query_optimizer.py
+++ b/python/djust/optimization/query_optimizer.py
@@ -91,6 +91,12 @@ def _analyze_path(
             optimization.annotations[annotation_key] = annotations[field_name]
         return
 
+    # get_field() also accepts a ForeignKey's scalar attname (owner_id).
+    # Only the relation name is legal in select_related; its ID is already
+    # present on the row, including nullable and to_field relationships.
+    if isinstance(field, (ForeignKey, OneToOneField)) and field_name != field.name:
+        return
+
     # Build Django ORM path
     django_path = f"{prefix}__{field_name}" if prefix else field_name
 

--- a/python/tests/test_bool_before_int_converters_2212.py
+++ b/python/tests/test_bool_before_int_converters_2212.py
@@ -70,7 +70,7 @@ EXPECTED = {
     ("crates/djust_live/src/lib.rs", "python_to_json_value"),
     ("crates/djust_live/src/lib.rs", "python_to_value"),
     ("crates/djust_live/src/lib.rs", "serialize_python_value"),
-    ("crates/djust_live/src/lib.rs", "python_to_json"),
+    ("crates/djust_live/src/lib.rs", "queryset_value_to_json"),
     ("crates/djust_live/src/model_serializer.rs", "python_to_json"),
 }
 

--- a/python/tests/test_jit_data_regressions.py
+++ b/python/tests/test_jit_data_regressions.py
@@ -1,0 +1,250 @@
+"""Model-backed template regressions reported against 1.2.0rc4 (#2802–#2805)."""
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+from django.db import models
+from django.template import Context, Engine
+
+from djust._rust import extract_template_variables, serialize_queryset, render_template
+from djust.mixins.jit import JITMixin
+from djust.optimization.codegen import compile_serializer, generate_serializer_code
+from djust.optimization.query_optimizer import analyze_queryset_optimization, optimize_queryset
+
+
+class DataOwner(models.Model):
+    code = models.CharField(max_length=20, unique=True)
+
+    @property
+    def avatar(self):
+        return {"layers": ["body", "eyes"], "settings": {"enabled": True, "price": Decimal("1.20")}}
+
+    class Meta:
+        app_label = "jit_data_regressions"
+
+
+class DataEntry(models.Model):
+    owner = models.ForeignKey(DataOwner, null=True, on_delete=models.CASCADE)
+    custom_owner = models.ForeignKey(
+        DataOwner,
+        null=True,
+        to_field="code",
+        db_column="owner_code",
+        on_delete=models.CASCADE,
+        related_name="+",
+    )
+    image = models.ImageField(blank=True)
+    document = models.FileField(blank=True)
+
+    @property
+    def tags(self):
+        return ["django", "python"]
+
+    class Meta:
+        app_label = "jit_data_regressions"
+
+
+def python_serializer(paths):
+    return compile_serializer(
+        generate_serializer_code("DataEntry", paths, "serialize_entry"), "serialize_entry"
+    )
+
+
+@pytest.mark.parametrize("path", ["owner_id", "custom_owner_id", "owner_id.real"])
+def test_fk_attname_does_not_join(path):
+    plan = analyze_queryset_optimization(DataEntry, [path])
+    assert not plan.select_related
+    assert not plan.prefetch_related
+    str(optimize_queryset(DataEntry.objects.all(), plan).query)
+
+
+def test_fk_names_still_join():
+    plan = analyze_queryset_optimization(DataEntry, ["owner.code", "custom_owner.code"])
+    assert plan.select_related == {"owner", "custom_owner"}
+    str(optimize_queryset(DataEntry.objects.all(), plan).query)
+
+
+@pytest.mark.parametrize("paths", [["owner.avatar", "tags"], ["owner.avatar.layers", "tags"]])
+def test_rust_preserves_property_containers(paths):
+    entry = DataEntry(pk=1, owner=DataOwner(pk=2))
+    result = serialize_queryset([entry], paths)[0]
+    assert result["tags"] == ["django", "python"]
+    assert result["owner"]["avatar"]["layers"] == ["body", "eyes"]
+    if "owner.avatar" in paths:
+        assert result["owner"]["avatar"]["settings"] == {"enabled": True, "price": "1.20"}
+
+
+@pytest.mark.parametrize("field", ["image", "document"])
+@pytest.mark.parametrize("filename", ["", "uploads/example.png"])
+@pytest.mark.parametrize("backend", ["rust", "python"])
+def test_optional_file_guard_renders(field, filename, backend):
+    entry = DataEntry(pk=1, **{field: filename})
+    paths = [field, field + ".url"]
+    result = (
+        serialize_queryset([entry], paths)[0]
+        if backend == "rust"
+        else python_serializer(paths)(entry)
+    )
+    source = "{% if entry." + field + " %}{{ entry." + field + ".url }}{% else %}no-file{% endif %}"
+    expected = Engine().from_string(source).render(Context({"entry": entry}))
+    assert render_template(source, {"entry": result}) == expected
+
+
+def test_codegen_does_not_suppress_unrelated_property_errors():
+    class Broken:
+        @property
+        def url(self):
+            raise ValueError("application bug")
+
+    with pytest.raises(ValueError, match="application bug"):
+        python_serializer(["image.url"])(SimpleNamespace(image=Broken()))
+
+
+@pytest.mark.parametrize("only", ["", " only"])
+def test_include_alias_nested_loop_paths(tmp_path, only):
+    (tmp_path / "author.html").write_text(
+        "{% for layer in author.avatar.layers %}{{ layer }}{% endfor %}"
+    )
+    source = (
+        '{% for entry in entries %}{% include "author.html" with author=entry.owner'
+        + only
+        + " %}{% endfor %}"
+    )
+    inlined = JITMixin._inline_includes(source, [str(tmp_path)])
+    paths = extract_template_variables(inlined)
+    assert "owner.avatar.layers" in paths["entries"]
+
+
+def test_include_alias_shadowing_and_only(tmp_path):
+    (tmp_path / "inner.html").write_text("{{ author.avatar.layers }}{{ outside.secret }}")
+    (tmp_path / "outer.html").write_text(
+        '{% include "inner.html" with author=author.owner only %}{{ author.tags }}'
+    )
+    source = '{% include "outer.html" with author=entry %}{{ author.original }}'
+    paths = extract_template_variables(JITMixin._inline_includes(source, [str(tmp_path)]))
+    assert "owner.avatar.layers" in paths["entry"]
+    assert "tags" in paths["entry"]
+    assert paths["author"] == ["original"]
+    assert "outside" not in paths
+
+
+@pytest.mark.parametrize("paths", [["image", "image.url"], ["image.url", "image"]])
+def test_field_tree_keeps_nested_paths_in_either_order(paths):
+    assert serialize_queryset([DataEntry(image="photo.png")], paths)[0]["image"]["url"].endswith(
+        "photo.png"
+    )
+
+
+def test_recursive_property_is_bounded():
+    value = []
+    value.append(value)
+    with pytest.raises(RecursionError, match="nesting limit"):
+        serialize_queryset([SimpleNamespace(tags=value)], ["tags"])
+
+
+def test_container_snapshot_handles_conversion_side_effect():
+    value = {"first": None, "second": [1, None, False]}
+
+    class Mutating:
+        def __str__(self):
+            value.clear()
+            return "safe"
+
+    value["first"] = Mutating()
+    assert serialize_queryset([SimpleNamespace(tags=value)], ["tags"]) == [
+        {"tags": {"first": "safe", "second": [1, None, False]}}
+    ]
+
+
+def test_include_assignments_are_simultaneous(tmp_path):
+    (tmp_path / "partial.html").write_text("{{ a.title }}{{ b.name }}")
+    source = '{% include "partial.html" with a=entry b=a %}'
+    paths = extract_template_variables(JITMixin._inline_includes(source, [str(tmp_path)]))
+    assert paths["entry"] == ["title"]
+    assert paths["a"] == ["name"]
+
+
+from djust import LiveView  # noqa: E402
+
+
+class DataListView(LiveView):
+    login_required = False
+    template = """<div dj-view="test_jit_data_regressions.DataListView">
+    {% for entry in entries %}<section>
+    {% if entry.owner_id %}<b>has-owner</b>{% endif %}
+    {% for layer in entry.owner.avatar.layers %}<i>{{ layer }}</i>{% endfor %}
+    {% for tag in entry.tags %}<em>{{ tag }}</em>{% endfor %}
+    {% if entry.image %}<img src="{{ entry.image.url }}">{% else %}<b>no-image</b>{% endif %}
+    {% if entry.document %}<a href="{{ entry.document.url }}">file</a>{% else %}<b>no-document</b>{% endif %}
+    </section>{% endfor %}</div>"""
+
+    def mount(self, request, **kwargs):
+        self.entries = DataEntry.objects.all().order_by("pk")
+
+
+@pytest.fixture
+def data_rows(transactional_db):
+    from django.db import connection
+
+    with connection.schema_editor() as editor:
+        editor.create_model(DataOwner)
+        editor.create_model(DataEntry)
+    owner = DataOwner.objects.create(code="owner")
+    DataEntry.objects.create(owner=owner)
+    DataEntry.objects.create(owner=owner, image="photo.png", document="report.pdf")
+    try:
+        yield
+    finally:
+        with connection.schema_editor() as editor:
+            editor.delete_model(DataEntry)
+            editor.delete_model(DataOwner)
+
+
+def assert_list_html(html):
+    import re
+
+    html = re.sub(r' dj-id="[^"]*"', "", html)
+    assert html.count("<i>body</i>") == 2
+    assert html.count("<i>eyes</i>") == 2
+    assert html.count("<em>django</em>") == 2
+    assert html.count("<em>python</em>") == 2
+    assert html.count("has-owner") == 2
+    assert "no-image" in html and "photo.png" in html
+    assert "no-document" in html and "report.pdf" in html
+
+
+@pytest.mark.parametrize("force_codegen", [False, True])
+def test_http_model_list(data_rows, force_codegen, monkeypatch):
+    if force_codegen:
+        monkeypatch.setattr(
+            "djust._rust.serialize_queryset", lambda rows, paths: [{} for _ in rows]
+        )
+    from django.test import RequestFactory
+    from django.contrib.sessions.middleware import SessionMiddleware
+
+    request = RequestFactory().get("/jit-data/")
+    SessionMiddleware(lambda request: None).process_request(request)
+    response = DataListView.as_view()(request)
+    assert response.status_code == 200
+    assert_list_html(response.content.decode())
+
+
+@pytest.mark.asyncio
+async def test_websocket_model_list(data_rows):
+    from channels.testing import WebsocketCommunicator
+    from django.test import override_settings
+    from djust.websocket import LiveViewConsumer
+
+    with override_settings(LIVEVIEW_ALLOWED_MODULES=[__name__]):
+        communicator = WebsocketCommunicator(LiveViewConsumer.as_asgi(), "/ws/")
+        try:
+            connected, _ = await communicator.connect()
+            assert connected
+            await communicator.receive_json_from(timeout=5)
+            await communicator.send_json_to({"type": "mount", "view": f"{__name__}.DataListView"})
+            message = await communicator.receive_json_from(timeout=5)
+            assert message["type"] == "mount", message
+            assert_list_html(message["html"])
+        finally:
+            await communicator.disconnect()

--- a/python/tests/test_template_variable_extraction.py
+++ b/python/tests/test_template_variable_extraction.py
@@ -179,7 +179,7 @@ class TestTemplateTagsOther:
         result = extract_template_variables(template)
         assert "items" in result
         assert "count" in result["items"]
-        assert "total" in result
+        assert "total" not in result  # scoped binding, not a context dependency
 
     def test_block_tag(self):
         """Test extraction from block tag."""


### PR DESCRIPTION
## Summary

Model-backed templates in rc4 lose dict/list properties, request invalid joins for FK IDs, omit paths behind include aliases, and evaluate empty file attributes eagerly. Fix these connected JIT extraction and serialization boundaries so ordinary guarded files and nested model-list templates render correctly.

## Changes

- Keep structured property values in the Rust queryset converter, including nested dictionaries/lists, tuples, Decimal values, and snapshot iteration when conversion mutates a container. Bound recursive property containers before native stack exhaustion.
- Promote leaf nodes when a longer path follows them, so `image` never discards `image.url` or subsequent fields based on path order.
- Treat FK attnames as scalar columns, while keeping relation-name optimization for nullable and `to_field` relations.
- Skip attribute evaluation on empty Django FieldFile values in generated Python serializers, without suppressing unrelated application property errors. Preserve nested dictionary properties in that fallback too.
- Expand static include arguments into scoped extraction bindings, mask unbound roots for `only`, and resolve `with` aliases in their outer scope. Local binding names are no longer reported as independent context dependencies. Runtime template source is unchanged.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Test Plan

- Baseline reproduction: 12 failures across all four reported issues before changes.
- Focused checks: 87 passed, including real HTTP and WebSocket list rendering, forced Python fallback, empty/populated ImageField and FileField, include shadowing/`only`/nested loops, FK SQL compilation, container mutation and cyclic-container refusal.
- `make test-rust`: passed, including the no-default-features template build and tests.
- Complete final Python gate: 27,020 passed, 486 skipped. Normal commit and push hooks passed, with `DJUST_PREPUSH_FULL=1`; no hooks bypassed. An additional 91 converter-inventory, changelog, and variable-extraction guard tests passed.
- An initial sandboxed full Python run was interrupted after localhost-binding PermissionErrors; the complete gate is rerun with local networking permitted.

## Checklist

- [x] Self-reviewed for correctness, scope handling, and security
- [x] Existing per-model serialization permission gate retained
- [x] Documentation and changelog updated
- [x] Reproduction tests included

## Related Issues

Closes #2802
Closes #2803
Closes #2804
Closes #2805
