### PR TITLE
test: isolate auth sockets from hot-reload broadcasts

### DIFF
--- a/changelog.d/2788.fixed.md
+++ b/changelog.d/2788.fixed.md
@@ -1,0 +1,1 @@
+- **Isolate WebSocket authorization tests from development reloads.** Exclude the unrelated hot-reload subscription within this test module so a filesystem write in another xdist worker cannot replace the expected pong with a reload frame. Authentication and other channel groups remain real and exercised (#2788).

--- a/python/djust/tests/test_ws_auth_close_socket.py
+++ b/python/djust/tests/test_ws_auth_close_socket.py
@@ -27,6 +27,27 @@ from django.test import override_settings  # noqa: E402
 from djust import LiveView  # noqa: E402
 from djust.decorators import event_handler  # noqa: E402
 
+
+@pytest.fixture(autouse=True)
+def _exclude_unrelated_hotreload(monkeypatch):
+    """Auth/socket tests must not receive another worker's file-watch events.
+
+    Clearing a channel layer cannot isolate a filesystem observer: this test's
+    freshly connected consumer would immediately rejoin its broadcast group.
+    Exclude only that subscription for this module; retain real auth, socket,
+    and all other channel-layer behavior. Monkeypatch restores it after each test.
+    """
+    from channels.layers import InMemoryChannelLayer
+
+    original = InMemoryChannelLayer.group_add
+
+    async def group_add(layer, group, channel):
+        if group != "djust_hotreload":
+            await original(layer, group, channel)
+
+    monkeypatch.setattr(InMemoryChannelLayer, "group_add", group_add)
+
+
 # Module-level flag the mutating handler flips if it ever executes. A raw client
 # that bypasses auth and reaches the handler would set this True.
 _HANDLER_RAN = False
@@ -363,3 +384,33 @@ async def test_single_objperm_denied_mount_still_closes_socket():
     assert out["type"] == "websocket.close", f"socket not closed after object-perm denial: {out!r}"
     assert out.get("code") == 4403
     await communicator.disconnect()
+
+
+@pytest.mark.django_db
+async def test_auth_socket_is_not_subscribed_to_development_reload():
+    """The fixture excludes reload traffic, while other channel groups work."""
+    from channels.layers import channel_layers, get_channel_layer
+    from channels.testing import WebsocketCommunicator
+
+    from djust.websocket import LiveViewConsumer
+
+    channel_layers.backends.clear()
+    communicator = WebsocketCommunicator(LiveViewConsumer.as_asgi(), "/ws/")
+    try:
+        connected, _ = await communicator.connect()
+        assert connected
+        await communicator.receive_json_from(timeout=3)
+        layer = get_channel_layer()
+        assert not layer.groups.get("djust_hotreload")
+        probe = await layer.new_channel()
+        await layer.group_add("auth_probe", probe)
+        await layer.group_send("auth_probe", {"type": "probe"})
+        assert await layer.receive(probe) == {"type": "probe"}
+        await layer.group_discard("auth_probe", probe)
+        # Use the real broadcaster, not a hand-built browser frame. A watcher
+        # in another xdist worker can make exactly this call at any time.
+        await LiveViewConsumer.broadcast_reload("example.py")
+        await communicator.send_json_to({"type": "ping"})
+        assert (await communicator.receive_json_from(timeout=3))["type"] == "pong"
+    finally:
+        await communicator.disconnect()


### PR DESCRIPTION
## Summary

A filesystem change from another xdist worker can deliver a development reload frame to the WebSocket auth tests, replacing their expected pong. Clearing the channel-layer cache alone does not isolate this: a new auth-test consumer immediately rejoins the reload group.

## Changes

Exclude only the `djust_hotreload` subscription for this test module using a automatically restored fixture. Production hot reload, authorization, socket closure, and other channel groups are unchanged.

## Type of Change

- [x] Bug fix (test isolation)

## Test Plan

- All six WebSocket authorization tests passed.
- The new regression uses a real consumer and broadcaster, verifies it does not subscribe to development reloads, verifies another channel group still delivers, and confirms ping/pong remains functional.
- Disabling only the fixture makes the new test fail at the unwanted subscription assertion; the fixture was restored afterward.
- Normal commit and push hooks passed; no bypasses.

## Checklist

- [x] Self-reviewed: no weakened auth assertions or ignored unexpected frames
- [x] Deterministic regression included
- [x] Changelog added

## Related Issues

Closes #2788
