### PR TITLE
fix: preserve native temporal values in queryset templates

### DIFF
--- a/changelog.d/2810.fixed.md
+++ b/changelog.d/2810.fixed.md
@@ -1,0 +1,1 @@
+- **Queryset datetime filters** — Preserve native datetime, date, time, and timedelta values in queryset template contexts so Django timezone and date filters behave consistently with model-list assignments.

--- a/crates/djust_live/src/lib.rs
+++ b/crates/djust_live/src/lib.rs
@@ -3405,9 +3405,7 @@ fn serialize_queryset_py(
         // Iterate over objects
         for obj in objects.iter() {
             let serialized = serialize_object_with_paths(py, &obj, &path_tree, gate)?;
-            // Convert serde_json::Value to Python dict
-            let py_dict = json_value_to_py(py, &serialized)?;
-            result_list.append(py_dict)?;
+            result_list.append(serialized)?;
         }
 
         Ok(result_list.into())
@@ -3816,10 +3814,8 @@ fn serialize_object_with_paths(
     obj: &Bound<'_, PyAny>,
     tree: &std::collections::HashMap<String, PathNode>,
     gate: &Bound<'_, PyAny>,
-) -> PyResult<serde_json::Value> {
-    use serde_json::{Map, Value as JsonValue};
-
-    let mut result = Map::new();
+) -> PyResult<Py<PyAny>> {
+    let result = PyDict::new(py);
 
     // Every attribute this function reads is gated by the ONE serialization
     // chokepoint (#2685). A denied name is omitted from the dict, so the
@@ -3843,7 +3839,7 @@ fn serialize_object_with_paths(
 
         // Check if None
         if attr_value.is_none() {
-            result.insert(attr_name.clone(), JsonValue::Null);
+            result.set_item(attr_name, py.None())?;
             continue;
         }
 
@@ -3855,7 +3851,8 @@ fn serialize_object_with_paths(
                     match attr_value.call0() {
                         Ok(method_result) => {
                             // Method call succeeded - use the result
-                            result.insert(attr_name.clone(), python_to_json(py, &method_result)?);
+                            result
+                                .set_item(attr_name, queryset_template_value(&method_result, 0)?)?;
                         }
                         Err(_) => {
                             // Method call failed - skip this attribute (don't insert null)
@@ -3865,7 +3862,7 @@ fn serialize_object_with_paths(
                     }
                 } else {
                     // Not callable - it's a direct attribute value
-                    result.insert(attr_name.clone(), python_to_json(py, &attr_value)?);
+                    result.set_item(attr_name, queryset_template_value(&attr_value, 0)?)?;
                 }
             }
             PathNode::Object(nested_tree) => {
@@ -3875,11 +3872,11 @@ fn serialize_object_with_paths(
                     || attr_value.is_instance_of::<PyList>()
                     || attr_value.is_instance_of::<PyTuple>()
                 {
-                    python_to_json(py, &attr_value)?
+                    queryset_template_value(&attr_value, 0)?
                 } else {
                     serialize_object_with_paths(py, &attr_value, nested_tree, gate)?
                 };
-                result.insert(attr_name.clone(), nested_result);
+                result.set_item(attr_name, nested_result)?;
             }
             PathNode::List(nested_tree) => {
                 // Iterate over list and serialize each item
@@ -3920,20 +3917,18 @@ fn serialize_object_with_paths(
                     }
                 }
 
-                result.insert(attr_name.clone(), JsonValue::Array(list_results));
+                result.set_item(attr_name, PyList::new(py, list_results)?)?;
             }
         }
     }
 
-    Ok(JsonValue::Object(result))
+    Ok(result.into_any().unbind())
 }
 
-/// Convert Python value to JSON value
-fn python_to_json(_py: Python, value: &Bound<'_, PyAny>) -> PyResult<serde_json::Value> {
-    queryset_value_to_json(value, 0)
-}
-
-fn queryset_value_to_json(value: &Bound<'_, PyAny>, depth: usize) -> PyResult<serde_json::Value> {
+/// Preserve native temporal values for Django filters; normalize other leaves
+/// using the existing queryset scalar conversion contract.
+fn queryset_template_value(value: &Bound<'_, PyAny>, depth: usize) -> PyResult<Py<PyAny>> {
+    let py = value.py();
     // Properties can return cyclic containers. Refuse before exhausting the
     // native stack, matching Python's recursion-error failure mode.
     if depth >= 64 {
@@ -3944,14 +3939,14 @@ fn queryset_value_to_json(value: &Bound<'_, PyAny>, depth: usize) -> PyResult<se
     if let Ok(dict) = value.cast::<PyDict>() {
         let pairs =
             djust_core::multi_value_dict_pairs(value).unwrap_or_else(|| dict.iter().collect());
-        let mut result = serde_json::Map::with_capacity(pairs.len());
+        let result = PyDict::new(py);
         for (key, item) in pairs {
-            result.insert(
+            result.set_item(
                 key.extract::<String>()?,
-                queryset_value_to_json(&item, depth + 1)?,
-            );
+                queryset_template_value(&item, depth + 1)?,
+            )?;
         }
-        return Ok(serde_json::Value::Object(result));
+        return Ok(result.into_any().unbind());
     }
     let items: Option<Vec<Bound<'_, PyAny>>> = if let Ok(list) = value.cast::<PyList>() {
         Some(list.iter().collect())
@@ -3961,12 +3956,23 @@ fn queryset_value_to_json(value: &Bound<'_, PyAny>, depth: usize) -> PyResult<se
         None
     };
     if let Some(items) = items {
-        return items
+        let values = items
             .iter()
-            .map(|item| queryset_value_to_json(item, depth + 1))
-            .collect::<PyResult<Vec<_>>>()
-            .map(serde_json::Value::Array);
+            .map(|item| queryset_template_value(item, depth + 1))
+            .collect::<PyResult<Vec<_>>>()?;
+        return Ok(PyList::new(py, values)?.into_any().unbind());
     }
+    // datetime is a date subclass; these checks also preserve user subclasses.
+    if value.is_instance_of::<pyo3::types::PyDate>()
+        || value.is_instance_of::<pyo3::types::PyTime>()
+        || value.is_instance_of::<pyo3::types::PyDelta>()
+    {
+        return Ok(value.clone().unbind());
+    }
+    json_value_to_py(py, &queryset_value_to_json(value)?)
+}
+
+fn queryset_value_to_json(value: &Bound<'_, PyAny>) -> PyResult<serde_json::Value> {
     // Handle None
     if value.is_none() {
         return Ok(serde_json::Value::Null);

--- a/docs/JIT_SERIALIZATION_PATTERN.md
+++ b/docs/JIT_SERIALIZATION_PATTERN.md
@@ -413,7 +413,7 @@ When a Django model is passed to a template, djust automatically serializes:
 #### 1. All Model Fields
 All concrete fields on the model are serialized:
 - CharField, TextField, IntegerField, etc. → their values
-- DateTimeField, DateField, TimeField → ISO 8601 strings (see [Datetime Gotcha](#datetime-fields-become-iso-strings))
+- DateTimeField, DateField, TimeField → native Python temporal values in JIT template contexts
 - ForeignKey → `{id: ..., pk: ..., __str__: ...}` (if not prefetched)
 - ForeignKey (prefetched) → full nested serialization
 
@@ -500,40 +500,20 @@ These methods are intentionally skipped:
 
 ### Common Gotchas
 
-#### Datetime Fields Become ISO Strings
+#### Datetime Fields and Django Filters
 
-**Problem:** Django template filters like `|date` don't work with ISO strings.
-
-```python
-# Model
-class Event(models.Model):
-    start_time = models.DateTimeField()
-```
+JIT queryset and model serializers preserve native Python datetime, date, time,
+and timedelta values for template rendering. Keep formatting in templates:
 
 ```html
-<!-- ❌ This WON'T work as expected -->
-{{ event.start_time|date:"M d, Y" }}
-<!-- Outputs: "2024-01-15T09:30:00" (the raw string) -->
+{% load tz %}
+{{ event.start_time|utc|date:"M d, Y · H:i" }} UTC
 ```
 
-**Solution:** Use a `get_*` method to format dates:
-
-```python
-class Event(models.Model):
-    start_time = models.DateTimeField()
-
-    def get_start_time_formatted(self):
-        """Return formatted date string for templates."""
-        if self.start_time:
-            return self.start_time.strftime("%b %d, %Y")
-        return ""
-```
-
-```html
-<!-- ✅ This works -->
-{{ event.get_start_time_formatted }}
-<!-- Outputs: "Jan 15, 2024" -->
-```
+This also applies to temporal values returned by methods or nested inside
+containers. JSON transport encoding remains a separate step. In 1.2.0rc5 and
+earlier, the queryset path converted temporal values to strings; assigning
+`list(queryset)` was a workaround for native Django filters.
 
 #### Related Objects Without Prefetching
 
@@ -600,8 +580,8 @@ If data isn't appearing in your template, check:
    - Returns str/int/float/bool/None
 
 4. **For datetime issues:**
-   - Create a `get_*_formatted()` method
-   - Or use JavaScript to format in the client
+   - Use native Django `date`, `time`, and timezone filters in templates
+   - Ensure the value is a Python temporal object rather than a preformatted string
 
 ### Cache Invalidation
 

--- a/python/tests/test_queryset_temporal_2810.py
+++ b/python/tests/test_queryset_temporal_2810.py
@@ -1,0 +1,65 @@
+"""Queryset values must retain the temporal types consumed by Django filters."""
+
+from datetime import date, datetime, time, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+from django.db import models
+from django.template import Context, Engine
+
+from djust._rust import serialize_queryset
+from djust.optimization.codegen import compile_serializer, generate_serializer_code
+
+
+class TemporalEntry(models.Model):
+    created_at = models.DateTimeField(null=True)
+
+    class Meta:
+        app_label = "queryset_temporal_2810"
+
+
+def test_queryset_utc_filter_matches_model_serializer():
+    entry = TemporalEntry(
+        created_at=datetime(2024, 1, 2, 14, 34, tzinfo=timezone(timedelta(hours=2)))
+    )
+    serializer = compile_serializer(
+        generate_serializer_code("TemporalEntry", ["created_at"], "serialize_entry"),
+        "serialize_entry",
+    )
+    template = Engine(libraries={"tz": "django.templatetags.tz"}).from_string(
+        '{% load tz %}{{ entry.created_at|utc|date:"M d, Y · H:i" }} UTC'
+    )
+    values = [serialize_queryset([entry], ["created_at"])[0], serializer(entry)]
+    assert [template.render(Context({"entry": value})) for value in values] == [
+        "Jan 02, 2024 · 12:34 UTC",
+        "Jan 02, 2024 · 12:34 UTC",
+    ]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime(2024, 1, 2, 12, 34),
+        datetime(2024, 1, 2, 12, 34, tzinfo=timezone.utc),
+        date(2024, 1, 2),
+        time(12, 34),
+        timedelta(days=2),
+        None,
+    ],
+)
+def test_temporal_values_survive_all_queryset_paths(value):
+    entry = SimpleNamespace(
+        direct=value,
+        nested=SimpleNamespace(value=value),
+        children=[SimpleNamespace(value=value)],
+        payload={"values": [value]},
+        method=lambda: value,
+    )
+    result = serialize_queryset(
+        [entry], ["direct", "nested.value", "children.0.value", "payload", "method"]
+    )[0]
+    assert result["direct"] is value
+    assert result["nested"]["value"] is value
+    assert result["children"][0]["value"] is value
+    assert result["payload"]["values"][0] is value
+    assert result["method"] is value


### PR DESCRIPTION
## Summary
Fixes #2810. Queryset serialization previously round-tripped datetime values through JSON, so Django's `utc` filter received a string and rendered an empty timestamp. Build the template dictionaries directly in Python and preserve native datetime/date/time/timedelta objects, including nested containers, relations, and method results.

The existing attribute security gate, container snapshots and nesting limit, and non-temporal scalar conversion behavior remain intact. Update JIT documentation to recommend template filters instead of preformatted timestamps.

## Validation
- Reproduced the reported UTC timestamp failure against the prior extension.
- Real SQLite queryset through `JITMixin._jit_serialize_queryset` retains datetime type and renders `Jan 02, 2024 · 12:34 UTC` using native Django filters.
- 147 focused temporal, nested-container, scalar-conversion, and serialization-security tests passed against the rebuilt extension.
- Full Python suite: 27,040 passed, 486 skipped.
- `make test-rust`: all three phases passed, including djust_live and djust_templates without default features.
- Normal commit and pre-push hooks run before publication; current-head CI must pass before merge.
