### PR TITLE
test: restore source coverage for dynamically executed JavaScript

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -457,6 +457,17 @@ jobs:
       - name: Run JavaScript tests
         run: npm test
 
+      - name: Measure JavaScript source coverage
+        run: npm run test:coverage
+
+      - name: Upload JavaScript coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: javascript-coverage
+          path: coverage/
+          if-no-files-found: ignore
+
       - name: Run JavaScript linter (if configured)
         run: |
           if [ -f "package.json" ] && grep -q "lint" package.json; then

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ packages/
 docs/website/guides/scaffolding.md
 python/djust/libdjust_live.dylib.dSYM/
 context/
+
+# Instrumented scripts used only by JavaScript coverage
+.coverage-scripts/

--- a/Makefile
+++ b/Makefile
@@ -816,3 +816,7 @@ endif
 		exit 1; \
 	fi
 	@echo "$(GREEN)No existing v$(VERSION) tag found locally or on origin.$(NC)"
+
+.PHONY: test-js-coverage
+test-js-coverage: ## Measure dynamic JavaScript coverage and enforce regression floors
+	@npm run test:coverage

--- a/changelog.d/2812.fixed.md
+++ b/changelog.d/2812.fixed.md
@@ -1,0 +1,1 @@
+- **JavaScript coverage attribution** — Instrument dynamically executed bundles and standalone modules with source maps, collect JSDOM coverage, and enforce measured source-coverage regression floors in CI.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1147,6 +1147,7 @@ pytest -m "not slow"
 ## Additional Resources
 
 - [Testing JavaScript](testing/TESTING_JAVASCRIPT.md) - JavaScript testing guide
+- [JavaScript source coverage](testing/JAVASCRIPT_COVERAGE.md) - Dynamic-script instrumentation and regression floors
 - [Testing Pages](testing/TESTING_PAGES.md) - Automated test pages
 - [Smoke & Fuzz Testing](testing/TESTING_SMOKE_FUZZ.md) - Smoke and fuzz testing
 - [Pull Request Checklist](PULL_REQUEST_CHECKLIST.md) - PR review checklist

--- a/docs/testing/JAVASCRIPT_COVERAGE.md
+++ b/docs/testing/JAVASCRIPT_COVERAGE.md
@@ -1,0 +1,77 @@
+# JavaScript source coverage
+
+Run from the repository root after `npm ci`:
+
+```bash
+npm run test:coverage
+# Equivalent Make target:
+make test-js-coverage
+```
+
+This prepares instrumented scripts, runs the JavaScript suite using
+`vitest.coverage.config.js`, writes `coverage/index.html`,
+`coverage/coverage-final.json`, and `coverage/coverage-summary.json`, and enforces
+regression floors. CI runs this command after the ordinary `npm test` suite and
+uploads the `javascript-coverage` artifact, including on failure.
+
+Use the npm command rather than bare `vitest --coverage`: preparing the script
+maps and selecting the coverage setup are required. `npm test` continues to run
+against uninstrumented production scripts.
+
+## How attribution works
+
+Most browser tests read the shipped bundles with `readFileSync` and execute them
+with `eval` or `new Function`. V8 sees anonymous executions and cannot attribute
+them to the configured source files. Some source fragments also share an opening
+block or class across file boundaries, so they are not independent programs.
+
+The preparation step reconstructs each bundle from its ordered source fragments
+and verifies that it exactly matches the committed bundle. A stale bundle fails
+with instructions to run `make build-js`. It then instruments the executable
+bundle with Istanbul and records a concatenation source map. Coverage reads of
+`client.js` and `debug-panel.js` use these instrumented scripts; production files
+on disk are never modified. The output maps counters back to the original
+`python/djust/static/djust/src/` files, including `src/debug/`.
+
+Each source file starts with its zero-hit counter map, so unexecuted modules stay
+in the denominator. Delimiter-only fragments have empty records because a closing
+brace has no executable location. JSDOM contexts are collected once after each
+test, even when the test has already closed its window.
+
+Tests that execute an independently parseable source module should use:
+
+```javascript
+import { readScript } from './coverage-support/instrument.js';
+const source = readScript('./python/djust/static/djust/src/07-form-data.js');
+```
+
+`readScript` returns original text during normal tests and instrumented code during
+coverage. Its identity source map ensures that module and bundle execution merge
+into the same source locations without duplicating the denominator. Keep ordinary
+`readFileSync` for assertions about source text. Text inspection and raw extracted
+snippets do not earn execution coverage. Minified-bundle tests continue to execute
+the actual minified artifacts unchanged; they do not contribute source coverage.
+
+## Measured baseline and floors
+
+The initial corrected measurement on September 12, 2026 was:
+
+| Metric | Measured | Enforced floor |
+| --- | ---: | ---: |
+| Lines | 68.18% | 67% |
+| Statements | 65.87% | 65% |
+| Functions | 63.70% | 63% |
+| Branches | 54.62% | 54% |
+
+The previous 85% settings reported 0% for these dynamically loaded scripts and
+were not enforced by the JavaScript CI job. They were not evidence of 85% coverage.
+The new floors provide a small margin for platform-dependent branches and protect
+the measured baseline. Raise them deliberately as coverage improves; do not lower
+them or remove source files to hide regressions. Reaching 85% remains additional
+test work, not a result of fixing instrumentation.
+
+The attribution regression tests verify positive hits, a deliberately untaken
+branch, identical source locations for bundle/module execution, collection without
+double-counting contexts, and rejection of stale bundles. Zero coverage in a
+module now means the instrumented execution did not reach it; inspect the HTML
+report and its tests before treating that as a production defect.

--- a/docs/testing/TESTING_JAVASCRIPT.md
+++ b/docs/testing/TESTING_JAVASCRIPT.md
@@ -43,7 +43,7 @@ and evaluate it, or drive it through `window.djust.*` on the booted DOM.
 npm test                                   # all JS tests
 npx vitest run tests/js/foo.test.js        # one file
 npx vitest                                 # watch mode
-npx vitest run --coverage                  # coverage over static/djust/src/
+npm run test:coverage                      # mapped source coverage + regression floors
 ```
 
 Rebuild the bundle after editing `src/` — tests load `client.js`, not the
@@ -111,3 +111,5 @@ was loaded by nothing. Edit the `src/` module instead and rebuild.
 Yes — `tests/js/min_bundle_applypatches_1676.test.js` evaluates
 `client.min.js` to catch mangling regressions. Prefer `client.js` for
 readability unless the behaviour under test is minification-specific.
+
+See [JavaScript source coverage](JAVASCRIPT_COVERAGE.md) for instrumentation, reports, measured floors, and how to add covered module tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,16 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@vitest/coverage-v8": "^5.0.0",
+        "@vitest/coverage-istanbul": "^5.0.0",
+        "@vitest/istanbul-lib-coverage": "^1.0.1",
+        "@vitest/istanbul-lib-instrument": "^1.0.1",
+        "@vitest/istanbul-lib-source-maps": "^1.0.1",
         "@vitest/ui": "^5.0.0",
         "eslint": "^10.10.0",
         "eslint-plugin-security": "^4.0.1",
         "happy-dom": "^20.14.0",
         "jsdom": "^30.0.1",
+        "magic-string": "^1.2.3",
         "terser": "^5.51.2",
         "vitest": "^5.0.0"
       }
@@ -52,6 +56,217 @@
         "node": "^22.13.0 || >=24.0.0"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.5.tgz",
+      "integrity": "sha512-YLsYoQMvL8l8WrGpN3Zj7O1wK5LEBN+cQtux7BcuHyxIXve724XG+zuJ1n3U1cUweRtTzQOA4IHbuQw3N34SZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+      "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helpers": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@types/gensync": "^1.0.5",
+        "convert-source-map": "^2.0.0",
+        "empathic": "^2.0.1",
+        "gensync": "^1.0.0-beta.2",
+        "import-meta-resolve": "^4.2.0",
+        "json5": "^2.2.3",
+        "obug": "^2.1.1",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.5.tgz",
+      "integrity": "sha512-Qk8ahMGooH5mz6uuhoDvfZGkUf/Mf3RTBucVVl4MKx4LKMTv872TeW8O92h15iVtlN8wAROBIpI1aV6x1z0LCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^8.0.5",
+        "@babel/helper-validator-option": "^8.0.0",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^11.0.0",
+        "verkit": "^0.3.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -72,6 +287,64 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+      "integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
     "node_modules/@babel/parser": {
       "version": "7.29.8",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
@@ -88,6 +361,140 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/template": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+      "integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.4",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.4",
+        "obug": "^2.1.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
     "node_modules/@babel/types": {
       "version": "7.29.8",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
@@ -100,16 +507,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@bcoe/v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -478,6 +875,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -900,6 +1307,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/gensync": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
+      "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -934,33 +1355,28 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@vitest/coverage-v8": {
+    "node_modules/@vitest/coverage-istanbul": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-5.0.0.tgz",
-      "integrity": "sha512-toMg6PZGCIa/lQNCDoASrfb1ly4hsUKXFtFYC9kD4t78o5Y6LyNJU7AENt8eHPr3quYdxaxK7hj2mnbFfUk9NA==",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-5.0.0.tgz",
+      "integrity": "sha512-L0Rh+O61F2FV3+Xc3iGqeW5Tp0fs41VXy0hth84UCcMZGqlTjM1n5PUDqdaJD2xmQ/jZY3SJ9k7A2IKpKZRT8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
+        "@jridgewell/gen-mapping": "^0.3.13",
+        "@jridgewell/trace-mapping": "0.3.31",
         "@vitest/istanbul-lib-coverage": "^1.0.0",
+        "@vitest/istanbul-lib-instrument": "^1.0.0",
         "@vitest/istanbul-lib-report": "^1.0.0",
-        "ast-v8-to-istanbul": "^1.0.5",
+        "@vitest/istanbul-lib-source-maps": "^1.0.0",
         "magicast": "^0.5.4",
         "obug": "^2.1.4",
-        "std-env": "^4.2.0",
         "tinyrainbow": "^3.1.1"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "5.0.0",
         "vitest": "5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
       }
     },
     "node_modules/@vitest/istanbul-lib-coverage": {
@@ -973,6 +1389,73 @@
         "node": ">=22"
       }
     },
+    "node_modules/@vitest/istanbul-lib-instrument": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vitest/istanbul-lib-instrument/-/istanbul-lib-instrument-1.0.1.tgz",
+      "integrity": "sha512-sSwnQN40rt2TiJeW30tBhMKi+6oTZkD3OzdzHAl7o5NJzWtp//sCN2abHfEXQV9dfwTto8Fu+nyQRygcQt/pjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^8.0.1",
+        "@babel/parser": "^8.0.4",
+        "@istanbuljs/schema": "^0.1.3",
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "@vitest/istanbul-lib-coverage": "1.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@vitest/istanbul-lib-instrument/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@vitest/istanbul-lib-instrument/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@vitest/istanbul-lib-instrument/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@vitest/istanbul-lib-instrument/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
     "node_modules/@vitest/istanbul-lib-report": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@vitest/istanbul-lib-report/-/istanbul-lib-report-1.0.1.tgz",
@@ -981,6 +1464,21 @@
       "license": "MIT",
       "dependencies": {
         "@vitest/istanbul-lib-coverage": "1.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@vitest/istanbul-lib-source-maps": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vitest/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.0.1.tgz",
+      "integrity": "sha512-3/9S3YuBDg2X2+gM40jUTfwV66w8LrDUF/YPdqVElDwh/541cKSb8A7Eqd0N/Fza1FXeMp6XGzilLDEMOhk6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "@vitest/istanbul-lib-coverage": "1.0.1",
+        "obug": "^2.1.4"
       },
       "engines": {
         "node": ">=22"
@@ -1123,18 +1621,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/ast-v8-to-istanbul": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
-      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.31",
-        "estree-walker": "^3.0.3",
-        "js-tokens": "^10.0.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1143,6 +1629,19 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bidi-js": {
@@ -1166,6 +1665,40 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/buffer-from": {
@@ -1201,6 +1734,27 @@
         "keyv": "^5.6.0",
         "qified": "^0.10.1"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -1322,6 +1876,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.422",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+      "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/entities": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
@@ -1341,6 +1912,16 @@
       "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1654,6 +2235,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1727,6 +2318,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {
@@ -1849,6 +2451,19 @@
         "node": "^22.14.0 || >=24.0.0"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1862,6 +2477,19 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/keyv": {
       "version": "5.6.0",
@@ -2287,6 +2915,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-releases": {
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
@@ -2409,8 +3047,7 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.7",
@@ -2571,6 +3208,19 @@
       },
       "engines": {
         "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -2822,6 +3472,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -2830,6 +3511,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/verkit": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/verkit/-/verkit-0.3.2.tgz",
+      "integrity": "sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -7,17 +7,21 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
-    "test:coverage": "vitest run --coverage",
+    "test:coverage": "node scripts/prepare-js-coverage.mjs && vitest run --coverage --config vitest.coverage.config.js",
     "lint": "eslint python/djust/static/djust/ --max-warnings 0",
     "lint:fix": "eslint python/djust/static/djust/ --fix"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^5.0.0",
+    "@vitest/coverage-istanbul": "^5.0.0",
+    "@vitest/istanbul-lib-coverage": "^1.0.1",
+    "@vitest/istanbul-lib-instrument": "^1.0.1",
+    "@vitest/istanbul-lib-source-maps": "^1.0.1",
     "@vitest/ui": "^5.0.0",
     "eslint": "^10.10.0",
     "eslint-plugin-security": "^4.0.1",
     "happy-dom": "^20.14.0",
     "jsdom": "^30.0.1",
+    "magic-string": "^1.2.3",
     "terser": "^5.51.2",
     "vitest": "^5.0.0"
   },

--- a/scripts/prepare-js-coverage.mjs
+++ b/scripts/prepare-js-coverage.mjs
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createCoverageMap, createFileCoverage } from '@vitest/istanbul-lib-coverage';
+import { createSourceMapStore } from '@vitest/istanbul-lib-source-maps';
+import { instrumentBundle } from '../tests/js/coverage-support/instrument.js';
+
+const output = path.resolve('.coverage-scripts');
+fs.mkdirSync(output, { recursive: true });
+const baseline = createCoverageMap({});
+for (const name of ['client.js', 'debug-panel.js']) {
+  const filename = path.resolve('python/djust/static/djust', name);
+  const { code, coverage, sources } = instrumentBundle(fs, filename);
+  fs.writeFileSync(path.join(output, name), code);
+  const mapped = await createSourceMapStore().transformCoverage(createCoverageMap({ [filename]: coverage }));
+  for (const source of sources) {
+    // Delimiter-only fragments (e.g. the double-load guard's closing brace)
+    // have no executable locations. Keep an empty record instead of asking
+    // the provider to parse them as independent JavaScript programs.
+    if (!mapped.files().includes(source)) mapped.addFileCoverage(createFileCoverage(source));
+  }
+  baseline.merge(mapped);
+}
+fs.writeFileSync(path.join(output, 'baseline.json'), JSON.stringify(baseline));
+console.log(`Prepared coverage for ${baseline.files().length} source fragments.`);

--- a/tests/js/coverage-support/collect.js
+++ b/tests/js/coverage-support/collect.js
@@ -1,0 +1,12 @@
+import * as libCoverage from '@vitest/istanbul-lib-coverage';
+
+// Keep references even after JSDOM.close(); drain once so a later test cannot
+// count the same window's execution again.
+export function collectWindowCoverage(current, windows) {
+  const coverage = libCoverage.createCoverageMap(current || {});
+  for (const window of windows.splice(0)) {
+    const data = window.__VITEST_COVERAGE__;
+    if (data && data !== current) coverage.merge(data);
+  }
+  return coverage.toJSON();
+}

--- a/tests/js/coverage-support/instrument.js
+++ b/tests/js/coverage-support/instrument.js
@@ -1,0 +1,45 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import MagicString, { Bundle } from 'magic-string';
+import { createInstrumenter } from '@vitest/istanbul-lib-instrument';
+
+function scriptInstrumenter() {
+  return createInstrumenter({
+    coverageVariable: '__VITEST_COVERAGE__', coverageGlobalScope: 'this',
+    coverageGlobalScopeFunc: true, produceSourceMap: true,
+    preserveComments: true, compact: false,
+  });
+}
+
+// The build joins fragments that may share a block or class. Instrument that
+// exact executable unit and use its concatenation map to recover module lines.
+export function instrumentBundle(fs, filename) {
+  const client = path.basename(filename) === 'client.js';
+  const dir = path.join(path.dirname(filename), client ? 'src' : 'src/debug');
+  const bundle = new Bundle({ separator: '', intro: client ? ';(function () {\n' : '' });
+  const sources = fs.readdirSync(dir).filter(name => /^\d.*\.js$/.test(name)).sort().map(name => path.join(dir, name));
+  for (const source of sources) {
+    bundle.addSource({ filename: source, content: new MagicString(fs.readFileSync(source, 'utf8')) });
+  }
+  if (client) bundle.append('\n})();\n');
+  const original = fs.readFileSync(filename, 'utf8');
+  if (bundle.toString() !== original) throw new Error(`Stale bundle: ${filename}. Run make build-js.`);
+  const map = bundle.generateMap({ hires: true, includeContent: true, file: filename });
+  const instrumenter = scriptInstrumenter();
+  const code = instrumenter.instrumentSync(original, filename, JSON.parse(map.toString()));
+  return { code, coverage: instrumenter.lastFileCoverage(), sources };
+}
+
+// Use explicitly for independently executable modules. Source-inspection tests
+// keep readFileSync so instrumentation never changes their text assertions.
+export function readScript(filename) {
+  const source = fs.readFileSync(filename, 'utf8');
+  if (!globalThis.__VITEST_COVERAGE__) return source;
+  return instrumentSource(source, filename);
+}
+
+export function instrumentSource(source, filename) {
+  const absolute = path.resolve(filename);
+  const map = new MagicString(source).generateMap({ hires: true, includeContent: true, source: absolute });
+  return scriptInstrumenter().instrumentSync(source, absolute + '.instrumented', JSON.parse(map.toString()));
+}

--- a/tests/js/coverage-support/instrumentation.test.js
+++ b/tests/js/coverage-support/instrumentation.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { runInNewContext } from 'node:vm';
+import path from 'node:path';
+import * as libCoverage from '@vitest/istanbul-lib-coverage';
+import * as libSourceMaps from '@vitest/istanbul-lib-source-maps';
+import { collectWindowCoverage } from './collect.js';
+import { instrumentBundle, instrumentSource } from './instrument.js';
+
+function fixture() {
+  const filename = path.resolve('scratch/coverage-fixture/client.js');
+  const first = path.resolve('scratch/coverage-fixture/src/00-open.js');
+  const second = path.resolve('scratch/coverage-fixture/src/01-close.js');
+  const files = {
+    [first]: 'function choose(flag) {\n  if (flag) { return "yes"; }\n',
+    [second]: '  return "no";\n}\nglobalThis.result = choose(true);\n',
+  };
+  files[filename] = ';(function () {\n' + files[first] + files[second] + '\n})();\n';
+  return {
+    filename, first, second, files,
+    fs: { readFileSync: name => files[name], readdirSync: () => ['00-open.js', '01-close.js'] },
+  };
+}
+
+describe('dynamic script coverage attribution', () => {
+  it('maps executed and unexecuted branches to original cross-file fragments', async () => {
+    const f = fixture();
+    const { code } = instrumentBundle(f.fs, f.filename);
+    const context = {};
+    runInNewContext(code, context);
+    expect(context.result).toBe('yes');
+    const mapped = await libSourceMaps.createSourceMapStore().transformCoverage(
+      libCoverage.createCoverageMap(context.__VITEST_COVERAGE__),
+    );
+    expect(mapped.files().sort()).toEqual([f.first, f.second].sort());
+    const first = mapped.fileCoverageFor(f.first).data;
+    expect(Object.entries(first.statementMap).some(([id, loc]) => loc.start.line === 2 && first.s[id] === 1)).toBe(true);
+    const second = mapped.fileCoverageFor(f.second).data;
+    const unexecuted = Object.entries(second.statementMap).filter(([, loc]) => loc.start.line === 1);
+    expect(unexecuted.length).toBeGreaterThan(0);
+    expect(unexecuted.every(([id]) => second.s[id] === 0)).toBe(true);
+    expect(Object.values(first.b).some(hits => hits.includes(0) && hits.includes(1))).toBe(true);
+  });
+
+  it('merges standalone and bundle execution without duplicating source locations', async () => {
+    const f = fixture();
+    f.files[f.first] = 'function choose(flag) { if (flag) return 1; return 2; }\n';
+    f.files[f.second] = 'globalThis.result = choose(true);\n';
+    f.files[f.filename] = ';(function () {\n' + f.files[f.first] + f.files[f.second] + '\n})();\n';
+    const bundle = {};
+    runInNewContext(instrumentBundle(f.fs, f.filename).code, bundle);
+    const standalone = {};
+    runInNewContext(instrumentSource(f.files[f.first], f.first) + '\nchoose(false);', standalone);
+    const remap = data => libSourceMaps.createSourceMapStore().transformCoverage(libCoverage.createCoverageMap(data));
+    const bundledMap = await remap(bundle.__VITEST_COVERAGE__);
+    const mergedMap = await remap(collectWindowCoverage({}, [bundle, standalone]));
+    const before = bundledMap.fileCoverageFor(f.first).toSummary().data;
+    const after = mergedMap.fileCoverageFor(f.first).toSummary().data;
+    for (const metric of ['statements', 'functions', 'branches', 'lines']) {
+      expect(after[metric].total).toBe(before[metric].total);
+    }
+    expect(after.branches.covered).toBeGreaterThan(before.branches.covered);
+  });
+
+  it('collects independent contexts exactly once without covering the untaken branch', () => {
+    const f = fixture();
+    const { code } = instrumentBundle(f.fs, f.filename);
+    const windows = [{}, {}];
+    for (const window of windows) runInNewContext(code, window);
+    const once = collectWindowCoverage({}, windows);
+    expect(windows).toHaveLength(0);
+    const twice = collectWindowCoverage(once, windows);
+    expect(twice).toEqual(once);
+    const data = libCoverage.createCoverageMap(twice).fileCoverageFor(f.filename).data;
+    expect(Object.values(data.b).some(hits => hits.includes(0) && hits.includes(2))).toBe(true);
+  });
+
+  it('does not invent execution when instrumentation is disabled', () => {
+    const f = fixture();
+    const context = {};
+    runInNewContext(f.files[f.filename], context);
+    expect(context.result).toBe('yes');
+    expect(context.__VITEST_COVERAGE__).toBeUndefined();
+  });
+
+  it('rejects stale bundles instead of assigning counts to the wrong source', () => {
+    const f = fixture();
+    f.files[f.filename] += '\n// stale output';
+    expect(() => instrumentBundle(f.fs, f.filename)).toThrow('Stale bundle');
+  });
+});

--- a/tests/js/coverage-support/setup.js
+++ b/tests/js/coverage-support/setup.js
@@ -1,0 +1,39 @@
+import { afterEach, vi } from 'vitest';
+import { collectWindowCoverage } from './collect.js';
+
+const state = vi.hoisted(() => ({ windows: [] }));
+
+async function mockFs() {
+  const fs = await vi.importActual('node:fs');
+  const path = await import('node:path');
+  const { fileURLToPath } = await import('node:url');
+  function readFileSync(file, options) {
+    const filename = path.resolve(file instanceof URL ? fileURLToPath(file) : String(file));
+    const name = path.basename(filename);
+    if (['client.js', 'debug-panel.js'].includes(name)
+        && filename === path.resolve('python/djust/static/djust', name)) {
+      return fs.readFileSync(path.resolve('.coverage-scripts', name), options);
+    }
+    return fs.readFileSync(file, options);
+  }
+  return { ...fs, readFileSync, default: { ...fs.default, readFileSync } };
+}
+vi.mock('node:fs', () => mockFs());
+vi.mock('fs', () => mockFs());
+vi.mock('jsdom', async () => {
+  const actual = await vi.importActual('jsdom');
+  class JSDOM extends actual.JSDOM {
+    constructor(...args) {
+      super(...args);
+      state.windows.push(this.window);
+    }
+  }
+  return { ...actual, JSDOM };
+});
+
+const fs = await vi.importActual('node:fs');
+globalThis.__VITEST_COVERAGE__ = JSON.parse(fs.readFileSync('.coverage-scripts/baseline.json', 'utf8'));
+
+afterEach(() => {
+  globalThis.__VITEST_COVERAGE__ = collectWindowCoverage(globalThis.__VITEST_COVERAGE__, state.windows);
+});

--- a/tests/js/draft-manager.test.js
+++ b/tests/js/draft-manager.test.js
@@ -1,3 +1,4 @@
+import { readScript } from './coverage-support/instrument.js';
 /**
  * Unit tests for DraftMode (localStorage auto-save) — ported from the deleted
  * tests/js/draft_mode.test.js (#2659), which exercised the never-shipped copy
@@ -5,15 +6,14 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import fs from 'fs';
 
 // Evaluate the REAL bundle modules (not a copy): 06-draft-manager.js defines
 // DraftManager/globalDraftManager, 07-form-data.js defines the form helpers.
 // Both are plain scripts inside the client IIFE, so evaluate them in a
 // function scope with the two bundle globals they use shimmed: djLog
 // (00-namespace.js:110) and UNSAFE_KEYS (00-namespace.js:128, same value).
-const DRAFT_SRC = fs.readFileSync('./python/djust/static/djust/src/06-draft-manager.js', 'utf-8');
-const FORM_SRC = fs.readFileSync('./python/djust/static/djust/src/07-form-data.js', 'utf-8');
+const DRAFT_SRC = readScript('./python/djust/static/djust/src/06-draft-manager.js');
+const FORM_SRC = readScript('./python/djust/static/djust/src/07-form-data.js');
 // eslint-disable-next-line no-new-func -- evaluates the real bundle modules (test-only)
 const { DraftManager, globalDraftManager, collectFormData, restoreFormData } = new Function(
     'djLog', 'UNSAFE_KEYS',

--- a/tests/js/navigation.test.js
+++ b/tests/js/navigation.test.js
@@ -1,3 +1,4 @@
+import { readScript } from './coverage-support/instrument.js';
 /**
  * Tests for navigation — URL state management (src/18-navigation.js)
  */
@@ -7,7 +8,7 @@ import { JSDOM } from 'jsdom';
 import fs from 'fs';
 
 const clientCode = fs.readFileSync('./python/djust/static/djust/client.js', 'utf-8');
-const navSourceCode = fs.readFileSync('./python/djust/static/djust/src/18-navigation.js', 'utf-8');
+const navSourceCode = readScript('./python/djust/static/djust/src/18-navigation.js');
 
 function createEnv(bodyHtml = '') {
     const dom = new JSDOM(

--- a/tests/js/safe_nav.test.js
+++ b/tests/js/safe_nav.test.js
@@ -1,3 +1,4 @@
+import { readScript } from './coverage-support/instrument.js';
 /**
  * Tests for the shared client-side navigation scheme/origin guard
  * (src/02b-safe-nav.js) and its application at every location.href sink:
@@ -24,10 +25,10 @@ import { dirname, resolve } from 'path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SRC = resolve(__dirname, '../../python/djust/static/djust/src');
 
-const safeNavSrc = readFileSync(resolve(SRC, '02b-safe-nav.js'), 'utf8');
-const navSrc = readFileSync(resolve(SRC, '18-navigation.js'), 'utf8');
-const sseSrc = readFileSync(resolve(SRC, '03b-sse.js'), 'utf8');
-const wsSrc = readFileSync(resolve(SRC, '03-websocket.js'), 'utf8');
+const safeNavSrc = readScript(resolve(SRC, '02b-safe-nav.js'));
+const navSrc = readScript(resolve(SRC, '18-navigation.js'));
+const sseSrc = readScript(resolve(SRC, '03b-sse.js'));
+const wsSrc = readScript(resolve(SRC, '03-websocket.js'));
 
 const ORIGIN = 'https://app.example.com';
 

--- a/tests/js/strip_internal_params.test.js
+++ b/tests/js/strip_internal_params.test.js
@@ -1,3 +1,4 @@
+import { readScript } from './coverage-support/instrument.js';
 /**
  * Tests that internal/client-only properties (_targetElement, _optimisticUpdateId,
  * _skipLoading, _djTargetSelector) are stripped from params before sending to server.
@@ -10,10 +11,9 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { readFileSync } from 'fs';
 
 // Load just the event handler source (not the full bundled client)
-const eventHandlerCode = readFileSync('./python/djust/static/djust/src/11-event-handler.js', 'utf-8');
+const eventHandlerCode = readScript('./python/djust/static/djust/src/11-event-handler.js');
 
 describe('handleEvent strips internal params before sending', () => {
     let handleEvent;

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -74,22 +74,5 @@ export default defineConfig({
       // Anything else — let vitest surface it.
       return true;
     },
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-      include: ['python/djust/static/djust/src/**/*.js'],
-      exclude: ['node_modules', 'tests', '**/*.test.js'],
-      // Coverage thresholds
-      thresholds: {
-        lines: 85,
-        functions: 85,
-        branches: 85,
-        statements: 85,
-      },
-      // Report uncovered lines
-      all: true,
-      // Skip full coverage check (we want to see what's missing)
-      skipFull: false,
-    },
   },
 });

--- a/vitest.coverage.config.js
+++ b/vitest.coverage.config.js
@@ -1,0 +1,17 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import base from './vitest.config.js';
+
+export default mergeConfig(base, defineConfig({
+  test: {
+    setupFiles: ['./tests/js/coverage-support/setup.js'],
+    coverage: {
+      provider: 'istanbul',
+      reporter: ['text', 'json', 'html', 'json-summary'],
+      include: ['python/djust/static/djust/src/**/*.js'],
+      exclude: ['node_modules', 'tests', '**/*.test.js'],
+      // Regression floors measured over the entire client + debug module tree.
+      // The old 85% values were never measuring these dynamically loaded scripts.
+      thresholds: { lines: 67, functions: 63, branches: 54, statements: 65 },
+    },
+  },
+}));


### PR DESCRIPTION
## Problem and change
Fixes #2812. Tests loaded production scripts with `readFileSync` and executed them anonymously, so V8 reported 0% source coverage. Some modules also share a block or class across files and cannot be parsed individually.

Instrument the verified assembled client and debug bundles once, map their counters back to all 75 original source fragments, and collect JSDOM contexts after each test. Seed zero-hit records so unexecuted modules remain visible. Standalone-module tests use an explicit reader with an identity map; a regression test prevents bundle/module execution from duplicating source locations. Source inspection and minified-artifact tests retain their original inputs. Production assets are unchanged.

The supported command is `npm run test:coverage` (also `make test-js-coverage`). CI runs it after the ordinary suite and uploads HTML/JSON reports. The old blanket 85% values did not measure these scripts and were not enforced in the JS CI job. New explicit regression floors protect the measured baseline rather than claiming the suite reaches 85%.

| Metric | Measured | Floor |
| --- | ---: | ---: |
| Lines | 68.18% | 67% |
| Statements | 65.87% | 65% |
| Functions | 63.70% | 63% |
| Branches | 54.62% | 54% |

## Validation
- All 1,787 JavaScript tests pass both normally and with coverage enabled.
- Coverage command and ESLint pass.
- Five attribution regressions verify positive and zero hits, standalone/bundle location merging, context collection exactly once, disabled instrumentation, and stale-bundle rejection.
- Normal commit and pre-push checks run before publication; complete current-head CI is required before merge.

## Limits
Coverage remains below 85%; improving it needs additional tests. Raw source inspection/extracted snippets and unchanged minified-bundle executions do not earn source coverage. Unexecuted source files remain in the report and denominator. The documentation explains these boundaries and how new executable-module tests should participate.
