### PR TITLE
docs: teach native application conventions and agent discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Working with djust
+
+Read [CLAUDE.md](CLAUDE.md) for framework build, security, testing and review
+requirements. Those instructions apply to all coding agents working here.
+
+For application code, examples, forms, templates or scaffolding, read
+[Application engineering conventions](docs/ai/conventions.md) first, then the
+relevant sections of the [AI reference index](docs/ai/README.md).
+Prefer native Django/djust behavior and declarations before adding wrappers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 This file provides guidance to Claude Code when working with the djust framework.
 
+## Application conventions
+
+For application code, examples and scaffolding, start with
+[Application engineering conventions](docs/ai/conventions.md) and load the
+relevant [AI reference sections](docs/ai/README.md).
+
 ## Project Overview
 
 djust is a hybrid Python/Rust framework bringing Phoenix LiveView-style reactive server-side rendering to Django. Rust handles performance-critical operations (template rendering, VDOM diffing, HTML parsing) via PyO3; Python provides the developer-facing API.

--- a/README.md
+++ b/README.md
@@ -407,6 +407,10 @@ pip install target/wheels/djust-*.whl
 
 ## Documentation
 
+Building with an AI coding agent? Start with the [application conventions](docs/ai/conventions.md)
+and [focused AI references](docs/ai/README.md). `djust new` includes an `AGENTS.md`
+entry point; existing applications can add the same pointer to their agent instructions.
+
 The full documentation lives at [docs.djust.org](https://docs.djust.org). The
 sections below cover the core API; see [Getting Started](#getting-started) above
 for first-time setup.

--- a/changelog.d/ai-conventions.documentation.md
+++ b/changelog.d/ai-conventions.documentation.md
@@ -1,0 +1,1 @@
+- **AI application conventions**: Add canonical native-first guidance, discovery links and a generated AGENTS.md entry point for `djust new` projects.

--- a/docs/PULL_REQUEST_CHECKLIST.md
+++ b/docs/PULL_REQUEST_CHECKLIST.md
@@ -2,6 +2,15 @@
 
 This document outlines the mandatory checks that must be evaluated when reviewing any Pull Request to djust.
 
+## Native-first application review
+
+- [ ] New application helpers/mixins identify the product behavior they add and
+  the native Django/djust capability considered. Prefer native declarations and
+  hooks to duplicate plumbing; services are not mandatory for every write.
+- [ ] Framework accommodations include a version, reproduction, issue and removal
+  condition. Test the behavior claimed, not just successful rendering.
+- [ ] Application examples follow [the conventions](ai/conventions.md).
+
 ## 🔍 Pre-Review Quick Checks
 
 - [ ] **PR Title** follows format: `[type]: brief description` (e.g., `feat:`, `fix:`, `docs:`, `refactor:`)

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -2,6 +2,10 @@
 
 Focused, standalone reference sections for AI code generation. Each file is self-contained and under 500 tokens.
 
+Start with [Application engineering conventions](conventions.md). It explains
+ownership, native-first decisions, verification and how application agents find
+these references. The topic sections below are concise API examples.
+
 ## Sections
 
 - [lifecycle.md](lifecycle.md) -- LiveView lifecycle: mount, refresh, render

--- a/docs/ai/conventions.md
+++ b/docs/ai/conventions.md
@@ -1,0 +1,92 @@
+# Application engineering conventions
+
+Use Django and djust as part of the implementation. Prefer their supported APIs
+and declarative options before writing application plumbing. This guide applies
+to applications; framework contributor build/review rules remain in `CLAUDE.md`.
+
+## Before writing code
+
+1. Read the affected flow and identify the installed djust version. A sibling
+   checkout or online main branch may differ from the deployed release.
+2. Check the relevant [AI reference](README.md), installed API, and existing
+   application pattern. An unfamiliar API is not a missing capability.
+3. Reuse native behavior before reusing an application wrapper that duplicates
+   it. Write custom code for product behavior or a reproduced framework gap.
+4. Prefer readable declarations and the smallest correct implementation. Do not
+   optimize for line count, fewer files, or fewer tests at the cost of clarity,
+   security, accessibility, or the requested behavior.
+
+## Ownership and native patterns
+
+| Concern | Convention | Reference |
+| --- | --- | --- |
+| Lifecycle and state | Initialize state in `mount()`. Keep internal objects in private attributes; expose only rendering data before calling `super().get_context_data()`. Refresh authorized queries when their inputs change. A `_refresh()` helper is an application pattern, not another lifecycle to implement. | [Lifecycle](lifecycle.md), [JIT](jit.md) |
+| Ordinary editors | Use `FormMixin`, `form_class`, native field validation and submit hooks. Use `as_live()` or `as_live_field()` with declarative widget options. Do not maintain a second draft/error/renderer system. | [Forms](forms.md) |
+| Input rules | Prefer explicit-field `ModelForm`s for single-model editors; use `Form` for composite inputs and actions. Derive lengths/choices from model metadata. Share validators, not copied schemas. Coercion alone is not validation. | [Forms](forms.md), [Security](security.md) |
+| Template data | Pass authorized models/querysets to native rendering. Templates own related access, labels, dates, URLs and loops. Do not flatten models into presentation dictionaries merely for transport. Declare sensitive-field exclusions and verify HTTP/socket output. | [JIT](jit.md), [Templates](templates.md) |
+| Custom events | Use `@event_handler()` for client-callable handlers, compatible signatures/defaults, `value` for input/change events, and native debounce/throttle where needed. Validate untrusted parameters and authorize the selected object at mutation time. | [Events](events.md), [Security](security.md) |
+| Navigation | Use `dj-navigate` between live pages and `dj-patch` for state within a view. Preserve real URLs and URL-backed filters/pagination. Auth/admin/external boundaries can use ordinary navigation. | [Navigation guide](../guides/navigation.md) |
+| Form markup and fallback | Keep semantic forms and CSRF. Native JSON HTTP fallback invokes the event flow when WebSockets are unavailable; it is not JavaScript-disabled HTML POST support. Do not add duplicate mutation routes unless the product explicitly requires them. | [Forms](forms.md) |
+| Loading and background work | Use native loading/disabled directives and `start_async()` or `@background` when appropriate. Show save/error feedback beside the action. Do not block event handlers with long work or add redundant async mixins already inherited by LiveView. | [Loading/background](loading-states.md) |
+| Shared UI | Reuse templates, existing components, and the application's theme. Keep stable element identities in changing lists; preserve focus, keyboard behavior and accessible feedback. Use client hooks only for browser behavior that needs them. | [Templates](templates.md), [Components](components.md) |
+| Auth, uploads and realtime | Inspect native auth, upload, presence, streaming and push APIs before adding parallel systems. Keep binary uploads out of serializable form state. Scope presence/push and recheck current access on refresh. | [Security](security.md), [Capability lookup](#capability-lookup) |
+
+## Application policy stays in the application
+
+A simple authorized `form.save()` or ORM operation may live in a view. Services
+are optional: use them for shared workflows, multi-record transactions, locking
+or rules used by multiple entry points. Do not create pass-through services.
+Django apps and workflow-based view packages are organization choices, not extra
+framework requirements.
+
+Define each input rule once, but validate at every relevant trust boundary.
+A service accepting raw input must remain safe for commands/background callers.
+Native form validation does not replace fresh authorization, current-state checks
+or database constraints. Model `save()` does not automatically call `full_clean()`.
+Publish mutation notifications after commit when consumers must observe committed
+records. Keep genuine transformations such as image sanitization and sanitized
+Markdown; do not confuse them with redundant model serialization.
+
+## Small examples to follow
+
+- [Lifecycle example](lifecycle.md): private queryset preparation and public assigns.
+- [FormMixin examples](forms.md): native form validation, rendering and save hooks.
+- [Event examples](events.md): input values, data attributes and debounce.
+- [Loading examples](loading-states.md): native feedback and background work.
+
+Use the example matching the task; do not copy every helper into every view.
+Examples illustrate mechanisms, not a complete authorization policy.
+
+## Capability lookup
+
+In a matching djust checkout, start with `python/djust/forms.py`,
+`mixins/context.py`, `mixins/request.py`, `mixins/navigation.py`, `auth/`,
+`uploads.py`, `presence.py`, `streaming.py`, and `push.py` under `python/djust/`.
+Verify paths/signatures in the installed release before claiming support is
+missing. Run Django checks and the applicable `djust_check` / `djust_audit`
+commands; investigate findings rather than blanket-silencing them.
+
+## Review and verification
+
+For every new helper/mixin/renderer/transport layer, identify:
+
+- The application behavior it adds and the native capability considered.
+- Why native configuration or an existing hook is insufficient.
+- For a framework bug: affected release, minimal reproduction, upstream issue,
+  narrow accommodation and removal condition.
+
+Test the behavior claimed: validation and authorization, actual rendering,
+native navigation and HTTP/socket transport as relevant. Browser checks should
+cover visible feedback, focus and persistence; reconnect claims need a real
+reconnect sequence. Distributed claims need multiple workers. A passing unit
+suite does not establish all of those behaviors. After upgrades, rerun the
+reproduction before retaining or removing a workaround.
+
+## Discovery in application repositories
+
+`djust new` supplies a short `AGENTS.md` pointer to this guide. Existing projects
+can add the same pointer to their own agent entry file, preserving their local
+instructions. Tools that use another entry file can link from that file too.
+Installing a Python package or publishing `llms.txt` does not by itself load
+these instructions into an agent's context. Keep one canonical guide and load
+relevant reference sections rather than copying the whole guide into each app.

--- a/docs/guides/scaffolding.md
+++ b/docs/guides/scaffolding.md
@@ -184,3 +184,11 @@ The legacy commands mirror Django's vanilla `django-admin startproject`
 `LIVEVIEW_ALLOWED_MODULES`, `LiveSessionMiddleware`, the WS routing
 include). Reach for these when you want explicit Django parity over
 the curated `djust new` experience.
+
+## AI agent discovery
+
+Generated projects include `AGENTS.md`, a short pointer to the canonical
+[application conventions](../ai/conventions.md) and focused API references.
+Add project-specific rules there. Existing project directories are not
+rewritten by `djust new`; for existing applications, add the pointer to their
+current agent entry file. Agents do not automatically read dependency docs.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,6 +2,12 @@
 
 djust is a Python/Rust framework that brings Phoenix LiveView-style reactive server-side rendering to Django. Views update in real-time over WebSockets with ~58 KB gzipped client JS, no build step.
 
+## Application conventions for AI agents
+
+Read [Application engineering conventions](https://github.com/djust-org/djust/blob/main/docs/ai/conventions.md)
+and the [focused AI reference](https://github.com/djust-org/djust/tree/main/docs/ai).
+Use documentation matching the installed release; main may describe newer APIs.
+
 ## Setup
 
 ```bash

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -2,6 +2,12 @@
 
 > djust is a Python/Rust framework that brings Phoenix LiveView-style reactive server-side rendering to Django. Real-time UI updates over WebSockets with ~58 KB gzipped client JS, zero build step, and Rust-powered VDOM diffing + template rendering (roughly 7-11x faster than Django on variable- and filter-heavy templates; see the README's Performance section for the measured table and the benchmark script).
 
+## Application conventions for AI agents
+
+Read [Application engineering conventions](https://github.com/djust-org/djust/blob/main/docs/ai/conventions.md)
+and the [focused AI reference](https://github.com/djust-org/djust/tree/main/docs/ai).
+Use documentation matching the installed release; main may describe newer APIs.
+
 ## Docs
 
 - [Getting Started](https://djust.org/docs/getting-started/): Installation, setup, and your first LiveView

--- a/python/djust/scaffolding/generator.py
+++ b/python/djust/scaffolding/generator.py
@@ -245,6 +245,9 @@ def _create_project_files(project_dir: Path, app_name: str, ctx: Dict[str, Any])
     # .gitignore
     _write(project_dir / ".gitignore", T.GITIGNORE)
 
+    # Agent entry point: link to the canonical conventions.
+    _write(project_dir / "AGENTS.md", T.AGENTS_MD)
+
     # .env.example — committed template the developer copies to .env for
     # local dev. Scaffolded settings.py reads DEBUG / SECRET_KEY /
     # ALLOWED_HOSTS from the environment with fail-safe defaults, so an

--- a/python/djust/scaffolding/templates.py
+++ b/python/djust/scaffolding/templates.py
@@ -955,3 +955,16 @@ SCHEMA_LIST_HTML = """\
 </div>
 {%% endblock %%}
 """
+
+
+# Keep this an entry point, not a second copy of the framework conventions.
+AGENTS_MD = """# djust application guidance
+
+Before changing live views, forms, templates or navigation, read:
+- [Application engineering conventions](https://github.com/djust-org/djust/blob/main/docs/ai/conventions.md)
+- [Focused AI reference](https://github.com/djust-org/djust/tree/main/docs/ai)
+
+Use the documentation/source matching the installed djust release; main may
+contain newer APIs. Prefer native Django/djust behavior and declarative options
+before application wrappers. Keep project-specific instructions in this file.
+"""

--- a/python/tests/test_scaffold_agent_guidance.py
+++ b/python/tests/test_scaffold_agent_guidance.py
@@ -1,0 +1,17 @@
+"""Agent discovery is present in actual generated projects, without setup calls."""
+
+import pytest
+
+from djust.scaffolding.generator import generate_project
+
+
+def test_generated_project_has_canonical_agent_guidance_and_preserves_existing(tmp_path):
+    project = generate_project("guided_app", target_dir=str(tmp_path), auto_setup=False)
+    entry = project / "AGENTS.md"
+    guidance = entry.read_text()
+    assert "https://github.com/djust-org/djust/blob/main/docs/ai/conventions.md" in guidance
+    assert "installed djust release" in guidance
+    entry.write_text("Project-specific instructions")
+    with pytest.raises(ValueError, match="already exists"):
+        generate_project("guided_app", target_dir=str(tmp_path), auto_setup=False)
+    assert entry.read_text() == "Project-specific instructions"


### PR DESCRIPTION
## Summary

Application agents can miss djust's native capabilities and add duplicate form, rendering or transport layers. Add a canonical application conventions guide and make it discoverable from the framework repository, LLM indexes, README and generated applications.

`djust new` now writes a short `AGENTS.md` linking to that guide. Existing directories remain protected by the generator's existing refusal to overwrite them. The entry point explains release-aware lookup rather than copying a second rulebook into each app.

## Changes

- Document native ownership, declarative forms, lifecycle/state, template data, events, navigation, background work, authorization, optional services and evidence-based workarounds.
- Link to the existing focused examples and add a native-first PR review checklist.
- Add root AGENTS.md and CLAUDE.md discovery links, plus README, scaffolding guide and LLM index pointers.
- Test actual generated guidance and preservation of an existing project's instructions.

## Type of Change

- [x] Documentation update
- [x] New feature (generated agent entry point)

## Test Plan

- [x] 21 scaffold/CLI tests passed against this worktree's Python source.
- [x] Ruff and relative-link checks passed; docs lint reported zero stale references.
- [x] All configured commit and pre-push hooks passed; no hooks bypassed.
- [ ] Broad `make test` is not fully green. Rust passed. Python: 27,039 passed, 486 skipped, two failures. The changelog test saw the initial fragment before its correction; it passes on the final commit (also covered by the successful pre-push gate). The shard-collection test's nested process imports the main checkout's conftest, producing an ImportPathMismatchError in this linked worktree.
- [ ] JavaScript broad run: 1,677 passed, five failed tests, six failed files and one error. Failures include missing @vitest/istanbul test dependencies and unavailable localStorage under Node 26. No JavaScript implementation changed. CI on this PR must establish a clean-environment result; these local results are not a full-release-green claim.

## Checklist

- [x] Self-reviewed for correctness and security; no new runtime dependency or authentication behavior.
- [x] Documentation and changelog fragment updated.
- [x] No breaking API change.

This PR intentionally does not install a third-party agent plugin or copy djust.org's historical incidents into the framework guide.
